### PR TITLE
Hotfix/gemmver

### DIFF
--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -181,30 +181,24 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
   setDefaultSize( m_ni*m_nj*(1+m_nk) + m_ni*m_nl*(1+m_nj) );
   setDefaultReps(m_run_reps);
 
-  allocAndInitData(m_tmp, m_ni * m_nj);
-  allocAndInitData(m_A, m_ni * m_nk);
-  allocAndInitData(m_B, m_nk * m_nj);
-  allocAndInitData(m_C, m_nj * m_nl);
-  allocAndInitData(m_D, m_ni * m_nl);
-  allocAndInitData(m_DD, m_ni * m_nl);
-  //printf("maps ctor polybench tmp=%p A=%p B=%p C=%p D=%p DD=%p\n",m_tmp,m_A,m_B,m_C,m_D,m_DD);
+
 
 }
 
 POLYBENCH_2MM::~POLYBENCH_2MM() 
 {
-  deallocData(m_tmp);
-  deallocData(m_A);
-  deallocData(m_B);
-  deallocData(m_C);
-  deallocData(m_D);
-  deallocData(m_DD);
+
 }
 
 void POLYBENCH_2MM::setUp(VariantID vid)
 {
   (void) vid;
-  initDataConst(m_D, m_ni * m_nl, 0.0);
+  allocAndInitData(m_tmp, m_ni * m_nj, vid);
+  allocAndInitData(m_A, m_ni * m_nk, vid);
+  allocAndInitData(m_B, m_nk * m_nj, vid);
+  allocAndInitData(m_C, m_nj * m_nl, vid);
+  allocAndInitDataConst(m_D, m_ni * m_nl, 0.0, vid);
+  allocAndInitData(m_DD, m_ni * m_nl, vid);
 }
 
 void POLYBENCH_2MM::runKernel(VariantID vid)
@@ -553,7 +547,12 @@ void POLYBENCH_2MM::updateChecksum(VariantID vid)
 void POLYBENCH_2MM::tearDown(VariantID vid)
 {
   (void) vid;
-
+  deallocData(m_tmp);
+  deallocData(m_A);
+  deallocData(m_B);
+  deallocData(m_C);
+  deallocData(m_D);
+  deallocData(m_DD);
 }
 
 } // end namespace basic

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -213,30 +213,23 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   setDefaultSize(m_ni*m_nj*(1+m_nk) + m_nj*m_nl*(1+m_nm) + m_ni*m_nl*(1+m_nj));
   setDefaultReps(m_run_reps);
 
-  allocAndInitData(m_A, m_ni * m_nk);
-  allocAndInitData(m_B, m_nk * m_nj);
-  allocAndInitData(m_C, m_nj * m_nm);
-  allocAndInitData(m_D, m_nm * m_nl);
-  allocAndInitData(m_E, m_ni * m_nj);
-  allocAndInitData(m_F, m_nj * m_nl);
-  allocAndInitData(m_G, m_ni * m_nl);
+
 }
 
 POLYBENCH_3MM::~POLYBENCH_3MM() 
 {
-  deallocData(m_A);
-  deallocData(m_B);
-  deallocData(m_C);
-  deallocData(m_D);
-  deallocData(m_E);
-  deallocData(m_F);
-  deallocData(m_G);
 }
 
 void POLYBENCH_3MM::setUp(VariantID vid)
 {
   (void) vid;
-  initDataConst(m_G, m_ni * m_nl, 0.0);
+  allocAndInitData(m_A, m_ni * m_nk, vid);
+  allocAndInitData(m_B, m_nk * m_nj, vid);
+  allocAndInitData(m_C, m_nj * m_nm, vid);
+  allocAndInitData(m_D, m_nm * m_nl, vid);
+  allocAndInitData(m_E, m_ni * m_nj, vid);
+  allocAndInitData(m_F, m_nj * m_nl, vid);
+  allocAndInitDataConst(m_G, m_ni * m_nl, 0.0, vid);
 }
 
 void POLYBENCH_3MM::runKernel(VariantID vid)
@@ -652,7 +645,13 @@ void POLYBENCH_3MM::updateChecksum(VariantID vid)
 void POLYBENCH_3MM::tearDown(VariantID vid)
 {
   (void) vid;
-
+  deallocData(m_A);
+  deallocData(m_B);
+  deallocData(m_C);
+  deallocData(m_D);
+  deallocData(m_E);
+  deallocData(m_F);
+  deallocData(m_G);
 }
 
 } // end namespace basic

--- a/src/polybench/POLYBENCH_GEMMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMMVER.cpp
@@ -53,6 +53,8 @@ namespace rajaperf
 namespace polybench
 {
 
+
+
 #define POLYBENCH_GEMMVER_DATA \
   Real_type alpha = m_alpha; \
   Real_type beta = m_beta; \
@@ -274,11 +276,8 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
           }
         }
 
-// RDH This should not be a loop nest, only an 'i' loop
         for (Index_type i = 0; i < n; i++ ) { 
-          for (Index_type j = 0; j < n; j++) {
-            POLYBENCH_GEMMVER_BODY3;
-          }
+          POLYBENCH_GEMMVER_BODY3;
         }
 
         for (Index_type i = 0; i < n; i++ ) { 
@@ -360,9 +359,7 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
 
         #pragma omp parallel for  
         for (Index_type i = 0; i < n; i++ ) {
-          for (Index_type j = 0; j < n; j++) {
-            POLYBENCH_GEMMVER_BODY3;
-          }
+          POLYBENCH_GEMMVER_BODY3;
         }
 
         #pragma omp parallel for  
@@ -451,9 +448,7 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
 
         #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) collapse(2)
         for (Index_type i = 0; i < n; i++ ) {
-          for(Index_type j = 0; j < n; j++) {
-            POLYBENCH_GEMMVER_BODY3;
-          }
+          POLYBENCH_GEMMVER_BODY3;
         }
 
         #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) collapse(2)

--- a/src/polybench/POLYBENCH_GEMMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMMVER.cpp
@@ -135,7 +135,8 @@ __global__ void polybench_gemmver_cuda_1(Real_ptr A,
    Index_type i,j;
    if (ii < n * n) {
      i = ii/n; j = ii % n;
-     POLYBENCH_GEMMVER_BODY1;              
+     POLYBENCH_GEMMVER_BODY1;
+
    }
 }
 
@@ -147,7 +148,10 @@ __global__ void polybench_gemmver_cuda_2(Real_type beta,
    Index_type i,j;
    if (ii < n * n) {
      i = ii/n; j = ii % n;
-     POLYBENCH_GEMMVER_BODY2;              
+     if(i == 0 && j == 10) printf("CUDA A[0,%d] = %lf  x[%d] = %lf y[%d] = %lf \n",j,*(A + i * n + j),j,*(x + i), j, *(y + i ));    
+     POLYBENCH_GEMMVER_BODY2;
+     if(i == 0 && j == 10) printf("CUDA A[0,%d] = %lf  x[%d] = %lf y[%d] = %lf \n",j,*(A + i * n + j),j,*(x + i), j, *(y + i ));    
+          
    }
 }
 
@@ -213,6 +217,9 @@ POLYBENCH_GEMMVER::POLYBENCH_GEMMVER(const RunParams& params)
   setDefaultSize(m_n*m_n + m_n*m_n + m_n + m_n*m_n);
   setDefaultReps(run_reps);
 
+  m_alpha = 1.5;
+  m_beta = 1.2;
+#if 0
   allocAndInitData(m_A, m_n * m_n);
   allocAndInitData(m_u1, m_n);
   allocAndInitData(m_v1, m_n);
@@ -222,10 +229,12 @@ POLYBENCH_GEMMVER::POLYBENCH_GEMMVER(const RunParams& params)
   allocAndInitData(m_x, m_n);
   allocAndInitData(m_y, m_n);
   allocAndInitData(m_z, m_n);
+#endif
 }
 
 POLYBENCH_GEMMVER::~POLYBENCH_GEMMVER() 
 {
+#if 0  
   deallocData(m_A);
   deallocData(m_u1);
   deallocData(m_v1);
@@ -235,18 +244,23 @@ POLYBENCH_GEMMVER::~POLYBENCH_GEMMVER()
   deallocData(m_x);
   deallocData(m_y);
   deallocData(m_z);
+#endif  
 }
 
 void POLYBENCH_GEMMVER::setUp(VariantID vid)
 {
   (void) vid;
-#if 0 // RDH attempt to initialize alpha and beta to non-zero values and
-      // w to zero so checksum indicates whether kernel variant is run.
-      // These changes break the code...
-  initData(m_alpha);
-  initData(m_beta);
-  initDataConst(m_w, m_n, 0.0);
-#endif
+
+  allocAndInitData(m_A, m_n * m_n, vid);
+  allocAndInitData(m_u1, m_n, vid);
+  allocAndInitData(m_v1, m_n, vid);
+  allocAndInitData(m_u2, m_n, vid);
+  allocAndInitData(m_v2, m_n, vid);
+  allocAndInitDataConst(m_w, m_n, 0.0, vid);
+  allocAndInitData(m_x, m_n, vid);
+  allocAndInitData(m_y, m_n, vid);
+  allocAndInitData(m_z, m_n, vid);
+
 }
 
 void POLYBENCH_GEMMVER::runKernel(VariantID vid)
@@ -267,12 +281,15 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
         for (Index_type i = 0; i < n; i++ ) {
           for (Index_type j = 0; j < n; j++) {
             POLYBENCH_GEMMVER_BODY1;
+
           }
         }
 
         for (Index_type i = 0; i < n; i++ ) { 
           for (Index_type j = 0; j < n; j++) {
+            if(i == 0 && j == 10) printf("SEQ A[0,%d] = %lf  x[%d] = %lf y[%d] = %lf \n",j,*(A + i * n + j),j,*(x + i), j, *(y + i ));    
             POLYBENCH_GEMMVER_BODY2;
+     if(i == 0 && j == 10) printf("SEQ A[0,%d] = %lf  x[%d] = %lf y[%d] = %lf \n",j,*(A + i * n + j),j,*(x + i), j, *(y + i ));    
           }
         }
 
@@ -596,7 +613,15 @@ void POLYBENCH_GEMMVER::updateChecksum(VariantID vid)
 void POLYBENCH_GEMMVER::tearDown(VariantID vid)
 {
   (void) vid;
-
+  deallocData(m_A);
+  deallocData(m_u1);
+  deallocData(m_v1);
+  deallocData(m_u2);
+  deallocData(m_v2);
+  deallocData(m_w);
+  deallocData(m_x);
+  deallocData(m_y);
+  deallocData(m_z);
 }
 
 } // end namespace basic

--- a/src/polybench/POLYBENCH_GEMMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMMVER.cpp
@@ -184,8 +184,6 @@ __global__ void polybench_gemmver_cuda_4(Real_type alpha,
    }
 }
 
-
-
 #endif // if defined(RAJA_ENABLE_CUDA)
   
 POLYBENCH_GEMMVER::POLYBENCH_GEMMVER(const RunParams& params)
@@ -203,7 +201,7 @@ POLYBENCH_GEMMVER::POLYBENCH_GEMMVER(const RunParams& params)
       run_reps = 20000;
       break;
     case Medium:
-      m_n=16;
+      m_n=400;
       run_reps = 2000;
       break;
     case Large:
@@ -215,7 +213,7 @@ POLYBENCH_GEMMVER::POLYBENCH_GEMMVER(const RunParams& params)
       run_reps = 5;
       break;
     default:
-      m_n=5;
+      m_n=400;
       run_reps = 2000;
       break;
   }
@@ -267,23 +265,11 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
             POLYBENCH_GEMMVER_BODY1;
           }
         }
-        for (Index_type i = 0; i < n; i++) {
-          //printf("SEQ b x[%ld] = %f\n",i,*(x+i)); 
-        }
 
         for (Index_type i = 0; i < n; i++ ) { 
           for (Index_type j = 0; j < n; j++) {
-                if(j==0) {
-                   printf("x = %lf\n",*(x+i));
-                   printf("A = %lf\n",*(A+j*n+i));
-                   printf("y = %lf\n",*(y+j));
-                } 
             POLYBENCH_GEMMVER_BODY2;
-            printf("SEQ a %ld x[%ld] = %f\n",j,i,*(x+i)); 
           }
-        }
-        for (Index_type i = 0; i < n; i++) {
-          //printf("SEQ a x[%ld] = %f\n",i,*(x+i)); 
         }
 
         for (Index_type i = 0; i < n; i++ ) { 
@@ -294,11 +280,6 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
           for (Index_type j = 0; j < n; j++) {
             POLYBENCH_GEMMVER_BODY4;
           }
-        }
-
-
-        for (Index_type i = 0; i < n; i++) {
-          //printf("SEQ a w[%ld] = %f\n",i,*(w+i)); 
         }
 
       }
@@ -486,7 +467,7 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
       }
       stopTimer();
 
-      #pragma omp target exit data map(from:w[0:m_n]) map(delete: u1[0:m_n],v1[0:m_n], u2[0:m_n], v2[0:m_n], x[0: m_n], y[0: m_n], z[0:m_n], alpha, beta)
+      #pragma omp target exit data map(from:w[0:n]) map(delete: A[0:n*n],u1[0:n],v1[0:n], u2[0:n], v2[0:n], x[0:n], y[0:n], z[0:n], alpha, beta)
 
       break;
     }
@@ -514,14 +495,7 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
             i = ii/n; jj = ii % n;
             if(jj == 0) {
               for(Index_type j=0; j < n; j++) {
-                if(j==0) {
-                   printf("x = %lf\n",*(x+i));
-                   printf("A = %lf\n",*(A+j*n+i));
-                   printf("y = %lf\n",*(y+j));
-                } 
-                //printf("ompt b %ld x[%ld] = %f\n",j,i,*(x+i)); 
                 POLYBENCH_GEMMVER_BODY2;
-                printf("ompt a %ld x[%ld] = %f\n",j,i,*(x+i)); 
               } 
             }
         });
@@ -538,20 +512,15 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
             if(jj == 0) {
               for(Index_type j=0; j < n; j++) { 
                 POLYBENCH_GEMMVER_BODY4;
-                //if(j==n-1)printf("ompt a w[%ld] = %f\n",i,*(w+i)); 
               } 
             }   
         });
 
-
       } // for run_reps   
       stopTimer();
 
-      #pragma omp target exit data map(from:w[0:m_n]) map(delete: u1[0:m_n],v1[0:m_n], u2[0:m_n], v2[0:m_n], x[0: m_n], y[0: m_n], z[0:m_n], alpha, beta)
+      #pragma omp target exit data map(from:w[0:n]) map(delete: A[0:n*n], u1[0:n],v1[0:n], u2[0:n], v2[0:n], x[0:n], y[0:n], z[0:n], alpha, beta)
     
-      //for (Index_type i = 0; i < 16; i++) {
-      //  printf("ompt a w[%ld] = %f\n",i,*(w+i)); 
-      //}
       break;                        
     }  
 #endif //RAJA_ENABLE_TARGET_OPENMP


### PR DESCRIPTION
New alloc and init strategy exposed incorrect algorithm in cuda/omp-target variants which were caught when viewing checksum. There was also a bug in delete map clause in omp-target variants, forgetting a delete will cause cascade memory corruption bug.  All the Polybench kernels now have consistent setup/teardown wrt all the other kernels.