### PR TITLE
Task/omp target rework data

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ Lastly, the program will emit a summary of provided input if it is given
 something that it does not understand. Hopefully, this will make it easy for
 users to understand and correct erroneous usage.
 
+# Important note
+
+The OpenMP target variants of the kernels should be considered a 
+work-in-progress. They are incomplete (a few RAJA features must be
+filled in to make them comparable to other variants of 'nested' kernels).
+Also, the build system for the Suite needs to be reworked to have the
+OpenMP target kernel variants run from the same executable as the CUDA
+variants. Currently, a separate executable `./bin/raja-perf-nolibs.exe`
+is generated for running OpenMP target variants when they are enabled.
+
 * * *
 
 # Generated output
@@ -165,7 +175,7 @@ Adding a new kernel to the suite involves three main steps:
 
 1. Add unique kernel ID and unique name to the suite. 
 2. If the kernel is part of a new kernel group, also add a unique group ID and name for the group.
-3. Implement a kernel class that contains all operations needed to run it.
+3. Implement a kernel class that contains all operations needed to run it, with source files organized as described below.
 
 These steps are described in the following sections.
 
@@ -174,11 +184,11 @@ These steps are described in the following sections.
 Two key pieces of information identify a kernel: the group in which it 
 resides and the name of the kernel itself. For concreteness, we describe
 how to add a kernel "Foo" that lives in the kernel group "Bar". The files 
-`RAJAPerfSuite.hxx` and `RAJAPerfSuite.cxx` define enumeration 
+`RAJAPerfSuite.hpp` and `RAJAPerfSuite.cpp` define enumeration 
 values and arrays of string names for the kernels, respectively. 
 
 First, add an enumeration value identifier for the kernel, that is unique 
-among all kernels, in the enum 'KerneID' in the header file `RAJAPerfSuite.hxx`:
+among all kernels, in the enum 'KerneID' in the header file `RAJAPerfSuite.hpp`:
 
 ```cpp
 enum KernelID {
@@ -194,7 +204,7 @@ this convention so that the kernel works with existing performance
 suite machinery. 
 
 Second, add the kernel name to the array of strings 'KernelNames' in the file
-`RAJAPerfSuite.cxx`:
+`RAJAPerfSuite.cpp`:
 
 ```cpp
 static const std::string KernelNames [] =
@@ -216,8 +226,8 @@ and matching one-to-one).
 
 If a kernel is added as part of a new group of kernels in the suite, a
 new value must be added to the 'GroupID' enum in the header file 
-`RAJAPerfSuite.hxx` and an associated group string name must be added to
-the 'GroupNames' array of strings in the file `RAJAPerfSuite.cxx`. Again,
+`RAJAPerfSuite.hpp` and an associated group string name must be added to
+the 'GroupNames' array of strings in the file `RAJAPerfSuite.cpp`. Again,
 the enumeration values and items in the string array must be kept
 consistent.
 
@@ -231,7 +241,8 @@ all operations needed to execute and record execution timing and result
 checksum information for each variant of the kernel. 
 
 Continuing with our example, we add 'Foo' class header and implementation 
-files 'Foo.hxx' and 'Foo.cxx', respectively, to the 'src/bar' directory. 
+files 'Foo.hpp', 'Foo.cpp' (CPU variants), `Foo-Cuda.cpp` (CUDA variants), 
+and `Foo-OMPTarget.cpp` (OpenMP target variants) to the 'src/bar' directory. 
 The class must inherit from the 'KernelBase' base class that defines the 
 interface for kernels in the suite. 
 
@@ -243,7 +254,15 @@ Here is what the header file for the Foo kernel object may look like:
 #ifndef RAJAPerf_Bar_Foo_HXX
 #define RAJAPerf_Bar_Foo_HXX
 
-#include "common/KernelBase.hxx"
+
+///
+/// Foo kernel reference implementation:
+///
+/// Describe it here...
+///
+
+
+#include "common/KernelBase.hpp"
 
 namespace rajaperf  
 {
@@ -264,6 +283,9 @@ public:
   void runKernel(VariantID vid);
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid); 
 
 private:
   // Kernel-specific data (pointers, scalars, etc.) used in kernel...
@@ -345,7 +367,8 @@ checksums can be compared at the end of a run.
 
 Note: to simplify these operations and help ensure consistency, there exist 
 utility methods to allocate, initialize, deallocate, and copy data, and compute
-checksums defined in the `DataUtils.hxx` header file in the 'common' directory.
+checksums defined in the `DataUtils.hpp` `CudaDataUtils.hpp`, and 
+`OpenMPTargetDataUtils.hpp` header files in the 'common' directory.
 
 ##### runKernel() method
 
@@ -360,17 +383,60 @@ void Foo::runKernel(VariantID vid)
   const Index_type run_reps = getRunReps();
   // ...
 
-  // Declare data for vid variant of kernel...
+  switch ( vid ) {
 
-  startTimer();
-  for (SampIndex_type irep = 0; irep < run_reps; ++irep) {
-     // Implementation of vid variant of kernel...
+    case Base_Seq : {
+
+      // Declare data for baseline sequential variant of kernel...
+
+      startTimer();
+      for (SampIndex_type irep = 0; irep < run_reps; ++irep) {
+         // Implementation of kernel variant...
+      }
+      stopTimer();
+
+      // ...
+
+      break; 
+    }
+
+    // case statements for other CPU kernel variants.... 
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
+      break;
+    }
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
+      break;
+    }
+#endif
+
+    default : {
+      std::cout << "\n  <kernel-name> : Unknown variant id = " << vid << std::endl;
+    }
+
   }
-  stopTimer();
-
-  // ...
 }
 ```
+
+All kernel implementation files are organized in this way. So following this
+pattern will keep all new additions consistent. 
+
+Note: There are three source files for each kernel: 'Foo.cpp' contains CPU 
+variants, `Foo-Cuda.cpp` contains CUDA variants, and `Foo-OMPTarget.cpp` 
+constains OpenMP target variants. The reason for this is that it makes it 
+easier to apply unique compiler flags to different variants and to manage
+compilation and linking issues that arise when some kernel variants are
+combined in the same translation unit.
 
 Note: for convenience, we make heavy use of macros to define data 
 declarations and kernel bodies in the suite. This significantly reduces
@@ -391,7 +457,7 @@ compared to help identify differences, and potentially errors, in
 implementations, compiler optimizations, programming model execution, etc.
 
 Note: to simplify checksum computations and help ensure consistency, there 
-are methods to compute checksums defined in the `DataUtils.hxx` header file 
+are methods to compute checksums defined in the `DataUtils.hpp` header file 
 in the 'common' directory.
 
 ##### tearDown() method
@@ -407,7 +473,7 @@ The 'Executor' class object is responsible for creating kernel objects
 for the kernels to be run based on the suite input options. To ensure a new
 kernel object will be created properly, add a call to its class constructor 
 based on its 'KernelID' in the 'getKernelObject()' method in the 
-`RAJAPerfSuite.cxx` file.
+`RAJAPerfSuite.cpp` file.
 
   
 ## Adding a variant
@@ -420,7 +486,7 @@ items similar to adding a kernel as described above.
 
 First, add an enumeration value identifier for the variant, that is unique 
 among all variants, in the enum 'VariantID' in the header file 
-`RAJAPerfSuite.hxx`:
+`RAJAPerfSuite.hpp`:
 
 ```cpp
 enum VariantID {
@@ -431,7 +497,7 @@ enum VariantID {
 ```
 
 Second, add the variant name to the array of strings 'VariantNames' in the file
-`RAJAPerfSuite.cxx`:
+`RAJAPerfSuite.cpp`:
 
 ```cpp
 static const std::string VariantNames [] =

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,8 +78,14 @@ blt_add_executable(
   stream/ADD-Cuda.cpp
   stream/ADD-OMPTarget.cpp
   stream/COPY.cpp
+  stream/COPY-Cuda.cpp
+  stream/COPY-OMPTarget.cpp
   stream/DOT.cpp
+  stream/DOT-Cuda.cpp
+  stream/DOT-OMPTarget.cpp
   stream/MUL.cpp
+  stream/MUL-Cuda.cpp
+  stream/MUL-OMPTarget.cpp
   stream/TRIAD.cpp
   stream/TRIAD-Cuda.cpp
   stream/TRIAD-OMPTarget.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,8 @@ blt_add_executable(
   lcals/HYDRO_1D-Cuda.cpp
   lcals/HYDRO_1D-OMPTarget.cpp
   lcals/INT_PREDICT.cpp
+  lcals/INT_PREDICT-Cuda.cpp
+  lcals/INT_PREDICT-OMPTarget.cpp
   lcals/PLANCKIAN.cpp
   polybench/POLYBENCH_2MM.cpp
   polybench/POLYBENCH_3MM.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,11 @@ blt_add_executable(
   apps/WIP-COUPLE.cpp
   basic/IF_QUAD.cpp
   basic/INIT3.cpp
+  basic/INIT3-Cuda.cpp
+  basic/INIT3-OMPTarget.cpp
   basic/MULADDSUB.cpp
+  basic/MULADDSUB-Cuda.cpp
+  basic/MULADDSUB-OMPTarget.cpp
   basic/NESTED_INIT.cpp
   basic/REDUCE3_INT.cpp
   basic/TRAP_INT.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,6 +62,8 @@ blt_add_executable(
   basic/NESTED_INIT.cpp
   basic/REDUCE3_INT.cpp
   basic/TRAP_INT.cpp
+  basic/TRAP_INT-Cuda.cpp
+  basic/TRAP_INT-OMPTarget.cpp
   basic/INIT_VIEW1D.cpp
   basic/INIT_VIEW1D-Cuda.cpp
   basic/INIT_VIEW1D-OMPTarget.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,8 @@ blt_add_executable(
   apps/ENERGY-Cuda.cpp
   apps/ENERGY-OMPTarget.cpp
   apps/FIR.cpp
+  apps/FIR-Cuda.cpp
+  apps/FIR-OMPTarget.cpp
   apps/PRESSURE.cpp
   apps/PRESSURE-Cuda.cpp
   apps/PRESSURE-OMPTarget.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,6 +95,8 @@ blt_add_executable(
   lcals/INT_PREDICT-Cuda.cpp
   lcals/INT_PREDICT-OMPTarget.cpp
   lcals/PLANCKIAN.cpp
+  lcals/PLANCKIAN-Cuda.cpp
+  lcals/PLANCKIAN-OMPTarget.cpp
   polybench/POLYBENCH_2MM.cpp
   polybench/POLYBENCH_3MM.cpp
   polybench/POLYBENCH_GEMMVER.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,8 @@ blt_add_executable(
   apps/ENERGY.cpp
   apps/FIR.cpp
   apps/PRESSURE.cpp
+  apps/PRESSURE-Cuda.cpp
+  apps/PRESSURE-OMPTarget.cpp
   apps/VOL3D.cpp
   apps/VOL3D-Cuda.cpp
   apps/VOL3D-OMPTarget.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,8 @@ blt_add_executable(
   basic/MULADDSUB-OMPTarget.cpp
   basic/NESTED_INIT.cpp
   basic/REDUCE3_INT.cpp
+  basic/REDUCE3_INT-Cuda.cpp
+  basic/REDUCE3_INT-OMPTarget.cpp
   basic/TRAP_INT.cpp
   basic/TRAP_INT-Cuda.cpp
   basic/TRAP_INT-OMPTarget.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,8 @@ blt_add_executable(
   apps/LTIMES_NOVIEW.cpp
   apps/WIP-COUPLE.cpp
   basic/IF_QUAD.cpp
+  basic/IF_QUAD-Cuda.cpp
+  basic/IF_QUAD-OMPTarget.cpp
   basic/INIT3.cpp
   basic/INIT3-Cuda.cpp
   basic/INIT3-OMPTarget.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,8 @@ blt_add_executable(
   SOURCES RAJAPerfSuiteDriver.cpp
   apps/AppsData.cpp
   apps/DEL_DOT_VEC_2D.cpp
+  apps/DEL_DOT_VEC_2D-Cuda.cpp
+  apps/DEL_DOT_VEC_2D-OMPTarget.cpp
   apps/ENERGY.cpp
   apps/FIR.cpp
   apps/PRESSURE.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,8 @@ blt_add_executable(
   apps/FIR.cpp
   apps/PRESSURE.cpp
   apps/VOL3D.cpp
+  apps/VOL3D-Cuda.cpp
+  apps/VOL3D-OMPTarget.cpp
   apps/LTIMES.cpp
   apps/LTIMES_NOVIEW.cpp
   apps/WIP-COUPLE.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,8 @@ blt_add_executable(
   lcals/FIRST_DIFF-Cuda.cpp
   lcals/FIRST_DIFF-OMPTarget.cpp
   lcals/HYDRO_1D.cpp
+  lcals/HYDRO_1D-Cuda.cpp
+  lcals/HYDRO_1D-OMPTarget.cpp
   lcals/INT_PREDICT.cpp
   lcals/PLANCKIAN.cpp
   polybench/POLYBENCH_2MM.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,8 @@ blt_add_executable(
   polybench/POLYBENCH_3MM.cpp
   polybench/POLYBENCH_GEMMVER.cpp
   stream/ADD.cpp
+  stream/ADD-Cuda.cpp
+  stream/ADD-OMPTarget.cpp
   stream/COPY.cpp
   stream/DOT.cpp
   stream/MUL.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,5 +81,7 @@ blt_add_executable(
   stream/DOT.cpp
   stream/MUL.cpp
   stream/TRIAD.cpp
+  stream/TRIAD-Cuda.cpp
+  stream/TRIAD-OMPTarget.cpp
   DEPENDS_ON ${RAJA_PERFSUITE_DEPENDS}
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,8 +80,14 @@ blt_add_executable(
   common/RPTypes.hpp
   common/RunParams.cpp
   lcals/DIFF_PREDICT.cpp
+  lcals/DIFF_PREDICT-Cuda.cpp
+  lcals/DIFF_PREDICT-OMPTarget.cpp
   lcals/EOS.cpp
+  lcals/EOS-Cuda.cpp
+  lcals/EOS-OMPTarget.cpp
   lcals/FIRST_DIFF.cpp
+  lcals/FIRST_DIFF-Cuda.cpp
+  lcals/FIRST_DIFF-OMPTarget.cpp
   lcals/HYDRO_1D.cpp
   lcals/INT_PREDICT.cpp
   lcals/PLANCKIAN.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,8 @@ blt_add_executable(
   apps/VOL3D-OMPTarget.cpp
   apps/LTIMES.cpp
   apps/LTIMES_NOVIEW.cpp
+  apps/LTIMES_NOVIEW-Cuda.cpp
+  apps/LTIMES_NOVIEW-OMPTarget.cpp
   apps/WIP-COUPLE.cpp
   basic/IF_QUAD.cpp
   basic/IF_QUAD-Cuda.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,8 @@ blt_add_executable(
   basic/MULADDSUB-Cuda.cpp
   basic/MULADDSUB-OMPTarget.cpp
   basic/NESTED_INIT.cpp
+  basic/NESTED_INIT-Cuda.cpp
+  basic/NESTED_INIT-OMPTarget.cpp
   basic/REDUCE3_INT.cpp
   basic/REDUCE3_INT-Cuda.cpp
   basic/REDUCE3_INT-OMPTarget.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,8 @@ blt_add_executable(
   apps/DEL_DOT_VEC_2D-Cuda.cpp
   apps/DEL_DOT_VEC_2D-OMPTarget.cpp
   apps/ENERGY.cpp
+  apps/ENERGY-Cuda.cpp
+  apps/ENERGY-OMPTarget.cpp
   apps/FIR.cpp
   apps/PRESSURE.cpp
   apps/PRESSURE-Cuda.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,8 @@ blt_add_executable(
   basic/INIT_VIEW1D-Cuda.cpp
   basic/INIT_VIEW1D-OMPTarget.cpp
   basic/INIT_VIEW1D_OFFSET.cpp
+  basic/INIT_VIEW1D_OFFSET-Cuda.cpp
+  basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
   common/DataUtils.cpp
   common/Executor.cpp
   common/KernelBase.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,8 @@ blt_add_executable(
   basic/REDUCE3_INT.cpp
   basic/TRAP_INT.cpp
   basic/INIT_VIEW1D.cpp
+  basic/INIT_VIEW1D-Cuda.cpp
+  basic/INIT_VIEW1D-OMPTarget.cpp
   basic/INIT_VIEW1D_OFFSET.cpp
   common/DataUtils.cpp
   common/Executor.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,8 @@ blt_add_executable(
   apps/VOL3D-Cuda.cpp
   apps/VOL3D-OMPTarget.cpp
   apps/LTIMES.cpp
+  apps/LTIMES-Cuda.cpp
+  apps/LTIMES-OMPTarget.cpp
   apps/LTIMES_NOVIEW.cpp
   apps/LTIMES_NOVIEW-Cuda.cpp
   apps/LTIMES_NOVIEW-OMPTarget.cpp

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -20,6 +20,8 @@ blt_add_library(
           PRESSURE-Cuda.cpp 
           PRESSURE-OMPTarget.cpp 
           ENERGY.cpp 
+          ENERGY-Cuda.cpp 
+          ENERGY-OMPTarget.cpp 
           VOL3D.cpp 
           VOL3D-Cuda.cpp 
           VOL3D-OMPTarget.cpp 

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -17,6 +17,8 @@ blt_add_library(
   NAME apps
   SOURCES AppsData.cpp
           PRESSURE.cpp 
+          PRESSURE-Cuda.cpp 
+          PRESSURE-OMPTarget.cpp 
           ENERGY.cpp 
           VOL3D.cpp 
           VOL3D-Cuda.cpp 

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -33,6 +33,8 @@ blt_add_library(
           FIR-OMPTarget.cpp
           LTIMES.cpp
           LTIMES_NOVIEW.cpp
+          LTIMES_NOVIEW-Cuda.cpp
+          LTIMES_NOVIEW-OMPTarget.cpp
           WIP-COUPLE.cpp
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -29,6 +29,8 @@ blt_add_library(
           DEL_DOT_VEC_2D-Cuda.cpp 
           DEL_DOT_VEC_2D-OMPTarget.cpp 
           FIR.cpp
+          FIR-Cuda.cpp
+          FIR-OMPTarget.cpp
           LTIMES.cpp
           LTIMES_NOVIEW.cpp
           WIP-COUPLE.cpp

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -19,6 +19,8 @@ blt_add_library(
           PRESSURE.cpp 
           ENERGY.cpp 
           VOL3D.cpp 
+          VOL3D-Cuda.cpp 
+          VOL3D-OMPTarget.cpp 
           DEL_DOT_VEC_2D.cpp 
           DEL_DOT_VEC_2D-Cuda.cpp 
           DEL_DOT_VEC_2D-OMPTarget.cpp 

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -32,6 +32,8 @@ blt_add_library(
           FIR-Cuda.cpp
           FIR-OMPTarget.cpp
           LTIMES.cpp
+          LTIMES-Cuda.cpp
+          LTIMES-OMPTarget.cpp
           LTIMES_NOVIEW.cpp
           LTIMES_NOVIEW-Cuda.cpp
           LTIMES_NOVIEW-OMPTarget.cpp

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -20,6 +20,8 @@ blt_add_library(
           ENERGY.cpp 
           VOL3D.cpp 
           DEL_DOT_VEC_2D.cpp 
+          DEL_DOT_VEC_2D-Cuda.cpp 
+          DEL_DOT_VEC_2D-OMPTarget.cpp 
           FIR.cpp
           LTIMES.cpp
           LTIMES_NOVIEW.cpp

--- a/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
@@ -92,7 +92,6 @@ __global__ void deldotvec2d(Real_ptr div,
 void DEL_DOT_VEC_2D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type ibegin = 0;
   const Index_type iend = m_domain->n_real_zones;
 
   if ( vid == Base_CUDA ) {

--- a/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
@@ -1,0 +1,158 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DEL_DOT_VEC_2D.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include "AppsData.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define DEL_DOT_VEC_2D_DATA_SETUP_CUDA \
+  Real_ptr x; \
+  Real_ptr y; \
+  Real_ptr xdot; \
+  Real_ptr ydot; \
+  Real_ptr div; \
+  Index_ptr real_zones; \
+\
+  const Real_type ptiny = m_ptiny; \
+  const Real_type half = m_half; \
+\
+  Real_ptr x1,x2,x3,x4 ; \
+  Real_ptr y1,y2,y3,y4 ; \
+  Real_ptr fx1,fx2,fx3,fx4 ; \
+  Real_ptr fy1,fy2,fy3,fy4 ; \
+\
+  allocAndInitCudaDeviceData(x, m_x, m_array_length); \
+  allocAndInitCudaDeviceData(y, m_y, m_array_length); \
+  allocAndInitCudaDeviceData(xdot, m_xdot, m_array_length); \
+  allocAndInitCudaDeviceData(ydot, m_ydot, m_array_length); \
+  allocAndInitCudaDeviceData(div, m_div, m_array_length); \
+  allocAndInitCudaDeviceData(real_zones, m_domain->real_zones, iend);
+
+#define DEL_DOT_VEC_2D_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_div, div, m_array_length); \
+  deallocCudaDeviceData(x); \
+  deallocCudaDeviceData(y); \
+  deallocCudaDeviceData(xdot); \
+  deallocCudaDeviceData(ydot); \
+  deallocCudaDeviceData(div); \
+  deallocCudaDeviceData(real_zones);
+
+__global__ void deldotvec2d(Real_ptr div, 
+                            const Real_ptr x1, const Real_ptr x2,
+                            const Real_ptr x3, const Real_ptr x4,
+                            const Real_ptr y1, const Real_ptr y2,
+                            const Real_ptr y3, const Real_ptr y4,
+                            const Real_ptr fx1, const Real_ptr fx2,
+                            const Real_ptr fx3, const Real_ptr fx4,
+                            const Real_ptr fy1, const Real_ptr fy2,
+                            const Real_ptr fy3, const Real_ptr fy4,
+                            const Index_ptr real_zones,
+                            const Real_type half, const Real_type ptiny,
+                            Index_type iend)
+{
+   Index_type ii = blockIdx.x * blockDim.x + threadIdx.x;
+   if (ii < iend) {
+     DEL_DOT_VEC_2D_BODY_INDEX;
+     DEL_DOT_VEC_2D_BODY;
+   }
+}
+
+
+void DEL_DOT_VEC_2D::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = m_domain->n_real_zones;
+
+  if ( vid == Base_CUDA ) {
+
+    DEL_DOT_VEC_2D_DATA_SETUP_CUDA;
+
+    NDSET2D(m_domain->jp, x,x1,x2,x3,x4) ;
+    NDSET2D(m_domain->jp, y,y1,y2,y3,y4) ;
+    NDSET2D(m_domain->jp, xdot,fx1,fx2,fx3,fx4) ;
+    NDSET2D(m_domain->jp, ydot,fy1,fy2,fy3,fy4) ;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+
+      deldotvec2d<<<grid_size, block_size>>>(div, 
+                                             x1, x2, x3, x4,
+                                             y1, y2, y3, y4,
+                                             fx1, fx2, fx3, fx4,
+                                             fy1, fy2, fy3, fy4,
+                                             real_zones,
+                                             half, ptiny,
+                                             iend);
+
+    }
+    stopTimer();
+
+    DEL_DOT_VEC_2D_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    DEL_DOT_VEC_2D_DATA_SETUP_CUDA;
+
+    NDSET2D(m_domain->jp, x,x1,x2,x3,x4) ;
+    NDSET2D(m_domain->jp, y,y1,y2,y3,y4) ;
+    NDSET2D(m_domain->jp, xdot,fx1,fx2,fx3,fx4) ;
+    NDSET2D(m_domain->jp, ydot,fy1,fy2,fy3,fy4) ;
+
+    RAJA::ListSegment zones(m_domain->real_zones, m_domain->n_real_zones);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         zones, [=] __device__ (Index_type i) {
+         DEL_DOT_VEC_2D_BODY;
+       });
+
+    }
+    stopTimer();
+
+    DEL_DOT_VEC_2D_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  DEL_DOT_VEC_2D : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/apps/DEL_DOT_VEC_2D-OMPTarget.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-OMPTarget.cpp
@@ -1,0 +1,143 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DEL_DOT_VEC_2D.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include "AppsData.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define DEL_DOT_VEC_2D_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr x = m_x; \
+  Real_ptr y = m_y; \
+  Real_ptr xdot = m_xdot; \
+  Real_ptr ydot = m_ydot; \
+  Real_ptr div = m_div; \
+  Index_ptr real_zones; \
+\
+  const Real_type ptiny = m_ptiny; \
+  const Real_type half = m_half; \
+\
+  Real_ptr x1,x2,x3,x4 ; \
+  Real_ptr y1,y2,y3,y4 ; \
+  Real_ptr fx1,fx2,fx3,fx4 ; \
+  Real_ptr fy1,fy2,fy3,fy4 ; \
+\
+  allocAndInitOpenMPDeviceData(x, m_x, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(y, m_y, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(xdot, m_xdot, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(ydot, m_ydot, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(div, m_div, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(real_zones, m_domain->real_zones, iend, did, hid);
+
+#define DEL_DOT_VEC_2D_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_div, div, m_array_length, hid, did); \
+  deallocOpenMPDeviceData(x, did); \
+  deallocOpenMPDeviceData(y, did); \
+  deallocOpenMPDeviceData(xdot, did); \
+  deallocOpenMPDeviceData(ydot, did); \
+  deallocOpenMPDeviceData(div, did); \
+  deallocOpenMPDeviceData(real_zones, did);
+
+
+void DEL_DOT_VEC_2D::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = m_domain->n_real_zones;
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    DEL_DOT_VEC_2D_DATA_SETUP_OMP_TARGET;
+     
+    NDSET2D(m_domain->jp, x,x1,x2,x3,x4) ;
+    NDSET2D(m_domain->jp, y,y1,y2,y3,y4) ;
+    NDSET2D(m_domain->jp, xdot,fx1,fx2,fx3,fx4) ;
+    NDSET2D(m_domain->jp, ydot,fy1,fy2,fy3,fy4) ;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(x1,x2,x3,x4, y1,y2,y3,y4, \
+                                       fx1,fx2,fx3,fx4, fy1,fy2,fy3,fy4, \
+                                       div, real_zones) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
+      for (Index_type ii = ibegin ; ii < iend ; ++ii ) {
+        DEL_DOT_VEC_2D_BODY_INDEX;
+        DEL_DOT_VEC_2D_BODY;
+      }
+
+    }
+    stopTimer();
+
+    DEL_DOT_VEC_2D_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    DEL_DOT_VEC_2D_DATA_SETUP_OMP_TARGET;
+     
+    NDSET2D(m_domain->jp, x,x1,x2,x3,x4) ;
+    NDSET2D(m_domain->jp, y,y1,y2,y3,y4) ;
+    NDSET2D(m_domain->jp, xdot,fx1,fx2,fx3,fx4) ;
+    NDSET2D(m_domain->jp, ydot,fy1,fy2,fy3,fy4) ;
+
+#if 0
+// we need to fix the fact that list segment data is in UM iff CUDA is 
+// enabled...
+    RAJA::ListSegment zones(m_domain->real_zones, m_domain->n_real_zones);  
+#endif
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::policy::omp::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type ii) {
+        DEL_DOT_VEC_2D_BODY_INDEX;
+        DEL_DOT_VEC_2D_BODY;
+      });
+
+    }
+    stopTimer();
+
+    DEL_DOT_VEC_2D_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  DEL_DOT_VEC_2D : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -48,6 +48,8 @@
 
 #include "AppsData.hpp"
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/apps/DEL_DOT_VEC_2D.hpp
+++ b/src/apps/DEL_DOT_VEC_2D.hpp
@@ -13,12 +13,74 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// DEL_DOT_VEC_2D kernel reference implementation:
+///
+/// for (Index_type ii = ibegin; ii < iend; ++ii ) {
+///   Index_type i = real_zones[ii];
+///
+///   Real_type xi  = half * ( x1[i]  + x2[i]  - x3[i]  - x4[i]  ) ;
+///   Real_type xj  = half * ( x2[i]  + x3[i]  - x4[i]  - x1[i]  ) ;
+///
+///   Real_type yi  = half * ( y1[i]  + y2[i]  - y3[i]  - y4[i]  ) ;
+///   Real_type yj  = half * ( y2[i]  + y3[i]  - y4[i]  - y1[i]  ) ;
+///
+///   Real_type fxi = half * ( fx1[i] + fx2[i] - fx3[i] - fx4[i] ) ;
+///   Real_type fxj = half * ( fx2[i] + fx3[i] - fx4[i] - fx1[i] ) ;
+///
+///   Real_type fyi = half * ( fy1[i] + fy2[i] - fy3[i] - fy4[i] ) ;
+///   Real_type fyj = half * ( fy2[i] + fy3[i] - fy4[i] - fy1[i] ) ;
+///
+///   Real_type rarea  = 1.0 / ( xi * yj - xj * yi + ptiny ) ;
+///
+///   Real_type dfxdx  = rarea * ( fxi * yj - fxj * yi ) ;
+///
+///   Real_type dfydy  = rarea * ( fyj * xi - fyi * xj ) ;
+///
+///   Real_type affine = ( fy1[i] + fy2[i] + fy3[i] + fy4[i] ) /
+///                      ( y1[i]  + y2[i]  + y3[i]  + y4[i]  ) ;
+///
+///   div[i] = dfxdx + dfydy + affine ;
+/// }
+///
 
 #ifndef RAJAPerf_Apps_DEL_DOT_VEC_2D_HPP
 #define RAJAPerf_Apps_DEL_DOT_VEC_2D_HPP
 
-#include "common/KernelBase.hpp"
 
+#define DEL_DOT_VEC_2D_DATA_INDEX \
+  Index_ptr real_zones = m_domain->real_zones;
+
+#define DEL_DOT_VEC_2D_BODY_INDEX \
+  Index_type i = real_zones[ii];
+
+#define DEL_DOT_VEC_2D_BODY \
+\
+  Real_type xi  = half * ( x1[i]  + x2[i]  - x3[i]  - x4[i]  ) ; \
+  Real_type xj  = half * ( x2[i]  + x3[i]  - x4[i]  - x1[i]  ) ; \
+ \
+  Real_type yi  = half * ( y1[i]  + y2[i]  - y3[i]  - y4[i]  ) ; \
+  Real_type yj  = half * ( y2[i]  + y3[i]  - y4[i]  - y1[i]  ) ; \
+ \
+  Real_type fxi = half * ( fx1[i] + fx2[i] - fx3[i] - fx4[i] ) ; \
+  Real_type fxj = half * ( fx2[i] + fx3[i] - fx4[i] - fx1[i] ) ; \
+ \
+  Real_type fyi = half * ( fy1[i] + fy2[i] - fy3[i] - fy4[i] ) ; \
+  Real_type fyj = half * ( fy2[i] + fy3[i] - fy4[i] - fy1[i] ) ; \
+ \
+  Real_type rarea  = 1.0 / ( xi * yj - xj * yi + ptiny ) ; \
+ \
+  Real_type dfxdx  = rarea * ( fxi * yj - fxj * yi ) ; \
+ \
+  Real_type dfydy  = rarea * ( fyj * xi - fyi * xj ) ; \
+ \
+  Real_type affine = ( fy1[i] + fy2[i] + fy3[i] + fy4[i] ) / \
+                     ( y1[i]  + y2[i]  + y3[i]  + y4[i]  ) ; \
+ \
+  div[i] = dfxdx + dfydy + affine ;
+
+
+#include "common/KernelBase.hpp"
 
 namespace rajaperf 
 {
@@ -42,6 +104,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_x;

--- a/src/apps/ENERGY-Cuda.cpp
+++ b/src/apps/ENERGY-Cuda.cpp
@@ -1,0 +1,274 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ENERGY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define ENERGY_DATA_SETUP_CUDA \
+  Real_ptr e_new; \
+  Real_ptr e_old; \
+  Real_ptr delvc; \
+  Real_ptr p_new; \
+  Real_ptr p_old; \
+  Real_ptr q_new; \
+  Real_ptr q_old; \
+  Real_ptr work; \
+  Real_ptr compHalfStep; \
+  Real_ptr pHalfStep; \
+  Real_ptr bvc; \
+  Real_ptr pbvc; \
+  Real_ptr ql_old; \
+  Real_ptr qq_old; \
+  Real_ptr vnewc; \
+  const Real_type rho0 = m_rho0; \
+  const Real_type e_cut = m_e_cut; \
+  const Real_type emin = m_emin; \
+  const Real_type q_cut = m_q_cut; \
+\
+  allocAndInitCudaDeviceData(e_new, m_e_new, iend); \
+  allocAndInitCudaDeviceData(e_old, m_e_old, iend); \
+  allocAndInitCudaDeviceData(delvc, m_delvc, iend); \
+  allocAndInitCudaDeviceData(p_new, m_p_new, iend); \
+  allocAndInitCudaDeviceData(p_old, m_p_old, iend); \
+  allocAndInitCudaDeviceData(q_new, m_q_new, iend); \
+  allocAndInitCudaDeviceData(q_old, m_q_old, iend); \
+  allocAndInitCudaDeviceData(work, m_work, iend); \
+  allocAndInitCudaDeviceData(compHalfStep, m_compHalfStep, iend); \
+  allocAndInitCudaDeviceData(pHalfStep, m_pHalfStep, iend); \
+  allocAndInitCudaDeviceData(bvc, m_bvc, iend); \
+  allocAndInitCudaDeviceData(pbvc, m_pbvc, iend); \
+  allocAndInitCudaDeviceData(ql_old, m_ql_old, iend); \
+  allocAndInitCudaDeviceData(qq_old, m_qq_old, iend); \
+  allocAndInitCudaDeviceData(vnewc, m_vnewc, iend);
+
+#define ENERGY_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_e_new, e_new, iend); \
+  getCudaDeviceData(m_q_new, q_new, iend); \
+  deallocCudaDeviceData(e_new); \
+  deallocCudaDeviceData(e_old); \
+  deallocCudaDeviceData(delvc); \
+  deallocCudaDeviceData(p_new); \
+  deallocCudaDeviceData(p_old); \
+  deallocCudaDeviceData(q_new); \
+  deallocCudaDeviceData(q_old); \
+  deallocCudaDeviceData(work); \
+  deallocCudaDeviceData(compHalfStep); \
+  deallocCudaDeviceData(pHalfStep); \
+  deallocCudaDeviceData(bvc); \
+  deallocCudaDeviceData(pbvc); \
+  deallocCudaDeviceData(ql_old); \
+  deallocCudaDeviceData(qq_old); \
+  deallocCudaDeviceData(vnewc);
+
+__global__ void energycalc1(Real_ptr e_new, Real_ptr e_old, Real_ptr delvc,
+                            Real_ptr p_old, Real_ptr q_old, Real_ptr work,
+                            Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     ENERGY_BODY1;
+   }
+}
+
+__global__ void energycalc2(Real_ptr delvc, Real_ptr q_new,
+                            Real_ptr compHalfStep, Real_ptr pHalfStep,
+                            Real_ptr e_new, Real_ptr bvc, Real_ptr pbvc,
+                            Real_ptr ql_old, Real_ptr qq_old,
+                            Real_type rho0,
+                            Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     ENERGY_BODY2;
+   }
+}
+
+__global__ void energycalc3(Real_ptr e_new, Real_ptr delvc,
+                            Real_ptr p_old, Real_ptr q_old, 
+                            Real_ptr pHalfStep, Real_ptr q_new,
+                            Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     ENERGY_BODY3;
+   }
+}
+
+__global__ void energycalc4(Real_ptr e_new, Real_ptr work,
+                            Real_type e_cut, Real_type emin,
+                            Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     ENERGY_BODY4;
+   }
+}
+
+__global__ void energycalc5(Real_ptr delvc,
+                            Real_ptr pbvc, Real_ptr e_new, Real_ptr vnewc,
+                            Real_ptr bvc, Real_ptr p_new,
+                            Real_ptr ql_old, Real_ptr qq_old,
+                            Real_ptr p_old, Real_ptr q_old,
+                            Real_ptr pHalfStep, Real_ptr q_new,
+                            Real_type rho0, Real_type e_cut, Real_type emin,
+                            Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     ENERGY_BODY5;
+   }
+}
+
+__global__ void energycalc6(Real_ptr delvc,
+                            Real_ptr pbvc, Real_ptr e_new, Real_ptr vnewc,
+                            Real_ptr bvc, Real_ptr p_new,
+                            Real_ptr q_new,
+                            Real_ptr ql_old, Real_ptr qq_old,
+                            Real_type rho0, Real_type q_cut,
+                            Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     ENERGY_BODY6;
+   }
+}
+
+
+void ENERGY::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+    
+    ENERGY_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+
+       energycalc1<<<grid_size, block_size>>>( e_new, e_old, delvc,
+                                               p_old, q_old, work,
+                                               iend );
+
+       energycalc2<<<grid_size, block_size>>>( delvc, q_new,
+                                               compHalfStep, pHalfStep,
+                                               e_new, bvc, pbvc,
+                                               ql_old, qq_old,
+                                               rho0,
+                                               iend );
+
+       energycalc3<<<grid_size, block_size>>>( e_new, delvc,
+                                               p_old, q_old,
+                                               pHalfStep, q_new,
+                                               iend );
+
+       energycalc4<<<grid_size, block_size>>>( e_new, work,
+                                               e_cut, emin,
+                                               iend );
+
+       energycalc5<<<grid_size, block_size>>>( delvc,
+                                               pbvc, e_new, vnewc,
+                                               bvc, p_new,
+                                               ql_old, qq_old,
+                                               p_old, q_old,
+                                               pHalfStep, q_new,
+                                               rho0, e_cut, emin,
+                                               iend );
+
+       energycalc6<<<grid_size, block_size>>>( delvc,
+                                               pbvc, e_new, vnewc,
+                                               bvc, p_new,
+                                               q_new,
+                                               ql_old, qq_old,
+                                               rho0, q_cut,
+                                               iend );
+
+    }
+    stopTimer();
+
+    ENERGY_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    ENERGY_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         ENERGY_BODY1;
+       });
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         ENERGY_BODY2;
+       });
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         ENERGY_BODY3;
+       });
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         ENERGY_BODY4;
+       });
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         ENERGY_BODY5;
+       });
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         ENERGY_BODY6;
+       });
+
+    }
+    stopTimer();
+
+    ENERGY_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  ENERGY : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/apps/ENERGY-OMPTarget.cpp
+++ b/src/apps/ENERGY-OMPTarget.cpp
@@ -197,7 +197,7 @@ void ENERGY::runOpenMPTargetVariant(VariantID vid)
     ENERGY_DATA_TEARDOWN_OMP_TARGET;
 
   } else {
-     std::cout << "\n  ENERGY : Unknown variant id = " << vid << std::endl;
+     std::cout << "\n  ENERGY : Unknown OMP Target variant id = " << vid << std::endl;
   }
 }
 

--- a/src/apps/ENERGY-OMPTarget.cpp
+++ b/src/apps/ENERGY-OMPTarget.cpp
@@ -1,0 +1,207 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ENERGY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define ENERGY_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr e_new; \
+  Real_ptr e_old; \
+  Real_ptr delvc; \
+  Real_ptr p_new; \
+  Real_ptr p_old; \
+  Real_ptr q_new; \
+  Real_ptr q_old; \
+  Real_ptr work; \
+  Real_ptr compHalfStep; \
+  Real_ptr pHalfStep; \
+  Real_ptr bvc; \
+  Real_ptr pbvc; \
+  Real_ptr ql_old; \
+  Real_ptr qq_old; \
+  Real_ptr vnewc; \
+  const Real_type rho0 = m_rho0; \
+  const Real_type e_cut = m_e_cut; \
+  const Real_type emin = m_emin; \
+  const Real_type q_cut = m_q_cut; \
+\
+  allocAndInitOpenMPDeviceData(e_new, m_e_new, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(e_old, m_e_old, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(delvc, m_delvc, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(p_new, m_p_new, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(p_old, m_p_old, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(q_new, m_q_new, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(q_old, m_q_old, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(work, m_work, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(compHalfStep, m_compHalfStep, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(pHalfStep, m_pHalfStep, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(bvc, m_bvc, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(pbvc, m_pbvc, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(ql_old, m_ql_old, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(qq_old, m_qq_old, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(vnewc, m_vnewc, iend, did, hid);
+
+#define ENERGY_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_e_new, e_new, iend, hid, did); \
+  getOpenMPDeviceData(m_q_new, q_new, iend, hid, did); \
+  deallocOpenMPDeviceData(e_new, did); \
+  deallocOpenMPDeviceData(e_old, did); \
+  deallocOpenMPDeviceData(delvc, did); \
+  deallocOpenMPDeviceData(p_new, did); \
+  deallocOpenMPDeviceData(p_old, did); \
+  deallocOpenMPDeviceData(q_new, did); \
+  deallocOpenMPDeviceData(q_old, did); \
+  deallocOpenMPDeviceData(work, did); \
+  deallocOpenMPDeviceData(compHalfStep, did); \
+  deallocOpenMPDeviceData(pHalfStep, did); \
+  deallocOpenMPDeviceData(bvc, did); \
+  deallocOpenMPDeviceData(pbvc, did); \
+  deallocOpenMPDeviceData(ql_old, did); \
+  deallocOpenMPDeviceData(qq_old, did); \
+  deallocOpenMPDeviceData(vnewc, did);
+
+void ENERGY::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    ENERGY_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(e_new, e_old, delvc, \
+                                       p_old, q_old, work) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        ENERGY_BODY1;
+      }
+
+      #pragma omp target is_device_ptr(delvc, q_new, compHalfStep, \
+                                       pHalfStep, e_new, bvc, pbvc, \
+                                       ql_old, qq_old) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        ENERGY_BODY2;
+      }
+
+      #pragma omp target is_device_ptr(e_new, delvc, p_old, \
+                                       q_old, pHalfStep, q_new) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        ENERGY_BODY3;
+      }
+
+      #pragma omp target is_device_ptr(e_new, work) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        ENERGY_BODY4;
+      }
+
+      #pragma omp target is_device_ptr(delvc, pbvc, e_new, vnewc, \
+                                       bvc, p_new, ql_old, qq_old, \
+                                       p_old, q_old, pHalfStep, q_new) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        ENERGY_BODY5;
+      }
+
+      #pragma omp target is_device_ptr(delvc, pbvc, e_new, vnewc, \
+                                       bvc, p_new, q_new, ql_old, qq_old) \
+                                       device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        ENERGY_BODY6;
+      }
+        
+    }
+    stopTimer();
+
+    ENERGY_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    ENERGY_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](int i) {
+        ENERGY_BODY1;
+      });
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](int i) {
+        ENERGY_BODY2;
+      });
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](int i) {
+        ENERGY_BODY3;
+      });
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](int i) {
+        ENERGY_BODY4;
+      });
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](int i) {
+        ENERGY_BODY5;
+      });
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](int i) {
+        ENERGY_BODY6;
+     });
+
+    }
+    stopTimer();
+
+    ENERGY_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  ENERGY : Unknown variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -94,6 +94,8 @@
 #include "ENERGY.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -13,91 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// ENERGY kernel reference implementation:
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   e_new[i] = e_old[i] - 0.5 * delvc[i] * 
-///              (p_old[i] + q_old[i]) + 0.5 * work[i];
-/// }
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   if ( delvc[i] > 0.0 ) { 
-///      q_new[i] = 0.0 ; 
-///   } 
-///   else { 
-///      Real_type vhalf = 1.0 / (1.0 + compHalfStep[i]) ; 
-///      Real_type ssc = ( pbvc[i] * e_new[i] 
-///         + vhalf * vhalf * bvc[i] * pHalfStep[i] ) / rho0 ; 
-///      if ( ssc <= 0.1111111e-36 ) { 
-///         ssc = 0.3333333e-18 ; 
-///      } else { 
-///         ssc = sqrt(ssc) ; 
-///      } 
-///      q_new[i] = (ssc*ql_old[i] + qq_old[i]) ; 
-///   }
-/// }
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   e_new[i] = e_new[i] + 0.5 * delvc[i] 
-///              * ( 3.0*(p_old[i] + q_old[i]) 
-///                  - 4.0*(pHalfStep[i] + q_new[i])) ;
-/// }
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   e_new[i] += 0.5 * work[i]; 
-///   if ( fabs(e_new[i]) < e_cut ) { e_new[i] = 0.0  ; } 
-///   if ( e_new[i]  < emin ) { e_new[i] = emin ; }
-/// }
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   Real_type q_tilde ; 
-///   if (delvc[i] > 0.0) { 
-///      q_tilde = 0. ; 
-///   } 
-///   else { 
-///      Real_type ssc = ( pbvc[i] * e_new[i] 
-///          + vnewc[i] * vnewc[i] * bvc[i] * p_new[i] ) / rho0 ; 
-///      if ( ssc <= 0.1111111e-36 ) { 
-///         ssc = 0.3333333e-18 ; 
-///      } else { 
-///         ssc = sqrt(ssc) ; 
-///      } 
-///      q_tilde = (ssc*ql_old[i] + qq_old[i]) ; 
-///   } 
-///   e_new[i] = e_new[i] - ( 7.0*(p_old[i] + q_old[i]) 
-///                          - 8.0*(pHalfStep[i] + q_new[i]) 
-///                          + (p_new[i] + q_tilde)) * delvc[i] / 6.0 ; 
-///   if ( fabs(e_new[i]) < e_cut ) { 
-///      e_new[i] = 0.0  ; 
-///   } 
-///   if ( e_new[i]  < emin ) { 
-///      e_new[i] = emin ; 
-///   }
-/// }
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   if ( delvc[i] <= 0.0 ) { 
-///      Real_type ssc = ( pbvc[i] * e_new[i] 
-///              + vnewc[i] * vnewc[i] * bvc[i] * p_new[i] ) / rho0 ; 
-///      if ( ssc <= 0.1111111e-36 ) { 
-///         ssc = 0.3333333e-18 ; 
-///      } else { 
-///         ssc = sqrt(ssc) ; 
-///      } 
-///      q_new[i] = (ssc*ql_old[i] + qq_old[i]) ; 
-///      if (fabs(q_new[i]) < q_cut) q_new[i] = 0.0 ; 
-///   }
-/// }
-///
-
 #include "ENERGY.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 
@@ -106,7 +26,7 @@ namespace rajaperf
 namespace apps
 {
 
-#define ENERGY_DATA \
+#define ENERGY_DATA_SETUP_CPU \
   ResReal_ptr e_new = m_e_new; \
   ResReal_ptr e_old = m_e_old; \
   ResReal_ptr delvc = m_delvc; \
@@ -126,214 +46,6 @@ namespace apps
   const Real_type e_cut = m_e_cut; \
   const Real_type emin = m_emin; \
   const Real_type q_cut = m_q_cut;
-
-
-#define ENERGY_BODY1 \
-  e_new[i] = e_old[i] - 0.5 * delvc[i] * \
-             (p_old[i] + q_old[i]) + 0.5 * work[i];
-
-#define ENERGY_BODY2 \
-  if ( delvc[i] > 0.0 ) { \
-     q_new[i] = 0.0 ; \
-  } \
-  else { \
-     Real_type vhalf = 1.0 / (1.0 + compHalfStep[i]) ; \
-     Real_type ssc = ( pbvc[i] * e_new[i] \
-        + vhalf * vhalf * bvc[i] * pHalfStep[i] ) / rho0 ; \
-     if ( ssc <= 0.1111111e-36 ) { \
-        ssc = 0.3333333e-18 ; \
-     } else { \
-        ssc = sqrt(ssc) ; \
-     } \
-     q_new[i] = (ssc*ql_old[i] + qq_old[i]) ; \
-  }
-
-#define ENERGY_BODY3 \
-  e_new[i] = e_new[i] + 0.5 * delvc[i] \
-             * ( 3.0*(p_old[i] + q_old[i]) \
-                 - 4.0*(pHalfStep[i] + q_new[i])) ;
-
-#define ENERGY_BODY4 \
-  e_new[i] += 0.5 * work[i]; \
-  if ( fabs(e_new[i]) < e_cut ) { e_new[i] = 0.0  ; } \
-  if ( e_new[i]  < emin ) { e_new[i] = emin ; }
-
-#define ENERGY_BODY5 \
-  Real_type q_tilde ; \
-  if (delvc[i] > 0.0) { \
-     q_tilde = 0. ; \
-  } \
-  else { \
-     Real_type ssc = ( pbvc[i] * e_new[i] \
-         + vnewc[i] * vnewc[i] * bvc[i] * p_new[i] ) / rho0 ; \
-     if ( ssc <= 0.1111111e-36 ) { \
-        ssc = 0.3333333e-18 ; \
-     } else { \
-        ssc = sqrt(ssc) ; \
-     } \
-     q_tilde = (ssc*ql_old[i] + qq_old[i]) ; \
-  } \
-  e_new[i] = e_new[i] - ( 7.0*(p_old[i] + q_old[i]) \
-                         - 8.0*(pHalfStep[i] + q_new[i]) \
-                         + (p_new[i] + q_tilde)) * delvc[i] / 6.0 ; \
-  if ( fabs(e_new[i]) < e_cut ) { \
-     e_new[i] = 0.0  ; \
-  } \
-  if ( e_new[i]  < emin ) { \
-     e_new[i] = emin ; \
-  }
-
-#define ENERGY_BODY6 \
-  if ( delvc[i] <= 0.0 ) { \
-     Real_type ssc = ( pbvc[i] * e_new[i] \
-             + vnewc[i] * vnewc[i] * bvc[i] * p_new[i] ) / rho0 ; \
-     if ( ssc <= 0.1111111e-36 ) { \
-        ssc = 0.3333333e-18 ; \
-     } else { \
-        ssc = sqrt(ssc) ; \
-     } \
-     q_new[i] = (ssc*ql_old[i] + qq_old[i]) ; \
-     if (fabs(q_new[i]) < q_cut) q_new[i] = 0.0 ; \
-  }
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define ENERGY_DATA_SETUP_CUDA \
-  Real_ptr e_new; \
-  Real_ptr e_old; \
-  Real_ptr delvc; \
-  Real_ptr p_new; \
-  Real_ptr p_old; \
-  Real_ptr q_new; \
-  Real_ptr q_old; \
-  Real_ptr work; \
-  Real_ptr compHalfStep; \
-  Real_ptr pHalfStep; \
-  Real_ptr bvc; \
-  Real_ptr pbvc; \
-  Real_ptr ql_old; \
-  Real_ptr qq_old; \
-  Real_ptr vnewc; \
-  const Real_type rho0 = m_rho0; \
-  const Real_type e_cut = m_e_cut; \
-  const Real_type emin = m_emin; \
-  const Real_type q_cut = m_q_cut; \
-\
-  allocAndInitCudaDeviceData(e_new, m_e_new, iend); \
-  allocAndInitCudaDeviceData(e_old, m_e_old, iend); \
-  allocAndInitCudaDeviceData(delvc, m_delvc, iend); \
-  allocAndInitCudaDeviceData(p_new, m_p_new, iend); \
-  allocAndInitCudaDeviceData(p_old, m_p_old, iend); \
-  allocAndInitCudaDeviceData(q_new, m_q_new, iend); \
-  allocAndInitCudaDeviceData(q_old, m_q_old, iend); \
-  allocAndInitCudaDeviceData(work, m_work, iend); \
-  allocAndInitCudaDeviceData(compHalfStep, m_compHalfStep, iend); \
-  allocAndInitCudaDeviceData(pHalfStep, m_pHalfStep, iend); \
-  allocAndInitCudaDeviceData(bvc, m_bvc, iend); \
-  allocAndInitCudaDeviceData(pbvc, m_pbvc, iend); \
-  allocAndInitCudaDeviceData(ql_old, m_ql_old, iend); \
-  allocAndInitCudaDeviceData(qq_old, m_qq_old, iend); \
-  allocAndInitCudaDeviceData(vnewc, m_vnewc, iend);
-
-#define ENERGY_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_e_new, e_new, iend); \
-  getCudaDeviceData(m_q_new, q_new, iend); \
-  deallocCudaDeviceData(e_new); \
-  deallocCudaDeviceData(e_old); \
-  deallocCudaDeviceData(delvc); \
-  deallocCudaDeviceData(p_new); \
-  deallocCudaDeviceData(p_old); \
-  deallocCudaDeviceData(q_new); \
-  deallocCudaDeviceData(q_old); \
-  deallocCudaDeviceData(work); \
-  deallocCudaDeviceData(compHalfStep); \
-  deallocCudaDeviceData(pHalfStep); \
-  deallocCudaDeviceData(bvc); \
-  deallocCudaDeviceData(pbvc); \
-  deallocCudaDeviceData(ql_old); \
-  deallocCudaDeviceData(qq_old); \
-  deallocCudaDeviceData(vnewc);
-
-__global__ void energycalc1(Real_ptr e_new, Real_ptr e_old, Real_ptr delvc,
-                            Real_ptr p_old, Real_ptr q_old, Real_ptr work,
-                            Index_type iend)
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     ENERGY_BODY1;
-   }
-}
-
-__global__ void energycalc2(Real_ptr delvc, Real_ptr q_new,
-                            Real_ptr compHalfStep, Real_ptr pHalfStep,
-                            Real_ptr e_new, Real_ptr bvc, Real_ptr pbvc,
-                            Real_ptr ql_old, Real_ptr qq_old,
-                            Real_type rho0,
-                            Index_type iend)
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     ENERGY_BODY2;
-   }
-}
-
-__global__ void energycalc3(Real_ptr e_new, Real_ptr delvc,
-                            Real_ptr p_old, Real_ptr q_old, 
-                            Real_ptr pHalfStep, Real_ptr q_new,
-                            Index_type iend)
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     ENERGY_BODY3;
-   }
-}
-
-__global__ void energycalc4(Real_ptr e_new, Real_ptr work,
-                            Real_type e_cut, Real_type emin,
-                            Index_type iend)
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     ENERGY_BODY4;
-   }
-}
-
-__global__ void energycalc5(Real_ptr delvc,
-                            Real_ptr pbvc, Real_ptr e_new, Real_ptr vnewc,
-                            Real_ptr bvc, Real_ptr p_new,
-                            Real_ptr ql_old, Real_ptr qq_old,
-                            Real_ptr p_old, Real_ptr q_old,
-                            Real_ptr pHalfStep, Real_ptr q_new,
-                            Real_type rho0, Real_type e_cut, Real_type emin,
-                            Index_type iend)
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     ENERGY_BODY5;
-   }
-}
-
-__global__ void energycalc6(Real_ptr delvc,
-                            Real_ptr pbvc, Real_ptr e_new, Real_ptr vnewc,
-                            Real_ptr bvc, Real_ptr p_new,
-                            Real_ptr q_new,
-                            Real_ptr ql_old, Real_ptr qq_old,
-                            Real_type rho0, Real_type q_cut,
-                            Index_type iend)
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     ENERGY_BODY6;
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 ENERGY::ENERGY(const RunParams& params)
@@ -381,7 +93,7 @@ void ENERGY::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      ENERGY_DATA;
+      ENERGY_DATA_SETUP_CPU;
   
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -418,7 +130,7 @@ void ENERGY::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      ENERGY_DATA;
+      ENERGY_DATA_SETUP_CPU;
  
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -473,7 +185,7 @@ void ENERGY::runKernel(VariantID vid)
 //       is added to RAJA.
 //
 
-      ENERGY_DATA;
+      ENERGY_DATA_SETUP_CPU;
       
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -516,7 +228,7 @@ void ENERGY::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      ENERGY_DATA;
+      ENERGY_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -553,220 +265,24 @@ void ENERGY::runKernel(VariantID vid)
 
       }
       stopTimer();
-      break;
-    }
-#if defined(RAJA_ENABLE_TARGET_OPENMP)
-#define NUMTEAMS 128
-    case Base_OpenMPTarget : {
-      ENERGY_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:e_new[0:n],e_old[0:n],delvc[0:n],p_new[0:n],p_old[0:n], \
-       q_new[0:n],q_old[0:n],work[0:n],compHalfStep[0:n],pHalfStep[0:n],bvc[0:n],pbvc[0:n], \
-       ql_old[0:n],qq_old[0:n],vnewc[0:n],rho0,e_cut,emin,q_cut)
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          ENERGY_BODY1;
-        }
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          ENERGY_BODY2;
-        }
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          ENERGY_BODY3;
-        }
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          ENERGY_BODY4;
-        }
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          ENERGY_BODY5;
-        }
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          ENERGY_BODY6;
-        }
-
-        
-      }
-      stopTimer();
-      #pragma omp target exit data map(from:q_new[0:n],e_new[0:n]) map(delete:e_old[0:n],delvc[0:n],p_new[0:n],p_old[0:n], \
-       q_old[0:n],work[0:n],compHalfStep[0:n],pHalfStep[0:n],bvc[0:n],pbvc[0:n], \
-       ql_old[0:n],qq_old[0:n],vnewc[0:n],rho0,e_cut,emin,q_cut)
-      break;
-    }
-
-    case RAJA_OpenMPTarget : {
-      ENERGY_DATA;
-
-      int n = getRunSize();
-
-      #pragma omp target enter data map(to:e_new[0:n],e_old[0:n],delvc[0:n],p_new[0:n],p_old[0:n], \
-       q_new[0:n],q_old[0:n],work[0:n],compHalfStep[0:n],pHalfStep[0:n],bvc[0:n],pbvc[0:n], \
-       ql_old[0:n],qq_old[0:n],vnewc[0:n],rho0,e_cut,emin,q_cut)
-
-      startTimer();
-      #pragma omp target data use_device_ptr(e_new,e_old,delvc,p_new,p_old, \
-       q_new,q_old,work,compHalfStep,pHalfStep,bvc,pbvc, \
-       ql_old,qq_old,vnewc)
-
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-          RAJA::RangeSegment(ibegin, iend), [=](int i) {
-          ENERGY_BODY1;
-        });
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-          RAJA::RangeSegment(ibegin, iend), [=](int i) {
-          ENERGY_BODY2;
-        });
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-          RAJA::RangeSegment(ibegin, iend), [=](int i) {
-          ENERGY_BODY3;
-        });
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-          RAJA::RangeSegment(ibegin, iend), [=](int i) {
-          ENERGY_BODY4;
-        });
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-          RAJA::RangeSegment(ibegin, iend), [=](int i) {
-          ENERGY_BODY5;
-        });
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-          RAJA::RangeSegment(ibegin, iend), [=](int i) {
-          ENERGY_BODY6;
-       });
-
-      }
-      stopTimer();
-      #pragma omp target exit data map(from:q_new[0:n],e_new[0:n]) map(delete:e_old[0:n],delvc[0:n],p_new[0:n],p_old[0:n], \
-       q_old[0:n],work[0:n],compHalfStep[0:n],pHalfStep[0:n],bvc[0:n],pbvc[0:n], \
-       ql_old[0:n],qq_old[0:n],vnewc[0:n],rho0,e_cut,emin,q_cut)
-
       break;
     }
 #endif
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
+      break;
+    }
 #endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-    
-      ENERGY_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-
-         energycalc1<<<grid_size, block_size>>>( e_new, e_old, delvc,
-                                                 p_old, q_old, work,
-                                                 iend );
-
-         energycalc2<<<grid_size, block_size>>>( delvc, q_new,
-                                                 compHalfStep, pHalfStep,
-                                                 e_new, bvc, pbvc,
-                                                 ql_old, qq_old,
-                                                 rho0,
-                                                 iend );
-
-         energycalc3<<<grid_size, block_size>>>( e_new, delvc,
-                                                 p_old, q_old,
-                                                 pHalfStep, q_new,
-                                                 iend );
-
-         energycalc4<<<grid_size, block_size>>>( e_new, work,
-                                                 e_cut, emin,
-                                                 iend );
-
-         energycalc5<<<grid_size, block_size>>>( delvc,
-                                                 pbvc, e_new, vnewc,
-                                                 bvc, p_new,
-                                                 ql_old, qq_old,
-                                                 p_old, q_old,
-                                                 pHalfStep, q_new,
-                                                 rho0, e_cut, emin,
-                                                 iend );
-
-         energycalc6<<<grid_size, block_size>>>( delvc,
-                                                 pbvc, e_new, vnewc,
-                                                 bvc, p_new,
-                                                 q_new,
-                                                 ql_old, qq_old,
-                                                 rho0, q_cut,
-                                                 iend );
-
-      }
-      stopTimer();
-
-      ENERGY_DATA_TEARDOWN_CUDA;
-
-    }
-
-    case RAJA_CUDA : {
-
-      ENERGY_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           ENERGY_BODY1;
-         });
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           ENERGY_BODY2;
-         });
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           ENERGY_BODY3;
-         });
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           ENERGY_BODY4;
-         });
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           ENERGY_BODY5;
-         });
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           ENERGY_BODY6;
-         });
-
-      }
-      stopTimer();
-
-      ENERGY_DATA_TEARDOWN_CUDA;
-
-      break;
-    }
-#endif
-
-#if 0
-    case Base_OpenMPTarget :
-    case RAJA_OpenMPTarget : {
-      // Fill these in later...you get the idea...
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/apps/ENERGY.hpp
+++ b/src/apps/ENERGY.hpp
@@ -13,12 +13,158 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// ENERGY kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   e_new[i] = e_old[i] - 0.5 * delvc[i] *
+///              (p_old[i] + q_old[i]) + 0.5 * work[i];
+/// }
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   if ( delvc[i] > 0.0 ) {
+///      q_new[i] = 0.0 ;
+///   }
+///   else {
+///      Real_type vhalf = 1.0 / (1.0 + compHalfStep[i]) ;
+///      Real_type ssc = ( pbvc[i] * e_new[i]
+///         + vhalf * vhalf * bvc[i] * pHalfStep[i] ) / rho0 ;
+///      if ( ssc <= 0.1111111e-36 ) {
+///         ssc = 0.3333333e-18 ;
+///      } else {
+///         ssc = sqrt(ssc) ;
+///      }
+///      q_new[i] = (ssc*ql_old[i] + qq_old[i]) ;
+///   }
+/// }
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   e_new[i] = e_new[i] + 0.5 * delvc[i]
+///              * ( 3.0*(p_old[i] + q_old[i])
+///                  - 4.0*(pHalfStep[i] + q_new[i])) ;
+/// }
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   e_new[i] += 0.5 * work[i];
+///   if ( fabs(e_new[i]) < e_cut ) { e_new[i] = 0.0  ; }
+///   if ( e_new[i]  < emin ) { e_new[i] = emin ; }
+/// }
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   Real_type q_tilde ;
+///   if (delvc[i] > 0.0) {
+///      q_tilde = 0. ;
+///   }
+///   else {
+///      Real_type ssc = ( pbvc[i] * e_new[i]
+///          + vnewc[i] * vnewc[i] * bvc[i] * p_new[i] ) / rho0 ;
+///      if ( ssc <= 0.1111111e-36 ) {
+///         ssc = 0.3333333e-18 ;
+///      } else {
+///         ssc = sqrt(ssc) ;
+///      }
+///      q_tilde = (ssc*ql_old[i] + qq_old[i]) ;
+///   }
+///   e_new[i] = e_new[i] - ( 7.0*(p_old[i] + q_old[i])
+///                          - 8.0*(pHalfStep[i] + q_new[i])
+///                          + (p_new[i] + q_tilde)) * delvc[i] / 6.0 ;
+///   if ( fabs(e_new[i]) < e_cut ) {
+///      e_new[i] = 0.0  ;
+///   }
+///   if ( e_new[i]  < emin ) {
+///      e_new[i] = emin ;
+///   }
+/// }
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   if ( delvc[i] <= 0.0 ) {
+///      Real_type ssc = ( pbvc[i] * e_new[i]
+///              + vnewc[i] * vnewc[i] * bvc[i] * p_new[i] ) / rho0 ;
+///      if ( ssc <= 0.1111111e-36 ) {
+///         ssc = 0.3333333e-18 ;
+///      } else {
+///         ssc = sqrt(ssc) ;
+///      }
+///      q_new[i] = (ssc*ql_old[i] + qq_old[i]) ;
+///      if (fabs(q_new[i]) < q_cut) q_new[i] = 0.0 ;
+///   }
+/// }
+///
 
 #ifndef RAJAPerf_Apps_ENERGY_HPP
 #define RAJAPerf_Apps_ENERGY_HPP
 
-#include "common/KernelBase.hpp"
 
+#define ENERGY_BODY1 \
+  e_new[i] = e_old[i] - 0.5 * delvc[i] * \
+             (p_old[i] + q_old[i]) + 0.5 * work[i];
+
+#define ENERGY_BODY2 \
+  if ( delvc[i] > 0.0 ) { \
+     q_new[i] = 0.0 ; \
+  } \
+  else { \
+     Real_type vhalf = 1.0 / (1.0 + compHalfStep[i]) ; \
+     Real_type ssc = ( pbvc[i] * e_new[i] \
+        + vhalf * vhalf * bvc[i] * pHalfStep[i] ) / rho0 ; \
+     if ( ssc <= 0.1111111e-36 ) { \
+        ssc = 0.3333333e-18 ; \
+     } else { \
+        ssc = sqrt(ssc) ; \
+     } \
+     q_new[i] = (ssc*ql_old[i] + qq_old[i]) ; \
+  }
+
+#define ENERGY_BODY3 \
+  e_new[i] = e_new[i] + 0.5 * delvc[i] \
+             * ( 3.0*(p_old[i] + q_old[i]) \
+                 - 4.0*(pHalfStep[i] + q_new[i])) ;
+
+#define ENERGY_BODY4 \
+  e_new[i] += 0.5 * work[i]; \
+  if ( fabs(e_new[i]) < e_cut ) { e_new[i] = 0.0  ; } \
+  if ( e_new[i]  < emin ) { e_new[i] = emin ; }
+
+#define ENERGY_BODY5 \
+  Real_type q_tilde ; \
+  if (delvc[i] > 0.0) { \
+     q_tilde = 0. ; \
+  } \
+  else { \
+     Real_type ssc = ( pbvc[i] * e_new[i] \
+         + vnewc[i] * vnewc[i] * bvc[i] * p_new[i] ) / rho0 ; \
+     if ( ssc <= 0.1111111e-36 ) { \
+        ssc = 0.3333333e-18 ; \
+     } else { \
+        ssc = sqrt(ssc) ; \
+     } \
+     q_tilde = (ssc*ql_old[i] + qq_old[i]) ; \
+  } \
+  e_new[i] = e_new[i] - ( 7.0*(p_old[i] + q_old[i]) \
+                         - 8.0*(pHalfStep[i] + q_new[i]) \
+                         + (p_new[i] + q_tilde)) * delvc[i] / 6.0 ; \
+  if ( fabs(e_new[i]) < e_cut ) { \
+     e_new[i] = 0.0  ; \
+  } \
+  if ( e_new[i]  < emin ) { \
+     e_new[i] = emin ; \
+  }
+
+#define ENERGY_BODY6 \
+  if ( delvc[i] <= 0.0 ) { \
+     Real_type ssc = ( pbvc[i] * e_new[i] \
+             + vnewc[i] * vnewc[i] * bvc[i] * p_new[i] ) / rho0 ; \
+     if ( ssc <= 0.1111111e-36 ) { \
+        ssc = 0.3333333e-18 ; \
+     } else { \
+        ssc = sqrt(ssc) ; \
+     } \
+     q_new[i] = (ssc*ql_old[i] + qq_old[i]) ; \
+     if (fabs(q_new[i]) < q_cut) q_new[i] = 0.0 ; \
+  }
+
+
+#include "common/KernelBase.hpp"
 
 namespace rajaperf 
 {
@@ -39,6 +185,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_e_new;

--- a/src/apps/FIR-Cuda.cpp
+++ b/src/apps/FIR-Cuda.cpp
@@ -156,7 +156,7 @@ void FIR::runCudaVariant(VariantID vid)
     FIR_DATA_TEARDOWN_CUDA;
 
   } else {
-     std::cout << "\n  FIR : Unknown variant id = " << vid << std::endl;
+     std::cout << "\n  FIR : Unknown Cuda variant id = " << vid << std::endl;
   }
 }
 

--- a/src/apps/FIR-Cuda.cpp
+++ b/src/apps/FIR-Cuda.cpp
@@ -1,0 +1,166 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "FIR.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <algorithm>
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+#define USE_CUDA_CONSTANT_MEMORY
+//#undef USE_CUDA_CONSTANT_MEMORY
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#if defined(USE_CUDA_CONSTANT_MEMORY)
+
+__constant__ Real_type coeff[FIR_COEFFLEN];
+
+#define FIR_DATA_SETUP_CUDA \
+  Real_ptr in; \
+  Real_ptr out; \
+\
+  const Index_type coefflen = m_coefflen; \
+\
+  allocAndInitCudaDeviceData(in, m_in, getRunSize()); \
+  allocAndInitCudaDeviceData(out, m_out, getRunSize()); \
+  cudaMemcpyToSymbol(coeff, coeff_array, FIR_COEFFLEN * sizeof(Real_type));
+
+
+#define FIR_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_out, out, getRunSize()); \
+  deallocCudaDeviceData(in); \
+  deallocCudaDeviceData(out);
+
+__global__ void fir(Real_ptr out, Real_ptr in,
+                    const Index_type coefflen,
+                    Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     FIR_BODY;
+   }
+}
+
+#else  // use global memry for coefficients 
+
+#define FIR_DATA_SETUP_CUDA \
+  Real_ptr in; \
+  Real_ptr out; \
+  Real_ptr coeff; \
+\
+  const Index_type coefflen = m_coefflen; \
+\
+  allocAndInitCudaDeviceData(in, m_in, getRunSize()); \
+  allocAndInitCudaDeviceData(out, m_out, getRunSize()); \
+  Real_ptr tcoeff = &coeff_array[0]; \
+  allocAndInitCudaDeviceData(coeff, tcoeff, FIR_COEFFLEN);
+
+
+#define FIR_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_out, out, getRunSize()); \
+  deallocCudaDeviceData(in); \
+  deallocCudaDeviceData(out); \
+  deallocCudaDeviceData(coeff);
+
+__global__ void fir(Real_ptr out, Real_ptr in,
+                    Real_ptr coeff,
+                    const Index_type coefflen,
+                    Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     FIR_BODY;
+   }
+}
+
+#endif 
+
+
+void FIR::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize() - m_coefflen;
+
+  if ( vid == Base_CUDA ) {
+
+    FIR_COEFF;
+
+    FIR_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+
+#if defined(USE_CUDA_CONSTANT_MEMORY)
+       fir<<<grid_size, block_size>>>( out, in,
+                                       coefflen,
+                                       iend );
+#else
+       fir<<<grid_size, block_size>>>( out, in,
+                                       coeff,
+                                       coefflen,
+                                       iend );
+#endif
+
+    }
+    stopTimer();
+
+    FIR_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    FIR_COEFF;
+
+    FIR_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         FIR_BODY;
+       });
+
+    }
+    stopTimer();
+
+    FIR_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  FIR : Unknown variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/apps/FIR-OMPTarget.cpp
+++ b/src/apps/FIR-OMPTarget.cpp
@@ -103,7 +103,7 @@ void FIR::runOpenMPTargetVariant(VariantID vid)
     FIR_DATA_TEARDOWN_OMP_TARGET;
 
   } else {
-     std::cout << "\n  FIR : Unknown variant id = " << vid << std::endl;
+     std::cout << "\n  FIR : Unknown OMP Target variant id = " << vid << std::endl;
   }
 }
 

--- a/src/apps/FIR-OMPTarget.cpp
+++ b/src/apps/FIR-OMPTarget.cpp
@@ -1,0 +1,113 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "FIR.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <algorithm>
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define FIR_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr in; \
+  Real_ptr out; \
+  Real_ptr coeff; \
+\
+  const Index_type coefflen = m_coefflen; \
+\
+  allocAndInitOpenMPDeviceData(in, m_in, getRunSize(), did, hid); \
+  allocAndInitOpenMPDeviceData(out, m_out, getRunSize(), did, hid); \
+  Real_ptr tcoeff = &coeff_array[0]; \
+  allocAndInitOpenMPDeviceData(coeff, tcoeff, FIR_COEFFLEN, did, hid);
+
+
+#define FIR_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_out, out, getRunSize(), hid, did); \
+  deallocOpenMPDeviceData(in, did); \
+  deallocOpenMPDeviceData(out, did); \
+  deallocOpenMPDeviceData(coeff, did);
+
+
+void FIR::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize() - m_coefflen;
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    FIR_COEFF;
+
+    FIR_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(in, out, coeff) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+         FIR_BODY;
+      }
+
+    }
+    stopTimer();
+
+    FIR_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    FIR_COEFF;
+
+    FIR_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](int i) {
+        FIR_BODY;
+      });
+
+    }
+    stopTimer();
+
+    FIR_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  FIR : Unknown variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -13,30 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// FIR kernel reference implementation:
-///
-/// Real_type coeff[COEFFLEN] = { 3.0, -1.0, -1.0, -1.0, 
-///                               -1.0, 3.0, -1.0, -1.0, 
-///                               -1.0, -1.0, 3.0, -1.0, 
-///                               -1.0, -1.0, -1.0, 3.0 };
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   Real_type sum = 0.0; 
-///   for (Index_type j = 0; j < coefflen; ++j ) { 
-///     sum += coeff[j]*in[i+j]; 
-///   } 
-///   out[i] = sum;
-/// }
-///
-
 #include "FIR.hpp"
 
 #include "RAJA/RAJA.hpp"
 
 #include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
 
 #include <algorithm>
 #include <iostream>
@@ -46,109 +27,15 @@ namespace rajaperf
 namespace apps
 {
 
-#define USE_CONSTANT_MEMORY
-//#undef USE_CONSTANT_MEMORY
 
-#define COEFFLEN (16)
-
-#define FIR_COEFF \
-  Real_type coeff_array[COEFFLEN] = { 3.0, -1.0, -1.0, -1.0, \
-                                      -1.0, 3.0, -1.0, -1.0, \
-                                      -1.0, -1.0, 3.0, -1.0, \
-                                      -1.0, -1.0, -1.0, 3.0 };
-
-
-#define FIR_DATA \
+#define FIR_DATA_SETUP_CPU \
   ResReal_ptr in = m_in; \
   ResReal_ptr out = m_out; \
 \
-  Real_type coeff[COEFFLEN]; \
+  Real_type coeff[FIR_COEFFLEN]; \
   std::copy(std::begin(coeff_array), std::end(coeff_array), std::begin(coeff));\
 \
   const Index_type coefflen = m_coefflen;
-
-
-#define FIR_BODY \
-  Real_type sum = 0.0; \
-\
-  for (Index_type j = 0; j < coefflen; ++j ) { \
-    sum += coeff[j]*in[i+j]; \
-  } \
-  out[i] = sum;
-
-
-#if defined(RAJA_ENABLE_CUDA)
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#if defined(USE_CONSTANT_MEMORY)
-
-__constant__ Real_type coeff[COEFFLEN];
-
-#define FIR_DATA_SETUP_CUDA \
-  Real_ptr in; \
-  Real_ptr out; \
-\
-  const Index_type coefflen = m_coefflen; \
-\
-  allocAndInitCudaDeviceData(in, m_in, getRunSize()); \
-  allocAndInitCudaDeviceData(out, m_out, getRunSize()); \
-  cudaMemcpyToSymbol(coeff, coeff_array, COEFFLEN * sizeof(Real_type));
-
-
-#define FIR_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_out, out, getRunSize()); \
-  deallocCudaDeviceData(in); \
-  deallocCudaDeviceData(out);
-
-__global__ void fir(Real_ptr out, Real_ptr in,
-                    const Index_type coefflen,
-                    Index_type iend)
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     FIR_BODY;
-   }
-}
-
-#else  // use global memry for coefficients 
-
-#define FIR_DATA_SETUP_CUDA \
-  Real_ptr in; \
-  Real_ptr out; \
-  Real_ptr coeff; \
-\
-  const Index_type coefflen = m_coefflen; \
-\
-  allocAndInitCudaDeviceData(in, m_in, getRunSize()); \
-  allocAndInitCudaDeviceData(out, m_out, getRunSize()); \
-  Real_ptr tcoeff = &coeff_array[0]; \
-  allocAndInitCudaDeviceData(coeff, tcoeff, COEFFLEN);
-
-
-#define FIR_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_out, out, getRunSize()); \
-  deallocCudaDeviceData(in); \
-  deallocCudaDeviceData(out); \
-  deallocCudaDeviceData(coeff);
-
-__global__ void fir(Real_ptr out, Real_ptr in,
-                    Real_ptr coeff,
-                    const Index_type coefflen,
-                    Index_type iend)
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     FIR_BODY;
-   }
-}
-
-#endif 
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 FIR::FIR(const RunParams& params)
@@ -157,7 +44,7 @@ FIR::FIR(const RunParams& params)
   setDefaultSize(100000);
   setDefaultReps(1600);
 
-  m_coefflen = COEFFLEN;
+  m_coefflen = FIR_COEFFLEN;
 }
 
 FIR::~FIR() 
@@ -186,7 +73,7 @@ void FIR::runKernel(VariantID vid)
 
       FIR_COEFF;
 
-      FIR_DATA;
+      FIR_DATA_SETUP_CPU;
   
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -205,7 +92,7 @@ void FIR::runKernel(VariantID vid)
 
       FIR_COEFF;
 
-      FIR_DATA;
+      FIR_DATA_SETUP_CPU;
  
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -226,7 +113,7 @@ void FIR::runKernel(VariantID vid)
 
       FIR_COEFF;
 
-      FIR_DATA;
+      FIR_DATA_SETUP_CPU;
  
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -246,7 +133,7 @@ void FIR::runKernel(VariantID vid)
 
       FIR_COEFF;
 
-      FIR_DATA;
+      FIR_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -261,112 +148,22 @@ void FIR::runKernel(VariantID vid)
 
       break;
     }
-#if defined(RAJA_ENABLE_TARGET_OPENMP)
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      FIR_COEFF;
-
-      FIR_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:coeff[0:COEFFLEN],in[0:n],out[0:n])
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-           FIR_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:out[0:n]) map(delete:coeff[0:COEFFLEN],in[0:n])
-
-      break;
-    }
-
-    case RAJA_OpenMPTarget : {
-
-      FIR_COEFF;
-
-      FIR_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:coeff[0:COEFFLEN],in[0:n],out[0:n])
-
-      startTimer();
-      #pragma omp target data use_device_ptr(in,out)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-          RAJA::RangeSegment(ibegin, iend), [=](int i) {
-          FIR_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:out[0:n]) map(delete:coeff[0:COEFFLEN],in[0:n])
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
-
-#if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      FIR_COEFF;
-
-      FIR_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-
-#if defined(USE_CONSTANT_MEMORY)
-         fir<<<grid_size, block_size>>>( out, in,
-                                         coefflen,
-                                         iend );
-#else
-         fir<<<grid_size, block_size>>>( out, in,
-                                         coeff,
-                                         coefflen,
-                                         iend );
 #endif
 
-      }
-      stopTimer();
-
-      FIR_DATA_TEARDOWN_CUDA;
-
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
+#endif
 
-    case RAJA_CUDA : {
-
-      FIR_COEFF;
-
-      FIR_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           FIR_BODY;
-         });
-
-      }
-      stopTimer();
-
-      FIR_DATA_TEARDOWN_CUDA;
-
+#if defined(RAJA_ENABLE_CUDA)
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -35,6 +35,8 @@
 #include "RAJA/RAJA.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include <algorithm>
 #include <iostream>

--- a/src/apps/FIR.hpp
+++ b/src/apps/FIR.hpp
@@ -13,12 +13,47 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// FIR kernel reference implementation:
+///
+/// #define FIR_COEFFLEN (16)
+///
+/// Real_type coeff[FIR_COEFFLEN] = { 3.0, -1.0, -1.0, -1.0,
+///                                  -1.0, 3.0, -1.0, -1.0,
+///                                  -1.0, -1.0, 3.0, -1.0,
+///                                  -1.0, -1.0, -1.0, 3.0 };
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   Real_type sum = 0.0;
+///   for (Index_type j = 0; j < coefflen; ++j ) {
+///     sum += coeff[j]*in[i+j];
+///   }
+///   out[i] = sum;
+/// }
+///
 
 #ifndef RAJAPerf_Apps_FIR_HPP
 #define RAJAPerf_Apps_FIR_HPP
 
-#include "common/KernelBase.hpp"
 
+#define FIR_COEFFLEN (16)
+
+#define FIR_COEFF \
+  Real_type coeff_array[FIR_COEFFLEN] = { 3.0, -1.0, -1.0, -1.0, \
+                                         -1.0, 3.0, -1.0, -1.0, \
+                                         -1.0, -1.0, 3.0, -1.0, \
+                                         -1.0, -1.0, -1.0, 3.0 };
+
+#define FIR_BODY \
+  Real_type sum = 0.0; \
+\
+  for (Index_type j = 0; j < coefflen; ++j ) { \
+    sum += coeff[j]*in[i+j]; \
+  } \
+  out[i] = sum;
+
+
+#include "common/KernelBase.hpp"
 
 namespace rajaperf 
 {
@@ -41,6 +76,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_in;

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -1,0 +1,160 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "LTIMES.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include "camp/camp.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+
+#define LTIMES_DATA_SETUP_CUDA \
+  Real_ptr phidat; \
+  Real_ptr elldat; \
+  Real_ptr psidat; \
+\
+  Index_type num_d = m_num_d; \
+  Index_type num_z = m_num_z; \
+  Index_type num_g = m_num_g; \
+  Index_type num_m = m_num_m; \
+\
+  allocAndInitCudaDeviceData(phidat, m_phidat, m_philen); \
+  allocAndInitCudaDeviceData(elldat, m_elldat, m_elllen); \
+  allocAndInitCudaDeviceData(psidat, m_psidat, m_psilen);
+
+#define LTIMES_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_phidat, phidat, m_philen); \
+  deallocCudaDeviceData(phidat); \
+  deallocCudaDeviceData(elldat); \
+  deallocCudaDeviceData(psidat);
+
+__global__ void ltimes(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
+                       Index_type num_d, Index_type num_g, Index_type num_m)
+{
+   Index_type m = threadIdx.x;
+   Index_type g = blockIdx.y;
+   Index_type z = blockIdx.z;
+
+   for (Index_type d = 0; d < num_d; ++d ) {
+     LTIMES_BODY;
+   }
+}
+
+
+void LTIMES::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  if ( vid == Base_CUDA ) {
+
+    LTIMES_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      dim3 nthreads_per_block(num_m, 1, 1);
+      dim3 nblocks(1, num_g, num_z);
+
+      ltimes<<<nblocks, nthreads_per_block>>>(phidat, elldat, psidat,
+                                              num_d, num_g, num_m);  
+
+    }
+    stopTimer();
+
+    LTIMES_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+#if defined(USE_FORALLN_FOR_CUDA)
+
+      LTIMES_DATA_SETUP_CUDA;
+
+      LTIMES_VIEWS_RANGES_RAJA;
+
+      using EXEC_POL =
+        RAJA::NestedPolicy<RAJA::ExecList< RAJA::seq_exec,              //d
+                                           RAJA::cuda_block_z_exec,     //z
+                                           RAJA::cuda_block_y_exec,     //g
+                                           RAJA::cuda_thread_x_exec > >;//m
+              
+      startTimer(); 
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+        
+        RAJA::forallN< EXEC_POL, ID, IZ, IG, IM >(
+              IDRange(0, num_d),
+              IZRange(0, num_z),
+              IGRange(0, num_g),
+              IMRange(0, num_m),
+          [=] __device__ (ID d, IZ z, IG g, IM m) {
+          LTIMES_BODY_RAJA;
+        });
+      
+      }
+      stopTimer();
+
+      LTIMES_DATA_TEARDOWN_CUDA;
+
+#else // use RAJA::nested
+
+      LTIMES_DATA_SETUP_CUDA;
+
+      LTIMES_VIEWS_RANGES_RAJA;
+
+      using EXEC_POL = RAJA::nested::Policy<
+                  RAJA::nested::CudaCollapse<
+                     RAJA::nested::TypedFor<1, RAJA::cuda_block_z_exec, IZ>,
+                     RAJA::nested::TypedFor<2, RAJA::cuda_block_y_exec, IG>,
+                     RAJA::nested::TypedFor<3, RAJA::cuda_thread_x_exec, IM> >,
+                   RAJA::nested::TypedFor<0, RAJA::cuda_loop_exec, ID> >;
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::nested::forall(EXEC_POL{},
+                             camp::make_tuple(IDRange(0, num_d),
+                                              IZRange(0, num_z),
+                                              IGRange(0, num_g),
+                                              IMRange(0, num_m)),
+          [=] __device__ (ID d, IZ z, IG g, IM m) {
+          LTIMES_BODY_RAJA;
+        });
+
+      }
+      stopTimer();
+
+      LTIMES_DATA_TEARDOWN_CUDA;
+
+#endif
+
+  } else {
+     std::cout << "\n LTIMES : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -35,6 +35,8 @@
 #include "LTIMES.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 #include "camp/camp.hpp"

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -13,35 +13,14 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// LTIMES kernel reference implementation:
-///
-/// for (Index_type z = 0; z < num_z; ++z ) {
-///   for (Index_type g = 0; g < num_g; ++g ) {
-///     for (Index_type m = 0; z < num_m; ++m ) {
-///       for (Index_type d = 0; d < num_d; ++d ) {
-///         phi[m+ (g * num_g) + (z * num_z * num_g)] +=  
-///           ell[d+ (m * num_m)] * psi[d+ (g * num_g) + (z * num_z * num_g];
-///          
-///       }
-///     }
-///   }
-/// }
-///
-/// RAJA variants of kernel use multi-dimensional layouts and views to 
-/// do the same thing.
-///
-
 #include "LTIMES.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
 #include "camp/camp.hpp"
 
-#include <cstdlib>
 #include <iostream>
 
 namespace rajaperf 
@@ -49,18 +28,8 @@ namespace rajaperf
 namespace apps
 {
 
-//
-// These index value types cannot be defined in function scope for
-// RAJA CUDA variant to work.
-//
-namespace ltimes_idx {
-  RAJA_INDEX_VALUE(ID, "ID");
-  RAJA_INDEX_VALUE(IZ, "IZ");
-  RAJA_INDEX_VALUE(IG, "IG");
-  RAJA_INDEX_VALUE(IM, "IM");
-}
 
-#define LTIMES_DATA \
+#define LTIMES_DATA_SETUP_CPU \
   ResReal_ptr phidat = m_phidat; \
   ResReal_ptr elldat = m_elldat; \
   ResReal_ptr psidat = m_psidat; \
@@ -69,91 +38,6 @@ namespace ltimes_idx {
   Index_type num_z = m_num_z; \
   Index_type num_g = m_num_g; \
   Index_type num_m = m_num_m;
-
-#define LTIMES_VIEWS_RANGES_RAJA \
-  using namespace ltimes_idx; \
-\
-  using PSI_VIEW = RAJA::TypedView<Real_type, RAJA::Layout<3>, IZ, IG, ID>; \
-  using ELL_VIEW = RAJA::TypedView<Real_type, RAJA::Layout<2>, IM, ID>; \
-  using PHI_VIEW = RAJA::TypedView<Real_type, RAJA::Layout<3>, IZ, IG, IM>; \
-\
-  PSI_VIEW psi(psidat, \
-               RAJA::make_permuted_layout( {num_z, num_g, num_d}, \
-                     RAJA::as_array<RAJA::Perm<0, 1, 2> >::get() ) ); \
-  ELL_VIEW ell(elldat, \
-               RAJA::make_permuted_layout( {num_m, num_d}, \
-                     RAJA::as_array<RAJA::Perm<0, 1> >::get() ) ); \
-  PHI_VIEW phi(phidat, \
-               RAJA::make_permuted_layout( {num_z, num_g, num_m}, \
-                     RAJA::as_array<RAJA::Perm<0, 1, 2> >::get() ) ); \
-\
-      using IDRange = RAJA::RangeSegment; \
-      using IZRange = RAJA::RangeSegment; \
-      using IGRange = RAJA::RangeSegment; \
-      using IMRange = RAJA::RangeSegment;
-
-#if 0 // Variants of views with non-permuted layout, end result is the same.
-#define LTIMES_NOPERMS_VIEWS_RANGES_RAJA \
-  using namespace ltimes_idx; \
-\
-  using PSI_VIEW = RAJA::TypedView<Real_type, RAJA::Layout<3>, IZ, IG, ID>; \
-  using ELL_VIEW = RAJA::TypedView<Real_type, RAJA::Layout<2>, IM, ID>; \
-  using PHI_VIEW = RAJA::TypedView<Real_type, RAJA::Layout<3>, IZ, IG, IM>; \
-\
-  PSI_VIEW psi(psidat, RAJA::Layout<3>(num_z, num_g, num_d)); \
-  ELL_VIEW ell(elldat, RAJA::Layout<2>(num_m, num_d)); \
-  PHI_VIEW phi(phidat, RAJA::Layout<3>(num_z, num_g, num_m)); \
-\
-      using IDRange = RAJA::RangeSegment; \
-      using IZRange = RAJA::RangeSegment; \
-      using IGRange = RAJA::RangeSegment; \
-      using IMRange = RAJA::RangeSegment;
-#endif
-
-
-#define LTIMES_BODY \
-  phidat[m+ (g * num_m) + (z * num_m * num_g)] += \
-    elldat[d+ (m * num_d)] * psidat[d+ (g * num_d) + (z * num_d * num_g)];
-
-#define LTIMES_BODY_RAJA \
-  phi(z, g, m) +=  ell(m, d) * psi(z, g, d);
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-#define LTIMES_DATA_SETUP_CUDA \
-  Real_ptr phidat; \
-  Real_ptr elldat; \
-  Real_ptr psidat; \
-\
-  Index_type num_d = m_num_d; \
-  Index_type num_z = m_num_z; \
-  Index_type num_g = m_num_g; \
-  Index_type num_m = m_num_m; \
-\
-  allocAndInitCudaDeviceData(phidat, m_phidat, m_philen); \
-  allocAndInitCudaDeviceData(elldat, m_elldat, m_elllen); \
-  allocAndInitCudaDeviceData(psidat, m_psidat, m_psilen);
-
-#define LTIMES_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_phidat, phidat, m_philen); \
-  deallocCudaDeviceData(phidat); \
-  deallocCudaDeviceData(elldat); \
-  deallocCudaDeviceData(psidat);
-
-__global__ void ltimes(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
-                       Index_type num_d, Index_type num_g, Index_type num_m)
-{
-   Index_type m = threadIdx.x;
-   Index_type g = blockIdx.y;
-   Index_type z = blockIdx.z;
-
-   for (Index_type d = 0; d < num_d; ++d ) {
-     LTIMES_BODY;
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 LTIMES::LTIMES(const RunParams& params)
@@ -197,7 +81,7 @@ void LTIMES::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      LTIMES_DATA;
+      LTIMES_DATA_SETUP_CPU;
   
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -222,7 +106,7 @@ void LTIMES::runKernel(VariantID vid)
 
 #if defined(USE_FORALLN_FOR_SEQ)
 
-      LTIMES_DATA;
+      LTIMES_DATA_SETUP_CPU;
 
       LTIMES_VIEWS_RANGES_RAJA;
  
@@ -249,7 +133,7 @@ void LTIMES::runKernel(VariantID vid)
 
 #else // use RAJA::nested
 
-      LTIMES_DATA;
+      LTIMES_DATA_SETUP_CPU;
 
       LTIMES_VIEWS_RANGES_RAJA;
 
@@ -282,7 +166,7 @@ void LTIMES::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)      
     case Base_OpenMP : {
 
-      LTIMES_DATA;
+      LTIMES_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -308,7 +192,7 @@ void LTIMES::runKernel(VariantID vid)
 
 #if defined(USE_FORALLN_FOR_OPENMP)
 
-      LTIMES_DATA;
+      LTIMES_DATA_SETUP_CPU;
 
       LTIMES_VIEWS_RANGES_RAJA;
  
@@ -335,7 +219,7 @@ void LTIMES::runKernel(VariantID vid)
 
 #else // use RAJA::nested
 
-      LTIMES_DATA;
+      LTIMES_DATA_SETUP_CPU;
 
       LTIMES_VIEWS_RANGES_RAJA;
 
@@ -364,106 +248,22 @@ void LTIMES::runKernel(VariantID vid)
 
       break;
     }
-
-#if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-    case Base_OpenMPTarget : {
-
-     break;
-    }
-
-    case RAJA_OpenMPTarget : {
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP
-
-#if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      LTIMES_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        dim3 nthreads_per_block(num_m, 1, 1);
-        dim3 nblocks(1, num_g, num_z);
-
-        ltimes<<<nblocks, nthreads_per_block>>>(phidat, elldat, psidat,
-                                                num_d, num_g, num_m);  
-
-      }
-      stopTimer();
-
-      LTIMES_DATA_TEARDOWN_CUDA;
-
-      break;
-    }
-
-    case RAJA_CUDA : {
-
-#if defined(USE_FORALLN_FOR_CUDA)
-
-      LTIMES_DATA_SETUP_CUDA;
-
-      LTIMES_VIEWS_RANGES_RAJA;
-
-      using EXEC_POL =
-        RAJA::NestedPolicy<RAJA::ExecList< RAJA::seq_exec,              //d
-                                           RAJA::cuda_block_z_exec,     //z
-                                           RAJA::cuda_block_y_exec,     //g
-                                           RAJA::cuda_thread_x_exec > >;//m
-              
-      startTimer(); 
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-        
-        RAJA::forallN< EXEC_POL, ID, IZ, IG, IM >(
-              RAJA::RangeSegment(0, num_d),
-              RAJA::RangeSegment(0, num_z),
-              RAJA::RangeSegment(0, num_g),
-              RAJA::RangeSegment(0, num_m),
-          [=] __device__ (ID d, IZ z, IG g, IM m) {
-          LTIMES_BODY_RAJA;
-        });
-      
-      }
-      stopTimer();
-
-      LTIMES_DATA_TEARDOWN_CUDA;
-
-#else // use RAJA::nested
-
-      LTIMES_DATA_SETUP_CUDA;
-
-      LTIMES_VIEWS_RANGES_RAJA;
-
-      using EXEC_POL = RAJA::nested::Policy<
-                  RAJA::nested::CudaCollapse<
-                     RAJA::nested::TypedFor<1, RAJA::cuda_block_z_exec, IZ>,
-                     RAJA::nested::TypedFor<2, RAJA::cuda_block_y_exec, IG>,
-                     RAJA::nested::TypedFor<3, RAJA::cuda_thread_x_exec, IM> >,
-                   RAJA::nested::TypedFor<0, RAJA::cuda_loop_exec, ID> >;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::nested::forall(EXEC_POL{},
-                             camp::make_tuple(IDRange(0, num_d),
-                                              IZRange(0, num_z),
-                                              IGRange(0, num_g),
-                                              IMRange(0, num_m)),
-          [=] __device__ (ID d, IZ z, IG g, IM m) {
-          LTIMES_BODY_RAJA;
-        });
-
-      }
-      stopTimer();
-
-      LTIMES_DATA_TEARDOWN_CUDA;
-
 #endif
 
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
+      break;
+    }
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -23,7 +23,6 @@
 
 #include "camp/camp.hpp"
 
-#include <cstdlib>
 #include <iostream>
 
 namespace rajaperf 
@@ -104,11 +103,10 @@ void LTIMES_NOVIEW::runCudaVariant(VariantID vid)
     startTimer(); 
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
       
-      RAJA::forallN< EXEC_POL >(
-            RAJA::RangeSegment(0, num_d),
-            RAJA::RangeSegment(0, num_z),
-            RAJA::RangeSegment(0, num_g),
-            RAJA::RangeSegment(0, num_m),
+      RAJA::forallN< EXEC_POL >( IDRange(0, num_d),
+                                 IZRange(0, num_z),
+                                 IGRange(0, num_g),
+                                 IMRange(0, num_m),
         [=] __device__ (Index_type d, Index_type z, Index_type g, Index_type m) {
         LTIMES_NOVIEW_BODY;
       });

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -1,0 +1,161 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "LTIMES_NOVIEW.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include "camp/camp.hpp"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+
+#define LTIMES_NOVIEW_DATA_SETUP_CUDA \
+  Real_ptr phidat; \
+  Real_ptr elldat; \
+  Real_ptr psidat; \
+\
+  Index_type num_d = m_num_d; \
+  Index_type num_z = m_num_z; \
+  Index_type num_g = m_num_g; \
+  Index_type num_m = m_num_m; \
+\
+  allocAndInitCudaDeviceData(phidat, m_phidat, m_philen); \
+  allocAndInitCudaDeviceData(elldat, m_elldat, m_elllen); \
+  allocAndInitCudaDeviceData(psidat, m_psidat, m_psilen);
+
+#define LTIMES_NOVIEW_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_phidat, phidat, m_philen); \
+  deallocCudaDeviceData(phidat); \
+  deallocCudaDeviceData(elldat); \
+  deallocCudaDeviceData(psidat);
+
+__global__ void ltimes_noview(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
+                              Index_type num_d, Index_type num_g, Index_type num_m)
+{
+   Index_type m = threadIdx.x;
+   Index_type g = blockIdx.y;
+   Index_type z = blockIdx.z;
+
+   for (Index_type d = 0; d < num_d; ++d ) {
+     LTIMES_NOVIEW_BODY;
+   }
+}
+
+
+void LTIMES_NOVIEW::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  if ( vid == Base_CUDA ) {
+
+    LTIMES_NOVIEW_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      dim3 nthreads_per_block(num_m, 1, 1);
+      dim3 nblocks(1, num_g, num_z);
+
+      ltimes_noview<<<nblocks, nthreads_per_block>>>(phidat, elldat, psidat,
+                                                     num_d, num_g, num_m);  
+
+    }
+    stopTimer();
+
+    LTIMES_NOVIEW_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+#if defined(USE_FORALLN_FOR_CUDA)
+
+    LTIMES_NOVIEW_DATA_SETUP_CUDA;
+
+    LTIMES_NOVIEW_RANGES_RAJA;
+
+    using EXEC_POL =
+      RAJA::NestedPolicy<RAJA::ExecList< RAJA::seq_exec,              //d
+                                         RAJA::cuda_block_z_exec,     //z
+                                         RAJA::cuda_block_y_exec,     //g
+                                         RAJA::cuda_thread_x_exec > >;//m
+            
+    startTimer(); 
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      
+      RAJA::forallN< EXEC_POL >(
+            RAJA::RangeSegment(0, num_d),
+            RAJA::RangeSegment(0, num_z),
+            RAJA::RangeSegment(0, num_g),
+            RAJA::RangeSegment(0, num_m),
+        [=] __device__ (Index_type d, Index_type z, Index_type g, Index_type m) {
+        LTIMES_NOVIEW_BODY;
+      });
+    
+    }
+    stopTimer();
+
+    LTIMES_NOVIEW_DATA_TEARDOWN_CUDA;
+
+#else // use RAJA::nested
+
+    LTIMES_NOVIEW_DATA_SETUP_CUDA;
+
+    LTIMES_NOVIEW_RANGES_RAJA;
+
+    using EXEC_POL = RAJA::nested::Policy<
+                RAJA::nested::CudaCollapse<
+                   RAJA::nested::For<1, RAJA::cuda_block_z_exec>,    //z
+                   RAJA::nested::For<2, RAJA::cuda_block_y_exec>,    //g
+                   RAJA::nested::For<3, RAJA::cuda_thread_x_exec> >, //m
+                 RAJA::nested::For<0, RAJA::cuda_loop_exec> >;       //d
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::nested::forall(EXEC_POL{},
+                           camp::make_tuple(IDRange(0, num_d),
+                                            IZRange(0, num_z),
+                                            IGRange(0, num_g),
+                                            IMRange(0, num_m)),
+        [=] __device__ (Index_type d, Index_type z, Index_type g, Index_type m) {
+        LTIMES_NOVIEW_BODY;
+      });
+
+    }
+    stopTimer();
+
+    LTIMES_NOVIEW_DATA_TEARDOWN_CUDA;
+
+#endif
+
+  } else {
+     std::cout << "\n LTIMES_NOVIEW : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/apps/LTIMES_NOVIEW-OMPTarget.cpp
+++ b/src/apps/LTIMES_NOVIEW-OMPTarget.cpp
@@ -1,0 +1,158 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "LTIMES_NOVIEW.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include "camp/camp.hpp"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define LTIMES_NOVIEW_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr phidat; \
+  Real_ptr elldat; \
+  Real_ptr psidat; \
+\
+  Index_type num_d = m_num_d; \
+  Index_type num_z = m_num_z; \
+  Index_type num_g = m_num_g; \
+  Index_type num_m = m_num_m; \
+\
+  allocAndInitOpenMPDeviceData(phidat, m_phidat, m_philen, did, hid); \
+  allocAndInitOpenMPDeviceData(elldat, m_elldat, m_elllen, did, hid); \
+  allocAndInitOpenMPDeviceData(psidat, m_psidat, m_psilen, did, hid);
+
+#define LTIMES_NOVIEW_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_phidat, phidat, m_philen, hid, did); \
+  deallocOpenMPDeviceData(phidat, did); \
+  deallocOpenMPDeviceData(elldat, did); \
+  deallocOpenMPDeviceData(psidat, did);
+
+
+void LTIMES_NOVIEW::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    LTIMES_NOVIEW_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(phidat, elldat, psidat) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) collapse(3)
+      for (Index_type z = 0; z < num_z; ++z ) {
+        for (Index_type g = 0; g < num_g; ++g ) {
+          for (Index_type m = 0; m < num_m; ++m ) {
+            for (Index_type d = 0; d < num_d; ++d ) {
+              LTIMES_NOVIEW_BODY;
+            }
+          }
+        }
+      }
+
+    }
+    stopTimer();
+
+    LTIMES_NOVIEW_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+#if 1 // temporary implementation until RAJA::nested::OmpTargetCollapse works.
+
+    LTIMES_NOVIEW_DATA_SETUP_OMP_TARGET;
+
+    LTIMES_NOVIEW_RANGES_RAJA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        IZRange(0, num_z), [=](Index_type z) {
+        for (Index_type g = 0; g < num_g; ++g ) {
+          for (Index_type m = 0; m < num_m; ++m ) {
+            for (Index_type d = 0; d < num_d; ++d ) {
+              LTIMES_NOVIEW_BODY;
+            }
+          }
+        }
+      });
+
+    }
+    stopTimer();
+
+    LTIMES_NOVIEW_DATA_TEARDOWN_OMP_TARGET;
+
+#else
+
+    LTIMES_NOVIEW_DATA_SETUP_OMP_TARGET;
+
+    LTIMES_NOVIEW_RANGES_RAJA;
+
+    using EXEC_POL = RAJA::nested::Policy<
+                RAJA::nested::OmpTargetCollapse<
+                   RAJA::nested::For<1>,                  // z 
+                   RAJA::nested::For<2>,                  // g
+                   RAJA::nested::For<3> >,                // m
+                 RAJA::nested::For<0, RAJA::loop_exec> >; // d
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::nested::forall(EXEC_POL{},
+                           camp::make_tuple(IDRange(0, num_d),
+                                            IZRange(0, num_z),
+                                            IGRange(0, num_g),
+                                            IMRange(0, num_m)),
+        [=] (Index_type d, Index_type z, Index_type g, Index_type m) {
+        LTIMES_NOVIEW_BODY;
+      });
+
+    }
+    stopTimer();
+
+    LTIMES_NOVIEW_DATA_TEARDOWN_OMP_TARGET;
+
+#endif
+
+  } else {
+     std::cout << "\n LTIMES_NOVIEW : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -34,6 +34,8 @@
 #include "LTIMES_NOVIEW.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 #include "camp/camp.hpp"

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -21,7 +21,6 @@
 
 #include "camp/camp.hpp"
 
-#include <cstdlib>
 #include <iostream>
 
 namespace rajaperf 

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -13,31 +13,12 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// LTIMES_NOVIEW kernel reference implementation:
-///
-/// for (Index_type z = 0; z < num_z; ++z ) {
-///   for (Index_type g = 0; g < num_g; ++g ) {
-///     for (Index_type m = 0; z < num_m; ++m ) {
-///       for (Index_type d = 0; d < num_d; ++d ) {
-///         phi[m+ (g * num_g) + (z * num_z * num_g)] +=  
-///           ell[d+ (m * num_m)] * psi[d+ (g * num_g) + (z * num_z * num_g];
-///          
-///       }
-///     }
-///   }
-/// }
-///
-/// RAJA variants of kernel use RAJA nested constructs to do the same thing.
-///
-
 #include "LTIMES_NOVIEW.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
 #include "camp/camp.hpp"
 
 #include <cstdlib>
@@ -48,7 +29,8 @@ namespace rajaperf
 namespace apps
 {
 
-#define LTIMES_NOVIEW_DATA \
+
+#define LTIMES_NOVIEW_DATA_SETUP_CPU \
   ResReal_ptr phidat = m_phidat; \
   ResReal_ptr elldat = m_elldat; \
   ResReal_ptr psidat = m_psidat; \
@@ -57,54 +39,6 @@ namespace apps
   Index_type num_z = m_num_z; \
   Index_type num_g = m_num_g; \
   Index_type num_m = m_num_m;
-
-#define LTIMES_NOVIEW_RANGES_RAJA \
-      using IDRange = RAJA::RangeSegment; \
-      using IZRange = RAJA::RangeSegment; \
-      using IGRange = RAJA::RangeSegment; \
-      using IMRange = RAJA::RangeSegment;
-
-
-#define LTIMES_NOVIEW_BODY \
-  phidat[m+ (g * num_m) + (z * num_m * num_g)] += \
-    elldat[d+ (m * num_d)] * psidat[d+ (g * num_d) + (z * num_d * num_g)];
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-#define LTIMES_NOVIEW_DATA_SETUP_CUDA \
-  Real_ptr phidat; \
-  Real_ptr elldat; \
-  Real_ptr psidat; \
-\
-  Index_type num_d = m_num_d; \
-  Index_type num_z = m_num_z; \
-  Index_type num_g = m_num_g; \
-  Index_type num_m = m_num_m; \
-\
-  allocAndInitCudaDeviceData(phidat, m_phidat, m_philen); \
-  allocAndInitCudaDeviceData(elldat, m_elldat, m_elllen); \
-  allocAndInitCudaDeviceData(psidat, m_psidat, m_psilen);
-
-#define LTIMES_NOVIEW_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_phidat, phidat, m_philen); \
-  deallocCudaDeviceData(phidat); \
-  deallocCudaDeviceData(elldat); \
-  deallocCudaDeviceData(psidat);
-
-__global__ void ltimes_noview(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
-                              Index_type num_d, Index_type num_g, Index_type num_m)
-{
-   Index_type m = threadIdx.x;
-   Index_type g = blockIdx.y;
-   Index_type z = blockIdx.z;
-
-   for (Index_type d = 0; d < num_d; ++d ) {
-     LTIMES_NOVIEW_BODY;
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
@@ -148,7 +82,7 @@ void LTIMES_NOVIEW::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      LTIMES_NOVIEW_DATA;
+      LTIMES_NOVIEW_DATA_SETUP_CPU;
   
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -173,7 +107,7 @@ void LTIMES_NOVIEW::runKernel(VariantID vid)
 
 #if defined(USE_FORALLN_FOR_SEQ)
 
-      LTIMES_NOVIEW_DATA;
+      LTIMES_NOVIEW_DATA_SETUP_CPU;
 
       LTIMES_NOVIEW_RANGES_RAJA;
  
@@ -200,7 +134,7 @@ void LTIMES_NOVIEW::runKernel(VariantID vid)
 
 #else // use RAJA::nested
 
-      LTIMES_NOVIEW_DATA;
+      LTIMES_NOVIEW_DATA_SETUP_CPU;
 
       LTIMES_NOVIEW_RANGES_RAJA;
 
@@ -233,7 +167,7 @@ void LTIMES_NOVIEW::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)      
     case Base_OpenMP : {
 
-      LTIMES_NOVIEW_DATA;
+      LTIMES_NOVIEW_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -259,7 +193,7 @@ void LTIMES_NOVIEW::runKernel(VariantID vid)
 
 #if defined(USE_FORALLN_FOR_OPENMP)
 
-      LTIMES_NOVIEW_DATA;
+      LTIMES_NOVIEW_DATA_SETUP_CPU;
 
       LTIMES_NOVIEW_RANGES_RAJA;
  
@@ -286,7 +220,7 @@ void LTIMES_NOVIEW::runKernel(VariantID vid)
 
 #else // use RAJA::nested
 
-      LTIMES_NOVIEW_DATA;
+      LTIMES_NOVIEW_DATA_SETUP_CPU;
 
       LTIMES_NOVIEW_RANGES_RAJA;
 
@@ -315,106 +249,22 @@ void LTIMES_NOVIEW::runKernel(VariantID vid)
 
       break;
     }
-
-#if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-    case Base_OpenMPTarget : {
-
-     break;
-    }
-
-    case RAJA_OpenMPTarget : {
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP
-
-#if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      LTIMES_NOVIEW_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        dim3 nthreads_per_block(num_m, 1, 1);
-        dim3 nblocks(1, num_g, num_z);
-
-        ltimes_noview<<<nblocks, nthreads_per_block>>>(phidat, elldat, psidat,
-                                                       num_d, num_g, num_m);  
-
-      }
-      stopTimer();
-
-      LTIMES_NOVIEW_DATA_TEARDOWN_CUDA;
-
-      break;
-    }
-
-    case RAJA_CUDA : {
-
-#if defined(USE_FORALLN_FOR_CUDA)
-
-      LTIMES_NOVIEW_DATA_SETUP_CUDA;
-
-      LTIMES_NOVIEW_RANGES_RAJA;
-
-      using EXEC_POL =
-        RAJA::NestedPolicy<RAJA::ExecList< RAJA::seq_exec,              //d
-                                           RAJA::cuda_block_z_exec,     //z
-                                           RAJA::cuda_block_y_exec,     //g
-                                           RAJA::cuda_thread_x_exec > >;//m
-              
-      startTimer(); 
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-        
-        RAJA::forallN< EXEC_POL >(
-              RAJA::RangeSegment(0, num_d),
-              RAJA::RangeSegment(0, num_z),
-              RAJA::RangeSegment(0, num_g),
-              RAJA::RangeSegment(0, num_m),
-          [=] __device__ (Index_type d, Index_type z, Index_type g, Index_type m) {
-          LTIMES_NOVIEW_BODY;
-        });
-      
-      }
-      stopTimer();
-
-      LTIMES_NOVIEW_DATA_TEARDOWN_CUDA;
-
-#else // use RAJA::nested
-
-      LTIMES_NOVIEW_DATA_SETUP_CUDA;
-
-      LTIMES_NOVIEW_RANGES_RAJA;
-
-      using EXEC_POL = RAJA::nested::Policy<
-                  RAJA::nested::CudaCollapse<
-                     RAJA::nested::For<1, RAJA::cuda_block_z_exec>,
-                     RAJA::nested::For<2, RAJA::cuda_block_y_exec>,
-                     RAJA::nested::For<3, RAJA::cuda_thread_x_exec> >,
-                   RAJA::nested::For<0, RAJA::cuda_loop_exec> >;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::nested::forall(EXEC_POL{},
-                             camp::make_tuple(IDRange(0, num_d),
-                                              IZRange(0, num_z),
-                                              IGRange(0, num_g),
-                                              IMRange(0, num_m)),
-          [=] __device__ (Index_type d, Index_type z, Index_type g, Index_type m) {
-          LTIMES_NOVIEW_BODY;
-        });
-
-      }
-      stopTimer();
-
-      LTIMES_NOVIEW_DATA_TEARDOWN_CUDA;
-
 #endif
 
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
+      break;
+    }
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/apps/LTIMES_NOVIEW.hpp
+++ b/src/apps/LTIMES_NOVIEW.hpp
@@ -13,12 +13,39 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// LTIMES_NOVIEW kernel reference implementation:
+///
+/// for (Index_type z = 0; z < num_z; ++z ) {
+///   for (Index_type g = 0; g < num_g; ++g ) {
+///     for (Index_type m = 0; z < num_m; ++m ) {
+///       for (Index_type d = 0; d < num_d; ++d ) {
+///
+///         phi[m+ (g * num_g) + (z * num_z * num_g)] +=
+///           ell[d+ (m * num_m)] * psi[d+ (g * num_g) + (z * num_z * num_g];
+///
+///       }
+///     }
+///   }
+/// }
+///
 
 #ifndef RAJAPerf_Apps_LTIMES_NOVIEW_HPP
 #define RAJAPerf_Apps_LTIMES_NOVIEW_HPP
 
-#include "common/KernelBase.hpp"
 
+#define LTIMES_NOVIEW_BODY \
+  phidat[m+ (g * num_m) + (z * num_m * num_g)] += \
+    elldat[d+ (m * num_d)] * psidat[d+ (g * num_d) + (z * num_d * num_g)];
+
+#define LTIMES_NOVIEW_RANGES_RAJA \
+      using IDRange = RAJA::RangeSegment; \
+      using IZRange = RAJA::RangeSegment; \
+      using IGRange = RAJA::RangeSegment; \
+      using IMRange = RAJA::RangeSegment;
+
+
+#include "common/KernelBase.hpp"
 
 namespace rajaperf 
 {
@@ -39,6 +66,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_phidat;

--- a/src/apps/PRESSURE-Cuda.cpp
+++ b/src/apps/PRESSURE-Cuda.cpp
@@ -1,0 +1,144 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "PRESSURE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define PRESSURE_DATA_SETUP_CUDA \
+  Real_ptr compression; \
+  Real_ptr bvc; \
+  Real_ptr p_new; \
+  Real_ptr e_old; \
+  Real_ptr vnewc; \
+  const Real_type cls = m_cls; \
+  const Real_type p_cut = m_p_cut; \
+  const Real_type pmin = m_pmin; \
+  const Real_type eosvmax = m_eosvmax; \
+\
+  allocAndInitCudaDeviceData(compression, m_compression, iend); \
+  allocAndInitCudaDeviceData(bvc, m_bvc, iend); \
+  allocAndInitCudaDeviceData(p_new, m_p_new, iend); \
+  allocAndInitCudaDeviceData(e_old, m_e_old, iend); \
+  allocAndInitCudaDeviceData(vnewc, m_vnewc, iend);
+
+#define PRESSURE_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_p_new, p_new, iend); \
+  deallocCudaDeviceData(compression); \
+  deallocCudaDeviceData(bvc); \
+  deallocCudaDeviceData(p_new); \
+  deallocCudaDeviceData(e_old); \
+  deallocCudaDeviceData(vnewc);
+
+__global__ void pressurecalc1(Real_ptr bvc, Real_ptr compression,
+                              const Real_type cls,
+                              Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     PRESSURE_BODY1;
+   }
+}
+
+__global__ void pressurecalc2(Real_ptr p_new, Real_ptr bvc, Real_ptr e_old,
+                              Real_ptr vnewc,
+                              const Real_type p_cut, const Real_type eosvmax,
+                              const Real_type pmin,
+                              Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     PRESSURE_BODY2;
+   }
+}
+
+
+void PRESSURE::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    PRESSURE_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+
+       pressurecalc1<<<grid_size, block_size>>>( bvc, compression,
+                                                 cls,
+                                                 iend );
+
+       pressurecalc2<<<grid_size, block_size>>>( p_new, bvc, e_old,
+                                                 vnewc,
+                                                 p_cut, eosvmax, pmin,
+                                                 iend );
+
+    }
+    stopTimer();
+
+    PRESSURE_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    PRESSURE_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         PRESSURE_BODY1;
+       });
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         PRESSURE_BODY2;
+       });
+
+    }
+    stopTimer();
+
+    PRESSURE_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  PRESSURE : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/apps/PRESSURE-OMPTarget.cpp
+++ b/src/apps/PRESSURE-OMPTarget.cpp
@@ -115,7 +115,7 @@ void PRESSURE::runOpenMPTargetVariant(VariantID vid)
     PRESSURE_DATA_TEARDOWN_OMP_TARGET;
 
   } else {
-    std::cout << "\n  PRESSURE : Unknown variant id = " << vid << std::endl;
+    std::cout << "\n  PRESSURE : Unknown OMP Target variant id = " << vid << std::endl;
   }
 }
 

--- a/src/apps/PRESSURE-OMPTarget.cpp
+++ b/src/apps/PRESSURE-OMPTarget.cpp
@@ -1,0 +1,125 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "PRESSURE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define PRESSURE_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr compression; \
+  Real_ptr bvc; \
+  Real_ptr p_new; \
+  Real_ptr e_old; \
+  Real_ptr vnewc; \
+  const Real_type cls = m_cls; \
+  const Real_type p_cut = m_p_cut; \
+  const Real_type pmin = m_pmin; \
+  const Real_type eosvmax = m_eosvmax; \
+\
+  allocAndInitOpenMPDeviceData(compression, m_compression, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(bvc, m_bvc, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(p_new, m_p_new, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(e_old, m_e_old, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(vnewc, m_vnewc, iend, did, hid);
+
+#define PRESSURE_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_p_new, p_new, iend, hid, did); \
+  deallocOpenMPDeviceData(compression, did); \
+  deallocOpenMPDeviceData(bvc, did); \
+  deallocOpenMPDeviceData(p_new, did); \
+  deallocOpenMPDeviceData(e_old, did); \
+  deallocOpenMPDeviceData(vnewc, did);
+
+
+void PRESSURE::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    PRESSURE_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(compression, bvc) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        PRESSURE_BODY1;
+      }
+
+      #pragma omp target is_device_ptr(bvc, p_new, e_old, vnewc) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        PRESSURE_BODY2;
+      }
+
+    }
+    stopTimer();
+
+    PRESSURE_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    PRESSURE_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](int i) {
+        PRESSURE_BODY1;
+      });
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](int i) {
+        PRESSURE_BODY2;
+      });
+
+    }
+    stopTimer();
+
+    PRESSURE_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+    std::cout << "\n  PRESSURE : Unknown variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/apps/PRESSURE.cpp
+++ b/src/apps/PRESSURE.cpp
@@ -31,6 +31,8 @@
 #include "PRESSURE.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/apps/PRESSURE.hpp
+++ b/src/apps/PRESSURE.hpp
@@ -13,12 +13,36 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// PRESSURE kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   bvc[i] = cls * (compression[i] + 1.0);
+/// }
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   p_new[i] = bvc[i] * e_old[i] ;
+///   if ( fabs(p_new[i]) <  p_cut ) p_new[i] = 0.0 ;
+///   if ( vnewc[i] >= eosvmax ) p_new[i] = 0.0 ;
+///   if ( p_new[i]  <  pmin ) p_new[i]   = pmin ;
+/// }
+///
 
 #ifndef RAJAPerf_Apps_PRESSURE_HPP
 #define RAJAPerf_Apps_PRESSURE_HPP
 
-#include "common/KernelBase.hpp"
 
+#define PRESSURE_BODY1 \
+  bvc[i] = cls * (compression[i] + 1.0);
+
+#define PRESSURE_BODY2 \
+  p_new[i] = bvc[i] * e_old[i] ; \
+  if ( fabs(p_new[i]) <  p_cut ) p_new[i] = 0.0 ; \
+  if ( vnewc[i] >= eosvmax ) p_new[i] = 0.0 ; \
+  if ( p_new[i]  <  pmin ) p_new[i]   = pmin ;
+
+
+#include "common/KernelBase.hpp"
 
 namespace rajaperf 
 {
@@ -39,6 +63,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_compression;

--- a/src/apps/VOL3D-Cuda.cpp
+++ b/src/apps/VOL3D-Cuda.cpp
@@ -1,0 +1,147 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "VOL3D.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include "AppsData.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define VOL3D_DATA_SETUP_CUDA \
+  Real_ptr x; \
+  Real_ptr y; \
+  Real_ptr z; \
+  Real_ptr vol; \
+\
+  const Real_type vnormq = m_vnormq; \
+\
+  Real_ptr x0,x1,x2,x3,x4,x5,x6,x7 ; \
+  Real_ptr y0,y1,y2,y3,y4,y5,y6,y7 ; \
+  Real_ptr z0,z1,z2,z3,z4,z5,z6,z7 ; \
+\
+  allocAndInitCudaDeviceData(x, m_x, m_array_length); \
+  allocAndInitCudaDeviceData(y, m_y, m_array_length); \
+  allocAndInitCudaDeviceData(z, m_z, m_array_length); \
+  allocAndInitCudaDeviceData(vol, m_vol, m_array_length);
+
+#define VOL3D_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_vol, vol, m_array_length); \
+  deallocCudaDeviceData(x); \
+  deallocCudaDeviceData(y); \
+  deallocCudaDeviceData(z); \
+  deallocCudaDeviceData(vol);
+
+__global__ void vol3d(Real_ptr vol,
+                      const Real_ptr x0, const Real_ptr x1,
+                      const Real_ptr x2, const Real_ptr x3,
+                      const Real_ptr x4, const Real_ptr x5,
+                      const Real_ptr x6, const Real_ptr x7,
+                      const Real_ptr y0, const Real_ptr y1,
+                      const Real_ptr y2, const Real_ptr y3,
+                      const Real_ptr y4, const Real_ptr y5,
+                      const Real_ptr y6, const Real_ptr y7,
+                      const Real_ptr z0, const Real_ptr z1,
+                      const Real_ptr z2, const Real_ptr z3,
+                      const Real_ptr z4, const Real_ptr z5,
+                      const Real_ptr z6, const Real_ptr z7,
+                      const Real_type vnormq,
+                      Index_type ibegin, Index_type iend)
+{
+   Index_type ii = blockIdx.x * blockDim.x + threadIdx.x;
+   Index_type i = ii + ibegin; 
+   if (i < iend) {
+     VOL3D_BODY;
+   }
+}
+
+
+void VOL3D::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = m_domain->fpz;
+  const Index_type iend = m_domain->lpz+1;
+
+  if ( vid == Base_CUDA ) {
+
+    VOL3D_DATA_SETUP_CUDA;
+
+    NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
+    NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
+    NDPTRSET(m_domain->jp, m_domain->kp, z,z0,z1,z2,z3,z4,z5,z6,z7) ;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+ 
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+
+      vol3d<<<grid_size, block_size>>>(vol,
+                                       x0, x1, x2, x3, x4, x5, x6, x7,
+                                       y0, y1, y2, y3, y4, y5, y6, y7,
+                                       z0, z1, z2, z3, z4, z5, z6, z7,
+                                       vnormq,
+                                       ibegin, iend);
+ 
+    }
+    stopTimer();
+ 
+    VOL3D_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    VOL3D_DATA_SETUP_CUDA;
+
+    NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
+    NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
+    NDPTRSET(m_domain->jp, m_domain->kp, z,z0,z1,z2,z3,z4,z5,z6,z7) ;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+ 
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        VOL3D_BODY;
+      });
+ 
+    }
+    stopTimer();
+ 
+    VOL3D_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  VOL3D : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/apps/VOL3D-OMPTarget.cpp
+++ b/src/apps/VOL3D-OMPTarget.cpp
@@ -1,0 +1,127 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "VOL3D.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include "AppsData.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace apps
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define VOL3D_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr x; \
+  Real_ptr y; \
+  Real_ptr z; \
+  Real_ptr vol; \
+\
+  const Real_type vnormq = m_vnormq; \
+\
+  Real_ptr x0,x1,x2,x3,x4,x5,x6,x7 ; \
+  Real_ptr y0,y1,y2,y3,y4,y5,y6,y7 ; \
+  Real_ptr z0,z1,z2,z3,z4,z5,z6,z7 ; \
+\
+  allocAndInitOpenMPDeviceData(x, m_x, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(y, m_y, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(z, m_z, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(vol, m_vol, m_array_length, did, hid);
+
+#define VOL3D_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_vol, vol, m_array_length, hid, did); \
+  deallocOpenMPDeviceData(x, did); \
+  deallocOpenMPDeviceData(y, did); \
+  deallocOpenMPDeviceData(z, did); \
+  deallocOpenMPDeviceData(vol, did);
+
+
+void VOL3D::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = m_domain->fpz;
+  const Index_type iend = m_domain->lpz+1;
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    VOL3D_DATA_SETUP_OMP_TARGET;
+
+    NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
+    NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
+    NDPTRSET(m_domain->jp, m_domain->kp, z,z0,z1,z2,z3,z4,z5,z6,z7) ;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(x0,x1,x2,x3,x4,x5,x6,x7, \
+                                       y0,y1,y2,y3,y4,y5,y6,y7, \
+                                       z0,z1,z2,z3,z4,z5,z6,z7, \
+                                       vol) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
+      for (Index_type i = ibegin ; i < iend ; ++i ) {
+        VOL3D_BODY;
+      }
+
+    }
+    stopTimer();
+
+    VOL3D_DATA_TEARDOWN_OMP_TARGET;     
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    VOL3D_DATA_SETUP_OMP_TARGET;
+
+    NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
+    NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
+    NDPTRSET(m_domain->jp, m_domain->kp, z,z0,z1,z2,z3,z4,z5,z6,z7) ;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+
+        VOL3D_BODY;
+      });
+
+    }
+    stopTimer();
+
+    VOL3D_DATA_TEARDOWN_OMP_TARGET;     
+
+  } else {
+    std::cout << "\n  VOL3D : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -77,6 +77,8 @@
 
 #include "AppsData.hpp"
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -13,74 +13,12 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// VOL3D kernel reference implementation:
-///
-/// NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
-/// NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
-/// NDPTRSET(m_domain->jp, m_domain->kp, z,z0,z1,z2,z3,z4,z5,z6,z7) ;
-///
-/// for (Index_type i = ibegin ; i < iend ; ++i ) {
-///   Real_type x71 = x7[i] - x1[i] ; 
-///   Real_type x72 = x7[i] - x2[i] ; 
-///   Real_type x74 = x7[i] - x4[i] ; 
-///   Real_type x30 = x3[i] - x0[i] ; 
-///   Real_type x50 = x5[i] - x0[i] ; 
-///   Real_type x60 = x6[i] - x0[i] ; 
-///  
-///   Real_type y71 = y7[i] - y1[i] ; 
-///   Real_type y72 = y7[i] - y2[i] ; 
-///   Real_type y74 = y7[i] - y4[i] ; 
-///   Real_type y30 = y3[i] - y0[i] ; 
-///   Real_type y50 = y5[i] - y0[i] ; 
-///   Real_type y60 = y6[i] - y0[i] ; 
-///  
-///   Real_type z71 = z7[i] - z1[i] ; 
-///   Real_type z72 = z7[i] - z2[i] ; 
-///   Real_type z74 = z7[i] - z4[i] ; 
-///   Real_type z30 = z3[i] - z0[i] ; 
-///   Real_type z50 = z5[i] - z0[i] ; 
-///   Real_type z60 = z6[i] - z0[i] ; 
-///  
-///   Real_type xps = x71 + x60 ; 
-///   Real_type yps = y71 + y60 ; 
-///   Real_type zps = z71 + z60 ; 
-///  
-///   Real_type cyz = y72 * z30 - z72 * y30 ; 
-///   Real_type czx = z72 * x30 - x72 * z30 ; 
-///   Real_type cxy = x72 * y30 - y72 * x30 ; 
-///   vol[i] = xps * cyz + yps * czx + zps * cxy ; 
-///  
-///   xps = x72 + x50 ; 
-///   yps = y72 + y50 ; 
-///   zps = z72 + z50 ; 
-///  
-///   cyz = y74 * z60 - z74 * y60 ; 
-///   czx = z74 * x60 - x74 * z60 ; 
-///   cxy = x74 * y60 - y74 * x60 ; 
-///   vol[i] += xps * cyz + yps * czx + zps * cxy ; 
-///  
-///   xps = x74 + x30 ; 
-///   yps = y74 + y30 ; 
-///   zps = z74 + z30 ; 
-///  
-///   cyz = y71 * z50 - z71 * y50 ; 
-///   czx = z71 * x50 - x71 * z50 ; 
-///   cxy = x71 * y50 - y71 * x50 ; 
-///   vol[i] += xps * cyz + yps * czx + zps * cxy ; 
-///  
-///   vol[i] *= vnormq ;
-/// }
-///
-
 #include "VOL3D.hpp"
+
+#include "RAJA/RAJA.hpp"
 
 #include "AppsData.hpp"
 #include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
-#include "RAJA/RAJA.hpp"
 
 #include <iostream>
 
@@ -89,7 +27,7 @@ namespace rajaperf
 namespace apps
 {
 
-#define VOL3D_DATA \
+#define VOL3D_DATA_SETUP_CPU \
   Real_ptr x = m_x; \
   Real_ptr y = m_y; \
   Real_ptr z = m_z; \
@@ -100,116 +38,6 @@ namespace apps
   Real_ptr x0,x1,x2,x3,x4,x5,x6,x7 ; \
   Real_ptr y0,y1,y2,y3,y4,y5,y6,y7 ; \
   Real_ptr z0,z1,z2,z3,z4,z5,z6,z7 ;
-
-
-#define VOL3D_BODY \
-  Real_type x71 = x7[i] - x1[i] ; \
-  Real_type x72 = x7[i] - x2[i] ; \
-  Real_type x74 = x7[i] - x4[i] ; \
-  Real_type x30 = x3[i] - x0[i] ; \
-  Real_type x50 = x5[i] - x0[i] ; \
-  Real_type x60 = x6[i] - x0[i] ; \
- \
-  Real_type y71 = y7[i] - y1[i] ; \
-  Real_type y72 = y7[i] - y2[i] ; \
-  Real_type y74 = y7[i] - y4[i] ; \
-  Real_type y30 = y3[i] - y0[i] ; \
-  Real_type y50 = y5[i] - y0[i] ; \
-  Real_type y60 = y6[i] - y0[i] ; \
- \
-  Real_type z71 = z7[i] - z1[i] ; \
-  Real_type z72 = z7[i] - z2[i] ; \
-  Real_type z74 = z7[i] - z4[i] ; \
-  Real_type z30 = z3[i] - z0[i] ; \
-  Real_type z50 = z5[i] - z0[i] ; \
-  Real_type z60 = z6[i] - z0[i] ; \
- \
-  Real_type xps = x71 + x60 ; \
-  Real_type yps = y71 + y60 ; \
-  Real_type zps = z71 + z60 ; \
- \
-  Real_type cyz = y72 * z30 - z72 * y30 ; \
-  Real_type czx = z72 * x30 - x72 * z30 ; \
-  Real_type cxy = x72 * y30 - y72 * x30 ; \
-  vol[i] = xps * cyz + yps * czx + zps * cxy ; \
- \
-  xps = x72 + x50 ; \
-  yps = y72 + y50 ; \
-  zps = z72 + z50 ; \
- \
-  cyz = y74 * z60 - z74 * y60 ; \
-  czx = z74 * x60 - x74 * z60 ; \
-  cxy = x74 * y60 - y74 * x60 ; \
-  vol[i] += xps * cyz + yps * czx + zps * cxy ; \
- \
-  xps = x74 + x30 ; \
-  yps = y74 + y30 ; \
-  zps = z74 + z30 ; \
- \
-  cyz = y71 * z50 - z71 * y50 ; \
-  czx = z71 * x50 - x71 * z50 ; \
-  cxy = x71 * y50 - y71 * x50 ; \
-  vol[i] += xps * cyz + yps * czx + zps * cxy ; \
- \
-  vol[i] *= vnormq ;
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define VOL3D_DATA_SETUP_CUDA \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr z; \
-  Real_ptr vol; \
-\
-  const Real_type vnormq = m_vnormq; \
-\
-  Real_ptr x0,x1,x2,x3,x4,x5,x6,x7 ; \
-  Real_ptr y0,y1,y2,y3,y4,y5,y6,y7 ; \
-  Real_ptr z0,z1,z2,z3,z4,z5,z6,z7 ; \
-\
-  allocAndInitCudaDeviceData(x, m_x, m_array_length); \
-  allocAndInitCudaDeviceData(y, m_y, m_array_length); \
-  allocAndInitCudaDeviceData(z, m_z, m_array_length); \
-  allocAndInitCudaDeviceData(vol, m_vol, m_array_length);
-
-#define VOL3D_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_vol, vol, m_array_length); \
-  deallocCudaDeviceData(x); \
-  deallocCudaDeviceData(y); \
-  deallocCudaDeviceData(z); \
-  deallocCudaDeviceData(vol);
-
-__global__ void vol3d(Real_ptr vol,
-                      const Real_ptr x0, const Real_ptr x1,
-                      const Real_ptr x2, const Real_ptr x3,
-                      const Real_ptr x4, const Real_ptr x5,
-                      const Real_ptr x6, const Real_ptr x7,
-                      const Real_ptr y0, const Real_ptr y1,
-                      const Real_ptr y2, const Real_ptr y3,
-                      const Real_ptr y4, const Real_ptr y5,
-                      const Real_ptr y6, const Real_ptr y7,
-                      const Real_ptr z0, const Real_ptr z1,
-                      const Real_ptr z2, const Real_ptr z3,
-                      const Real_ptr z4, const Real_ptr z5,
-                      const Real_ptr z6, const Real_ptr z7,
-                      const Real_type vnormq,
-                      Index_type ibegin, Index_type iend)
-{
-   Index_type ii = blockIdx.x * blockDim.x + threadIdx.x;
-   Index_type i = ii + ibegin; 
-   if (i < iend) {
-     VOL3D_BODY;
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 VOL3D::VOL3D(const RunParams& params)
@@ -258,7 +86,7 @@ void VOL3D::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      VOL3D_DATA;
+      VOL3D_DATA_SETUP_CPU;
 
       NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
       NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
@@ -279,7 +107,7 @@ void VOL3D::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      VOL3D_DATA;
+      VOL3D_DATA_SETUP_CPU;
 
       NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
       NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
@@ -302,7 +130,7 @@ void VOL3D::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)      
     case Base_OpenMP : {
 
-      VOL3D_DATA;
+      VOL3D_DATA_SETUP_CPU;
 
       NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
       NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
@@ -324,7 +152,7 @@ void VOL3D::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      VOL3D_DATA;
+      VOL3D_DATA_SETUP_CPU;
 
       NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
       NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
@@ -343,130 +171,22 @@ void VOL3D::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      VOL3D_DATA;
-
-      int n = m_array_length;
-      int jp = m_domain->jp;
-      int kp = m_domain->kp;
-
-      #pragma omp target enter data map(to:x[0:n],y[0:n],z[0:n],vnormq,vol[0:n],jp,kp)
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin ; i < iend ; ++i ) {
-          ResReal_ptr x0,x1,x2,x3,x4,x5,x6,x7 ;
-          ResReal_ptr y0,y1,y2,y3,y4,y5,y6,y7 ;
-          ResReal_ptr z0,z1,z2,z3,z4,z5,z6,z7 ;
-          NDPTRSET(jp, kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
-          NDPTRSET(jp, kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
-          NDPTRSET(jp, kp, z,z0,z1,z2,z3,z4,z5,z6,z7) ;
-
-          VOL3D_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete:x[0:n],y[0:n],z[0:n],vnormq,jp,kp) map(from:vol[0:n])
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget : {
-
-      VOL3D_DATA;
-
-      int n = m_array_length;
-      int jp = m_domain->jp;
-      int kp = m_domain->kp;
-
-      #pragma omp target enter data map(to:x[0:n],y[0:n],z[0:n],vnormq,vol[0:n],jp,kp)
-
-      startTimer();
-      #pragma omp target data use_device_ptr( x,y,z, vol )
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          ResReal_ptr x0,x1,x2,x3,x4,x5,x6,x7 ;
-          ResReal_ptr y0,y1,y2,y3,y4,y5,y6,y7 ;
-          ResReal_ptr z0,z1,z2,z3,z4,z5,z6,z7 ;
-          NDPTRSET(jp, kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
-          NDPTRSET(jp, kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
-          NDPTRSET(jp, kp, z,z0,z1,z2,z3,z4,z5,z6,z7) ;
-
-          VOL3D_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete:x[0:n],y[0:n],z[0:n],vnormq,jp,kp) map(from:vol[0:n])
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      VOL3D_DATA_SETUP_CUDA;
-
-      NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
-      NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
-      NDPTRSET(m_domain->jp, m_domain->kp, z,z0,z1,z2,z3,z4,z5,z6,z7) ;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-
-        vol3d<<<grid_size, block_size>>>(vol,
-                                         x0, x1, x2, x3, x4, x5, x6, x7,
-                                         y0, y1, y2, y3, y4, y5, y6, y7,
-                                         z0, z1, z2, z3, z4, z5, z6, z7,
-                                         vnormq,
-                                         ibegin, iend);
-
-      }
-      stopTimer();
-
-      VOL3D_DATA_TEARDOWN_CUDA;
-
-      break;
-    }
-
-    case RAJA_CUDA : {
-
-      VOL3D_DATA_SETUP_CUDA;
-
-      NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
-      NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
-      NDPTRSET(m_domain->jp, m_domain->kp, z,z0,z1,z2,z3,z4,z5,z6,z7) ;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           VOL3D_BODY;
-        });
-
-      }
-      stopTimer();
-
-      VOL3D_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/apps/VOL3D.hpp
+++ b/src/apps/VOL3D.hpp
@@ -13,9 +13,130 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// VOL3D kernel reference implementation:
+///
+/// NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
+/// NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
+/// NDPTRSET(m_domain->jp, m_domain->kp, z,z0,z1,z2,z3,z4,z5,z6,z7) ;
+///
+/// for (Index_type i = ibegin ; i < iend ; ++i ) {
+///   Real_type x71 = x7[i] - x1[i] ;
+///   Real_type x72 = x7[i] - x2[i] ;
+///   Real_type x74 = x7[i] - x4[i] ;
+///   Real_type x30 = x3[i] - x0[i] ;
+///   Real_type x50 = x5[i] - x0[i] ;
+///   Real_type x60 = x6[i] - x0[i] ;
+///
+///   Real_type y71 = y7[i] - y1[i] ;
+///   Real_type y72 = y7[i] - y2[i] ;
+///   Real_type y74 = y7[i] - y4[i] ;
+///   Real_type y30 = y3[i] - y0[i] ;
+///   Real_type y50 = y5[i] - y0[i] ;
+///   Real_type y60 = y6[i] - y0[i] ;
+///
+///   Real_type z71 = z7[i] - z1[i] ;
+///   Real_type z72 = z7[i] - z2[i] ;
+///   Real_type z74 = z7[i] - z4[i] ;
+///   Real_type z30 = z3[i] - z0[i] ;
+///   Real_type z50 = z5[i] - z0[i] ;
+///   Real_type z60 = z6[i] - z0[i] ;
+///
+///   Real_type xps = x71 + x60 ;
+///   Real_type yps = y71 + y60 ;
+///   Real_type zps = z71 + z60 ;
+///
+///   Real_type cyz = y72 * z30 - z72 * y30 ;
+///   Real_type czx = z72 * x30 - x72 * z30 ;
+///   Real_type cxy = x72 * y30 - y72 * x30 ;
+///   vol[i] = xps * cyz + yps * czx + zps * cxy ;
+///
+///   xps = x72 + x50 ;
+///   yps = y72 + y50 ;
+///   zps = z72 + z50 ;
+///
+///   cyz = y74 * z60 - z74 * y60 ;
+///   czx = z74 * x60 - x74 * z60 ;
+///   cxy = x74 * y60 - y74 * x60 ;
+///   vol[i] += xps * cyz + yps * czx + zps * cxy ;
+///
+///   xps = x74 + x30 ;
+///   yps = y74 + y30 ;
+///   zps = z74 + z30 ;
+///
+///   cyz = y71 * z50 - z71 * y50 ;
+///   czx = z71 * x50 - x71 * z50 ;
+///   cxy = x71 * y50 - y71 * x50 ;
+///   vol[i] += xps * cyz + yps * czx + zps * cxy ;
+///
+///   vol[i] *= vnormq ;
+/// }
+///
 
 #ifndef RAJAPerf_Apps_VOL3D_HPP
 #define RAJAPerf_Apps_VOL3D_HPP
+
+
+#define VOL3D_BODY \
+  Real_type x71 = x7[i] - x1[i] ; \
+  Real_type x72 = x7[i] - x2[i] ; \
+  Real_type x74 = x7[i] - x4[i] ; \
+  Real_type x30 = x3[i] - x0[i] ; \
+  Real_type x50 = x5[i] - x0[i] ; \
+  Real_type x60 = x6[i] - x0[i] ; \
+ \
+  Real_type y71 = y7[i] - y1[i] ; \
+  Real_type y72 = y7[i] - y2[i] ; \
+  Real_type y74 = y7[i] - y4[i] ; \
+  Real_type y30 = y3[i] - y0[i] ; \
+  Real_type y50 = y5[i] - y0[i] ; \
+  Real_type y60 = y6[i] - y0[i] ; \
+ \
+  Real_type z71 = z7[i] - z1[i] ; \
+  Real_type z72 = z7[i] - z2[i] ; \
+  Real_type z74 = z7[i] - z4[i] ; \
+  Real_type z30 = z3[i] - z0[i] ; \
+  Real_type z50 = z5[i] - z0[i] ; \
+  Real_type z60 = z6[i] - z0[i] ; \
+ \
+  Real_type xps = x71 + x60 ; \
+  Real_type yps = y71 + y60 ; \
+  Real_type zps = z71 + z60 ; \
+ \
+  Real_type cyz = y72 * z30 - z72 * y30 ; \
+  Real_type czx = z72 * x30 - x72 * z30 ; \
+  Real_type cxy = x72 * y30 - y72 * x30 ; \
+  vol[i] = xps * cyz + yps * czx + zps * cxy ; \
+ \
+  xps = x72 + x50 ; \
+  yps = y72 + y50 ; \
+  zps = z72 + z50 ; \
+ \
+  cyz = y74 * z60 - z74 * y60 ; \
+  czx = z74 * x60 - x74 * z60 ; \
+  cxy = x74 * y60 - y74 * x60 ; \
+  vol[i] += xps * cyz + yps * czx + zps * cxy ; \
+ \
+  xps = x74 + x30 ; \
+  yps = y74 + y30 ; \
+  zps = z74 + z30 ; \
+ \
+  cyz = y74 * z60 - z74 * y60 ; \
+  czx = z74 * x60 - x74 * z60 ; \
+  cxy = x74 * y60 - y74 * x60 ; \
+  vol[i] += xps * cyz + yps * czx + zps * cxy ; \
+ \
+  xps = x74 + x30 ; \
+  yps = y74 + y30 ; \
+  zps = z74 + z30 ; \
+ \
+  cyz = y71 * z50 - z71 * y50 ; \
+  czx = z71 * x50 - x71 * z50 ; \
+  cxy = x71 * y50 - y71 * x50 ; \
+  vol[i] += xps * cyz + yps * czx + zps * cxy ; \
+ \
+  vol[i] *= vnormq ;
+
 
 #include "common/KernelBase.hpp"
 
@@ -41,6 +162,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_x;

--- a/src/apps/WIP-COUPLE.cpp
+++ b/src/apps/WIP-COUPLE.cpp
@@ -13,73 +13,12 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// COUPLE kernel reference implementation:
-///
-/// for (Index_type k = kmin ; k < kmax ; ++k ) {
-///   for (Index_type j = jmin; j < jmax; j++) { 
-///    
-///      Index_type it0=    ((k)*(jmax+1) + (j))*(imax+1) ; 
-///      Index_type idenac= ((k)*(jmax+2) + (j))*(imax+2) ; 
-///    
-///      for (Index_type i = imin; i < imax; i++) { 
-///    
-///         Complex_type c1 = c10 * denac[idenac+i]; 
-///         Complex_type c2 = c20 * denlw[it0+i]; 
-///    
-///         /* promote to doubles to avoid possible divide by zero */ 
-///         Real_type c1re = real(c1);  Real_type c1im = imag(c1); 
-///         Real_type c2re = real(c2);  Real_type c2im = imag(c2); 
-///    
-///         /* lamda = sqrt(|c1|^2 + |c2|^2) uses doubles to avoid underflow. */
-///         Real_type zlam = c1re*c1re + c1im*c1im + 
-///                          c2re*c2re + c2im*c2im + 1.0e-34; 
-///         zlam = sqrt(zlam); 
-///         Real_type snlamt = sin(zlam * dt * 0.5); 
-///         Real_type cslamt = cos(zlam * dt * 0.5); 
-///    
-///         Complex_type a0t = t0[it0+i]; 
-///         Complex_type a1t = t1[it0+i]; 
-///         Complex_type a2t = t2[it0+i] * fratio; 
-///    
-///         Real_type r_zlam= 1.0/zlam; 
-///         c1 *= r_zlam; 
-///         c2 *= r_zlam; 
-///         Real_type zac1 = zabs2(c1); 
-///         Real_type zac2 = zabs2(c2); 
-///    
-///         /* compute new A0 */ 
-///         Complex_type z3 = ( c1 * a1t + c2 * a2t ) * snlamt ; 
-///         t0[it0+i] = a0t * cslamt -  ireal * z3; 
-///    
-///         /* compute new A1  */ 
-///         Real_type r = zac1 * cslamt + zac2; 
-///         Complex_type z5 = c2 * a2t; 
-///         Complex_type z4 = conj(c1) * z5 * (cslamt-1); 
-///         z3 = conj(c1) * a0t * snlamt; 
-///         t1[it0+i] = a1t * r + z4 - ireal * z3; 
-///    
-///         /* compute new A2  */ 
-///         r = zac1 + zac2 * cslamt; 
-///         z5 = c1 * a1t; 
-///         z4 = conj(c2) * z5 * (cslamt-1); 
-///         z3 = conj(c2) * a0t * snlamt; 
-///         t2[it0+i] = ( a2t * r + z4 - ireal * z3 ) * r_fratio; 
-///    
-///      } /* i loop */ 
-///    
-///   } /* j loop */
-/// } /* k loop */
-///
-
 #include "WIP-COUPLE.hpp"
+
+#include "RAJA/RAJA.hpp"
 
 #include "AppsData.hpp"
 #include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
-#include "RAJA/RAJA.hpp"
 
 #include <iostream>
 
@@ -88,7 +27,7 @@ namespace rajaperf
 namespace apps
 {
 
-#define COUPLE_DATA \
+#define COUPLE_DATA_SETUP_CPU \
   ResComplex_ptr t0 = m_t0; \
   ResComplex_ptr t1 = m_t1; \
   ResComplex_ptr t2 = m_t2; \
@@ -107,61 +46,6 @@ namespace apps
   const Index_type jmax = m_jmax; \
   const Index_type kmin = m_kmin; \
   const Index_type kmax = m_kmax;
-
-
-#define COUPLE_BODY \
-for (Index_type j = jmin; j < jmax; j++) { \
- \
-   Index_type it0=    ((k)*(jmax+1) + (j))*(imax+1) ; \
-   Index_type idenac= ((k)*(jmax+2) + (j))*(imax+2) ; \
- \
-   for (Index_type i = imin; i < imax; i++) { \
- \
-      Complex_type c1 = c10 * denac[idenac+i]; \
-      Complex_type c2 = c20 * denlw[it0+i]; \
- \
-      /* promote to doubles to avoid possible divide by zero */ \
-      Real_type c1re = real(c1);  Real_type c1im = imag(c1); \
-      Real_type c2re = real(c2);  Real_type c2im = imag(c2); \
- \
-      /* lamda = sqrt(|c1|^2 + |c2|^2) uses doubles to avoid underflow. */ \
-      Real_type zlam = c1re*c1re + c1im*c1im + \
-                       c2re*c2re + c2im*c2im + 1.0e-34; \
-      zlam = sqrt(zlam); \
-      Real_type snlamt = sin(zlam * dt * 0.5); \
-      Real_type cslamt = cos(zlam * dt * 0.5); \
- \
-      Complex_type a0t = t0[it0+i]; \
-      Complex_type a1t = t1[it0+i]; \
-      Complex_type a2t = t2[it0+i] * fratio; \
- \
-      Real_type r_zlam= 1.0/zlam; \
-      c1 *= r_zlam; \
-      c2 *= r_zlam; \
-      Real_type zac1 = zabs2(c1); \
-      Real_type zac2 = zabs2(c2); \
- \
-      /* compute new A0 */ \
-      Complex_type z3 = ( c1 * a1t + c2 * a2t ) * snlamt ; \
-      t0[it0+i] = a0t * cslamt -  ireal * z3; \
- \
-      /* compute new A1  */ \
-      Real_type r = zac1 * cslamt + zac2; \
-      Complex_type z5 = c2 * a2t; \
-      Complex_type z4 = conj(c1) * z5 * (cslamt-1); \
-      z3 = conj(c1) * a0t * snlamt; \
-      t1[it0+i] = a1t * r + z4 - ireal * z3; \
- \
-      /* compute new A2  */ \
-      r = zac1 + zac2 * cslamt; \
-      z5 = c1 * a1t; \
-      z4 = conj(c2) * z5 * (cslamt-1); \
-      z3 = conj(c2) * a0t * snlamt; \
-      t2[it0+i] = ( a2t * r + z4 - ireal * z3 ) * r_fratio; \
- \
-   } /* i loop */ \
- \
-} /* j loop */
 
 
 COUPLE::COUPLE(const RunParams& params)
@@ -216,15 +100,11 @@ void COUPLE::runKernel(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
-//
-// RDH: Should we use forallN for this kernel???
-//
-
   switch ( vid ) {
 
     case Base_Seq : {
 
-      COUPLE_DATA;
+      COUPLE_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -241,7 +121,7 @@ void COUPLE::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      COUPLE_DATA;
+      COUPLE_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -259,7 +139,7 @@ void COUPLE::runKernel(VariantID vid)
 
 #if defined(RAJA_ENABLE_OPENMP)      
     case Base_OpenMP : {
-      COUPLE_DATA;
+      COUPLE_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -276,7 +156,7 @@ void COUPLE::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      COUPLE_DATA;
+      COUPLE_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -291,46 +171,22 @@ void COUPLE::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP) && 0
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
+#endif
 
-    case RAJA_OpenMPTarget : {
-
-      COUPLE_DATA;
-
-      int n = m_domain->lrn;
-      #pragma omp target enter data map(to:t0[0:n],t1[0:n],t2[0:n],denac[0:n],denlw[0:n], \
-         dt, c10, fratio, r_fratio, c20, ireal, imin, imax, jmin, jmax, kmin, kmax )
-
-      startTimer();
-      #pragma omp target data use_device_ptr(t0,t1,t2,denac,denlw)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(kmin, kmax, [=](int k) {
-          COUPLE_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:t0[0:n],t1[0:n],t2[0:n]) map(delete:denac[0:n],denlw[0:n])
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP
-
-#if defined(RAJA_ENABLE_CUDA)
+#if defined(RAJA_ENABLE_CUDA) && 0
     case Base_CUDA :
-    case RAJA_CUDA : {
-      // Fill these in later...you get the idea...
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/apps/WIP-COUPLE.cpp
+++ b/src/apps/WIP-COUPLE.cpp
@@ -76,6 +76,8 @@
 
 #include "AppsData.hpp"
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/apps/WIP-COUPLE.hpp
+++ b/src/apps/WIP-COUPLE.hpp
@@ -13,12 +13,125 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// COUPLE kernel reference implementation:
+///
+/// for (Index_type k = kmin ; k < kmax ; ++k ) {
+///   for (Index_type j = jmin; j < jmax; j++) {
+///
+///      Index_type it0=    ((k)*(jmax+1) + (j))*(imax+1) ;
+///      Index_type idenac= ((k)*(jmax+2) + (j))*(imax+2) ;
+///
+///      for (Index_type i = imin; i < imax; i++) {
+///
+///         Complex_type c1 = c10 * denac[idenac+i];
+///         Complex_type c2 = c20 * denlw[it0+i];
+///
+///         /* promote to doubles to avoid possible divide by zero */
+///         Real_type c1re = real(c1);  Real_type c1im = imag(c1);
+///         Real_type c2re = real(c2);  Real_type c2im = imag(c2);
+///
+///         /* lamda = sqrt(|c1|^2 + |c2|^2) uses doubles to avoid underflow. */
+///         Real_type zlam = c1re*c1re + c1im*c1im +
+///                          c2re*c2re + c2im*c2im + 1.0e-34;
+///         zlam = sqrt(zlam);
+///         Real_type snlamt = sin(zlam * dt * 0.5);
+///         Real_type cslamt = cos(zlam * dt * 0.5);
+///
+///         Complex_type a0t = t0[it0+i];
+///         Complex_type a1t = t1[it0+i];
+///         Complex_type a2t = t2[it0+i] * fratio;
+///
+///         Real_type r_zlam= 1.0/zlam;
+///         c1 *= r_zlam;
+///         c2 *= r_zlam;
+///         Real_type zac1 = zabs2(c1);
+///         Real_type zac2 = zabs2(c2);
+///
+///         /* compute new A0 */
+///         Complex_type z3 = ( c1 * a1t + c2 * a2t ) * snlamt ;
+///         t0[it0+i] = a0t * cslamt -  ireal * z3;
+///
+///         /* compute new A1  */
+///         Real_type r = zac1 * cslamt + zac2;
+///         Complex_type z5 = c2 * a2t;
+///         Complex_type z4 = conj(c1) * z5 * (cslamt-1);
+///         z3 = conj(c1) * a0t * snlamt;
+///         t1[it0+i] = a1t * r + z4 - ireal * z3;
+///
+///         /* compute new A2  */
+///         r = zac1 + zac2 * cslamt;
+///         z5 = c1 * a1t;
+///         z4 = conj(c2) * z5 * (cslamt-1);
+///         z3 = conj(c2) * a0t * snlamt;
+///         t2[it0+i] = ( a2t * r + z4 - ireal * z3 ) * r_fratio;
+///
+///      } /* i loop */
+///
+///   } /* j loop */
+/// } /* k loop */
+///
 
 #ifndef RAJAPerf_Apps_COUPLE_HPP
 #define RAJAPerf_Apps_COUPLE_HPP
 
-#include "common/KernelBase.hpp"
 
+#define COUPLE_BODY \
+for (Index_type j = jmin; j < jmax; j++) { \
+ \
+   Index_type it0=    ((k)*(jmax+1) + (j))*(imax+1) ; \
+   Index_type idenac= ((k)*(jmax+2) + (j))*(imax+2) ; \
+ \
+   for (Index_type i = imin; i < imax; i++) { \
+ \
+      Complex_type c1 = c10 * denac[idenac+i]; \
+      Complex_type c2 = c20 * denlw[it0+i]; \
+ \
+      /* promote to doubles to avoid possible divide by zero */ \
+      Real_type c1re = real(c1);  Real_type c1im = imag(c1); \
+      Real_type c2re = real(c2);  Real_type c2im = imag(c2); \
+ \
+      /* lamda = sqrt(|c1|^2 + |c2|^2) uses doubles to avoid underflow. */ \
+      Real_type zlam = c1re*c1re + c1im*c1im + \
+                       c2re*c2re + c2im*c2im + 1.0e-34; \
+      zlam = sqrt(zlam); \
+      Real_type snlamt = sin(zlam * dt * 0.5); \
+      Real_type cslamt = cos(zlam * dt * 0.5); \
+ \
+      Complex_type a0t = t0[it0+i]; \
+      Complex_type a1t = t1[it0+i]; \
+      Complex_type a2t = t2[it0+i] * fratio; \
+ \
+      Real_type r_zlam= 1.0/zlam; \
+      c1 *= r_zlam; \
+      c2 *= r_zlam; \
+      Real_type zac1 = zabs2(c1); \
+      Real_type zac2 = zabs2(c2); \
+ \
+      /* compute new A0 */ \
+      Complex_type z3 = ( c1 * a1t + c2 * a2t ) * snlamt ; \
+      t0[it0+i] = a0t * cslamt -  ireal * z3; \
+ \
+      /* compute new A1  */ \
+      Real_type r = zac1 * cslamt + zac2; \
+      Complex_type z5 = c2 * a2t; \
+      Complex_type z4 = conj(c1) * z5 * (cslamt-1); \
+      z3 = conj(c1) * a0t * snlamt; \
+      t1[it0+i] = a1t * r + z4 - ireal * z3; \
+ \
+      /* compute new A2  */ \
+      r = zac1 + zac2 * cslamt; \
+      z5 = c1 * a1t; \
+      z4 = conj(c2) * z5 * (cslamt-1); \
+      z3 = conj(c2) * a0t * snlamt; \
+      t2[it0+i] = ( a2t * r + z4 - ireal * z3 ) * r_fratio; \
+ \
+   } /* i loop */ \
+ \
+} /* j loop */
+
+
+#include "common/KernelBase.hpp"
 
 namespace rajaperf 
 {
@@ -42,6 +155,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Complex_ptr m_t0;

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -22,6 +22,8 @@ blt_add_library(
           IF_QUAD-Cuda.cpp 
           IF_QUAD-OMPTarget.cpp 
           TRAP_INT.cpp 
+          TRAP_INT-Cuda.cpp 
+          TRAP_INT-OMPTarget.cpp 
           INIT3.cpp
           INIT3-Cuda.cpp
           INIT3-OMPTarget.cpp

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -26,6 +26,8 @@ blt_add_library(
           REDUCE3_INT.cpp
           NESTED_INIT.cpp
           INIT_VIEW1D.cpp
+          INIT_VIEW1D-Cuda.cpp
+          INIT_VIEW1D-OMPTarget.cpp
           INIT_VIEW1D_OFFSET.cpp
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -31,6 +31,8 @@ blt_add_library(
           REDUCE3_INT-Cuda.cpp
           REDUCE3_INT-OMPTarget.cpp
           NESTED_INIT.cpp
+          NESTED_INIT-Cuda.cpp
+          NESTED_INIT-OMPTarget.cpp
           INIT_VIEW1D.cpp
           INIT_VIEW1D-Cuda.cpp
           INIT_VIEW1D-OMPTarget.cpp

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -28,6 +28,8 @@ blt_add_library(
           INIT3-Cuda.cpp
           INIT3-OMPTarget.cpp
           REDUCE3_INT.cpp
+          REDUCE3_INT-Cuda.cpp
+          REDUCE3_INT-OMPTarget.cpp
           NESTED_INIT.cpp
           INIT_VIEW1D.cpp
           INIT_VIEW1D-Cuda.cpp

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -15,10 +15,14 @@
 
 blt_add_library(
   NAME basic
-  SOURCES MULADDSUB.cpp 
+  SOURCES MULADDSUB.cpp
+          MULADDSUB-Cuda.cpp 
+          MULADDSUB-OMPTarget.cpp 
           IF_QUAD.cpp 
           TRAP_INT.cpp 
           INIT3.cpp
+          INIT3-Cuda.cpp
+          INIT3-OMPTarget.cpp
           REDUCE3_INT.cpp
           NESTED_INIT.cpp
           INIT_VIEW1D.cpp

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -19,6 +19,8 @@ blt_add_library(
           MULADDSUB-Cuda.cpp 
           MULADDSUB-OMPTarget.cpp 
           IF_QUAD.cpp 
+          IF_QUAD-Cuda.cpp 
+          IF_QUAD-OMPTarget.cpp 
           TRAP_INT.cpp 
           INIT3.cpp
           INIT3-Cuda.cpp

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -29,5 +29,7 @@ blt_add_library(
           INIT_VIEW1D-Cuda.cpp
           INIT_VIEW1D-OMPTarget.cpp
           INIT_VIEW1D_OFFSET.cpp
+          INIT_VIEW1D_OFFSET-Cuda.cpp
+          INIT_VIEW1D_OFFSET-OMPTarget.cpp
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/basic/IF_QUAD-OMPTarget.cpp
+++ b/src/basic/IF_QUAD-OMPTarget.cpp
@@ -1,0 +1,110 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "IF_QUAD.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define IF_QUAD_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr a; \
+  Real_ptr b; \
+  Real_ptr c; \
+  Real_ptr x1; \
+  Real_ptr x2; \
+\
+  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(x1, m_x1, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(x2, m_x2, iend, did, hid);
+
+#define IF_QUAD_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_x1, x1, iend, hid, did); \
+  getOpenMPDeviceData(m_x2, x2, iend, hid, did); \
+  deallocOpenMPDeviceData(a, did); \
+  deallocOpenMPDeviceData(b, did); \
+  deallocOpenMPDeviceData(c, did); \
+  deallocOpenMPDeviceData(x1, did); \
+  deallocOpenMPDeviceData(x2, did);
+
+void IF_QUAD::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    IF_QUAD_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(a, b, c, x1, x2) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        IF_QUAD_BODY;
+      }
+
+    }
+    stopTimer();
+
+    IF_QUAD_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    IF_QUAD_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        IF_QUAD_BODY;
+      });
+
+    }
+    stopTimer();
+
+    IF_QUAD_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  IF_QUAD : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -13,30 +13,13 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-
-///
-/// IF_QUAD kernel reference implementation:
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   Real_type s = b[i]*b[i] - 4.0*a[i]*c[i];
-///   if ( s >= 0 ) {
-///     s = sqrt(s);
-///     x2[i] = (-b[i]+s)/(2.0*a[i]);
-///     x1[i] = (-b[i]-s)/(2.0*a[i]);
-///   } else {
-///     x2[i] = 0.0;
-///     x1[i] = 0.0;
-///   }
-/// }
-///
-
 #include "IF_QUAD.hpp"
+
+#include "RAJA/RAJA.hpp"
 
 #include "common/DataUtils.hpp"
 #include "common/CudaDataUtils.hpp"
 
-
-#include "RAJA/RAJA.hpp"
 
 #include <iostream>
 
@@ -45,66 +28,13 @@ namespace rajaperf
 namespace basic
 {
 
-#define IF_QUAD_DATA \
+
+#define IF_QUAD_DATA_SETUP_CPU \
   ResReal_ptr a = m_a; \
   ResReal_ptr b = m_b; \
   ResReal_ptr c = m_c; \
   ResReal_ptr x1 = m_x1; \
   ResReal_ptr x2 = m_x2;
-
-#define IF_QUAD_BODY  \
-  x1[i] = 0.0; \
-  Real_type s = b[i]*b[i] - 4.0*a[i]*c[i]; \
-  if ( s >= 0 ) { \
-    s = sqrt(s); \
-    x2[i] = (-b[i]+s)/(2.0*a[i]); \
-    x1[i] = (-b[i]-s)/(2.0*a[i]); \
-  } else { \
-    x2[i] = 0.0; \
-    x1[i] = 0.0; \
-  }
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define IF_QUAD_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  Real_ptr b; \
-  Real_ptr c; \
-  Real_ptr x1; \
-  Real_ptr x2; \
-\
-  allocAndInitCudaDeviceData(a, m_a, iend); \
-  allocAndInitCudaDeviceData(b, m_b, iend); \
-  allocAndInitCudaDeviceData(c, m_c, iend); \
-  allocAndInitCudaDeviceData(x1, m_x1, iend); \
-  allocAndInitCudaDeviceData(x2, m_x2, iend);
-
-#define IF_QUAD_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_x1, x1, iend); \
-  getCudaDeviceData(m_x2, x2, iend); \
-  deallocCudaDeviceData(a); \
-  deallocCudaDeviceData(b); \
-  deallocCudaDeviceData(c); \
-  deallocCudaDeviceData(x1); \
-  deallocCudaDeviceData(x2);
-
-__global__ void ifquad(Real_ptr x1, Real_ptr x2,
-                       Real_ptr a, Real_ptr b, Real_ptr c,
-                       Index_type iend)
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     IF_QUAD_BODY;
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 IF_QUAD::IF_QUAD(const RunParams& params)
@@ -137,7 +67,7 @@ void IF_QUAD::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      IF_QUAD_DATA;
+      IF_QUAD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -154,7 +84,7 @@ void IF_QUAD::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      IF_QUAD_DATA;
+      IF_QUAD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -173,7 +103,7 @@ void IF_QUAD::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      IF_QUAD_DATA;
+      IF_QUAD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -191,7 +121,7 @@ void IF_QUAD::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      IF_QUAD_DATA;
+      IF_QUAD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -207,97 +137,22 @@ void IF_QUAD::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      IF_QUAD_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:a[0:n],b[0:n],c[0:n],x1[0:n],x2[0:n])
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          IF_QUAD_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete:a[0:n],b[0:n],c[0:n]) map(from:x1[0:n],x2[0:n])
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget : {
-
-      IF_QUAD_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:a[0:n],b[0:n],c[0:n],x1[0:n],x2[0:n])
-
-      startTimer();
-      #pragma omp target data use_device_ptr(a,b,c,x1,x2)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          IF_QUAD_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete:a[0:n],b[0:n],c[0:n]) map(from:x1[0:n],x2[0:n])
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      IF_QUAD_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         ifquad<<<grid_size, block_size>>>( x1, x2, a, b, c,
-                                            iend );
-
-      }
-      stopTimer();
-
-      IF_QUAD_DATA_TEARDOWN_CUDA;
-
-      break;
-    }
-
-    case RAJA_CUDA : {
-
-      IF_QUAD_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           IF_QUAD_BODY;
-         });
-
-      }
-      stopTimer();
-
-      IF_QUAD_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -33,6 +33,8 @@
 #include "IF_QUAD.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -18,8 +18,6 @@
 #include "RAJA/RAJA.hpp"
 
 #include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
 
 #include <iostream>
 

--- a/src/basic/IF_QUAD.hpp
+++ b/src/basic/IF_QUAD.hpp
@@ -13,11 +13,39 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// IF_QUAD kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   Real_type s = b[i]*b[i] - 4.0*a[i]*c[i];
+///   if ( s >= 0 ) {
+///     s = sqrt(s);
+///     x2[i] = (-b[i]+s)/(2.0*a[i]);
+///     x1[i] = (-b[i]-s)/(2.0*a[i]);
+///   } else {
+///     x2[i] = 0.0;
+///     x1[i] = 0.0;
+///   }
+/// }
+///
 
 #ifndef RAJAPerf_Basic_IF_QUAD_HPP
 #define RAJAPerf_Basic_IF_QUAD_HPP
 
 #include "common/KernelBase.hpp"
+
+
+#define IF_QUAD_BODY  \
+  Real_type s = b[i]*b[i] - 4.0*a[i]*c[i]; \
+  if ( s >= 0 ) { \
+    s = sqrt(s); \
+    x2[i] = (-b[i]+s)/(2.0*a[i]); \
+    x1[i] = (-b[i]-s)/(2.0*a[i]); \
+  } else { \
+    x2[i] = 0.0; \
+    x1[i] = 0.0; \
+  }
+
 
 namespace rajaperf 
 {
@@ -38,6 +66,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_a;

--- a/src/basic/INIT3-Cuda.cpp
+++ b/src/basic/INIT3-Cuda.cpp
@@ -1,0 +1,118 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "INIT3.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define INIT3_DATA_SETUP_CUDA \
+  Real_ptr out1; \
+  Real_ptr out2; \
+  Real_ptr out3; \
+  Real_ptr in1; \
+  Real_ptr in2; \
+\
+  allocAndInitCudaDeviceData(out1, m_out1, iend); \
+  allocAndInitCudaDeviceData(out2, m_out2, iend); \
+  allocAndInitCudaDeviceData(out3, m_out3, iend); \
+  allocAndInitCudaDeviceData(in1, m_in1, iend); \
+  allocAndInitCudaDeviceData(in2, m_in2, iend);
+
+#define INIT3_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_out1, out1, iend); \
+  getCudaDeviceData(m_out2, out2, iend); \
+  getCudaDeviceData(m_out3, out3, iend); \
+  deallocCudaDeviceData(out1); \
+  deallocCudaDeviceData(out2); \
+  deallocCudaDeviceData(out3); \
+  deallocCudaDeviceData(in1); \
+  deallocCudaDeviceData(in2);
+
+__global__ void init3(Real_ptr out1, Real_ptr out2, Real_ptr out3, 
+                      Real_ptr in1, Real_ptr in2, 
+                      Index_type iend) 
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     INIT3_BODY; 
+   }
+}
+
+
+void INIT3::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    INIT3_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      init3<<<grid_size, block_size>>>( out1, out2, out3, in1, in2, 
+                                        iend ); 
+
+    }
+    stopTimer();
+
+    INIT3_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    INIT3_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        INIT3_BODY;
+      });
+
+    }
+    stopTimer();
+
+    INIT3_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  INIT3 : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/basic/INIT3-OMPTarget.cpp
+++ b/src/basic/INIT3-OMPTarget.cpp
@@ -1,0 +1,111 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "INIT3.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+//// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define INIT3_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr out1; \
+  Real_ptr out2; \
+  Real_ptr out3; \
+  Real_ptr in1; \
+  Real_ptr in2; \
+\
+  allocAndInitOpenMPDeviceData(out1, m_out1, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(out2, m_out2, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(out3, m_out3, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(in1, m_in1, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(in2, m_in2, iend, did, hid);
+
+#define INIT3_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_out1, out1, iend, hid, did); \
+  getOpenMPDeviceData(m_out2, out2, iend, hid, did); \
+  getOpenMPDeviceData(m_out3, out3, iend, hid, did); \
+  deallocOpenMPDeviceData(out1, did); \
+  deallocOpenMPDeviceData(out2, did); \
+  deallocOpenMPDeviceData(out3, did); \
+  deallocOpenMPDeviceData(in1, did); \
+  deallocOpenMPDeviceData(in2, did);
+
+
+void INIT3::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    INIT3_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(out1, out2, out3, in1, in2) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        INIT3_BODY;
+      }
+
+    }
+    stopTimer();
+
+    INIT3_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    INIT3_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        INIT3_BODY;
+      });
+
+    }
+    stopTimer();
+
+    INIT3_DATA_TEARDOWN_OMP_TARGET;
+  
+  } else {
+     std::cout << "\n  INIT3 : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/basic/INIT3-OMPTarget.cpp
+++ b/src/basic/INIT3-OMPTarget.cpp
@@ -28,7 +28,8 @@ namespace rajaperf
 namespace basic
 {
 
-//// Define thread block size for target execution
+//
+// Define thread block size for target execution
 //
 #define NUMTEAMS 128
 

--- a/src/basic/INIT3.cpp
+++ b/src/basic/INIT3.cpp
@@ -13,21 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// INIT3 kernel reference implementation:
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   out1[i] = out2[i] = out3[i] = - in1[i] - in2[i] ;
-/// }
-///
-
 #include "INIT3.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 
@@ -36,59 +26,13 @@ namespace rajaperf
 namespace basic
 {
 
-#define INIT3_DATA \
+
+#define INIT3_DATA_SETUP_CPU \
   ResReal_ptr out1 = m_out1; \
   ResReal_ptr out2 = m_out2; \
   ResReal_ptr out3 = m_out3; \
   ResReal_ptr in1 = m_in1; \
   ResReal_ptr in2 = m_in2;
-
-#define INIT3_BODY  \
-  out1[i] = out2[i] = out3[i] = - in1[i] - in2[i] ;
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define INIT3_DATA_SETUP_CUDA \
-  Real_ptr out1; \
-  Real_ptr out2; \
-  Real_ptr out3; \
-  Real_ptr in1; \
-  Real_ptr in2; \
-\
-  allocAndInitCudaDeviceData(out1, m_out1, iend); \
-  allocAndInitCudaDeviceData(out2, m_out2, iend); \
-  allocAndInitCudaDeviceData(out3, m_out3, iend); \
-  allocAndInitCudaDeviceData(in1, m_in1, iend); \
-  allocAndInitCudaDeviceData(in2, m_in2, iend);
-
-#define INIT3_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_out1, out1, iend); \
-  getCudaDeviceData(m_out2, out2, iend); \
-  getCudaDeviceData(m_out3, out3, iend); \
-  deallocCudaDeviceData(out1); \
-  deallocCudaDeviceData(out2); \
-  deallocCudaDeviceData(out3); \
-  deallocCudaDeviceData(in1); \
-  deallocCudaDeviceData(in2);
-
-__global__ void init3(Real_ptr out1, Real_ptr out2, Real_ptr out3, 
-                      Real_ptr in1, Real_ptr in2, 
-                      Index_type iend) 
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     INIT3_BODY; 
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 INIT3::INIT3(const RunParams& params)
@@ -121,7 +65,7 @@ void INIT3::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      INIT3_DATA;
+      INIT3_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -138,7 +82,7 @@ void INIT3::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      INIT3_DATA;
+      INIT3_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -157,7 +101,7 @@ void INIT3::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      INIT3_DATA;
+      INIT3_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -175,7 +119,7 @@ void INIT3::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      INIT3_DATA;
+      INIT3_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -190,97 +134,22 @@ void INIT3::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      INIT3_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:in1[0:n],in2[0:n],out1[0:n],out2[0:n],out3[0:n])
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          INIT3_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete:in1[0:n],in2[0:n]) map(from:out1[0:n],out2[0:n],out3[0:n])
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget : {
-
-      INIT3_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:in1[0:n],in2[0:n],out1[0:n],out2[0:n],out3[0:n])
-
-      startTimer();
-      #pragma omp target data use_device_ptr(in1,in2,out1,out2,out3)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          INIT3_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete:in1[0:n],in2[0:n]) map(from:out1[0:n],out2[0:n],out3[0:n])
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      INIT3_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         init3<<<grid_size, block_size>>>( out1, out2, out3, in1, in2, 
-                                           iend ); 
-
-      }
-      stopTimer();
-
-      INIT3_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      INIT3_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           INIT3_BODY;
-         });
-
-      }
-      stopTimer();
-
-      INIT3_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/basic/INIT3.cpp
+++ b/src/basic/INIT3.cpp
@@ -24,6 +24,8 @@
 #include "INIT3.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/basic/INIT3.hpp
+++ b/src/basic/INIT3.hpp
@@ -13,9 +13,21 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// INIT3 kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   out1[i] = out2[i] = out3[i] = - in1[i] - in2[i] ;
+/// }
+///
 
 #ifndef RAJAPerf_Basic_INIT3_HPP
 #define RAJAPerf_Basic_INIT3_HPP
+
+
+#define INIT3_BODY  \
+  out1[i] = out2[i] = out3[i] = - in1[i] - in2[i] ;
+
 
 #include "common/KernelBase.hpp"
 
@@ -38,6 +50,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_out1;

--- a/src/basic/INIT_VIEW1D-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D-Cuda.cpp
@@ -1,0 +1,116 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "INIT_VIEW1D.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define INIT_VIEW1D_DATA_SETUP_CUDA \
+  Real_ptr a; \
+  const Real_type v = m_val; \
+\
+  allocAndInitCudaDeviceData(a, m_a, iend);
+
+#define INIT_VIEW1D_DATA_RAJA_SETUP_CUDA \
+  Real_ptr a; \
+  const Real_type v = m_val; \
+\
+  allocAndInitCudaDeviceData(a, m_a, iend); \
+\
+  using ViewType = RAJA::View<Real_type, RAJA::Layout<1> >; \
+  const RAJA::Layout<1> my_layout(iend); \
+  ViewType view(a, my_layout);
+
+#define INIT_VIEW1D_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_a, a, iend); \
+  deallocCudaDeviceData(a);
+
+__global__ void initview1d(Real_ptr a, 
+                           Real_type v,
+                           const Index_type iend) 
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     INIT_VIEW1D_BODY; 
+   }
+}
+
+
+void INIT_VIEW1D::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    INIT_VIEW1D_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       initview1d<<<grid_size, block_size>>>( a,
+                                              v, 
+                                              iend ); 
+
+    }
+    stopTimer();
+
+    INIT_VIEW1D_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    INIT_VIEW1D_DATA_RAJA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+      RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        INIT_VIEW1D_BODY_RAJA;
+      });
+
+    }
+    stopTimer();
+
+    INIT_VIEW1D_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  INIT_VIEW1D : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/basic/INIT_VIEW1D-OMPTarget.cpp
+++ b/src/basic/INIT_VIEW1D-OMPTarget.cpp
@@ -1,0 +1,111 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "INIT_VIEW1D.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+//// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define INIT_VIEW1D_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr a; \
+  const Real_type v = m_val; \
+\
+  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid);
+
+#define INIT_VIEW1D_DATA_SETUP_RAJA_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr a; \
+  const Real_type v = m_val; \
+\
+  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
+\
+  using ViewType = RAJA::View<Real_type, RAJA::Layout<1> >; \
+  const RAJA::Layout<1> my_layout(iend); \
+  ViewType view(a, my_layout);
+
+#define INIT_VIEW1D_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_a, a, iend, hid, did); \
+  deallocOpenMPDeviceData(a, did);
+
+
+void INIT_VIEW1D::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    INIT_VIEW1D_DATA_SETUP_OMP_TARGET;                 
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(a) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        INIT_VIEW1D_BODY;
+      }
+
+    }
+    stopTimer();
+
+    INIT_VIEW1D_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+     INIT_VIEW1D_DATA_SETUP_RAJA_OMP_TARGET
+
+     startTimer();
+     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+         RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+         INIT_VIEW1D_BODY_RAJA;
+       });
+
+     }
+     stopTimer();
+
+     INIT_VIEW1D_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  INIT_VIEW1D : Unknown OMP Targetvariant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/basic/INIT_VIEW1D-OMPTarget.cpp
+++ b/src/basic/INIT_VIEW1D-OMPTarget.cpp
@@ -28,7 +28,8 @@ namespace rajaperf
 namespace basic
 {
 
-//// Define thread block size for target execution
+//
+// Define thread block size for target execution
 //
 #define NUMTEAMS 128
 

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -13,92 +13,31 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// INIT_VIEW1D kernel reference implementation:
-///
-/// const Real_type val = ...;
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   a[i] = val;
-/// }
-///
-/// RAJA variants use a "view" and "layout" to do the same thing
-/// where the loop runs over the same range.
-///
-
 #include "INIT_VIEW1D.hpp"
-
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
 
 #include "RAJA/RAJA.hpp"
 
+#include "common/DataUtils.hpp"
+
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
 
-#define INIT_VIEW1D_DATA \
+
+#define INIT_VIEW1D_DATA_SETUP_CPU \
   Real_ptr a = m_a; \
   const Real_type v = m_val;
 
-#define INIT_VIEW1D_DATA_RAJA \
+#define INIT_VIEW1D_DATA_RAJA_SETUP_CPU \
   Real_ptr a = m_a; \
   const Real_type v = m_val; \
 \
+  using ViewType = RAJA::View<Real_type, RAJA::Layout<1> >; \
   const RAJA::Layout<1> my_layout(iend); \
   ViewType view(a, my_layout);
-
-
-#define INIT_VIEW1D_BODY  \
-  a[i] = v;
-
-#define INIT_VIEW1D_BODY_RAJA  \
-  view(i) = v;
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define INIT_VIEW1D_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  const Real_type v = m_val; \
-\
-  allocAndInitCudaDeviceData(a, m_a, iend);
-
-#define INIT_VIEW1D_DATA_SETUP_CUDA_RAJA \
-  Real_ptr a; \
-  const Real_type v = m_val; \
-\
-  allocAndInitCudaDeviceData(a, m_a, iend); \
-\
-  const RAJA::Layout<1> my_layout(iend); \
-  ViewType view(a, my_layout);
-
-
-#define INIT_VIEW1D_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_a, a, iend); \
-  deallocCudaDeviceData(a);
-
-__global__ void initview1d(Real_ptr a, 
-                           Real_type v,
-                           const Index_type iend) 
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     INIT_VIEW1D_BODY; 
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 INIT_VIEW1D::INIT_VIEW1D(const RunParams& params)
@@ -124,13 +63,11 @@ void INIT_VIEW1D::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  using ViewType = RAJA::View<Real_type, RAJA::Layout<1> >;
-
   switch ( vid ) {
 
     case Base_Seq : {
 
-      INIT_VIEW1D_DATA;
+      INIT_VIEW1D_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -147,7 +84,7 @@ void INIT_VIEW1D::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      INIT_VIEW1D_DATA_RAJA;
+      INIT_VIEW1D_DATA_RAJA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -166,7 +103,7 @@ void INIT_VIEW1D::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      INIT_VIEW1D_DATA;
+      INIT_VIEW1D_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -184,7 +121,7 @@ void INIT_VIEW1D::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      INIT_VIEW1D_DATA_RAJA;
+      INIT_VIEW1D_DATA_RAJA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -199,98 +136,22 @@ void INIT_VIEW1D::runKernel(VariantID vid)
 
       break;
     }
-
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      INIT_VIEW1D_DATA                 
-
-      #pragma omp target enter data map(to:a[0:iend],v)
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          INIT_VIEW1D_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:a[0:iend]) map(delete:v)
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget : {
-
-#if 0 
-      INIT_VIEW1D_DATA_RAJA                 
-      #pragma omp target enter data map(to:a[0:iend],v)
-
-      startTimer();
-      #pragma omp target data use_device_ptr(a)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          INIT_VIEW1D_BODY_RAJA;;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:a[0:iend]) map(delete:v)
-#endif // still need to figure out how layout and view will work under RAJA omp-target
-
-      break;
-    }
-
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      INIT_VIEW1D_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         initview1d<<<grid_size, block_size>>>( a,
-                                                v, 
-                                                iend ); 
-
-      }
-      stopTimer();
-
-      INIT_VIEW1D_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      INIT_VIEW1D_DATA_SETUP_CUDA_RAJA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           INIT_VIEW1D_BODY_RAJA;
-         });
-
-      }
-      stopTimer();
-
-      INIT_VIEW1D_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -29,6 +29,8 @@
 #include "INIT_VIEW1D.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/basic/INIT_VIEW1D.hpp
+++ b/src/basic/INIT_VIEW1D.hpp
@@ -22,8 +22,9 @@
 ///   a[i] = val;
 /// }
 ///
-/// RAJA variants use a "view" and "layout" to do the same thing
-/// where the loop runs over the same range.
+/// RAJA variants use a "View" and "Layout" to do the same thing. These 
+/// RAJA constructs provide little benfit in 1D, but they are used here
+/// to exercise those RAJA mechanics in the simplest scenario.
 ///
 
 #ifndef RAJAPerf_Basic_INIT_VIEW1D_HPP

--- a/src/basic/INIT_VIEW1D.hpp
+++ b/src/basic/INIT_VIEW1D.hpp
@@ -13,9 +13,29 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// INIT_VIEW1D kernel reference implementation:
+///
+/// const Real_type val = ...;
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   a[i] = val;
+/// }
+///
+/// RAJA variants use a "view" and "layout" to do the same thing
+/// where the loop runs over the same range.
+///
 
 #ifndef RAJAPerf_Basic_INIT_VIEW1D_HPP
 #define RAJAPerf_Basic_INIT_VIEW1D_HPP
+
+
+#define INIT_VIEW1D_BODY  \
+  a[i] = v;
+
+#define INIT_VIEW1D_BODY_RAJA  \
+  view(i) = v;
+
 
 #include "common/KernelBase.hpp"
 
@@ -38,6 +58,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_a;

--- a/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
@@ -13,7 +13,7 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "INIT_VIEW1D.hpp"
+#include "INIT_VIEW1D_OFFSET.hpp"
 
 #include "RAJA/RAJA.hpp"
 
@@ -22,8 +22,9 @@
 #include "common/CudaDataUtils.hpp"
 
 #include <iostream>
+#include <iostream>
 
-namespace rajaperf
+namespace rajaperf 
 {
 namespace basic
 {
@@ -34,79 +35,79 @@ namespace basic
   const size_t block_size = 256;
 
 
-#define INIT_VIEW1D_DATA_SETUP_CUDA \
+#define INIT_VIEW1D_OFFSET_DATA_SETUP_CUDA \
   Real_ptr a; \
   const Real_type v = m_val; \
 \
   allocAndInitCudaDeviceData(a, m_a, iend);
 
-#define INIT_VIEW1D_DATA_RAJA_SETUP_CUDA \
+#define INIT_VIEW1D_OFFSET_DATA_RAJA_SETUP_CUDA \
   Real_ptr a; \
   const Real_type v = m_val; \
 \
   allocAndInitCudaDeviceData(a, m_a, iend); \
 \
-  using ViewType = RAJA::View<Real_type, RAJA::Layout<1> >; \
-  const RAJA::Layout<1> my_layout(iend); \
-  ViewType view(a, my_layout);
+  using ViewType = RAJA::View<Real_type, RAJA::OffsetLayout<1> >; \
+  ViewType view(a, RAJA::make_offset_layout<1>({{1}}, {{iend+1}}));
 
-#define INIT_VIEW1D_DATA_TEARDOWN_CUDA \
+#define INIT_VIEW1D_OFFSET_DATA_TEARDOWN_CUDA \
   getCudaDeviceData(m_a, a, iend); \
   deallocCudaDeviceData(a);
 
-__global__ void initview1d(Real_ptr a, 
-                           Real_type v,
-                           const Index_type iend) 
+__global__ void initview1d_offset(Real_ptr a, 
+                                  Real_type v,
+                                  const Index_type ibegin,
+                                  const Index_type iend) 
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i < iend) {
-     INIT_VIEW1D_BODY; 
+     INIT_VIEW1D_OFFSET_BODY; 
    }
 }
 
 
-void INIT_VIEW1D::runCudaVariant(VariantID vid)
+void INIT_VIEW1D_OFFSET::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type ibegin = 1;
+  const Index_type iend = getRunSize()+1;
 
   if ( vid == Base_CUDA ) {
 
-    INIT_VIEW1D_DATA_SETUP_CUDA;
+    INIT_VIEW1D_OFFSET_DATA_SETUP_CUDA;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       initview1d<<<grid_size, block_size>>>( a,
-                                              v, 
-                                              iend ); 
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      initview1d_offset<<<grid_size, block_size>>>( a, v,
+                                                    ibegin,
+                                                    iend ); 
 
     }
     stopTimer();
 
-    INIT_VIEW1D_DATA_TEARDOWN_CUDA;
+    INIT_VIEW1D_OFFSET_DATA_TEARDOWN_CUDA;
 
   } else if ( vid == RAJA_CUDA ) {
 
-    INIT_VIEW1D_DATA_RAJA_SETUP_CUDA;
+    INIT_VIEW1D_OFFSET_DATA_RAJA_SETUP_CUDA;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-        INIT_VIEW1D_BODY_RAJA;
+        INIT_VIEW1D_OFFSET_BODY_RAJA;
       });
 
     }
     stopTimer();
 
-    INIT_VIEW1D_DATA_TEARDOWN_CUDA;
+    INIT_VIEW1D_OFFSET_DATA_TEARDOWN_CUDA;
 
   } else {
-     std::cout << "\n  INIT_VIEW1D : Unknown Cuda variant id = " << vid << std::endl;
+     std::cout << "\n  INIT_VIEW1D_OFFSET : Unknown Cuda variant id = " << vid << std::endl;
   }
 }
 

--- a/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
@@ -22,7 +22,6 @@
 #include "common/CudaDataUtils.hpp"
 
 #include <iostream>
-#include <iostream>
 
 namespace rajaperf 
 {

--- a/src/basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
@@ -28,7 +28,8 @@ namespace rajaperf
 namespace basic
 {
 
-//// Define thread block size for target execution
+//
+// Define thread block size for target execution
 //
 #define NUMTEAMS 128
 

--- a/src/basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
@@ -1,0 +1,111 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "INIT_VIEW1D_OFFSET.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+//// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define INIT_VIEW1D_OFFSET_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr a; \
+  const Real_type v = m_val; \
+\
+  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid);
+
+#define INIT_VIEW1D_OFFSET_DATA_SETUP_RAJA_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr a; \
+  const Real_type v = m_val; \
+\
+  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
+\
+  using ViewType = RAJA::View<Real_type, RAJA::OffsetLayout<1> >; \
+  ViewType view(a, RAJA::make_offset_layout<1>({{1}}, {{iend+1}}));
+
+#define INIT_VIEW1D_OFFSET_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_a, a, iend, hid, did); \
+  deallocOpenMPDeviceData(a, did);
+
+
+void INIT_VIEW1D_OFFSET::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 1;
+  const Index_type iend = getRunSize()+1;
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    INIT_VIEW1D_OFFSET_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(a) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        INIT_VIEW1D_OFFSET_BODY;
+      }
+
+    }
+    stopTimer();
+
+    INIT_VIEW1D_OFFSET_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+     INIT_VIEW1D_OFFSET_DATA_SETUP_RAJA_OMP_TARGET
+
+     startTimer();
+     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+         RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+         INIT_VIEW1D_OFFSET_BODY_RAJA;
+       });
+
+     }
+     stopTimer();
+
+     INIT_VIEW1D_OFFSET_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  INIT_VIEW1D_OFFSET : Unknown OMP Targetvariant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP
+

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -29,6 +29,8 @@
 #include "INIT_VIEW1D_OFFSET.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -13,26 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// INIT_VIEW1D_OFFSET kernel reference implementation:
-///
-/// const Real_type val = ...;
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   a[i-ibegin] = val;
-/// }
-///
-/// RAJA variants use a "view" and an "offset layout" to do the same thing
-/// where the loop runs over the same index range.
-///
-
 #include "INIT_VIEW1D_OFFSET.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 
@@ -41,63 +26,15 @@ namespace rajaperf
 namespace basic
 {
 
-#define INIT_VIEW1D_OFFSET_DATA \
+#define INIT_VIEW1D_OFFSET_DATA_SETUP_CPU \
   Real_ptr a = m_a; \
   const Real_type v = m_val;
 
-#define INIT_VIEW1D_OFFSET_DATA_RAJA \
+#define INIT_VIEW1D_OFFSET_DATA_RAJA_SETUP_CPU \
   Real_ptr a = m_a; \
   const Real_type v = m_val; \
 \
   ViewType view(a, RAJA::make_offset_layout<1>({{1}}, {{iend+1}}));
-
-
-#define INIT_VIEW1D_OFFSET_BODY  \
-  a[i-ibegin] = v;
-
-#define INIT_VIEW1D_OFFSET_BODY_RAJA  \
-  view(i) = v;
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define INIT_VIEW1D_OFFSET_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  const Real_type v = m_val; \
-\
-  allocAndInitCudaDeviceData(a, m_a, iend);
-
-#define INIT_VIEW1D_OFFSET_DATA_SETUP_CUDA_RAJA \
-  Real_ptr a; \
-  const Real_type v = m_val; \
-\
-  allocAndInitCudaDeviceData(a, m_a, iend); \
-\
-  ViewType view(a, RAJA::make_offset_layout<1>({{1}}, {{iend+1}}));
-
-
-#define INIT_VIEW1D_OFFSET_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_a, a, iend); \
-  deallocCudaDeviceData(a);
-
-__global__ void initview1d(Real_ptr a, 
-                           Real_type v,
-                           const Index_type ibegin,
-                           const Index_type iend) 
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     INIT_VIEW1D_OFFSET_BODY; 
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 INIT_VIEW1D_OFFSET::INIT_VIEW1D_OFFSET(const RunParams& params)
@@ -129,7 +66,7 @@ void INIT_VIEW1D_OFFSET::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      INIT_VIEW1D_OFFSET_DATA;
+      INIT_VIEW1D_OFFSET_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -146,7 +83,7 @@ void INIT_VIEW1D_OFFSET::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      INIT_VIEW1D_OFFSET_DATA_RAJA;
+      INIT_VIEW1D_OFFSET_DATA_RAJA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -165,7 +102,7 @@ void INIT_VIEW1D_OFFSET::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      INIT_VIEW1D_OFFSET_DATA;
+      INIT_VIEW1D_OFFSET_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -183,7 +120,7 @@ void INIT_VIEW1D_OFFSET::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      INIT_VIEW1D_OFFSET_DATA_RAJA;
+      INIT_VIEW1D_OFFSET_DATA_RAJA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -198,100 +135,22 @@ void INIT_VIEW1D_OFFSET::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      INIT_VIEW1D_OFFSET_DATA                 
-
-      #pragma omp target enter data map(to:a[0:iend],v)
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          INIT_VIEW1D_OFFSET_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:a[0:iend]) map(delete:v)
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget : {
-
-#if 0
-      INIT_VIEW1D_DATA_RAJA                 
-
-      #pragma omp target enter data map(to:a[0:iend],v)
-
-      startTimer();
-      #pragma omp target data use_device_ptr(a)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          INIT_VIEW1D_BODY_RAJA;;
-        });
-
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:a[0:iend]) map(delete:v)
-#endif // still need to figure out how layout and view will work under RAJA omp-target
-
-      break;
-    }
-
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
-
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      INIT_VIEW1D_OFFSET_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         initview1d<<<grid_size, block_size>>>( a, v,
-                                                ibegin,
-                                                iend ); 
-
-      }
-      stopTimer();
-
-      INIT_VIEW1D_OFFSET_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      INIT_VIEW1D_OFFSET_DATA_SETUP_CUDA_RAJA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           INIT_VIEW1D_OFFSET_BODY_RAJA;
-         });
-
-      }
-      stopTimer();
-
-      INIT_VIEW1D_OFFSET_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/basic/INIT_VIEW1D_OFFSET.hpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.hpp
@@ -13,9 +13,30 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// INIT_VIEW1D_OFFSET kernel reference implementation:
+///
+/// const Real_type val = ...;
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   a[i-ibegin] = val;
+/// }
+///
+/// RAJA variants use a "View" and "Layout" to do the same thing. These 
+/// RAJA constructs provide little benfit in 1D, but they are used here
+/// to exercise those RAJA mechanics in the simplest scenario.
+///
 
 #ifndef RAJAPerf_Basic_INIT_VIEW1D_OFFSET_HPP
 #define RAJAPerf_Basic_INIT_VIEW1D_OFFSET_HPP
+
+
+#define INIT_VIEW1D_OFFSET_BODY  \
+  a[i-ibegin] = v;
+
+#define INIT_VIEW1D_OFFSET_BODY_RAJA  \
+  view(i) = v;
+
 
 #include "common/KernelBase.hpp"
 
@@ -38,6 +59,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_a;

--- a/src/basic/MULADDSUB-Cuda.cpp
+++ b/src/basic/MULADDSUB-Cuda.cpp
@@ -1,0 +1,118 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MULADDSUB.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define MULADDSUB_DATA_SETUP_CUDA \
+  Real_ptr out1; \
+  Real_ptr out2; \
+  Real_ptr out3; \
+  Real_ptr in1; \
+  Real_ptr in2; \
+\
+  allocAndInitCudaDeviceData(out1, m_out1, iend); \
+  allocAndInitCudaDeviceData(out2, m_out2, iend); \
+  allocAndInitCudaDeviceData(out3, m_out3, iend); \
+  allocAndInitCudaDeviceData(in1, m_in1, iend); \
+  allocAndInitCudaDeviceData(in2, m_in2, iend);
+
+#define MULADDSUB_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_out1, out1, iend); \
+  getCudaDeviceData(m_out2, out2, iend); \
+  getCudaDeviceData(m_out3, out3, iend); \
+  deallocCudaDeviceData(out1); \
+  deallocCudaDeviceData(out2); \
+  deallocCudaDeviceData(out3); \
+  deallocCudaDeviceData(in1); \
+  deallocCudaDeviceData(in2);
+
+__global__ void muladdsub(Real_ptr out1, Real_ptr out2, Real_ptr out3, 
+                          Real_ptr in1, Real_ptr in2, 
+                          Index_type iend) 
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     MULADDSUB_BODY; 
+   }
+}
+
+
+void MULADDSUB::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    MULADDSUB_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       muladdsub<<<grid_size, block_size>>>( out1, out2, out3, in1, in2, 
+                                             iend ); 
+
+    }
+    stopTimer();
+
+    MULADDSUB_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    MULADDSUB_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         MULADDSUB_BODY;
+       });
+
+    }
+    stopTimer();
+
+    MULADDSUB_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  MULADDSUB : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/basic/MULADDSUB-OMPTarget.cpp
+++ b/src/basic/MULADDSUB-OMPTarget.cpp
@@ -28,7 +28,8 @@ namespace rajaperf
 namespace basic
 {
 
-//// Define thread block size for target execution
+//
+// Define thread block size for target execution
 //
 #define NUMTEAMS 128
 

--- a/src/basic/MULADDSUB-OMPTarget.cpp
+++ b/src/basic/MULADDSUB-OMPTarget.cpp
@@ -1,0 +1,111 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MULADDSUB.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+//// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define MULADDSUB_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr out1; \
+  Real_ptr out2; \
+  Real_ptr out3; \
+  Real_ptr in1; \
+  Real_ptr in2; \
+\
+  allocAndInitOpenMPDeviceData(out1, m_out1, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(out2, m_out2, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(out3, m_out3, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(in1, m_in1, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(in2, m_in2, iend, did, hid);
+
+#define MULADDSUB_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_out1, out1, iend, hid, did); \
+  getOpenMPDeviceData(m_out2, out2, iend, hid, did); \
+  getOpenMPDeviceData(m_out3, out3, iend, hid, did); \
+  deallocOpenMPDeviceData(out1, did); \
+  deallocOpenMPDeviceData(out2, did); \
+  deallocOpenMPDeviceData(out3, did); \
+  deallocOpenMPDeviceData(in1, did); \
+  deallocOpenMPDeviceData(in2, did);
+
+
+void MULADDSUB::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    MULADDSUB_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(out1, out2, out3, in1, in2) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        MULADDSUB_BODY;
+      }
+
+    }
+    stopTimer();
+
+    MULADDSUB_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    MULADDSUB_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        MULADDSUB_BODY;
+      });
+
+    }
+    stopTimer();
+
+    MULADDSUB_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  MULADDSUB : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/basic/MULADDSUB.cpp
+++ b/src/basic/MULADDSUB.cpp
@@ -13,23 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// MULADDSUB kernel reference implementation:
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   out1[i] = in1[i] * in2[i] ;
-///   out2[i] = in1[i] + in2[i] ;
-///   out3[i] = in1[i] - in2[i] ;
-/// }
-///
-
 #include "MULADDSUB.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 
@@ -38,61 +26,13 @@ namespace rajaperf
 namespace basic
 {
 
-#define MULADDSUB_DATA \
+
+#define MULADDSUB_DATA_SETUP_CPU \
   ResReal_ptr out1 = m_out1; \
   ResReal_ptr out2 = m_out2; \
   ResReal_ptr out3 = m_out3; \
   ResReal_ptr in1 = m_in1; \
   ResReal_ptr in2 = m_in2;
-
-#define MULADDSUB_BODY  \
-  out1[i] = in1[i] * in2[i] ; \
-  out2[i] = in1[i] + in2[i] ; \
-  out3[i] = in1[i] - in2[i] ;
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define MULADDSUB_DATA_SETUP_CUDA \
-  Real_ptr out1; \
-  Real_ptr out2; \
-  Real_ptr out3; \
-  Real_ptr in1; \
-  Real_ptr in2; \
-\
-  allocAndInitCudaDeviceData(out1, m_out1, iend); \
-  allocAndInitCudaDeviceData(out2, m_out2, iend); \
-  allocAndInitCudaDeviceData(out3, m_out3, iend); \
-  allocAndInitCudaDeviceData(in1, m_in1, iend); \
-  allocAndInitCudaDeviceData(in2, m_in2, iend);
-
-#define MULADDSUB_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_out1, out1, iend); \
-  getCudaDeviceData(m_out2, out2, iend); \
-  getCudaDeviceData(m_out3, out3, iend); \
-  deallocCudaDeviceData(out1); \
-  deallocCudaDeviceData(out2); \
-  deallocCudaDeviceData(out3); \
-  deallocCudaDeviceData(in1); \
-  deallocCudaDeviceData(in2);
-
-__global__ void muladdsub(Real_ptr out1, Real_ptr out2, Real_ptr out3, 
-                          Real_ptr in1, Real_ptr in2, 
-                          Index_type iend) 
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     MULADDSUB_BODY; 
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 MULADDSUB::MULADDSUB(const RunParams& params)
@@ -125,7 +65,7 @@ void MULADDSUB::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      MULADDSUB_DATA;
+      MULADDSUB_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -142,7 +82,7 @@ void MULADDSUB::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      MULADDSUB_DATA;
+      MULADDSUB_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -161,7 +101,7 @@ void MULADDSUB::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      MULADDSUB_DATA;
+      MULADDSUB_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -179,7 +119,7 @@ void MULADDSUB::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      MULADDSUB_DATA;
+      MULADDSUB_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -194,101 +134,25 @@ void MULADDSUB::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      MULADDSUB_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:in1[0:n],in2[0:n],out1[0:n],out2[0:n],out3[0:n])
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          MULADDSUB_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete:in1[0:n],in2[0:n]) map(from:out1[0:n],out2[0:n],out3[0:n])
-
-      break;
-    }
-
-    case RAJA_OpenMPTarget : {
-
-      MULADDSUB_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:in1[0:n],in2[0:n],out1[0:n],out2[0:n],out3[0:n])
-
-      startTimer();
-      #pragma omp target data use_device_ptr(in1,in2,out1,out2,out3)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          MULADDSUB_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete:in1[0:n],in2[0:n]) map(from:out1[0:n],out2[0:n],out3[0:n])
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP
-
-#if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      MULADDSUB_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         muladdsub<<<grid_size, block_size>>>( out1, out2, out3, in1, in2, 
-                                               iend ); 
-
-      }
-      stopTimer();
-
-      MULADDSUB_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      MULADDSUB_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           MULADDSUB_BODY;
-         });
-
-      }
-      stopTimer();
-
-      MULADDSUB_DATA_TEARDOWN_CUDA;
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
 #endif
 
+#if defined(RAJA_ENABLE_CUDA)
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
+      break;
+    }
+#endif
 
     default : {
       std::cout << "\n  MULADDSUB : Unknown variant id = " << vid << std::endl;

--- a/src/basic/MULADDSUB.cpp
+++ b/src/basic/MULADDSUB.cpp
@@ -26,6 +26,8 @@
 #include "MULADDSUB.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/basic/MULADDSUB.hpp
+++ b/src/basic/MULADDSUB.hpp
@@ -13,9 +13,25 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// MULADDSUB kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   out1[i] = in1[i] * in2[i] ;
+///   out2[i] = in1[i] + in2[i] ;
+///   out3[i] = in1[i] - in2[i] ;
+/// }
+///
 
 #ifndef RAJAPerf_Basic_MULADDSUB_HPP
 #define RAJAPerf_Basic_MULADDSUB_HPP
+
+
+#define MULADDSUB_BODY  \
+  out1[i] = in1[i] * in2[i] ; \
+  out2[i] = in1[i] + in2[i] ; \
+  out3[i] = in1[i] - in2[i] ;
+
 
 #include "common/KernelBase.hpp"
 
@@ -38,6 +54,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_out1;

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -30,9 +30,9 @@ namespace basic
 
 #define NESTED_INIT_DATA_SETUP_CUDA \
   Real_ptr array; \
-  Int_type ni = m_ni; \
-  Int_type nj = m_nj; \
-  Int_type nk = m_nk; \
+  Index_type ni = m_ni; \
+  Index_type nj = m_nj; \
+  Index_type nk = m_nk; \
 \
   allocAndInitCudaDeviceData(array, m_array, m_array_length);
 
@@ -41,7 +41,7 @@ namespace basic
   deallocCudaDeviceData(array);
 
 __global__ void nested_init(Real_ptr array,
-                            Int_type ni, Int_type nj)
+                            Index_type ni, Index_type nj)
 {
    Index_type i = threadIdx.x;
    Index_type j = blockIdx.y;

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -1,0 +1,139 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "NESTED_INIT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+#define NESTED_INIT_DATA_SETUP_CUDA \
+  Real_ptr array; \
+  Int_type ni = m_ni; \
+  Int_type nj = m_nj; \
+  Int_type nk = m_nk; \
+\
+  allocAndInitCudaDeviceData(array, m_array, m_array_length);
+
+#define NESTED_INIT_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_array, array, m_array_length); \
+  deallocCudaDeviceData(array);
+
+__global__ void nested_init(Real_ptr array,
+                            Int_type ni, Int_type nj)
+{
+   Index_type i = threadIdx.x;
+   Index_type j = blockIdx.y;
+   Index_type k = blockIdx.z;
+
+   NESTED_INIT_BODY; 
+}
+
+
+void NESTED_INIT::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  if ( vid == Base_CUDA ) {
+
+    NESTED_INIT_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      dim3 nthreads_per_block(ni, 1, 1);
+      dim3 nblocks(1, nj, nk);
+
+      nested_init<<<nblocks, nthreads_per_block>>>(array,
+                                                   ni, nj);
+
+    }
+    stopTimer();
+
+    NESTED_INIT_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+#if defined(USE_FORALLN_FOR_CUDA)
+
+    NESTED_INIT_DATA_SETUP_CUDA;
+
+    using EXEC_POL = RAJA::NestedPolicy<
+                           RAJA::ExecList< RAJA::cuda_block_z_exec,      // k
+                                           RAJA::cuda_block_y_exec,      // j
+                                           RAJA::cuda_thread_x_exec > >; // i
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forallN< EXEC_POL >(
+            RAJA::RangeSegment(0, nk),
+            RAJA::RangeSegment(0, nj),
+            RAJA::RangeSegment(0, ni),
+        [=] __device__ (Index_type k, Index_type j, Index_type i) {
+        NESTED_INIT_BODY;
+      });
+
+    }
+    stopTimer();
+
+    NESTED_INIT_DATA_TEARDOWN_CUDA;
+
+#else // use RAJA::nested
+
+    NESTED_INIT_DATA_SETUP_CUDA;
+
+    using EXEC_POL = RAJA::nested::Policy<
+                       RAJA::nested::CudaCollapse<
+                         RAJA::nested::For<2, RAJA::cuda_block_z_exec>,   //k
+                         RAJA::nested::For<1, RAJA::cuda_block_y_exec>,   //j
+                         RAJA::nested::For<0, RAJA::cuda_thread_x_exec> > >;//i
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::nested::forall(EXEC_POL{},
+                           camp::make_tuple(RAJA::RangeSegment(0, ni),
+                                            RAJA::RangeSegment(0, nj),
+                                            RAJA::RangeSegment(0, nk)),
+        [=] __device__ (Index_type i, Index_type j, Index_type k) {
+        NESTED_INIT_BODY;
+      });
+
+    }
+    stopTimer();
+
+    NESTED_INIT_DATA_TEARDOWN_CUDA;
+
+#endif
+
+  } else {
+     std::cout << "\n  NESTED_INIT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/basic/NESTED_INIT-OMPTarget.cpp
+++ b/src/basic/NESTED_INIT-OMPTarget.cpp
@@ -38,9 +38,9 @@ namespace basic
   int did = omp_get_default_device(); \
 \
   Real_ptr array = m_array; \
-  Int_type ni = m_ni; \
-  Int_type nj = m_nj; \
-  Int_type nk = m_nk; \
+  Index_type ni = m_ni; \
+  Index_type nj = m_nj; \
+  Index_type nk = m_nk; \
 \
   allocAndInitOpenMPDeviceData(array, m_array, m_array_length, did, hid);
 

--- a/src/basic/NESTED_INIT-OMPTarget.cpp
+++ b/src/basic/NESTED_INIT-OMPTarget.cpp
@@ -103,10 +103,10 @@ void NESTED_INIT::runOpenMPTargetVariant(VariantID vid)
     NESTED_INIT_DATA_SETUP_OMP_TARGET;
 
     using EXEC_POL = RAJA::nested::Policy<
-                       RAJA::nested::OmpCollapse<
-                         RAJA::nested::For<2>,     //k
-                         RAJA::nested::For<1>,     //j
-                         RAJA::nested::For<0> > >; //i
+                       RAJA::nested::OmpTargetCollapse<
+                         RAJA::nested::For<2>,          //k
+                         RAJA::nested::For<1>,          //j
+                         RAJA::nested::For<0> > >;      //i
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/basic/NESTED_INIT-OMPTarget.cpp
+++ b/src/basic/NESTED_INIT-OMPTarget.cpp
@@ -1,0 +1,137 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "NESTED_INIT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define NESTED_INIT_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr array = m_array; \
+  Int_type ni = m_ni; \
+  Int_type nj = m_nj; \
+  Int_type nk = m_nk; \
+\
+  allocAndInitOpenMPDeviceData(array, m_array, m_array_length, did, hid);
+
+#define NESTED_INIT_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_array, array, m_array_length, hid, did); \
+  deallocOpenMPDeviceData(array, did);
+
+
+void NESTED_INIT::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    NESTED_INIT_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(array) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) collapse(3) 
+      for (Index_type k = 0; k < nk; ++k ) {
+        for (Index_type j = 0; j < nj; ++j ) {
+          for (Index_type i = 0; i < ni; ++i ) {
+            NESTED_INIT_BODY;
+          }
+        }
+      }  
+
+    }
+    stopTimer();
+
+    NESTED_INIT_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+#if 1 // temporary implementation until RAJA::nested::OmpCollapse works.
+
+    NESTED_INIT_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(0, nk), [=](Index_type k) {
+        for (Index_type j = 0; j < nj; ++j ) {
+          for (Index_type i = 0; i < ni; ++i ) {
+            NESTED_INIT_BODY;
+          }
+        }
+      });
+
+    }
+    stopTimer();
+
+    NESTED_INIT_DATA_TEARDOWN_OMP_TARGET;
+
+#else
+
+    NESTED_INIT_DATA_SETUP_OMP_TARGET;
+
+    using EXEC_POL = RAJA::nested::Policy<
+                       RAJA::nested::OmpCollapse<
+                         RAJA::nested::For<2>,     //k
+                         RAJA::nested::For<1>,     //j
+                         RAJA::nested::For<0> > >; //i
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::nested::forall(EXEC_POL{},
+                           camp::make_tuple(RAJA::RangeSegment(0, ni),
+                                            RAJA::RangeSegment(0, nj),
+                                            RAJA::RangeSegment(0, nk)),
+        [=] __device__ (Index_type i, Index_type j, Index_type k) {
+        NESTED_INIT_BODY;
+      });
+
+    }
+    stopTimer();
+
+    NESTED_INIT_DATA_TEARDOWN_OMP_TARGET;
+
+#endif                            
+
+  } else { 
+     std::cout << "\n  NESTED_INIT : Unknown variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -29,9 +29,9 @@ namespace basic
 
 #define NESTED_INIT_DATA_SETUP_CPU \
   ResReal_ptr array = m_array; \
-  Int_type ni = m_ni; \
-  Int_type nj = m_nj; \
-  Int_type nk = m_nk;
+  Index_type ni = m_ni; \
+  Index_type nj = m_nj; \
+  Index_type nk = m_nk;
 
 
 NESTED_INIT::NESTED_INIT(const RunParams& params)

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -28,6 +28,8 @@
 #include "NESTED_INIT.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 #include "RAJA/internal/MemUtils_CPU.hpp"

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -13,26 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// NESTED_INIT kernel reference implementation:
-///
-/// for (Index_type k = 0; k < nk; ++k ) {
-///   for (Index_type j = 0; j < nj; ++j ) {
-///     for (Index_type i = 0; i < ni; ++i ) {
-///       array[i+ni*(j+nj*k)] = 0.00000001 * i * j * k ;
-///     }
-///   }
-/// }
-///
-
 #include "NESTED_INIT.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
-#include "RAJA/internal/MemUtils_CPU.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 
@@ -41,41 +26,12 @@ namespace rajaperf
 namespace basic
 {
 
-#define NESTED_INIT_DATA \
+
+#define NESTED_INIT_DATA_SETUP_CPU \
   ResReal_ptr array = m_array; \
   Int_type ni = m_ni; \
   Int_type nj = m_nj; \
   Int_type nk = m_nk;
-
-#define NESTED_INIT_BODY  \
-  array[i+ni*(j+nj*k)] = 0.00000001 * i * j * k ;
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-#define NESTED_INIT_DATA_SETUP_CUDA \
-  Real_ptr array; \
-  Int_type ni = m_ni; \
-  Int_type nj = m_nj; \
-  Int_type nk = m_nk; \
-\
-  allocAndInitCudaDeviceData(array, m_array, ni * nj * nk);
-
-#define NESTED_INIT_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_array, array, ni * nj * nk); \
-  deallocCudaDeviceData(array);
-
-__global__ void nested_init(Real_ptr array,
-                            Int_type ni, Int_type nj)
-{
-   Index_type i = threadIdx.x;
-   Index_type j = blockIdx.y;
-   Index_type k = blockIdx.z;
-
-   NESTED_INIT_BODY; 
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 NESTED_INIT::NESTED_INIT(const RunParams& params)
@@ -95,17 +51,10 @@ NESTED_INIT::~NESTED_INIT()
 
 void NESTED_INIT::setUp(VariantID vid)
 {
-  (void) vid;
-
   m_nk = m_nk_init * static_cast<Real_type>( getRunSize() ) / getDefaultSize();
+  m_array_length = m_ni * m_nj * m_nk;
 
-  int len = m_ni * m_nj * m_nk;
-#if 0
-  m_array = RAJA::allocate_aligned_type<Real_type>(RAJA::DATA_ALIGN,
-                                                   len*sizeof(Real_type)); 
-#else
-  allocAndInitDataConst(m_array, len, 0.0, vid);
-#endif
+  allocAndInitDataConst(m_array, m_array_length, 0.0, vid);
 }
 
 void NESTED_INIT::runKernel(VariantID vid)
@@ -116,7 +65,7 @@ void NESTED_INIT::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      NESTED_INIT_DATA;
+      NESTED_INIT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -139,7 +88,7 @@ void NESTED_INIT::runKernel(VariantID vid)
 
 #if defined(USE_FORALLN_FOR_SEQ)
 
-      NESTED_INIT_DATA;
+      NESTED_INIT_DATA_SETUP_CPU;
 
       using EXEC_POL = RAJA::NestedPolicy<
                              RAJA::ExecList< RAJA::seq_exec,      // k
@@ -162,7 +111,7 @@ void NESTED_INIT::runKernel(VariantID vid)
 
 #else // use RAJA::nested
 
-      NESTED_INIT_DATA;
+      NESTED_INIT_DATA_SETUP_CPU;
 
       using EXEC_POL = RAJA::nested::Policy<
                              RAJA::nested::For<2, RAJA::seq_exec>,    // k
@@ -191,11 +140,12 @@ void NESTED_INIT::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      NESTED_INIT_DATA;
+      NESTED_INIT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+// using collapse here works, but doesn't appear to yield a performance benefit
 //        #pragma omp parallel for collapse(2)
           #pragma omp parallel for
           for (Index_type k = 0; k < nk; ++k ) {
@@ -216,7 +166,7 @@ void NESTED_INIT::runKernel(VariantID vid)
 
 #if defined(USE_FORALLN_FOR_OPENMP)
 
-      NESTED_INIT_DATA;
+      NESTED_INIT_DATA_SETUP_CPU;
 
       using EXEC_POL = RAJA::NestedPolicy<
                              RAJA::ExecList< RAJA::omp_parallel_for_exec,  // k
@@ -239,7 +189,7 @@ void NESTED_INIT::runKernel(VariantID vid)
 
 #else // use RAJA::nested
 
-      NESTED_INIT_DATA;
+      NESTED_INIT_DATA_SETUP_CPU;
 
       using EXEC_POL = RAJA::nested::Policy<
                            RAJA::nested::For<2, RAJA::omp_parallel_for_exec>,//k
@@ -264,149 +214,22 @@ void NESTED_INIT::runKernel(VariantID vid)
 
       break;
     }
-
-#if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      NESTED_INIT_DATA;
-
-      #pragma omp target enter data map(to:array[0:ni * nj * nk],ni,nj,nk)
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) collapse(3) 
-        for (Index_type k = 0; k < nk; ++k ) {
-          for (Index_type j = 0; j < nj; ++j ) {
-            for (Index_type i = 0; i < ni; ++i ) {
-              NESTED_INIT_BODY;
-            }
-          }
-        }  
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:array[0:ni * nj * nk]) map(delete:ni,nj,nk)
-
-      break;
-    }
-
-    case RAJA_OpenMPTarget: {
-                              
-#if 0  // crashes clang-coral compiler      
-      NESTED_INIT_DATA;
-
-      #pragma omp target enter data map(to:array[0:ni * nj * nk],ni,nj,nk)
-
-      startTimer();
-      #pragma omp target data use_device_ptr(array)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forallN< RAJA::NestedPolicy< 
-                       RAJA::ExecList< RAJA::simd_exec,
-                                       RAJA::seq_exec,
-                                       RAJA::omp_target_parallel_for_exec<NUMTEAMS>>, 
-                       RAJA::Permute<RAJA::PERM_KJI> > >(
-              RAJA::RangeSegment(0, ni),
-              RAJA::RangeSegment(0, nj),
-              RAJA::RangeSegment(0, nk),
-          [=](Index_type i, Index_type j, Index_type k) {     
-          NESTED_INIT_BODY;
-        });
-
-      }
-      stopTimer();
-    
-      #pragma omp target exit data map(from:array[0:ni * nj * nk]) map(delete:ni,nj,nk)
-#endif                            
-
-      break;                        
-    }  
-
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP   
-
-#if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      NESTED_INIT_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        dim3 nthreads_per_block(ni, 1, 1);
-        dim3 nblocks(1, nj, nk);
-
-        nested_init<<<nblocks, nthreads_per_block>>>(array,
-                                                     ni, nj);
-
-      }
-      stopTimer();
-
-      NESTED_INIT_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-#if defined(USE_FORALLN_FOR_CUDA)
-
-      NESTED_INIT_DATA_SETUP_CUDA;
-
-      using EXEC_POL = RAJA::NestedPolicy<
-                             RAJA::ExecList< RAJA::cuda_block_z_exec,      // k
-                                             RAJA::cuda_block_y_exec,      // j
-                                             RAJA::cuda_thread_x_exec > >; // i
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forallN< EXEC_POL >(
-              RAJA::RangeSegment(0, nk),
-              RAJA::RangeSegment(0, nj),
-              RAJA::RangeSegment(0, ni),
-          [=] __device__ (Index_type k, Index_type j, Index_type i) {
-          NESTED_INIT_BODY;
-        });
-
-      }
-      stopTimer();
-
-      NESTED_INIT_DATA_TEARDOWN_CUDA;
-
-#else // use RAJA::nested
-
-      NESTED_INIT_DATA_SETUP_CUDA;
-
-      using EXEC_POL = RAJA::nested::Policy<
-                         RAJA::nested::CudaCollapse<
-                           RAJA::nested::For<2, RAJA::cuda_block_z_exec>,   //k
-                           RAJA::nested::For<1, RAJA::cuda_block_y_exec>,   //j
-                           RAJA::nested::For<0, RAJA::cuda_thread_x_exec> > >;//i
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::nested::forall(EXEC_POL{},
-                             camp::make_tuple(RAJA::RangeSegment(0, ni),
-                                              RAJA::RangeSegment(0, nj),
-                                              RAJA::RangeSegment(0, nk)),
-          [=] __device__ (Index_type i, Index_type j, Index_type k) {
-          NESTED_INIT_BODY;
-        });
-
-      }
-      stopTimer();
-
-      NESTED_INIT_DATA_TEARDOWN_CUDA;
-
 #endif
 
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
+      break;
+    }
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif
@@ -421,7 +244,7 @@ void NESTED_INIT::runKernel(VariantID vid)
 
 void NESTED_INIT::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_array, m_ni * m_nj * m_nk);
+  checksum[vid] += calcChecksum(m_array, m_array_length);
 }
 
 void NESTED_INIT::tearDown(VariantID vid)

--- a/src/basic/NESTED_INIT.hpp
+++ b/src/basic/NESTED_INIT.hpp
@@ -13,9 +13,25 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// NESTED_INIT kernel reference implementation:
+///
+/// for (Index_type k = 0; k < nk; ++k ) {
+///   for (Index_type j = 0; j < nj; ++j ) {
+///     for (Index_type i = 0; i < ni; ++i ) {
+///       array[i+ni*(j+nj*k)] = 0.00000001 * i * j * k ;
+///     }
+///   }
+/// }
+///
 
 #ifndef RAJAPerf_Basic_NESTED_INIT_HPP
 #define RAJAPerf_Basic_NESTED_INIT_HPP
+
+
+#define NESTED_INIT_BODY  \
+  array[i+ni*(j+nj*k)] = 0.00000001 * i * j * k ;
+
 
 #include "common/KernelBase.hpp"
 
@@ -39,8 +55,14 @@ public:
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
 
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
+
 private:
+  Index_type m_array_length;
+
   Real_ptr m_array;
+
   Int_type m_ni;
   Int_type m_nj;
   Int_type m_nk;

--- a/src/basic/NESTED_INIT.hpp
+++ b/src/basic/NESTED_INIT.hpp
@@ -63,10 +63,10 @@ private:
 
   Real_ptr m_array;
 
-  Int_type m_ni;
-  Int_type m_nj;
-  Int_type m_nk;
-  Int_type m_nk_init;
+  Index_type m_ni;
+  Index_type m_nj;
+  Index_type m_nk;
+  Index_type m_nk_init;
 };
 
 } // end namespace basic

--- a/src/basic/REDUCE3_INT-Cuda.cpp
+++ b/src/basic/REDUCE3_INT-Cuda.cpp
@@ -1,0 +1,183 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "REDUCE3_INT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define REDUCE3_INT_DATA_SETUP_CUDA \
+  Int_ptr vec; \
+\
+  allocAndInitCudaDeviceData(vec, m_vec, iend);
+
+#define REDUCE3_INT_DATA_TEARDOWN_CUDA \
+  deallocCudaDeviceData(vec);
+
+
+__global__ void reduce3int(Int_ptr vec,
+                           Int_ptr vsum, Int_type vsum_init,
+                           Int_ptr vmin, Int_type vmin_init,
+                           Int_ptr vmax, Int_type vmax_init,
+                           Index_type iend) 
+{
+  extern __shared__ Int_type psum[ ];
+  Int_type* pmin = (Int_type*)&psum[ 1 * blockDim.x ];
+  Int_type* pmax = (Int_type*)&psum[ 2 * blockDim.x ];
+
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+
+  psum[ threadIdx.x ] = vsum_init;
+  pmin[ threadIdx.x ] = vmin_init;
+  pmax[ threadIdx.x ] = vmax_init;
+
+  for ( ; i < iend ; i += gridDim.x * blockDim.x ) {
+    psum[ threadIdx.x ] += vec[ i ];
+    pmin[ threadIdx.x ] = RAJA_MIN( pmin[ threadIdx.x ], vec[ i ] );
+    pmax[ threadIdx.x ] = RAJA_MAX( pmax[ threadIdx.x ], vec[ i ] );
+  }
+  __syncthreads();
+
+  for ( i = blockDim.x / 2; i > 0; i /= 2 ) { 
+    if ( threadIdx.x < i ) { 
+      psum[ threadIdx.x ] += psum[ threadIdx.x + i ];
+      pmin[ threadIdx.x ] = RAJA_MIN( pmin[ threadIdx.x ], pmin[ threadIdx.x + i ] );
+      pmax[ threadIdx.x ] = RAJA_MAX( pmax[ threadIdx.x ], pmax[ threadIdx.x + i ] );
+    }
+     __syncthreads();
+  }
+
+#if 1 // serialized access to shared data;
+  if ( threadIdx.x == 0 ) {
+    atomicAdd( vsum, psum[ 0 ] );
+    atomicMin( vmin, pmin[ 0 ] );
+    atomicMax( vmax, pmax[ 0 ] );
+  }
+#else // this doesn't work due to data races
+  if ( threadIdx.x == 0 ) {
+    *vsum += psum[ 0 ];
+    *vmin = RAJA_MIN( *vmin, pmin[ 0 ] );
+    *vmax = RAJA_MAX( *vmax, pmax[ 0 ] );
+  }
+#endif
+}
+
+
+void REDUCE3_INT::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    REDUCE3_INT_DATA_SETUP_CUDA;
+
+    Int_ptr vsum;
+    allocAndInitCudaDeviceData(vsum, &m_vsum_init, 1);
+    Int_ptr vmin;
+    allocAndInitCudaDeviceData(vmin, &m_vmin_init, 1);
+    Int_ptr vmax;
+    allocAndInitCudaDeviceData(vmax, &m_vmax_init, 1);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      initCudaDeviceData(vsum, &m_vsum_init, 1);
+      initCudaDeviceData(vmin, &m_vmin_init, 1);
+      initCudaDeviceData(vmax, &m_vmax_init, 1);
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      reduce3int<<<grid_size, block_size, 
+                   3*sizeof(Int_type)*block_size>>>(vec, 
+                                                    vsum, m_vsum_init,
+                                                    vmin, m_vmin_init,
+                                                    vmax, m_vmax_init,
+                                                    iend ); 
+
+      Int_type lsum;
+      Int_ptr plsum = &lsum;
+      getCudaDeviceData(plsum, vsum, 1);
+      m_vsum += lsum;
+
+      Int_type lmin;
+      Int_ptr plmin = &lmin;
+      getCudaDeviceData(plmin, vmin, 1);
+      m_vmin = RAJA_MIN(m_vmin, lmin);
+
+      Int_type lmax;
+      Int_ptr plmax = &lmax;
+      getCudaDeviceData(plmax, vmax, 1);
+      m_vmax = RAJA_MAX(m_vmax, lmax);
+
+    }
+    stopTimer();
+
+    REDUCE3_INT_DATA_TEARDOWN_CUDA;
+
+    deallocCudaDeviceData(vsum);
+    deallocCudaDeviceData(vmin);
+    deallocCudaDeviceData(vmax);
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    REDUCE3_INT_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce<block_size>, Int_type> vsum(m_vsum_init);
+      RAJA::ReduceMin<RAJA::cuda_reduce<block_size>, Int_type> vmin(m_vmin_init);
+      RAJA::ReduceMax<RAJA::cuda_reduce<block_size>, Int_type> vmax(m_vmax_init);
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        REDUCE3_INT_BODY_RAJA;
+      });
+
+      m_vsum += static_cast<Int_type>(vsum.get());
+      m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
+      m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
+
+    }
+    stopTimer();
+
+    REDUCE3_INT_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  REDUCE3_INT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/basic/REDUCE3_INT-OMPTarget.cpp
+++ b/src/basic/REDUCE3_INT-OMPTarget.cpp
@@ -1,0 +1,117 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "REDUCE3_INT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define REDUCE3_INT_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Int_ptr vec; \
+\
+  allocAndInitOpenMPDeviceData(vec, m_vec, iend, did, hid);
+
+#define REDUCE3_INT_DATA_TEARDOWN_OMP_TARGET \
+  deallocOpenMPDeviceData(vec, did); \
+
+
+void REDUCE3_INT::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    REDUCE3_INT_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Int_type vsum = m_vsum_init;
+      Int_type vmin = m_vmin_init;
+      Int_type vmax = m_vmax_init;
+
+      #pragma omp target is_device_ptr(vec) device( did ) map(tofrom:vsum, vmin, vmax)
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static,1) \
+                               reduction(+:vsum) \
+                               reduction(min:vmin) \
+                               reduction(max:vmax)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        REDUCE3_INT_BODY;
+      }
+
+      m_vsum += vsum;
+      m_vmin = RAJA_MIN(m_vmin, vmin);
+      m_vmax = RAJA_MAX(m_vmax, vmax);
+
+    }
+    stopTimer();
+
+    REDUCE3_INT_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    REDUCE3_INT_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::omp_target_reduce<NUMTEAMS>, Int_type> vsum(m_vsum_init);
+      RAJA::ReduceMin<RAJA::omp_target_reduce<NUMTEAMS>, Int_type> vmin(m_vmin_init);
+      RAJA::ReduceMax<RAJA::omp_target_reduce<NUMTEAMS>, Int_type> vmax(m_vmax_init);
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend),
+        [=](Index_type i) {
+        REDUCE3_INT_BODY_RAJA;
+      });
+
+      m_vsum += static_cast<Real_type>(vsum.get());
+      m_vmin = RAJA_MIN(m_vmin, static_cast<Real_type>(vmin.get()));
+      m_vmax = RAJA_MAX(m_vmax, static_cast<Real_type>(vmax.get()));
+
+    }
+    stopTimer();
+
+    REDUCE3_INT_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  REDUCE3_INT : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/basic/REDUCE3_INT.cpp
+++ b/src/basic/REDUCE3_INT.cpp
@@ -13,31 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// REDUCE3_INT kernel reference implementation:
-///
-/// Int_type vsum = m_vsum_init;
-/// Int_type vmin = m_vmin_init;
-/// Int_type vmax = m_vmax_init;
-/// 
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   vsum += vec[i] ;
-///   vmin = RAJA_MIN(vmin, vec[i]) ;
-///   vmax = RAJA_MAX(vmax, vec[i]) ;
-/// }
-///
-/// m_vsum += vsum;
-/// m_vmin = RAJA_MIN(m_vmin, vmin);
-/// m_vmax = RAJA_MAX(m_vmax, vmax);
-///
-
 #include "REDUCE3_INT.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <limits>
 #include <iostream>
@@ -47,91 +27,19 @@ namespace rajaperf
 namespace basic
 {
 
-#define REDUCE3_INT_DATA \
+
+#define REDUCE3_INT_DATA_SETUP_CPU \
   Int_ptr vec = m_vec; \
-
-#define REDUCE3_INT_BODY  \
-  vsum += vec[i] ; \
-  vmin = RAJA_MIN(vmin, vec[i]) ; \
-  vmax = RAJA_MAX(vmax, vec[i]) ;
-
-#define REDUCE3_INT_BODY_RAJA  \
-  vsum += vec[i] ; \
-  vmin.min(vec[i]) ; \
-  vmax.max(vec[i]) ;
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define REDUCE3_INT_DATA_SETUP_CUDA \
-  Int_ptr vec; \
-\
-  allocAndInitCudaDeviceData(vec, m_vec, iend);
-
-#define REDUCE3_INT_DATA_TEARDOWN_CUDA \
-  deallocCudaDeviceData(vec);
-
-
-__global__ void reduce3int(Int_ptr vec,
-                           Int_ptr vsum, Int_type vsum_init,
-                           Int_ptr vmin, Int_type vmin_init,
-                           Int_ptr vmax, Int_type vmax_init,
-                           Index_type iend) 
-{
-  extern __shared__ Int_type psum[ ];
-  Int_type* pmin = (Int_type*)&psum[ 1 * blockDim.x ];
-  Int_type* pmax = (Int_type*)&psum[ 2 * blockDim.x ];
-
-  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-
-  psum[ threadIdx.x ] = vsum_init;
-  pmin[ threadIdx.x ] = vmin_init;
-  pmax[ threadIdx.x ] = vmax_init;
-
-  for ( ; i < iend ; i += gridDim.x * blockDim.x ) {
-    psum[ threadIdx.x ] += vec[ i ];
-    pmin[ threadIdx.x ] = RAJA_MIN( pmin[ threadIdx.x ], vec[ i ] );
-    pmax[ threadIdx.x ] = RAJA_MAX( pmax[ threadIdx.x ], vec[ i ] );
-  }
-  __syncthreads();
-
-  for ( i = blockDim.x / 2; i > 0; i /= 2 ) { 
-    if ( threadIdx.x < i ) { 
-      psum[ threadIdx.x ] += psum[ threadIdx.x + i ];
-      pmin[ threadIdx.x ] = RAJA_MIN( pmin[ threadIdx.x ], pmin[ threadIdx.x + i ] );
-      pmax[ threadIdx.x ] = RAJA_MAX( pmax[ threadIdx.x ], pmax[ threadIdx.x + i ] );
-    }
-     __syncthreads();
-  }
-
-#if 1 // serialized access to shared data;
-  if ( threadIdx.x == 0 ) {
-    atomicAdd( vsum, psum[ 0 ] );
-    atomicMin( vmin, pmin[ 0 ] );
-    atomicMax( vmax, pmax[ 0 ] );
-  }
-#else // this doesn't work due to data races
-  if ( threadIdx.x == 0 ) {
-    *vsum += psum[ 0 ];
-    *vmin = RAJA_MIN( *vmin, pmin[ 0 ] );
-    *vmax = RAJA_MAX( *vmax, pmax[ 0 ] );
-  }
-#endif
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 REDUCE3_INT::REDUCE3_INT(const RunParams& params)
   : KernelBase(rajaperf::Basic_REDUCE3_INT, params)
 {
    setDefaultSize(1000000);
-   setDefaultReps(5000);
+// setDefaultReps(5000);
+// Set reps to low value until we resolve RAJA omp-target 
+// reduction performance issues
+   setDefaultReps(100);
 }
 
 REDUCE3_INT::~REDUCE3_INT() 
@@ -152,8 +60,7 @@ void REDUCE3_INT::setUp(VariantID vid)
 
 void REDUCE3_INT::runKernel(VariantID vid)
 {
-  //const Index_type run_reps = getRunReps();
-  const Index_type run_reps = 100; //artificially limit until we reconcile raja omp-target reducer performance
+  const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
@@ -161,7 +68,7 @@ void REDUCE3_INT::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      REDUCE3_INT_DATA;
+      REDUCE3_INT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -186,7 +93,7 @@ void REDUCE3_INT::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      REDUCE3_INT_DATA;
+      REDUCE3_INT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -213,7 +120,7 @@ void REDUCE3_INT::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      REDUCE3_INT_DATA;
+      REDUCE3_INT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -241,7 +148,7 @@ void REDUCE3_INT::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      REDUCE3_INT_DATA;
+      REDUCE3_INT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -264,155 +171,22 @@ void REDUCE3_INT::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      REDUCE3_INT_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:vec[0:n])
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        Int_type vsum = m_vsum_init;
-        Int_type vmin = m_vmin_init;
-        Int_type vmax = m_vmax_init;
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static,1) \
-                                 map(tofrom:vsum,vmin,vmax) \
-                                 reduction(+:vsum) \
-                                 reduction(min:vmin) \
-                                 reduction(max:vmax)
-
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          REDUCE3_INT_BODY;
-        }
-
-        m_vsum += vsum;
-        m_vmin = RAJA_MIN(m_vmin, vmin);
-        m_vmax = RAJA_MAX(m_vmax, vmax);
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete:vec[0:n])
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget : {
-
-      REDUCE3_INT_DATA;
-      int n = getRunSize();
-
-      #pragma omp target enter data map(to:vec[0:n])
-
-      startTimer();
-      #pragma omp target data use_device_ptr(vec)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::ReduceSum<RAJA::omp_target_reduce<NUMTEAMS>, Int_type> vsum(m_vsum_init);
-        RAJA::ReduceMin<RAJA::omp_target_reduce<NUMTEAMS>, Int_type> vmin(m_vmin_init);
-        RAJA::ReduceMax<RAJA::omp_target_reduce<NUMTEAMS>, Int_type> vmax(m_vmax_init);
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-          RAJA::RangeSegment(ibegin, iend),
-          [=](Index_type i) {
-          REDUCE3_INT_BODY_RAJA;
-        });
-
-        m_vsum += static_cast<Real_type>(vsum.get());
-        m_vmin = RAJA_MIN(m_vmin, static_cast<Real_type>(vmin.get()));
-        m_vmax = RAJA_MAX(m_vmax, static_cast<Real_type>(vmax.get()));
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete:vec[0:n])
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      REDUCE3_INT_DATA_SETUP_CUDA;
-      Int_ptr vsum;
-      allocAndInitCudaDeviceData(vsum, &m_vsum_init, 1);
-      Int_ptr vmin;
-      allocAndInitCudaDeviceData(vmin, &m_vmin_init, 1);
-      Int_ptr vmax;
-      allocAndInitCudaDeviceData(vmax, &m_vmax_init, 1);
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        initCudaDeviceData(vsum, &m_vsum_init, 1);
-
-        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-        reduce3int<<<grid_size, block_size, 
-                     3*sizeof(Int_type)*block_size>>>(vec, 
-                                                      vsum, m_vsum_init,
-                                                      vmin, m_vmin_init,
-                                                      vmax, m_vmax_init,
-                                                      iend ); 
-
-        Int_type lsum;
-        Int_ptr plsum = &lsum;
-        getCudaDeviceData(plsum, vsum, 1);
-        m_vsum += lsum;
-
-        Int_type lmin;
-        Int_ptr plmin = &lmin;
-        getCudaDeviceData(plmin, vmin, 1);
-        m_vmin = RAJA_MIN(m_vmin, lmin);
-
-        Int_type lmax;
-        Int_ptr plmax = &lmax;
-        getCudaDeviceData(plmax, vmax, 1);
-        m_vmax = RAJA_MAX(m_vmax, lmax);
-
-      }
-      stopTimer();
-
-      REDUCE3_INT_DATA_TEARDOWN_CUDA;
-      deallocCudaDeviceData(vsum);
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      REDUCE3_INT_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::ReduceSum<RAJA::cuda_reduce<block_size>, Int_type> vsum(m_vsum_init);
-        RAJA::ReduceMin<RAJA::cuda_reduce<block_size>, Int_type> vmin(m_vmin_init);
-        RAJA::ReduceMax<RAJA::cuda_reduce<block_size>, Int_type> vmax(m_vmax_init);
-
-        RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-          RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-          REDUCE3_INT_BODY_RAJA;
-        });
-
-        m_vsum += static_cast<Int_type>(vsum.get());
-        m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
-        m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
-
-      }
-      stopTimer();
-
-      REDUCE3_INT_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/basic/REDUCE3_INT.cpp
+++ b/src/basic/REDUCE3_INT.cpp
@@ -34,6 +34,8 @@
 #include "REDUCE3_INT.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/basic/REDUCE3_INT.hpp
+++ b/src/basic/REDUCE3_INT.hpp
@@ -13,9 +13,40 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// REDUCE3_INT kernel reference implementation:
+///
+/// Int_type vsum = m_vsum_init;
+/// Int_type vmin = m_vmin_init;
+/// Int_type vmax = m_vmax_init;
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   vsum += vec[i] ;
+///   vmin = RAJA_MIN(vmin, vec[i]) ;
+///   vmax = RAJA_MAX(vmax, vec[i]) ;
+/// }
+///
+/// m_vsum += vsum;
+/// m_vmin = RAJA_MIN(m_vmin, vmin);
+/// m_vmax = RAJA_MAX(m_vmax, vmax);
+///
+/// RAJA_MIN/MAX are macros that do what you would expect.
+///
 
 #ifndef RAJAPerf_Basic_REDUCE3_INT_HPP
 #define RAJAPerf_Basic_REDUCE3_INT_HPP
+
+
+#define REDUCE3_INT_BODY  \
+  vsum += vec[i] ; \
+  vmin = RAJA_MIN(vmin, vec[i]) ; \
+  vmax = RAJA_MAX(vmax, vec[i]) ;
+
+#define REDUCE3_INT_BODY_RAJA  \
+  vsum += vec[i] ; \
+  vmin.min(vec[i]) ; \
+  vmax.max(vec[i]) ;
+
 
 #include "common/KernelBase.hpp"
 
@@ -38,6 +69,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Int_ptr m_vec;

--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -1,0 +1,168 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "TRAP_INT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+//
+// Function used in TRAP_INT loop.
+//
+RAJA_INLINE
+RAJA_DEVICE
+Real_type trap_int_func(Real_type x,
+                        Real_type y,
+                        Real_type xp,
+                        Real_type yp)
+{
+   Real_type denom = (x - xp)*(x - xp) + (y - yp)*(y - yp);
+   denom = 1.0/sqrt(denom);
+   return denom;
+}
+
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define TRAP_INT_DATA_SETUP_CUDA \
+  Real_type x0 = m_x0; \
+  Real_type xp = m_xp; \
+  Real_type y = m_y; \
+  Real_type yp = m_yp; \
+  Real_type h = m_h;
+
+#define TRAP_INT_DATA_TEARDOWN_CUDA // nothing to do here...
+
+
+__global__ void trapint(Real_type x0, Real_type xp,
+                        Real_type y, Real_type yp, 
+                        Real_type h, 
+                        Real_ptr sumx,
+                        Index_type iend)
+{
+  extern __shared__ Real_type psumx[ ];
+
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+
+  psumx[ threadIdx.x ] = 0.0;
+  for ( ; i < iend ; i += gridDim.x * blockDim.x ) {
+    Real_type x = x0 + i*h;
+    Real_type val = trap_int_func(x, y, xp, yp);
+    psumx[ threadIdx.x ] += val;
+  }
+  __syncthreads();
+
+  for ( i = blockDim.x / 2; i > 0; i /= 2 ) {
+    if ( threadIdx.x < i ) {
+      psumx[ threadIdx.x ] += psumx[ threadIdx.x + i ];
+    }
+     __syncthreads();
+  }
+
+#if 1 // serialized access to shared data;
+  if ( threadIdx.x == 0 ) {
+    RAJA::atomic::atomicAdd<RAJA::atomic::cuda_atomic>( sumx, psumx[ 0 ] );
+  }
+#else // this doesn't work due to data races
+  if ( threadIdx.x == 0 ) {
+    *sumx += psumx[ 0 ];
+  }
+#endif
+
+}
+
+
+void TRAP_INT::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    TRAP_INT_DATA_SETUP_CUDA;
+
+    Real_ptr sumx;
+    allocAndInitCudaDeviceData(sumx, &m_sumx_init, 1);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      initCudaDeviceData(sumx, &m_sumx_init, 1); 
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      trapint<<<grid_size, block_size, 
+                sizeof(Real_type)*block_size>>>(x0, xp,
+                                                y, yp,
+                                                h,
+                                                sumx,
+                                                iend);
+
+      Real_type lsumx;
+      Real_ptr plsumx = &lsumx;
+      getCudaDeviceData(plsumx, sumx, 1);
+      m_sumx += lsumx * h;
+
+    }
+    stopTimer();
+
+    deallocCudaDeviceData(sumx);
+
+    TRAP_INT_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    TRAP_INT_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce<block_size>, Real_type> sumx(m_sumx_init);
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        TRAP_INT_BODY;
+      });
+
+      m_sumx += static_cast<Real_type>(sumx.get()) * h;
+
+    }
+    stopTimer();
+
+    TRAP_INT_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  TRAP_INT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/basic/TRAP_INT-OMPTarget.cpp
+++ b/src/basic/TRAP_INT-OMPTarget.cpp
@@ -1,0 +1,120 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "TRAP_INT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace basic
+{
+
+//
+// Function used in TRAP_INT loop.
+//
+RAJA_INLINE
+Real_type trap_int_func(Real_type x,
+                        Real_type y,
+                        Real_type xp,
+                        Real_type yp)
+{
+   Real_type denom = (x - xp)*(x - xp) + (y - yp)*(y - yp);
+   denom = 1.0/sqrt(denom);
+   return denom;
+}
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define TRAP_INT_DATA_SETUP_OMP_TARGET \
+  Real_type x0 = m_x0; \
+  Real_type xp = m_xp; \
+  Real_type y = m_y; \
+  Real_type yp = m_yp; \
+  Real_type h = m_h;
+
+#define TRAP_INT_DATA_TEARDOWN_OMP_TARGET // nothing to do here...
+
+
+void TRAP_INT::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    TRAP_INT_DATA_SETUP_OMP_TARGET;
+
+    #pragma omp target data map(to:x0,xp,y,yp,h)
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type sumx = m_sumx_init;
+
+      #pragma omp target teams distribute parallel for map(tofrom: sumx) reduction(+:sumx) \
+                         num_teams(NUMTEAMS) schedule(static, 1) 
+        
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        TRAP_INT_BODY;
+      }
+
+      m_sumx += sumx * h;
+
+    }
+    stopTimer();
+
+    #pragma omp target exit data map(delete: x0,xp,y,yp,h) 
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    TRAP_INT_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::omp_target_reduce<NUMTEAMS>, Real_type> sumx(m_sumx_init);
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        TRAP_INT_BODY;
+      });
+
+      m_sumx += static_cast<Real_type>(sumx.get()) * h;
+
+    }
+    stopTimer();
+
+    TRAP_INT_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  TRAP_INT : Unknown OMP Targetvariant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/basic/TRAP_INT.cpp
+++ b/src/basic/TRAP_INT.cpp
@@ -35,6 +35,8 @@
 #include "TRAP_INT.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 #include "RAJA/policy/cuda.hpp"

--- a/src/basic/TRAP_INT.cpp
+++ b/src/basic/TRAP_INT.cpp
@@ -13,33 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// TRAP_INT kernel reference implementation:
-///
-/// Real_type trap_int_func(Real_type x,
-///                         Real_type y,
-///                         Real_type xp,
-///                         Real_type yp)
-/// {
-///    Real_type denom = (x - xp)*(x - xp) + (y - yp)*(y - yp);
-///    denom = 1.0/sqrt(denom);
-///    return denom;
-/// }
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///    Real_type x = x0 + i*h;
-///    sumx += trap_int_func(x, y, xp, yp);
-/// }
-///
-
 #include "TRAP_INT.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
-#include "RAJA/policy/cuda.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 
@@ -52,7 +30,6 @@ namespace basic
 // Function used in TRAP_INT loop.
 //
 RAJA_INLINE
-RAJA_HOST_DEVICE
 Real_type trap_int_func(Real_type x,
                         Real_type y,
                         Real_type xp,
@@ -64,68 +41,12 @@ Real_type trap_int_func(Real_type x,
 }
 
 
-#define TRAP_INT_DATA \
+#define TRAP_INT_DATA_SETUP_CPU \
   Real_type x0 = m_x0; \
   Real_type xp = m_xp; \
   Real_type y = m_y; \
   Real_type yp = m_yp; \
   Real_type h = m_h;
-
-#define TRAP_INT_BODY \
-  Real_type x = x0 + i*h; \
-  sumx += trap_int_func(x, y, xp, yp);
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define TRAP_INT_DATA_SETUP_CUDA // nothing to do here...
-
-#define TRAP_INT_DATA_TEARDOWN_CUDA // nothing to do here...
-
-__global__ void trapint(Real_type x0, Real_type xp,
-                        Real_type y, Real_type yp, 
-                        Real_type h, 
-                        Real_ptr sumx,
-                        Index_type iend)
-{
-  extern __shared__ Real_type psumx[ ];
-
-  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-
-  psumx[ threadIdx.x ] = 0.0;
-  for ( ; i < iend ; i += gridDim.x * blockDim.x ) {
-    Real_type x = x0 + i*h;
-    Real_type val = trap_int_func(x, y, xp, yp);
-    psumx[ threadIdx.x ] += val;
-  }
-  __syncthreads();
-
-  for ( i = blockDim.x / 2; i > 0; i /= 2 ) {
-    if ( threadIdx.x < i ) {
-      psumx[ threadIdx.x ] += psumx[ threadIdx.x + i ];
-    }
-     __syncthreads();
-  }
-
-#if 1 // serialized access to shared data;
-  if ( threadIdx.x == 0 ) {
-    RAJA::atomic::atomicAdd<RAJA::atomic::cuda_atomic>( sumx, psumx[ 0 ] );
-  }
-#else // this doesn't work due to data races
-  if ( threadIdx.x == 0 ) {
-    *sumx += psumx[ 0 ];
-  }
-#endif
-
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 TRAP_INT::TRAP_INT(const RunParams& params)
@@ -166,7 +87,7 @@ void TRAP_INT::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      TRAP_INT_DATA;
+      TRAP_INT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -187,7 +108,7 @@ void TRAP_INT::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      TRAP_INT_DATA;
+      TRAP_INT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -210,7 +131,7 @@ void TRAP_INT::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      TRAP_INT_DATA;
+      TRAP_INT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -232,7 +153,7 @@ void TRAP_INT::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      TRAP_INT_DATA;
+      TRAP_INT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -251,125 +172,25 @@ void TRAP_INT::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      TRAP_INT_DATA;
-
-      #pragma omp target data map(to:x0,xp,y,yp,h)
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        Real_type sumx = m_sumx_init;
-        #pragma omp target teams distribute parallel for map(tofrom: sumx) reduction(+:sumx) \
-                           num_teams(NUMTEAMS) schedule(static, 1) 
-        
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          TRAP_INT_BODY;
-        }
-        m_sumx += sumx * h;
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete: x0,xp,y,yp,h) 
-
-      break;
-    }
-
-    case RAJA_OpenMPTarget : {
-
-      TRAP_INT_DATA;
-
-      #pragma omp target data map(to:x0,xp,y,yp,h)
-      {
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::ReduceSum<RAJA::omp_target_reduce<NUMTEAMS>, Real_type> sumx(m_sumx_init);
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          TRAP_INT_BODY;
-        });
-
-        m_sumx += static_cast<Real_type>(sumx.get()) * h;
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(delete: x0,xp,y,yp,h) 
-
-      }
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP       
-
-#if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      TRAP_INT_DATA;
-
-      Real_ptr sumx;
-      allocAndInitCudaDeviceData(sumx, &m_sumx_init, 1);
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        initCudaDeviceData(sumx, &m_sumx_init, 1); 
-
-        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-        trapint<<<grid_size, block_size, 
-                  sizeof(Real_type)*block_size>>>(x0, xp,
-                                                  y, yp,
-                                                  h,
-                                                  sumx,
-                                                  iend);
-
-        Real_type lsumx;
-        Real_ptr plsumx = &lsumx;
-        getCudaDeviceData(plsumx, sumx, 1);
-        m_sumx += lsumx * h;
-
-      }
-      stopTimer();
-
-      deallocCudaDeviceData(sumx);
-
-      break;
-    }
-
-    case RAJA_CUDA : {
-
-      TRAP_INT_DATA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::ReduceSum<RAJA::cuda_reduce<block_size>, Real_type> sumx(m_sumx_init);
-
-        RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-          RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-          TRAP_INT_BODY;
-        });
-
-        m_sumx += static_cast<Real_type>(sumx.get()) * h;
-
-      }
-      stopTimer();
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
 #endif
 
+#if defined(RAJA_ENABLE_CUDA)
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
+      break;
+    }
+#endif
 
     default : {
       std::cout << "\n  TRAP_INT : Unknown variant id = " << vid << std::endl;

--- a/src/basic/TRAP_INT.hpp
+++ b/src/basic/TRAP_INT.hpp
@@ -13,9 +13,33 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// TRAP_INT kernel reference implementation:
+///
+/// Real_type trap_int_func(Real_type x,
+///                         Real_type y,
+///                         Real_type xp,
+///                         Real_type yp)
+/// {
+///    Real_type denom = (x - xp)*(x - xp) + (y - yp)*(y - yp);
+///    denom = 1.0/sqrt(denom);
+///    return denom;
+/// }
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///    Real_type x = x0 + i*h;
+///    sumx += trap_int_func(x, y, xp, yp);
+/// }
+///
 
 #ifndef RAJAPerf_Basic_TRAP_INT_HPP
 #define RAJAPerf_Basic_TRAP_INT_HPP
+
+
+#define TRAP_INT_BODY \
+  Real_type x = x0 + i*h; \
+  sumx += trap_int_func(x, y, xp, yp);
+
 
 #include "common/KernelBase.hpp"
 
@@ -38,6 +62,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_type m_x0;

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -1,0 +1,94 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Methods for CUDA kernel data allocation, initialization, and deallocation.
+///
+
+
+#ifndef RAJAPerf_CudaDataUtils_HPP
+#define RAJAPerf_CudaDataUtils_HPP
+
+#include "RPTypes.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+
+#include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
+
+
+namespace rajaperf
+{
+
+/*!
+ * \brief Copy given hptr (host) data to CUDA device (dptr).
+ *
+ * Method assumes both host and device data arrays are allocated
+ * and of propoer size for copy operation to succeed.
+ */
+template <typename T>
+void initCudaDeviceData(T& dptr, const T hptr, int len)
+{
+  cudaErrchk( cudaMemcpy( dptr, hptr, 
+                          len * sizeof(typename std::remove_pointer<T>::type),
+                          cudaMemcpyHostToDevice ) );
+
+  incDataInitCount();
+}
+
+/*!
+ * \brief Allocate CUDA device data array (dptr) and copy given hptr (host) 
+ * data to device array.
+ */
+template <typename T>
+void allocAndInitCudaDeviceData(T& dptr, const T hptr, int len)
+{
+  cudaErrchk( cudaMalloc( (void**)&dptr,
+              len * sizeof(typename std::remove_pointer<T>::type) ) );
+
+  initCudaDeviceData(dptr, hptr, len);
+}
+
+/*!
+ * \brief Copy given dptr (CUDA device) data to host (hptr).
+ *
+ * Method assumes both host and device data arrays are allocated
+ * and of propoer size for copy operation to succeed.
+ */
+template <typename T>
+void getCudaDeviceData(T& hptr, const T dptr, int len)
+{
+  cudaErrchk( cudaMemcpy( hptr, dptr, 
+              len * sizeof(typename std::remove_pointer<T>::type),
+              cudaMemcpyDeviceToHost ) );
+}
+
+/*!
+ * \brief Free device data array.
+ */
+template <typename T>
+void deallocCudaDeviceData(T& dptr)
+{
+  cudaErrchk( cudaFree( dptr ) );
+  dptr = 0;
+}
+
+
+}  // closing brace for rajaperf namespace
+
+#endif // RAJA_ENABLE_CUDA
+
+#endif  // closing endif for header file include guard
+

--- a/src/common/DataUtils.cpp
+++ b/src/common/DataUtils.cpp
@@ -16,6 +16,7 @@
 
 #include "DataUtils.hpp"
 
+
 #include "RAJA/internal/MemUtils_CPU.hpp"
 
 #include <cstdlib>

--- a/src/common/DataUtils.hpp
+++ b/src/common/DataUtils.hpp
@@ -24,8 +24,6 @@
 #include "RAJAPerfSuite.hpp"
 #include "RPTypes.hpp"
 
-#include "RAJA/policy/cuda/raja_cudaerrchk.hpp"
-
 
 namespace rajaperf
 {
@@ -160,66 +158,6 @@ long double calcChecksum(Real_ptr d, int len,
 ///
 long double calcChecksum(Complex_ptr d, int len, 
                          Real_type scale_factor = 1.0);
-
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-/*!
- * \brief Copy given hptr (host) data to CUDA device (dptr).
- *
- * Method assumes both host and device data arrays are allocated
- * and of propoer size for copy operation to succeed.
- */
-template <typename T>
-void initCudaDeviceData(T& dptr, const T hptr, int len)
-{
-  cudaErrchk( cudaMemcpy( dptr, hptr, 
-                          len * sizeof(typename std::remove_pointer<T>::type),
-                          cudaMemcpyHostToDevice ) );
-
-  incDataInitCount();
-}
-
-/*!
- * \brief Allocate CUDA device data array (dptr) and copy given hptr (host) 
- * data to device array.
- */
-template <typename T>
-void allocAndInitCudaDeviceData(T& dptr, const T hptr, int len)
-{
-  cudaErrchk( cudaMalloc( (void**)&dptr,
-              len * sizeof(typename std::remove_pointer<T>::type) ) );
-
-  initCudaDeviceData(dptr, hptr, len);
-}
-
-/*!
- * \brief Copy given dptr (CUDA device) data to host (hptr).
- *
- * Method assumes both host and device data arrays are allocated
- * and of propoer size for copy operation to succeed.
- */
-template <typename T>
-void getCudaDeviceData(T& hptr, const T dptr, int len)
-{
-  cudaErrchk( cudaMemcpy( hptr, dptr, 
-              len * sizeof(typename std::remove_pointer<T>::type),
-              cudaMemcpyDeviceToHost ) );
-}
-
-/*!
- * \brief Free device data array.
- */
-template <typename T>
-void deallocCudaDeviceData(T& dptr)
-{
-  cudaErrchk( cudaFree( dptr ) );
-  dptr = 0;
-}
-
-#endif // RAJA_ENABLE_CUDA
-
 
 }  // closing brace for rajaperf namespace
 

--- a/src/common/DataUtils.hpp
+++ b/src/common/DataUtils.hpp
@@ -147,6 +147,21 @@ void initData(Complex_ptr& ptr, int len,
 void initData(Real_type& d,
               VariantID vid = NumVariants);
 
+/*!
+ * \brief Calculate and return checksum for data arrays.
+ * 
+ * Checksums are computed as a weighted sum of array entries,
+ * where weight is a simple function of elemtn index.
+ *
+ * Checksumn is multiplied by given scale factor.
+ */
+long double calcChecksum(Real_ptr d, int len, 
+                         Real_type scale_factor = 1.0);
+///
+long double calcChecksum(Complex_ptr d, int len, 
+                         Real_type scale_factor = 1.0);
+
+
 
 #if defined(RAJA_ENABLE_CUDA)
 
@@ -203,22 +218,7 @@ void deallocCudaDeviceData(T& dptr)
   dptr = 0;
 }
 
-#endif
-
-
-/*!
- * \brief Calculate and return checksum for data arrays.
- * 
- * Checksums are computed as a weighted sum of array entries,
- * where weight is a simple function of elemtn index.
- *
- * Checksumn is multiplied by given scale factor.
- */
-long double calcChecksum(Real_ptr d, int len, 
-                         Real_type scale_factor = 1.0);
-///
-long double calcChecksum(Complex_ptr d, int len, 
-                         Real_type scale_factor = 1.0);
+#endif // RAJA_ENABLE_CUDA
 
 
 }  // closing brace for rajaperf namespace

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -17,7 +17,6 @@
 #include "KernelBase.hpp"
 
 #include "RunParams.hpp"
-#include "DataUtils.hpp"
 
 #include <cmath>
 

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -29,15 +29,16 @@
 // of the corresponding variant will be used.
 //
 // Eventually, the 'forallN' functionality in RAJA will be deprecated in favor
-// of the new RAJA::nested capabilities. Some variants of nested loops are 
-// still using forallN since the RAJA::nested::forall interface does not 
-// support all required functionality yet. When it does, the new
-// versions will be enabled for all kernel variants.  --RDH
+// of RAJA::nested capabilities. When possible, both forallN and RAJA::nested
+// versions are implemented for nested loops to see if there is a performance
+// difference. When any observed issues in RAJA::nested versions are resolved,
+// forallN versions will be removed. --RDH 
 //
 //#define USE_FORALLN_FOR_SEQ
 //#define USE_FORALLN_FOR_OPENMP
 //#define USE_FORALLN_FOR_CUDA
-#define USE_FORALLN_FOR_OPENMPTARGET
+//
+//Only RAJA::nested will supoort OMP Target variants.
 
 #include <string>
 #include <iostream>

--- a/src/common/OpenMPTargetDataUtils.hpp
+++ b/src/common/OpenMPTargetDataUtils.hpp
@@ -1,0 +1,94 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Methods for openmp target kernel data allocation, initialization, 
+/// and deallocation.
+///
+
+
+#ifndef RAJAPerf_OpenMPTargetDataUtils_HPP
+#define RAJAPerf_OpenMPTargetDataUtils_HPP
+
+#include "RPTypes.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+
+namespace rajaperf
+{
+
+/*!
+ * \brief Copy given hptr (host) data to device (dptr).
+ *
+ * Method assumes both host and device data arrays are allocated
+ * and of propoer size for copy operation to succeed.
+ */
+template <typename T>
+void initOpenMPDeviceData(T& dptr, const T hptr, int len, 
+                          int did, int hid)
+{
+  omp_target_memcpy( dptr, hptr, 
+                     len * sizeof(typename std::remove_pointer<T>::type),
+                     0, 0, did, hid ); 
+
+  incDataInitCount();
+}
+
+/*!
+ * \brief Allocate device data array (dptr) and copy given hptr (host) 
+ * data to device array.
+ */
+template <typename T>
+void allocAndInitOpenMPDeviceData(T& dptr, const T hptr, int len,
+                                  int did, int hid)
+{
+  dptr = static_cast<T>( omp_target_alloc(
+                         len * sizeof(typename std::remove_pointer<T>::type), 
+                         did) );
+
+  initOpenMPDeviceData(dptr, hptr, len, did, hid);
+}
+
+/*!
+ * \brief Copy given device ptr (dptr) data to host ptr (hptr).
+ *
+ * Method assumes both host and device data arrays are allocated
+ * and of propoer size for copy operation to succeed.
+ */
+template <typename T>
+void getOpenMPDeviceData(T& hptr, const T dptr, int len, int hid, int did)
+{
+  omp_target_memcpy( hptr, dptr, 
+                     len * sizeof(typename std::remove_pointer<T>::type),
+                     0, 0, hid, did );
+}
+
+/*!
+ * \brief Free device data array.
+ */
+template <typename T>
+void deallocOpenMPDeviceData(T& dptr, int did)
+{
+  omp_target_free( dptr, did );
+  dptr = 0;
+}
+
+
+}  // closing brace for rajaperf namespace
+
+#endif // RAJA_ENABLE_TARGET_OPENMP
+
+#endif  // closing endif for header file include guard

--- a/src/lcals/CMakeLists.txt
+++ b/src/lcals/CMakeLists.txt
@@ -16,6 +16,8 @@
 blt_add_library(
   NAME lcals
   SOURCES HYDRO_1D.cpp 
+          HYDRO_1D-Cuda.cpp
+          HYDRO_1D-OMPTarget.cpp
           EOS.cpp 
           EOS-Cuda.cpp 
           EOS-OMPTarget.cpp 

--- a/src/lcals/CMakeLists.txt
+++ b/src/lcals/CMakeLists.txt
@@ -22,6 +22,8 @@ blt_add_library(
           EOS-Cuda.cpp 
           EOS-OMPTarget.cpp 
           INT_PREDICT.cpp 
+          INT_PREDICT-Cuda.cpp 
+          INT_PREDICT-OMPTarget.cpp 
           DIFF_PREDICT.cpp 
           DIFF_PREDICT-Cuda.cpp 
           DIFF_PREDICT-OMPTarget.cpp 

--- a/src/lcals/CMakeLists.txt
+++ b/src/lcals/CMakeLists.txt
@@ -17,9 +17,15 @@ blt_add_library(
   NAME lcals
   SOURCES HYDRO_1D.cpp 
           EOS.cpp 
+          EOS-Cuda.cpp 
+          EOS-OMPTarget.cpp 
           INT_PREDICT.cpp 
           DIFF_PREDICT.cpp 
+          DIFF_PREDICT-Cuda.cpp 
+          DIFF_PREDICT-OMPTarget.cpp 
           FIRST_DIFF.cpp 
+          FIRST_DIFF-Cuda.cpp 
+          FIRST_DIFF-OMPTarget.cpp 
           PLANCKIAN.cpp 
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/lcals/CMakeLists.txt
+++ b/src/lcals/CMakeLists.txt
@@ -31,5 +31,7 @@ blt_add_library(
           FIRST_DIFF-Cuda.cpp 
           FIRST_DIFF-OMPTarget.cpp 
           PLANCKIAN.cpp 
+          PLANCKIAN-Cuda.cpp 
+          PLANCKIAN-OMPTarget.cpp 
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/lcals/DIFF_PREDICT-Cuda.cpp
+++ b/src/lcals/DIFF_PREDICT-Cuda.cpp
@@ -1,0 +1,109 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DIFF_PREDICT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace lcals
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define DIFF_PREDICT_DATA_SETUP_CUDA \
+  Real_ptr px; \
+  Real_ptr cx; \
+  const Index_type offset = m_offset; \
+\
+  allocAndInitCudaDeviceData(px, m_px, m_array_length); \
+  allocAndInitCudaDeviceData(cx, m_cx, m_array_length);
+
+#define DIFF_PREDICT_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_px, px, m_array_length); \
+  deallocCudaDeviceData(px); \
+  deallocCudaDeviceData(cx);
+
+__global__ void diff_predict(Real_ptr px, Real_ptr cx,
+                             const Index_type offset, 
+                             Index_type iend) 
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     DIFF_PREDICT_BODY; 
+   }
+}
+
+
+void DIFF_PREDICT::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    DIFF_PREDICT_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       diff_predict<<<grid_size, block_size>>>( px, cx,
+                                                offset,
+                                                iend ); 
+
+    }
+    stopTimer();
+
+    DIFF_PREDICT_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    DIFF_PREDICT_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         DIFF_PREDICT_BODY;
+       });
+
+    }
+    stopTimer();
+
+    DIFF_PREDICT_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  DIFF_PREDICT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace lcals
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/lcals/DIFF_PREDICT-OMPTarget.cpp
+++ b/src/lcals/DIFF_PREDICT-OMPTarget.cpp
@@ -13,7 +13,7 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "MUL.hpp"
+#include "DIFF_PREDICT.hpp"
 
 #include "RAJA/RAJA.hpp"
 
@@ -25,7 +25,7 @@
 
 namespace rajaperf 
 {
-namespace stream
+namespace lcals
 {
 
 //
@@ -33,23 +33,24 @@ namespace stream
 //
 #define NUMTEAMS 128
 
-#define MUL_DATA_SETUP_OMP_TARGET \
+#define DIFF_PREDICT_DATA_SETUP_OMP_TARGET \
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr b; \
-  Real_ptr c; \
-  Real_type alpha = m_alpha; \
+  Real_ptr px; \
+  Real_ptr cx; \
+  const Index_type offset = m_offset; \
 \
-  allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid); \
-  allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid);
+  allocAndInitOpenMPDeviceData(px, m_px, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(cx, m_cx, m_array_length, did, hid);
 
-#define MUL_DATA_TEARDOWN_OMP_TARGET \
-  getOpenMPDeviceData(m_b, b, iend, hid, did); \
-  deallocOpenMPDeviceData(b, did); \
-  deallocOpenMPDeviceData(c, did);
+#define DIFF_PREDICT_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_px, px, m_array_length, hid, did); \
+  deallocOpenMPDeviceData(px, did); \
+  deallocOpenMPDeviceData(cx, did);
 
-void MUL::runOpenMPTargetVariant(VariantID vid)
+
+void DIFF_PREDICT::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -57,45 +58,45 @@ void MUL::runOpenMPTargetVariant(VariantID vid)
 
   if ( vid == Base_OpenMPTarget ) {
 
-    MUL_DATA_SETUP_OMP_TARGET;
+    DIFF_PREDICT_DATA_SETUP_OMP_TARGET;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      #pragma omp target is_device_ptr(b, c) device( did )
-      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      #pragma omp target is_device_ptr(px, cx) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
       for (Index_type i = ibegin; i < iend; ++i ) {
-        MUL_BODY;
+        DIFF_PREDICT_BODY;
       }
 
     }
     stopTimer();
 
-    MUL_DATA_TEARDOWN_OMP_TARGET;
+    DIFF_PREDICT_DATA_TEARDOWN_OMP_TARGET;
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    MUL_DATA_SETUP_OMP_TARGET;
+    DIFF_PREDICT_DATA_SETUP_OMP_TARGET;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
         RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-        MUL_BODY;
+        DIFF_PREDICT_BODY;
       });
 
     }
     stopTimer();
 
-    MUL_DATA_TEARDOWN_OMP_TARGET;
+    DIFF_PREDICT_DATA_TEARDOWN_OMP_TARGET;
 
   } else {
-     std::cout << "\n  MUL : Unknown OMP Target variant id = " << vid << std::endl;
+     std::cout << "\n  DIFF_PREDICT : Unknown OMP Target variant id = " << vid << std::endl;
   }
 }
 
-} // end namespace stream
+} // end namespace lcals
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/lcals/DIFF_PREDICT.cpp
+++ b/src/lcals/DIFF_PREDICT.cpp
@@ -44,6 +44,8 @@
 #include "DIFF_PREDICT.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 #include "RAJA/util/defines.hpp"

--- a/src/lcals/DIFF_PREDICT.hpp
+++ b/src/lcals/DIFF_PREDICT.hpp
@@ -13,9 +13,61 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// DIFF_PREDICT kernel reference implementation:
+///
+/// Index_type offset = iend - ibegin;
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   ar                  = cx[i + offset * 4];
+///   br                  = ar - px[i + offset * 4];
+///   px[i + offset * 4]  = ar;
+///   cr                  = br - px[i + offset * 5];
+///   px[i + offset * 5]  = br;
+///   ar                  = cr - px[i + offset * 6];
+///   px[i + offset * 6]  = cr;
+///   br                  = ar - px[i + offset * 7];
+///   px[i + offset * 7]  = ar;
+///   cr                  = br - px[i + offset * 8];
+///   px[i + offset * 8]  = br;
+///   ar                  = cr - px[i + offset * 9];
+///   px[i + offset * 9]  = cr;
+///   br                  = ar - px[i + offset * 10];
+///   px[i + offset * 10] = ar;
+///   cr                  = br - px[i + offset * 11];
+///   px[i + offset * 11] = br;
+///   px[i + offset * 13] = cr - px[i + offset * 12];
+///   px[i + offset * 12] = cr;
+/// }
+///
 
 #ifndef RAJAPerf_Basic_DIFF_PREDICT_HPP
 #define RAJAPerf_Basic_DIFF_PREDICT_HPP
+
+
+#define DIFF_PREDICT_BODY  \
+  Real_type ar, br, cr; \
+\
+  ar                  = cx[i + offset * 4];       \
+  br                  = ar - px[i + offset * 4];  \
+  px[i + offset * 4]  = ar;                       \
+  cr                  = br - px[i + offset * 5];  \
+  px[i + offset * 5]  = br;                       \
+  ar                  = cr - px[i + offset * 6];  \
+  px[i + offset * 6]  = cr;                       \
+  br                  = ar - px[i + offset * 7];  \
+  px[i + offset * 7]  = ar;                       \
+  cr                  = br - px[i + offset * 8];  \
+  px[i + offset * 8]  = br;                       \
+  ar                  = cr - px[i + offset * 9];  \
+  px[i + offset * 9]  = cr;                       \
+  br                  = ar - px[i + offset * 10]; \
+  px[i + offset * 10] = ar;                       \
+  cr                  = br - px[i + offset * 11]; \
+  px[i + offset * 11] = br;                       \
+  px[i + offset * 13] = cr - px[i + offset * 12]; \
+  px[i + offset * 12] = cr;
+
 
 #include "common/KernelBase.hpp"
 
@@ -39,10 +91,14 @@ public:
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
 
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
+
 private:
   Real_ptr m_px;
   Real_ptr m_cx;
 
+  Index_type m_array_length;
   Index_type m_offset;
 };
 

--- a/src/lcals/EOS-Cuda.cpp
+++ b/src/lcals/EOS-Cuda.cpp
@@ -1,0 +1,117 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "EOS.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace lcals
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define EOS_DATA_SETUP_CUDA \
+  Real_ptr x; \
+  Real_ptr y; \
+  Real_ptr z; \
+  Real_ptr u; \
+  const Real_type q = m_q; \
+  const Real_type r = m_r; \
+  const Real_type t = m_t; \
+\
+  allocAndInitCudaDeviceData(x, m_x, m_array_length); \
+  allocAndInitCudaDeviceData(y, m_y, m_array_length); \
+  allocAndInitCudaDeviceData(z, m_z, m_array_length); \
+  allocAndInitCudaDeviceData(u, m_u, m_array_length);
+
+#define EOS_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_x, x, m_array_length); \
+  deallocCudaDeviceData(x); \
+  deallocCudaDeviceData(y); \
+  deallocCudaDeviceData(z); \
+  deallocCudaDeviceData(u);
+
+__global__ void eos(Real_ptr x, Real_ptr y, Real_ptr z, Real_ptr u,
+                    Real_type q, Real_type r, Real_type t,
+                    Index_type iend) 
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     EOS_BODY; 
+   }
+}
+
+
+void EOS::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    EOS_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       eos<<<grid_size, block_size>>>( x, y, z, u, 
+                                       q, r, t,
+                                       iend ); 
+
+    }
+    stopTimer();
+
+    EOS_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    EOS_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         EOS_BODY;
+       });
+
+    }
+    stopTimer();
+
+    EOS_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  EOS : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace lcals
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/lcals/EOS-OMPTarget.cpp
+++ b/src/lcals/EOS-OMPTarget.cpp
@@ -13,7 +13,7 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "MUL.hpp"
+#include "EOS.hpp"
 
 #include "RAJA/RAJA.hpp"
 
@@ -25,7 +25,7 @@
 
 namespace rajaperf 
 {
-namespace stream
+namespace lcals
 {
 
 //
@@ -33,23 +33,32 @@ namespace stream
 //
 #define NUMTEAMS 128
 
-#define MUL_DATA_SETUP_OMP_TARGET \
+#define EOS_DATA_SETUP_OMP_TARGET \
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr b; \
-  Real_ptr c; \
-  Real_type alpha = m_alpha; \
+  Real_ptr x; \
+  Real_ptr y; \
+  Real_ptr z; \
+  Real_ptr u; \
+  const Real_type q = m_q; \
+  const Real_type r = m_r; \
+  const Real_type t = m_t; \
 \
-  allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid); \
-  allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid);
+  allocAndInitOpenMPDeviceData(x, m_x, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(y, m_y, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(z, m_z, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(u, m_u, m_array_length, did, hid);
 
-#define MUL_DATA_TEARDOWN_OMP_TARGET \
-  getOpenMPDeviceData(m_b, b, iend, hid, did); \
-  deallocOpenMPDeviceData(b, did); \
-  deallocOpenMPDeviceData(c, did);
+#define EOS_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_x, x, m_array_length, hid, did); \
+  deallocOpenMPDeviceData(x, did); \
+  deallocOpenMPDeviceData(y, did); \
+  deallocOpenMPDeviceData(z, did); \
+  deallocOpenMPDeviceData(u, did);
 
-void MUL::runOpenMPTargetVariant(VariantID vid)
+
+void EOS::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -57,45 +66,45 @@ void MUL::runOpenMPTargetVariant(VariantID vid)
 
   if ( vid == Base_OpenMPTarget ) {
 
-    MUL_DATA_SETUP_OMP_TARGET;
+    EOS_DATA_SETUP_OMP_TARGET
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      #pragma omp target is_device_ptr(b, c) device( did )
-      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      #pragma omp target is_device_ptr(x, y, z, u) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
       for (Index_type i = ibegin; i < iend; ++i ) {
-        MUL_BODY;
+        EOS_BODY;
       }
 
     }
     stopTimer();
 
-    MUL_DATA_TEARDOWN_OMP_TARGET;
+    EOS_DATA_TEARDOWN_OMP_TARGET
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    MUL_DATA_SETUP_OMP_TARGET;
+    EOS_DATA_SETUP_OMP_TARGET;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
         RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-        MUL_BODY;
-      });
+        EOS_BODY;
+      });  
 
     }
     stopTimer();
 
-    MUL_DATA_TEARDOWN_OMP_TARGET;
+    EOS_DATA_TEARDOWN_OMP_TARGET
 
-  } else {
-     std::cout << "\n  MUL : Unknown OMP Target variant id = " << vid << std::endl;
+  } else { 
+     std::cout << "\n  EOS : Unknown OMP Tagretvariant id = " << vid << std::endl;
   }
 }
 
-} // end namespace stream
+} // end namespace lcals
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -16,8 +16,6 @@
 #include "EOS.hpp"
 
 #include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -26,6 +26,8 @@
 #include "EOS.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -15,9 +15,9 @@
 
 #include "EOS.hpp"
 
-#include "common/DataUtils.hpp"
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -13,16 +13,6 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// EOS kernel reference implementation:
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   x[i] = u[i] + r*( z[i] + r*y[i] ) + 
-///                 t*( u[i+3] + r*( u[i+2] + r*u[i+1] ) + 
-///                    t*( u[i+6] + q*( u[i+5] + q*u[i+4] ) ) );
-/// }
-///
-
 #include "EOS.hpp"
 
 #include "common/DataUtils.hpp"
@@ -38,7 +28,8 @@ namespace rajaperf
 namespace lcals
 {
 
-#define EOS_DATA \
+
+#define EOS_DATA_SETUP_CPU \
   ResReal_ptr x = m_x; \
   ResReal_ptr y = m_y; \
   ResReal_ptr z = m_z; \
@@ -47,53 +38,6 @@ namespace lcals
   const Real_type q = m_q; \
   const Real_type r = m_r; \
   const Real_type t = m_t;
-
-#define EOS_BODY  \
-  x[i] = u[i] + r*( z[i] + r*y[i] ) + \
-                t*( u[i+3] + r*( u[i+2] + r*u[i+1] ) + \
-                   t*( u[i+6] + q*( u[i+5] + q*u[i+4] ) ) );
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define EOS_DATA_SETUP_CUDA \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr z; \
-  Real_ptr u; \
-  const Real_type q = m_q; \
-  const Real_type r = m_r; \
-  const Real_type t = m_t; \
-\
-  allocAndInitCudaDeviceData(x, m_x, iend+7); \
-  allocAndInitCudaDeviceData(y, m_y, iend+7); \
-  allocAndInitCudaDeviceData(z, m_z, iend+7); \
-  allocAndInitCudaDeviceData(u, m_u, iend+7);
-
-#define EOS_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_x, x, iend); \
-  deallocCudaDeviceData(x); \
-  deallocCudaDeviceData(y); \
-  deallocCudaDeviceData(z); \
-  deallocCudaDeviceData(u);
-
-__global__ void eos(Real_ptr x, Real_ptr y, Real_ptr z, Real_ptr u,
-                    Real_type q, Real_type r, Real_type t,
-                    Index_type iend) 
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     EOS_BODY; 
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 EOS::EOS(const RunParams& params)
@@ -109,10 +53,12 @@ EOS::~EOS()
 
 void EOS::setUp(VariantID vid)
 {
-  allocAndInitDataConst(m_x, getRunSize()+7, 0.0, vid);
-  allocAndInitData(m_y, getRunSize()+7, vid);
-  allocAndInitData(m_z, getRunSize()+7, vid);
-  allocAndInitData(m_u, getRunSize()+7, vid);
+  m_array_length = getRunSize() + 7;
+
+  allocAndInitDataConst(m_x, m_array_length, 0.0, vid);
+  allocAndInitData(m_y, m_array_length, vid);
+  allocAndInitData(m_z, m_array_length, vid);
+  allocAndInitData(m_u, m_array_length, vid);
 
   initData(m_q, vid);
   initData(m_r, vid);
@@ -129,7 +75,7 @@ void EOS::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      EOS_DATA;
+      EOS_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -146,7 +92,7 @@ void EOS::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      EOS_DATA;
+      EOS_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -165,7 +111,7 @@ void EOS::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      EOS_DATA;
+      EOS_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -183,7 +129,7 @@ void EOS::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      EOS_DATA;
+      EOS_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -198,99 +144,22 @@ void EOS::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
-                       
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      EOS_DATA;
-
-      Index_type n = iend + 7;
-      #pragma omp target enter data map(to:x[0:n],y[0:n],z[0:n],u[0:n],q,r,t)
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          EOS_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:x[0:n]) map(delete:y[0:n],z[0:n],u[0:n],q,r,t)
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget: {
-
-      EOS_DATA;
-
-      Index_type n = iend + 7;
-      #pragma omp target enter data map(to:x[0:n],y[0:n],z[0:n],u[0:n],q,r,t)
-
-      startTimer();
-      #pragma omp target data use_device_ptr(x,y,z,u)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          EOS_BODY;
-        });  
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:x[0:n]) map(delete:y[0:n],z[0:n],u[0:n],q,r,t)
-
-      break;                        
-    }  
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      EOS_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         eos<<<grid_size, block_size>>>( x, y, z, u, 
-                                         q, r, t,
-                                         iend ); 
-
-      }
-      stopTimer();
-
-      EOS_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      EOS_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           EOS_BODY;
-         });
-
-      }
-      stopTimer();
-
-      EOS_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/lcals/EOS.hpp
+++ b/src/lcals/EOS.hpp
@@ -13,9 +13,25 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// EOS kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   x[i] = u[i] + r*( z[i] + r*y[i] ) +
+///                 t*( u[i+3] + r*( u[i+2] + r*u[i+1] ) +
+///                    t*( u[i+6] + q*( u[i+5] + q*u[i+4] ) ) );
+/// }
+///
 
 #ifndef RAJAPerf_Basic_EOS_HPP
 #define RAJAPerf_Basic_EOS_HPP
+
+
+#define EOS_BODY  \
+  x[i] = u[i] + r*( z[i] + r*y[i] ) + \
+                t*( u[i+3] + r*( u[i+2] + r*u[i+1] ) + \
+                   t*( u[i+6] + q*( u[i+5] + q*u[i+4] ) ) );
+
 
 #include "common/KernelBase.hpp"
 
@@ -39,6 +55,9 @@ public:
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
 
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
+
 private:
   Real_ptr m_x;
   Real_ptr m_y;
@@ -48,6 +67,8 @@ private:
   Real_type m_q;
   Real_type m_r;
   Real_type m_t;
+
+  Index_type m_array_length;
 };
 
 } // end namespace lcals

--- a/src/lcals/FIRST_DIFF-Cuda.cpp
+++ b/src/lcals/FIRST_DIFF-Cuda.cpp
@@ -1,0 +1,106 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "FIRST_DIFF.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace lcals
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define FIRST_DIFF_DATA_SETUP_CUDA \
+  Real_ptr x; \
+  Real_ptr y; \
+\
+  allocAndInitCudaDeviceData(x, m_x, m_array_length); \
+  allocAndInitCudaDeviceData(y, m_y, m_array_length);
+
+#define FIRST_DIFF_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_x, x, m_array_length); \
+  deallocCudaDeviceData(x); \
+  deallocCudaDeviceData(y);
+
+__global__ void first_diff(Real_ptr x, Real_ptr y,
+                           Index_type iend) 
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     FIRST_DIFF_BODY; 
+   }
+}
+
+
+void FIRST_DIFF::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    FIRST_DIFF_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       first_diff<<<grid_size, block_size>>>( x, y,
+                                              iend ); 
+
+    }
+    stopTimer();
+
+    FIRST_DIFF_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    FIRST_DIFF_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         FIRST_DIFF_BODY;
+       });
+
+    }
+    stopTimer();
+
+    FIRST_DIFF_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  FIRST_DIFF : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace lcals
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/lcals/FIRST_DIFF-OMPTarget.cpp
+++ b/src/lcals/FIRST_DIFF-OMPTarget.cpp
@@ -13,7 +13,7 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "MUL.hpp"
+#include "FIRST_DIFF.hpp"
 
 #include "RAJA/RAJA.hpp"
 
@@ -25,7 +25,7 @@
 
 namespace rajaperf 
 {
-namespace stream
+namespace lcals
 {
 
 //
@@ -33,23 +33,23 @@ namespace stream
 //
 #define NUMTEAMS 128
 
-#define MUL_DATA_SETUP_OMP_TARGET \
+#define FIRST_DIFF_DATA_SETUP_OMP_TARGET \
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr b; \
-  Real_ptr c; \
-  Real_type alpha = m_alpha; \
+  Real_ptr x; \
+  Real_ptr y; \
 \
-  allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid); \
-  allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid);
+  allocAndInitOpenMPDeviceData(x, m_x, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(y, m_y, m_array_length, did, hid);
 
-#define MUL_DATA_TEARDOWN_OMP_TARGET \
-  getOpenMPDeviceData(m_b, b, iend, hid, did); \
-  deallocOpenMPDeviceData(b, did); \
-  deallocOpenMPDeviceData(c, did);
+#define FIRST_DIFF_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_x, x, iend, hid, did); \
+  deallocOpenMPDeviceData(x, did); \
+  deallocOpenMPDeviceData(y, did);
 
-void MUL::runOpenMPTargetVariant(VariantID vid)
+
+void FIRST_DIFF::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -57,45 +57,46 @@ void MUL::runOpenMPTargetVariant(VariantID vid)
 
   if ( vid == Base_OpenMPTarget ) {
 
-    MUL_DATA_SETUP_OMP_TARGET;
-
+    FIRST_DIFF_DATA_SETUP_OMP_TARGET;
+                       
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      #pragma omp target is_device_ptr(b, c) device( did )
-      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      #pragma omp target is_device_ptr(x, y) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
+        
       for (Index_type i = ibegin; i < iend; ++i ) {
-        MUL_BODY;
+        FIRST_DIFF_BODY;
       }
 
     }
     stopTimer();
 
-    MUL_DATA_TEARDOWN_OMP_TARGET;
-
+    FIRST_DIFF_DATA_TEARDOWN_OMP_TARGET;
+                       
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    MUL_DATA_SETUP_OMP_TARGET;
-
+    FIRST_DIFF_DATA_SETUP_OMP_TARGET;
+                       
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
         RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-        MUL_BODY;
+        FIRST_DIFF_BODY;
       });
 
     }
     stopTimer();
 
-    MUL_DATA_TEARDOWN_OMP_TARGET;
-
-  } else {
-     std::cout << "\n  MUL : Unknown OMP Target variant id = " << vid << std::endl;
+    FIRST_DIFF_DATA_TEARDOWN_OMP_TARGET;
+                       
+  } else {                          
+     std::cout << "\n  FIRST_DIFF : Unknown OMP Target variant id = " << vid << std::endl;
   }
 }
 
-} // end namespace stream
+} // end namespace lcals
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/lcals/FIRST_DIFF.cpp
+++ b/src/lcals/FIRST_DIFF.cpp
@@ -24,6 +24,8 @@
 #include "FIRST_DIFF.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/lcals/FIRST_DIFF.hpp
+++ b/src/lcals/FIRST_DIFF.hpp
@@ -13,9 +13,21 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// FIRST_DIFF kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   x[i] = y[i+1] - y[i];
+/// }
+///
 
 #ifndef RAJAPerf_Basic_FIRST_DIFF_HPP
 #define RAJAPerf_Basic_FIRST_DIFF_HPP
+
+
+#define FIRST_DIFF_BODY  \
+  x[i] = y[i+1] - y[i];
+
 
 #include "common/KernelBase.hpp"
 
@@ -39,9 +51,14 @@ public:
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
 
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
+
 private:
   Real_ptr m_x;
   Real_ptr m_y;
+
+  Index_type m_array_length;
 };
 
 } // end namespace lcals

--- a/src/lcals/HYDRO_1D-Cuda.cpp
+++ b/src/lcals/HYDRO_1D-Cuda.cpp
@@ -1,0 +1,114 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "HYDRO_1D.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace lcals
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define HYDRO_1D_DATA_SETUP_CUDA \
+  Real_ptr x; \
+  Real_ptr y; \
+  Real_ptr z; \
+  const Real_type q = m_q; \
+  const Real_type r = m_r; \
+  const Real_type t = m_t; \
+\
+  allocAndInitCudaDeviceData(x, m_x, m_array_length); \
+  allocAndInitCudaDeviceData(y, m_y, m_array_length); \
+  allocAndInitCudaDeviceData(z, m_z, m_array_length);
+
+#define HYDRO_1D_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_x, x, m_array_length); \
+  deallocCudaDeviceData(x); \
+  deallocCudaDeviceData(y); \
+  deallocCudaDeviceData(z); \
+
+__global__ void hydro_1d(Real_ptr x, Real_ptr y, Real_ptr z,
+                         Real_type q, Real_type r, Real_type t,
+                         Index_type iend) 
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     HYDRO_1D_BODY; 
+   }
+}
+
+
+void HYDRO_1D::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    HYDRO_1D_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       hydro_1d<<<grid_size, block_size>>>( x, y, z,
+                                            q, r, t,
+                                            iend ); 
+
+    }
+    stopTimer();
+
+    HYDRO_1D_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    HYDRO_1D_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         HYDRO_1D_BODY;
+       });
+
+    }
+    stopTimer();
+
+    HYDRO_1D_DATA_TEARDOWN_CUDA;
+
+  } else { 
+     std::cout << "\n  HYDRO_1D : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace lcals
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/lcals/HYDRO_1D-OMPTarget.cpp
+++ b/src/lcals/HYDRO_1D-OMPTarget.cpp
@@ -1,0 +1,107 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "HYDRO_1D.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace lcals
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define HYDRO_1D_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr x; \
+  Real_ptr y; \
+  Real_ptr z; \
+  const Real_type q = m_q; \
+  const Real_type r = m_r; \
+  const Real_type t = m_t; \
+\
+  allocAndInitOpenMPDeviceData(x, m_x, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(y, m_y, m_array_length, did, hid); \
+  allocAndInitOpenMPDeviceData(z, m_z, m_array_length, did, hid);
+
+#define HYDRO_1D_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_x, x, m_array_length, hid, did); \
+  deallocOpenMPDeviceData(x, did); \
+  deallocOpenMPDeviceData(y, did); \
+  deallocOpenMPDeviceData(z, did); \
+
+
+void HYDRO_1D::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    HYDRO_1D_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(x, y, z) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        HYDRO_1D_BODY;
+      }
+
+    }
+    stopTimer();
+
+    HYDRO_1D_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    HYDRO_1D_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        HYDRO_1D_BODY;
+      });
+
+    }
+    stopTimer();
+
+    HYDRO_1D_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  HYDRO_1D : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace lcals
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -13,21 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// HYDRO_1D kernel reference implementation:
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   x[i] = q + y[i]*( r*z[i+10] + t*z[i+11] );
-/// }
-///
-
 #include "HYDRO_1D.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 
@@ -36,7 +26,8 @@ namespace rajaperf
 namespace lcals
 {
 
-#define HYDRO_1D_DATA \
+
+#define HYDRO_1D_DATA_SETUP_CPU \
   ResReal_ptr x = m_x; \
   ResReal_ptr y = m_y; \
   ResReal_ptr z = m_z; \
@@ -44,48 +35,6 @@ namespace lcals
   const Real_type q = m_q; \
   const Real_type r = m_r; \
   const Real_type t = m_t;
-
-#define HYDRO_1D_BODY  \
-  x[i] = q + y[i]*( r*z[i+10] + t*z[i+11] );
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define HYDRO_1D_DATA_SETUP_CUDA \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr z; \
-  const Real_type q = m_q; \
-  const Real_type r = m_r; \
-  const Real_type t = m_t; \
-\
-  allocAndInitCudaDeviceData(x, m_x, iend+12); \
-  allocAndInitCudaDeviceData(y, m_y, iend+12); \
-  allocAndInitCudaDeviceData(z, m_z, iend+12);
-
-#define HYDRO_1D_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_x, x, iend); \
-  deallocCudaDeviceData(x); \
-  deallocCudaDeviceData(y); \
-  deallocCudaDeviceData(z); \
-
-__global__ void hydro_1d(Real_ptr x, Real_ptr y, Real_ptr z,
-                         Real_type q, Real_type r, Real_type t,
-                         Index_type iend) 
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     HYDRO_1D_BODY; 
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 HYDRO_1D::HYDRO_1D(const RunParams& params)
@@ -101,9 +50,11 @@ HYDRO_1D::~HYDRO_1D()
 
 void HYDRO_1D::setUp(VariantID vid)
 {
-  allocAndInitDataConst(m_x, getRunSize()+12, 0.0, vid);
-  allocAndInitData(m_y, getRunSize()+12, vid);
-  allocAndInitData(m_z, getRunSize()+12, vid);
+  m_array_length = getRunSize() + 12;
+
+  allocAndInitDataConst(m_x, m_array_length, 0.0, vid);
+  allocAndInitData(m_y, m_array_length, vid);
+  allocAndInitData(m_z, m_array_length, vid);
 
   initData(m_q, vid);
   initData(m_r, vid);
@@ -120,7 +71,7 @@ void HYDRO_1D::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      HYDRO_1D_DATA;
+      HYDRO_1D_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -137,7 +88,7 @@ void HYDRO_1D::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      HYDRO_1D_DATA;
+      HYDRO_1D_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -156,7 +107,7 @@ void HYDRO_1D::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      HYDRO_1D_DATA;
+      HYDRO_1D_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -174,7 +125,7 @@ void HYDRO_1D::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      HYDRO_1D_DATA;
+      HYDRO_1D_DATA_SETUP_CPU;
       
       startTimer();
 
@@ -190,99 +141,22 @@ void HYDRO_1D::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      HYDRO_1D_DATA;
-
-      Index_type n = iend + 12;
-      #pragma omp target enter data map(to:x[0:n],y[0:n],z[0:n],q,r,t)
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          HYDRO_1D_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:x[0:n]) map(delete:y[0:n],z[0:n],q,r,t)
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget: {
-                              
-      HYDRO_1D_DATA;
-
-      Index_type n = iend + 12;
-      #pragma omp target enter data map(to:x[0:n],y[0:n],z[0:n],q,r,t)
-
-      startTimer();
-      #pragma omp target data use_device_ptr(x,y,z)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          HYDRO_1D_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:x[0:n]) map(delete:y[0:n],z[0:n],q,r,t)
-
-      break;                        
-    }                          
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
-
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      HYDRO_1D_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         hydro_1d<<<grid_size, block_size>>>( x, y, z,
-                                              q, r, t,
-                                              iend ); 
-
-      }
-      stopTimer();
-
-      HYDRO_1D_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      HYDRO_1D_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           HYDRO_1D_BODY;
-         });
-
-      }
-      stopTimer();
-
-      HYDRO_1D_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -24,6 +24,8 @@
 #include "HYDRO_1D.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/lcals/HYDRO_1D.hpp
+++ b/src/lcals/HYDRO_1D.hpp
@@ -28,6 +28,7 @@
 #define HYDRO_1D_BODY  \
   x[i] = q + y[i]*( r*z[i+10] + t*z[i+11] );
 
+
 #include "common/KernelBase.hpp"
 
 namespace rajaperf 

--- a/src/lcals/HYDRO_1D.hpp
+++ b/src/lcals/HYDRO_1D.hpp
@@ -13,9 +13,20 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// HYDRO_1D kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   x[i] = q + y[i]*( r*z[i+10] + t*z[i+11] );
+/// }
+///
 
 #ifndef RAJAPerf_Basic_HYDRO_1D_HPP
 #define RAJAPerf_Basic_HYDRO_1D_HPP
+
+
+#define HYDRO_1D_BODY  \
+  x[i] = q + y[i]*( r*z[i+10] + t*z[i+11] );
 
 #include "common/KernelBase.hpp"
 
@@ -39,6 +50,9 @@ public:
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
 
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
+
 private:
   Real_ptr m_x;
   Real_ptr m_y;
@@ -47,6 +61,8 @@ private:
   Real_type m_q;
   Real_type m_r;
   Real_type m_t;
+
+  Index_type m_array_length; 
 };
 
 } // end namespace lcals

--- a/src/lcals/INT_PREDICT-Cuda.cpp
+++ b/src/lcals/INT_PREDICT-Cuda.cpp
@@ -1,0 +1,119 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "INT_PREDICT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace lcals
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define INT_PREDICT_DATA_SETUP_CUDA \
+  Real_ptr px; \
+  Real_type dm22 = m_dm22; \
+  Real_type dm23 = m_dm23; \
+  Real_type dm24 = m_dm24; \
+  Real_type dm25 = m_dm25; \
+  Real_type dm26 = m_dm26; \
+  Real_type dm27 = m_dm27; \
+  Real_type dm28 = m_dm28; \
+  Real_type c0 = m_c0; \
+  const Index_type offset = m_offset; \
+\
+  allocAndInitCudaDeviceData(px, m_px, m_array_length);
+
+#define INT_PREDICT_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_px, px, m_array_length); \
+  deallocCudaDeviceData(px);
+
+__global__ void int_predict(Real_ptr px,
+                            Real_type dm22, Real_type dm23, Real_type dm24,
+                            Real_type dm25, Real_type dm26, Real_type dm27,
+                            Real_type dm28, Real_type c0,
+                            const Index_type offset, 
+                            Index_type iend) 
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     INT_PREDICT_BODY; 
+   }
+}
+
+
+void INT_PREDICT::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    INT_PREDICT_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       int_predict<<<grid_size, block_size>>>( px, 
+                                               dm22, dm23, dm24, dm25,
+                                               dm26, dm27, dm28, c0,
+                                               offset,
+                                               iend ); 
+
+    }
+    stopTimer();
+
+    INT_PREDICT_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    INT_PREDICT_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         INT_PREDICT_BODY;
+       });
+
+    }
+    stopTimer();
+
+    INT_PREDICT_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  INT_PREDICT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace lcals
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/lcals/INT_PREDICT-OMPTarget.cpp
+++ b/src/lcals/INT_PREDICT-OMPTarget.cpp
@@ -1,0 +1,107 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "INT_PREDICT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace lcals
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define INT_PREDICT_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr px; \
+  Real_type dm22 = m_dm22; \
+  Real_type dm23 = m_dm23; \
+  Real_type dm24 = m_dm24; \
+  Real_type dm25 = m_dm25; \
+  Real_type dm26 = m_dm26; \
+  Real_type dm27 = m_dm27; \
+  Real_type dm28 = m_dm28; \
+  Real_type c0 = m_c0; \
+  const Index_type offset = m_offset; \
+\
+  allocAndInitOpenMPDeviceData(px, m_px, m_array_length, did, hid);
+
+#define INT_PREDICT_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_px, px, m_array_length, hid, did); \
+  deallocOpenMPDeviceData(px, did);
+
+
+void INT_PREDICT::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    INT_PREDICT_DATA_SETUP_OMP_TARGET;
+                              
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(px) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        INT_PREDICT_BODY;
+      }
+
+    }
+    stopTimer();
+
+    INT_PREDICT_DATA_TEARDOWN_OMP_TARGET;
+                              
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    INT_PREDICT_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) { 
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        INT_PREDICT_BODY;
+      });
+
+    }
+    stopTimer();
+
+    INT_PREDICT_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  INT_PREDICT : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace lcals
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/lcals/INT_PREDICT.cpp
+++ b/src/lcals/INT_PREDICT.cpp
@@ -31,6 +31,8 @@
 #include "INT_PREDICT.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/lcals/INT_PREDICT.cpp
+++ b/src/lcals/INT_PREDICT.cpp
@@ -13,28 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// INT_PREDICT kernel reference implementation:
-///
-/// Index_type offset = iend - ibegin;
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   px[i] = dm28*px[i + offset * 12] + dm27*px[i + offset * 11] + 
-///           dm26*px[i + offset * 10] + dm25*px[i + offset *  9] + 
-///           dm24*px[i + offset *  8] + dm23*px[i + offset *  7] + 
-///           dm22*px[i + offset *  6] + 
-///           c0*( px[i + offset *  4] + px[i + offset *  5] ) + 
-///           px[i + offset *  2];
-/// }
-///
-
 #include "INT_PREDICT.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 
@@ -43,7 +26,8 @@ namespace rajaperf
 namespace lcals
 {
 
-#define INT_PREDICT_DATA \
+
+#define INT_PREDICT_DATA_SETUP_CPU \
   ResReal_ptr px = m_px; \
   Real_type dm22 = m_dm22; \
   Real_type dm23 = m_dm23; \
@@ -54,56 +38,6 @@ namespace lcals
   Real_type dm28 = m_dm28; \
   Real_type c0 = m_c0; \
   const Index_type offset = m_offset;
-
-#define INT_PREDICT_BODY  \
-  px[i] = dm28*px[i + offset * 12] + dm27*px[i + offset * 11] + \
-          dm26*px[i + offset * 10] + dm25*px[i + offset *  9] + \
-          dm24*px[i + offset *  8] + dm23*px[i + offset *  7] + \
-          dm22*px[i + offset *  6] + \
-          c0*( px[i + offset *  4] + px[i + offset *  5] ) + \
-          px[i + offset *  2]; 
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define INT_PREDICT_DATA_SETUP_CUDA \
-  Real_ptr px; \
-  Real_type dm22 = m_dm22; \
-  Real_type dm23 = m_dm23; \
-  Real_type dm24 = m_dm24; \
-  Real_type dm25 = m_dm25; \
-  Real_type dm26 = m_dm26; \
-  Real_type dm27 = m_dm27; \
-  Real_type dm28 = m_dm28; \
-  Real_type c0 = m_c0; \
-  const Index_type offset = m_offset; \
-\
-  allocAndInitCudaDeviceData(px, m_px, m_offset*13);
-
-#define INT_PREDICT_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_px, px, m_offset*13); \
-  deallocCudaDeviceData(px);
-
-__global__ void int_predict(Real_ptr px,
-                            Real_type dm22, Real_type dm23, Real_type dm24,
-                            Real_type dm25, Real_type dm26, Real_type dm27,
-                            Real_type dm28, Real_type c0,
-                            const Index_type offset, 
-                            Index_type iend) 
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     INT_PREDICT_BODY; 
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 INT_PREDICT::INT_PREDICT(const RunParams& params)
@@ -119,10 +53,11 @@ INT_PREDICT::~INT_PREDICT()
 
 void INT_PREDICT::setUp(VariantID vid)
 {
-  m_px_initval = 1.0;
+  m_array_length = getRunSize() * 13;
   m_offset = getRunSize();
 
-  allocAndInitDataConst(m_px, m_offset*13, m_px_initval, vid);
+  m_px_initval = 1.0;
+  allocAndInitDataConst(m_px, m_array_length, m_px_initval, vid);
 
   initData(m_dm22);
   initData(m_dm23);
@@ -144,7 +79,7 @@ void INT_PREDICT::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      INT_PREDICT_DATA;
+      INT_PREDICT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -161,7 +96,7 @@ void INT_PREDICT::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      INT_PREDICT_DATA;
+      INT_PREDICT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -180,7 +115,7 @@ void INT_PREDICT::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      INT_PREDICT_DATA;
+      INT_PREDICT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -198,7 +133,7 @@ void INT_PREDICT::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      INT_PREDICT_DATA;
+      INT_PREDICT_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -213,100 +148,22 @@ void INT_PREDICT::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      INT_PREDICT_DATA;
-                              
-      Index_type n = m_offset*13;
-      #pragma omp target enter data map(to:px[0:n],dm22,dm23,dm24,dm25,dm26,dm27,dm28,c0,offset)
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          INT_PREDICT_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:px[0:n]) map(delete:dm22,dm23,dm24,dm25,dm26,dm27,dm28,c0,offset)
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget: {
-
-      INT_PREDICT_DATA;
-                              
-      Index_type n = m_offset*13;
-      #pragma omp target enter data map(to:px[0:n],dm22,dm23,dm24,dm25,dm26,dm27,dm28,c0,offset)
-
-      startTimer();
-      #pragma omp target data use_device_ptr(px)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          INT_PREDICT_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:px[0:n]) map(delete:dm22,dm23,dm24,dm25,dm26,dm27,dm28,c0,offset)
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      INT_PREDICT_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         int_predict<<<grid_size, block_size>>>( px, 
-                                                 dm22, dm23, dm24, dm25,
-                                                 dm26, dm27, dm28, c0,
-                                                 offset,
-                                                 iend ); 
-
-      }
-      stopTimer();
-
-      INT_PREDICT_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      INT_PREDICT_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           INT_PREDICT_BODY;
-         });
-
-      }
-      stopTimer();
-
-      INT_PREDICT_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif
@@ -321,11 +178,11 @@ void INT_PREDICT::runKernel(VariantID vid)
 
 void INT_PREDICT::updateChecksum(VariantID vid)
 {
-  for (Index_type i = 0; i < m_offset*13; ++i) {
+  for (Index_type i = 0; i < getRunSize(); ++i) {
     m_px[i] -= m_px_initval;
   }
   
-  checksum[vid] += calcChecksum(m_px, m_offset*13);
+  checksum[vid] += calcChecksum(m_px, getRunSize());
 }
 
 void INT_PREDICT::tearDown(VariantID vid)

--- a/src/lcals/INT_PREDICT.hpp
+++ b/src/lcals/INT_PREDICT.hpp
@@ -13,9 +13,33 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// INT_PREDICT kernel reference implementation:
+///
+/// Index_type offset = iend - ibegin;
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   px[i] = dm28*px[i + offset * 12] + dm27*px[i + offset * 11] +
+///           dm26*px[i + offset * 10] + dm25*px[i + offset *  9] +
+///           dm24*px[i + offset *  8] + dm23*px[i + offset *  7] +
+///           dm22*px[i + offset *  6] +
+///           c0*( px[i + offset *  4] + px[i + offset *  5] ) +
+///           px[i + offset *  2];
+/// }
+///
 
 #ifndef RAJAPerf_Basic_INT_PREDICT_HPP
 #define RAJAPerf_Basic_INT_PREDICT_HPP
+
+
+#define INT_PREDICT_BODY  \
+  px[i] = dm28*px[i + offset * 12] + dm27*px[i + offset * 11] + \
+          dm26*px[i + offset * 10] + dm25*px[i + offset *  9] + \
+          dm24*px[i + offset *  8] + dm23*px[i + offset *  7] + \
+          dm22*px[i + offset *  6] + \
+          c0*( px[i + offset *  4] + px[i + offset *  5] ) + \
+          px[i + offset *  2];
+
 
 #include "common/KernelBase.hpp"
 
@@ -39,11 +63,15 @@ public:
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
 
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
+
 private:
-  Real_type m_px_initval;
+  Index_type m_array_length;
   Index_type m_offset;
 
   Real_ptr m_px;
+  Real_type m_px_initval;
 
   Real_type m_dm22;
   Real_type m_dm23;

--- a/src/lcals/PLANCKIAN-Cuda.cpp
+++ b/src/lcals/PLANCKIAN-Cuda.cpp
@@ -1,0 +1,118 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "PLANCKIAN.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+#include <cmath>
+
+namespace rajaperf 
+{
+namespace lcals
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define PLANCKIAN_DATA_SETUP_CUDA \
+  Real_ptr x; \
+  Real_ptr y; \
+  Real_ptr u; \
+  Real_ptr v; \
+  Real_ptr w; \
+\
+  allocAndInitCudaDeviceData(x, m_x, iend); \
+  allocAndInitCudaDeviceData(y, m_y, iend); \
+  allocAndInitCudaDeviceData(u, m_u, iend); \
+  allocAndInitCudaDeviceData(v, m_v, iend); \
+  allocAndInitCudaDeviceData(w, m_w, iend);
+
+#define PLANCKIAN_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_w, w, iend); \
+  deallocCudaDeviceData(x); \
+  deallocCudaDeviceData(y); \
+  deallocCudaDeviceData(u); \
+  deallocCudaDeviceData(v); \
+  deallocCudaDeviceData(w);
+
+__global__ void planckian(Real_ptr x, Real_ptr y,
+                          Real_ptr u, Real_ptr v, Real_ptr w, 
+                          Index_type iend) 
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     PLANCKIAN_BODY; 
+   }
+}
+
+
+void PLANCKIAN::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    PLANCKIAN_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       planckian<<<grid_size, block_size>>>( x, y, 
+                                             u, v, w,
+                                             iend );
+
+    }
+    stopTimer();
+
+    PLANCKIAN_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    PLANCKIAN_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         PLANCKIAN_BODY;
+       });
+
+    }
+    stopTimer();
+
+    PLANCKIAN_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  PLANCKIAN : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace lcals
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/lcals/PLANCKIAN-OMPTarget.cpp
+++ b/src/lcals/PLANCKIAN-OMPTarget.cpp
@@ -1,0 +1,111 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "PLANCKIAN.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+#include <cmath>
+
+namespace rajaperf 
+{
+namespace lcals
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define PLANCKIAN_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr x; \
+  Real_ptr y; \
+  Real_ptr u; \
+  Real_ptr v; \
+  Real_ptr w; \
+\
+  allocAndInitOpenMPDeviceData(x, m_x, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(y, m_y, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(u, m_u, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(v, m_v, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(w, m_w, iend, did, hid);
+
+#define PLANCKIAN_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_w, w, iend, hid, did); \
+  deallocOpenMPDeviceData(x, did); \
+  deallocOpenMPDeviceData(y, did); \
+  deallocOpenMPDeviceData(u, did); \
+  deallocOpenMPDeviceData(v, did); \
+  deallocOpenMPDeviceData(w, did);
+
+
+void PLANCKIAN::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    PLANCKIAN_DATA_SETUP_OMP_TARGET;
+                              
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(x, y, u, v, w) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        PLANCKIAN_BODY;
+      }
+
+    }
+    stopTimer();
+
+    PLANCKIAN_DATA_TEARDOWN_OMP_TARGET; 
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    PLANCKIAN_DATA_SETUP_OMP_TARGET; 
+                              
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        PLANCKIAN_BODY;
+      });
+
+    }
+    stopTimer();
+
+    PLANCKIAN_DATA_TEARDOWN_OMP_TARGET; 
+
+  } else {
+     std::cout << "\n  PLANCKIAN : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace lcals
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/lcals/PLANCKIAN.cpp
+++ b/src/lcals/PLANCKIAN.cpp
@@ -25,6 +25,8 @@
 #include "PLANCKIAN.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/lcals/PLANCKIAN.cpp
+++ b/src/lcals/PLANCKIAN.cpp
@@ -13,22 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// PLANCKIAN kernel reference implementation:
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   y[i] = u[i] / v[i]; 
-///   w[i] = x[i] / ( exp( y[i] ) - 1.0 );
-/// }
-///
-
 #include "PLANCKIAN.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 #include <cmath>
@@ -38,58 +27,13 @@ namespace rajaperf
 namespace lcals
 {
 
-#define PLANCKIAN_DATA \
+
+#define PLANCKIAN_DATA_SETUP_CPU \
   ResReal_ptr x = m_x; \
   ResReal_ptr y = m_y; \
   ResReal_ptr u = m_u; \
   ResReal_ptr v = m_v; \
   ResReal_ptr w = m_w;
-
-#define PLANCKIAN_BODY  \
-  y[i] = u[i] / v[i]; \
-  w[i] = x[i] / ( exp( y[i] ) - 1.0 );
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define PLANCKIAN_DATA_SETUP_CUDA \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr u; \
-  Real_ptr v; \
-  Real_ptr w; \
-\
-  allocAndInitCudaDeviceData(x, m_x, iend); \
-  allocAndInitCudaDeviceData(y, m_y, iend); \
-  allocAndInitCudaDeviceData(u, m_u, iend); \
-  allocAndInitCudaDeviceData(v, m_v, iend); \
-  allocAndInitCudaDeviceData(w, m_w, iend);
-
-#define PLANCKIAN_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_w, w, iend); \
-  deallocCudaDeviceData(x); \
-  deallocCudaDeviceData(y); \
-  deallocCudaDeviceData(u); \
-  deallocCudaDeviceData(v); \
-  deallocCudaDeviceData(w);
-
-__global__ void planckian(Real_ptr x, Real_ptr y,
-                          Real_ptr u, Real_ptr v, Real_ptr w, 
-                          Index_type iend) 
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     PLANCKIAN_BODY; 
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
 
 
 PLANCKIAN::PLANCKIAN(const RunParams& params)
@@ -122,7 +66,7 @@ void PLANCKIAN::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      PLANCKIAN_DATA;
+      PLANCKIAN_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -139,7 +83,7 @@ void PLANCKIAN::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      PLANCKIAN_DATA;
+      PLANCKIAN_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -158,7 +102,7 @@ void PLANCKIAN::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      PLANCKIAN_DATA;
+      PLANCKIAN_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -176,7 +120,7 @@ void PLANCKIAN::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      PLANCKIAN_DATA;
+      PLANCKIAN_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -191,99 +135,22 @@ void PLANCKIAN::runKernel(VariantID vid)
 
       break;
     }
-
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      PLANCKIAN_DATA;
-                              
-      Index_type n = iend;
-      #pragma omp target enter data map(to:x[0:n],y[0:n],u[0:n],v[0:n],w[0:n])
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          PLANCKIAN_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:w[0:n]) map(delete:x[0:n],y[0:n],u[0:n],v[0:n])
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget: {
-
-      PLANCKIAN_DATA;
-                              
-      Index_type n = iend;
-      #pragma omp target enter data map(to:x[0:n],y[0:n],u[0:n],v[0:n],w[0:n])
-
-      startTimer();
-      #pragma omp target data use_device_ptr(x,y,u,v,w)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          PLANCKIAN_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:w[0:n]) map(delete:x[0:n],y[0:n],u[0:n],v[0:n])
-
-      break;                        
-    }                          
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      PLANCKIAN_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         planckian<<<grid_size, block_size>>>( x, y, 
-                                               u, v, w,
-                                               iend );
-
-      }
-      stopTimer();
-
-      PLANCKIAN_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      PLANCKIAN_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           PLANCKIAN_BODY;
-         });
-
-      }
-      stopTimer();
-
-      PLANCKIAN_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/lcals/PLANCKIAN.hpp
+++ b/src/lcals/PLANCKIAN.hpp
@@ -13,9 +13,23 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// PLANCKIAN kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   y[i] = u[i] / v[i];
+///   w[i] = x[i] / ( exp( y[i] ) - 1.0 );
+/// }
+///
 
 #ifndef RAJAPerf_Basic_PLANCKIAN_HPP
 #define RAJAPerf_Basic_PLANCKIAN_HPP
+
+
+#define PLANCKIAN_BODY  \
+  y[i] = u[i] / v[i]; \
+  w[i] = x[i] / ( exp( y[i] ) - 1.0 );
+
 
 #include "common/KernelBase.hpp"
 
@@ -39,14 +53,15 @@ public:
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
 
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
+
 private:
   Real_ptr m_x;
   Real_ptr m_y;
   Real_ptr m_u;
   Real_ptr m_v;
   Real_ptr m_w;
-
-  Real_type m_expmax;
 };
 
 } // end namespace lcals

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -42,6 +42,8 @@
 #include "RAJA/RAJA.hpp"
 #include "RAJA/util/defines.hpp"
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include <iostream>
 #include <cstring>

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -50,6 +50,8 @@
 
 #include "RAJA/RAJA.hpp"
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include <iostream>
 

--- a/src/polybench/POLYBENCH_GEMMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMMVER.cpp
@@ -43,6 +43,8 @@
 #include "POLYBENCH_GEMMVER.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 #include <RAJA/RAJA.hpp>
 
 

--- a/src/stream/ADD-Cuda.cpp
+++ b/src/stream/ADD-Cuda.cpp
@@ -47,7 +47,7 @@ namespace stream
   getCudaDeviceData(m_c, c, iend); \
   deallocCudaDeviceData(a); \
   deallocCudaDeviceData(b); \
-  deallocCudaDeviceData(c)
+  deallocCudaDeviceData(c);
 
 __global__ void add(Real_ptr c, Real_ptr a, Real_ptr b,
                      Index_type iend)

--- a/src/stream/ADD-Cuda.cpp
+++ b/src/stream/ADD-Cuda.cpp
@@ -1,0 +1,110 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ADD.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/DataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace stream
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define ADD_DATA_SETUP_CUDA \
+  Real_ptr a; \
+  Real_ptr b; \
+  Real_ptr c; \
+\
+  allocAndInitCudaDeviceData(a, m_a, iend); \
+  allocAndInitCudaDeviceData(b, m_b, iend); \
+  allocAndInitCudaDeviceData(c, m_c, iend);
+
+#define ADD_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_c, c, iend); \
+  deallocCudaDeviceData(a); \
+  deallocCudaDeviceData(b); \
+  deallocCudaDeviceData(c)
+
+__global__ void add(Real_ptr c, Real_ptr a, Real_ptr b,
+                     Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     ADD_BODY;
+   }
+}
+
+
+void ADD::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+    ADD_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      add<<<grid_size, block_size>>>( c, a, b,
+                                      iend );
+
+    }
+    stopTimer();
+
+    ADD_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    ADD_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        ADD_BODY;
+      });
+
+    }
+    stopTimer();
+
+    ADD_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  ADD : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace stream
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA
+

--- a/src/stream/ADD-OMPTarget.cpp
+++ b/src/stream/ADD-OMPTarget.cpp
@@ -1,0 +1,217 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ADD.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/DataUtils.hpp"
+
+#include <iostream>
+
+//#define ADD_USE_MAP
+#define ADD_USE_TARGETALLOC
+//#define ADD_USE_UM
+
+#if defined(ADD_USE_UM)
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
+
+namespace rajaperf
+{
+namespace stream
+{
+
+#define NUMTEAMS 128
+
+void ADD::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+#if defined(ADD_USE_MAP)
+    ADD_DATA;
+
+    int n = getRunSize();
+    #pragma omp target enter data map(to:a[0:n],b[0:n],c[0:n])
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        ADD_BODY;
+      }
+
+    }
+    stopTimer();
+
+    #pragma omp target exit data map(from:c[0:n]) map(delete:a[0:n],b[0:n])
+
+#elif defined(ADD_USE_TARGETALLOC)
+
+    int h = omp_get_initial_device();
+    int d = omp_get_default_device();
+
+    Real_ptr a;
+    Real_ptr b;
+    Real_ptr c;
+
+    a = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
+    b = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
+    c = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
+
+    omp_target_memcpy( a, m_a, iend * sizeof(Real_type), 0, 0, d, h );
+    omp_target_memcpy( b, m_b, iend * sizeof(Real_type), 0, 0, d, h );
+    omp_target_memcpy( c, m_c, iend * sizeof(Real_type), 0, 0, d, h );
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(a, b, c) device( d )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        ADD_BODY;
+      }
+
+    }
+    stopTimer();
+
+    omp_target_memcpy( m_c, c, iend * sizeof(Real_type), 0, 0, h, d );
+
+    omp_target_free( a, d );
+    omp_target_free( b, d );
+    omp_target_free( c, d );
+
+#elif defined(ADD_USE_UM)
+    Real_ptr a;
+    Real_ptr b;
+    Real_ptr c;
+
+    cudaMallocManaged( (void**)&a, iend*sizeof(Real_type), cudaMemAttachGlobal);
+    cudaMallocManaged( (void**)&b, iend*sizeof(Real_type), cudaMemAttachGlobal);
+    cudaMallocManaged( (void**)&c, iend*sizeof(Real_type), cudaMemAttachGlobal);
+    cudaDeviceSynchronize();
+
+    for (int i = 0; i < iend; ++i) {
+      a[i] = m_a[i]; 
+      b[i] = m_b[i]; 
+      c[i] = m_c[i]; 
+    }
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+//    #pragma omp target is_device_ptr(a, b, c) device( d )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        ADD_BODY;
+      }
+
+    }
+    stopTimer();
+
+    cudaDeviceSynchronize();
+    for (int i = 0; i < iend; ++i) {
+      m_c[i] = c[i];
+    }
+
+    cudaFree(a);
+    cudaFree(b);
+    cudaFree(c);
+
+#else
+#error ADD -- NO memory model defined!
+#endif 
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+#if defined(ADD_USE_MAP)
+    ADD_DATA;
+
+    int n = getRunSize();
+    #pragma omp target enter data map(to:a[0:n],b[0:n],c[0:n])
+
+    startTimer();
+    #pragma omp target data use_device_ptr(a,b,c)
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        ADD_BODY;
+      });
+
+    }
+    stopTimer();
+
+    #pragma omp target exit data map(from:c[0:n]) map(delete:a[0:n],b[0:n])
+
+#elif defined(ADD_USE_TARGETALLOC)
+
+    int h = omp_get_initial_device();
+    int d = omp_get_default_device();
+
+    Real_ptr a;
+    Real_ptr b;
+    Real_ptr c;
+
+    a = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
+    b = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
+    c = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
+
+    omp_target_memcpy( a, m_a, iend * sizeof(Real_type), 0, 0, d, h );
+    omp_target_memcpy( b, m_b, iend * sizeof(Real_type), 0, 0, d, h );
+    omp_target_memcpy( c, m_c, iend * sizeof(Real_type), 0, 0, d, h );
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+//      #pragma omp target data use_device_ptr(a,b,c)
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        ADD_BODY;
+      });
+
+    }
+    stopTimer();
+
+    omp_target_memcpy( m_c, c, iend * sizeof(Real_type), 0, 0, h, d );
+
+    omp_target_free( a, d );
+    omp_target_free( b, d );
+    omp_target_free( c, d );
+
+#elif defined(ADD_USE_UM)
+
+#else
+#error ADD -- NO memory model defined!
+#endif 
+
+  } else {
+     std::cout << "\n  ADD : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace stream
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA
+

--- a/src/stream/ADD-OMPTarget.cpp
+++ b/src/stream/ADD-OMPTarget.cpp
@@ -19,25 +19,37 @@
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
-#include "common/DataUtils.hpp"
+#include "common/OpenMPTargetDataUtils.hpp"
 
 #include <iostream>
-
-//#define ADD_USE_MAP
-#define ADD_USE_TARGETALLOC
-//#define ADD_USE_UM
-
-#if defined(ADD_USE_UM)
-#include <cuda.h>
-#include <cuda_runtime.h>
-#endif
 
 namespace rajaperf
 {
 namespace stream
 {
 
+//
+// Define thread block size for target execution
+//
 #define NUMTEAMS 128
+
+#define ADD_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr a; \
+  Real_ptr b; \
+  Real_ptr c; \
+\
+  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid);
+
+#define ADD_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_c, c, iend, hid, did); \
+  deallocOpenMPDeviceData(a, did); \
+  deallocOpenMPDeviceData(b, did); \
+  deallocOpenMPDeviceData(c, did);
 
 void ADD::runOpenMPTargetVariant(VariantID vid)
 {
@@ -47,46 +59,12 @@ void ADD::runOpenMPTargetVariant(VariantID vid)
 
   if ( vid == Base_OpenMPTarget ) {
 
-#if defined(ADD_USE_MAP)
-    ADD_DATA;
-
-    int n = getRunSize();
-    #pragma omp target enter data map(to:a[0:n],b[0:n],c[0:n])
+    ADD_DATA_SETUP_OMP_TARGET;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
-      for (Index_type i = ibegin; i < iend; ++i ) {
-        ADD_BODY;
-      }
-
-    }
-    stopTimer();
-
-    #pragma omp target exit data map(from:c[0:n]) map(delete:a[0:n],b[0:n])
-
-#elif defined(ADD_USE_TARGETALLOC)
-
-    int h = omp_get_initial_device();
-    int d = omp_get_default_device();
-
-    Real_ptr a;
-    Real_ptr b;
-    Real_ptr c;
-
-    a = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-    b = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-    c = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-
-    omp_target_memcpy( a, m_a, iend * sizeof(Real_type), 0, 0, d, h );
-    omp_target_memcpy( b, m_b, iend * sizeof(Real_type), 0, 0, d, h );
-    omp_target_memcpy( c, m_c, iend * sizeof(Real_type), 0, 0, d, h );
-
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-      #pragma omp target is_device_ptr(a, b, c) device( d )
+      #pragma omp target is_device_ptr(a, b, c) device( did )
       #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
       for (Index_type i = ibegin; i < iend; ++i ) {
         ADD_BODY;
@@ -95,91 +73,11 @@ void ADD::runOpenMPTargetVariant(VariantID vid)
     }
     stopTimer();
 
-    omp_target_memcpy( m_c, c, iend * sizeof(Real_type), 0, 0, h, d );
-
-    omp_target_free( a, d );
-    omp_target_free( b, d );
-    omp_target_free( c, d );
-
-#elif defined(ADD_USE_UM)
-    Real_ptr a;
-    Real_ptr b;
-    Real_ptr c;
-
-    cudaMallocManaged( (void**)&a, iend*sizeof(Real_type), cudaMemAttachGlobal);
-    cudaMallocManaged( (void**)&b, iend*sizeof(Real_type), cudaMemAttachGlobal);
-    cudaMallocManaged( (void**)&c, iend*sizeof(Real_type), cudaMemAttachGlobal);
-    cudaDeviceSynchronize();
-
-    for (int i = 0; i < iend; ++i) {
-      a[i] = m_a[i]; 
-      b[i] = m_b[i]; 
-      c[i] = m_c[i]; 
-    }
-
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-//    #pragma omp target is_device_ptr(a, b, c) device( d )
-      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
-      for (Index_type i = ibegin; i < iend; ++i ) {
-        ADD_BODY;
-      }
-
-    }
-    stopTimer();
-
-    cudaDeviceSynchronize();
-    for (int i = 0; i < iend; ++i) {
-      m_c[i] = c[i];
-    }
-
-    cudaFree(a);
-    cudaFree(b);
-    cudaFree(c);
-
-#else
-#error ADD -- NO memory model defined!
-#endif 
+    ADD_DATA_TEARDOWN_OMP_TARGET;
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-#if defined(ADD_USE_MAP)
-    ADD_DATA;
-
-    int n = getRunSize();
-    #pragma omp target enter data map(to:a[0:n],b[0:n],c[0:n])
-
-    startTimer();
-    #pragma omp target data use_device_ptr(a,b,c)
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-        ADD_BODY;
-      });
-
-    }
-    stopTimer();
-
-    #pragma omp target exit data map(from:c[0:n]) map(delete:a[0:n],b[0:n])
-
-#elif defined(ADD_USE_TARGETALLOC)
-
-    int h = omp_get_initial_device();
-    int d = omp_get_default_device();
-
-    Real_ptr a;
-    Real_ptr b;
-    Real_ptr c;
-
-    a = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-    b = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-    c = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-
-    omp_target_memcpy( a, m_a, iend * sizeof(Real_type), 0, 0, d, h );
-    omp_target_memcpy( b, m_b, iend * sizeof(Real_type), 0, 0, d, h );
-    omp_target_memcpy( c, m_c, iend * sizeof(Real_type), 0, 0, d, h );
+    ADD_DATA_SETUP_OMP_TARGET;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -193,17 +91,7 @@ void ADD::runOpenMPTargetVariant(VariantID vid)
     }
     stopTimer();
 
-    omp_target_memcpy( m_c, c, iend * sizeof(Real_type), 0, 0, h, d );
-
-    omp_target_free( a, d );
-    omp_target_free( b, d );
-    omp_target_free( c, d );
-
-#elif defined(ADD_USE_UM)
-
-#else
-#error ADD -- NO memory model defined!
-#endif 
+    ADD_DATA_TEARDOWN_OMP_TARGET;
 
   } else {
      std::cout << "\n  ADD : Unknown OMP Target variant id = " << vid << std::endl;
@@ -213,5 +101,5 @@ void ADD::runOpenMPTargetVariant(VariantID vid)
 } // end namespace stream
 } // end namespace rajaperf
 
-#endif  // RAJA_ENABLE_CUDA
+#endif  // RAJA_ENABLE_TARGET_OPENMP
 

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -15,9 +15,9 @@
 
 #include "ADD.hpp"
 
-#include "common/DataUtils.hpp"
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -13,20 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// ADD kernel reference implementation:
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   c[i] = a[i] + b[i];
-/// }
-///
-
 #include "ADD.hpp"
 
 #include "common/DataUtils.hpp"
 
 #include "RAJA/RAJA.hpp"
-#include "RAJA/util/defines.hpp"
 
 #include <iostream>
 
@@ -34,50 +25,6 @@ namespace rajaperf
 {
 namespace stream
 {
-
-#define ADD_DATA \
-  ResReal_ptr a = m_a; \
-  ResReal_ptr b = m_b; \
-  ResReal_ptr c = m_c;
-
-#define ADD_BODY  \
-  c[i] = a[i] + b[i];
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define ADD_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  Real_ptr b; \
-  Real_ptr c; \
-\
-  allocAndInitCudaDeviceData(a, m_a, iend); \
-  allocAndInitCudaDeviceData(b, m_b, iend); \
-  allocAndInitCudaDeviceData(c, m_c, iend);
-
-#define ADD_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_c, c, iend); \
-  deallocCudaDeviceData(a); \
-  deallocCudaDeviceData(b); \
-  deallocCudaDeviceData(c)
-
-__global__ void add(Real_ptr c, Real_ptr a, Real_ptr b,
-                     Index_type iend) 
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     ADD_BODY; 
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
-
 
 ADD::ADD(const RunParams& params)
   : KernelBase(rajaperf::Stream_ADD, params)
@@ -176,171 +123,22 @@ void ADD::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-#if 0
-      ADD_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:a[0:n],b[0:n],c[0:n])
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          ADD_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:c[0:n]) map(delete:a[0:n],b[0:n])
-
-#else
-      int h = omp_get_initial_device();
-      int d = omp_get_default_device();
-
-      Real_ptr a;
-      Real_ptr b;
-      Real_ptr c;
-
-      a = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-      b = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-      c = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-
-      omp_target_memcpy( a, m_a, iend * sizeof(Real_type), 0, 0, d, h );
-      omp_target_memcpy( b, m_b, iend * sizeof(Real_type), 0, 0, d, h );
-      omp_target_memcpy( c, m_c, iend * sizeof(Real_type), 0, 0, d, h );
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target is_device_ptr(a, b, c) device( d )
-        #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          ADD_BODY;
-        }
-
-      }
-      stopTimer();
-
-      omp_target_memcpy( m_c, c, iend * sizeof(Real_type), 0, 0, h, d );
-
-      omp_target_free( a, d );
-      omp_target_free( b, d );
-      omp_target_free( c, d );
-#endif
-
+    case Base_OpenMPTarget : 
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget : {
-
-#if 0
-      ADD_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:a[0:n],b[0:n],c[0:n])
-
-      startTimer();
-      #pragma omp target data use_device_ptr(a,b,c)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          ADD_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:c[0:n]) map(delete:a[0:n],b[0:n])
-
-#else
-
-      int h = omp_get_initial_device();
-      int d = omp_get_default_device();
-
-      Real_ptr a;
-      Real_ptr b;
-      Real_ptr c;
-
-      a = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-      b = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-      c = static_cast<Real_ptr>( omp_target_alloc(iend*sizeof(Real_type), d) );
-
-      omp_target_memcpy( a, m_a, iend * sizeof(Real_type), 0, 0, d, h );
-      omp_target_memcpy( b, m_b, iend * sizeof(Real_type), 0, 0, d, h );
-      omp_target_memcpy( c, m_c, iend * sizeof(Real_type), 0, 0, d, h );
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-//      #pragma omp target data use_device_ptr(a,b,c)
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          ADD_BODY;
-        });
-
-      }
-      stopTimer();
-
-      omp_target_memcpy( m_c, c, iend * sizeof(Real_type), 0, 0, h, d );
-
-      omp_target_free( a, d );
-      omp_target_free( b, d );
-      omp_target_free( c, d );
-
 #endif
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      ADD_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         add<<<grid_size, block_size>>>( c, a, b,
-                                         iend ); 
-
-      }
-      stopTimer();
-
-      ADD_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      ADD_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-          RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-          ADD_BODY;
-        });
-
-      }
-      stopTimer();
-
-      ADD_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA : 
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -26,6 +26,13 @@ namespace rajaperf
 namespace stream
 {
 
+ 
+#define ADD_DATA_SETUP_CPU \
+  ResReal_ptr a = m_a; \
+  ResReal_ptr b = m_b; \
+  ResReal_ptr c = m_c;
+
+
 ADD::ADD(const RunParams& params)
   : KernelBase(rajaperf::Stream_ADD, params)
 {
@@ -54,7 +61,7 @@ void ADD::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      ADD_DATA;
+      ADD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -71,7 +78,7 @@ void ADD::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      ADD_DATA;
+      ADD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -90,7 +97,7 @@ void ADD::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      ADD_DATA;
+      ADD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -108,7 +115,7 @@ void ADD::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      ADD_DATA;
+      ADD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/stream/ADD.hpp
+++ b/src/stream/ADD.hpp
@@ -21,17 +21,13 @@
 /// }
 ///
 
-#define ADD_DATA \
-  ResReal_ptr a = m_a; \
-  ResReal_ptr b = m_b; \
-  ResReal_ptr c = m_c;
-
-#define ADD_BODY  \
-  c[i] = a[i] + b[i];
-
-
 #ifndef RAJAPerf_Stream_ADD_HPP
 #define RAJAPerf_Stream_ADD_HPP
+
+
+#define ADD_BODY  \
+  c[i] = a[i] + b[i]; 
+
 
 #include "common/KernelBase.hpp"
 

--- a/src/stream/ADD.hpp
+++ b/src/stream/ADD.hpp
@@ -13,6 +13,22 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// ADD kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   c[i] = a[i] + b[i];
+/// }
+///
+
+#define ADD_DATA \
+  ResReal_ptr a = m_a; \
+  ResReal_ptr b = m_b; \
+  ResReal_ptr c = m_c;
+
+#define ADD_BODY  \
+  c[i] = a[i] + b[i];
+
 
 #ifndef RAJAPerf_Stream_ADD_HPP
 #define RAJAPerf_Stream_ADD_HPP
@@ -39,10 +55,14 @@ public:
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
 
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
+
 private:
   Real_ptr m_a;
   Real_ptr m_b;
   Real_ptr m_c;
+
 };
 
 } // end namespace stream

--- a/src/stream/CMakeLists.txt
+++ b/src/stream/CMakeLists.txt
@@ -18,6 +18,8 @@ blt_add_library(
   SOURCES COPY.cpp 
           MUL.cpp 
           ADD.cpp 
+          ADD-Cuda.cpp 
+          ADD-OMPTarget.cpp 
           TRIAD.cpp 
           DOT.cpp 
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}

--- a/src/stream/CMakeLists.txt
+++ b/src/stream/CMakeLists.txt
@@ -21,6 +21,8 @@ blt_add_library(
           ADD-Cuda.cpp 
           ADD-OMPTarget.cpp 
           TRIAD.cpp 
+          TRIAD-Cuda.cpp 
+          TRIAD-OMPTarget.cpp 
           DOT.cpp 
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/stream/CMakeLists.txt
+++ b/src/stream/CMakeLists.txt
@@ -15,14 +15,20 @@
 
 blt_add_library(
   NAME stream
-  SOURCES COPY.cpp 
+  SOURCES ADD.cpp
+          ADD-Cuda.cpp
+          ADD-OMPTarget.cpp
+          COPY.cpp 
+          COPY-Cuda.cpp
+          COPY-OMPTarget.cpp
+          DOT.cpp 
+          DOT-Cuda.cpp 
+          DOT-OMPTarget.cpp 
           MUL.cpp 
-          ADD.cpp 
-          ADD-Cuda.cpp 
-          ADD-OMPTarget.cpp 
+          MUL-Cuda.cpp 
+          MUL-OMPTarget.cpp 
           TRIAD.cpp 
           TRIAD-Cuda.cpp 
           TRIAD-OMPTarget.cpp 
-          DOT.cpp 
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/stream/COPY-OMPTarget.cpp
+++ b/src/stream/COPY-OMPTarget.cpp
@@ -1,0 +1,101 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "COPY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace stream
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define COPY_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr a; \
+  Real_ptr c; \
+\
+  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid);
+
+#define COPY_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_c, c, iend, hid, did); \
+  deallocOpenMPDeviceData(a, did); \
+  deallocOpenMPDeviceData(c, did);
+
+
+void COPY::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    COPY_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(a, c) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        COPY_BODY;
+      }
+
+    }
+    stopTimer();
+
+    COPY_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    COPY_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        COPY_BODY;
+      });
+
+    }
+    stopTimer();
+
+    COPY_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  COPY : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace stream
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -24,6 +24,8 @@
 #include "COPY.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -60,7 +60,7 @@ namespace stream
 #define COPY_DATA_TEARDOWN_CUDA \
   getCudaDeviceData(m_c, c, iend); \
   deallocCudaDeviceData(a); \
-  deallocCudaDeviceData(c)
+  deallocCudaDeviceData(c);
 
 __global__ void copy(Real_ptr c, Real_ptr a,
                      Index_type iend) 

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -13,21 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// COPY kernel reference implementation:
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   c[i] = a[i] ;
-/// }
-///
-
 #include "COPY.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 
@@ -36,45 +26,9 @@ namespace rajaperf
 namespace stream
 {
 
-#define COPY_DATA \
+#define COPY_DATA_SETUP_CPU \
   ResReal_ptr a = m_a; \
   ResReal_ptr c = m_c;
-
-#define COPY_BODY  \
-  c[i] = a[i] ;
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define COPY_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  Real_ptr c; \
-\
-  allocAndInitCudaDeviceData(a, m_a, iend); \
-  allocAndInitCudaDeviceData(c, m_c, iend);
-
-#define COPY_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_c, c, iend); \
-  deallocCudaDeviceData(a); \
-  deallocCudaDeviceData(c);
-
-__global__ void copy(Real_ptr c, Real_ptr a,
-                     Index_type iend) 
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     COPY_BODY; 
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
-
 
 COPY::COPY(const RunParams& params)
   : KernelBase(rajaperf::Stream_COPY, params)
@@ -103,7 +57,7 @@ void COPY::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      COPY_DATA;
+      COPY_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -120,7 +74,7 @@ void COPY::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      COPY_DATA;
+      COPY_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -139,7 +93,7 @@ void COPY::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      COPY_DATA;
+      COPY_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -157,7 +111,7 @@ void COPY::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      COPY_DATA;
+      COPY_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -172,97 +126,22 @@ void COPY::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      COPY_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:a[0:n],c[0:n])
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          COPY_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:c[0:n]) map(delete:a[0:n])
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget: {
-
-      COPY_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:a[0:n],c[0:n])
-
-      startTimer();
-      #pragma omp target data use_device_ptr(a,c)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          COPY_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:c[0:n]) map(delete:a[0:n])
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OMP                             
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      COPY_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         copy<<<grid_size, block_size>>>( c, a,
-                                          iend ); 
-
-      }
-      stopTimer();
-
-      COPY_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      COPY_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           COPY_BODY;
-         });
-
-      }
-      stopTimer();
-
-      COPY_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -26,9 +26,11 @@ namespace rajaperf
 namespace stream
 {
 
+
 #define COPY_DATA_SETUP_CPU \
   ResReal_ptr a = m_a; \
   ResReal_ptr c = m_c;
+
 
 COPY::COPY(const RunParams& params)
   : KernelBase(rajaperf::Stream_COPY, params)

--- a/src/stream/COPY.hpp
+++ b/src/stream/COPY.hpp
@@ -13,9 +13,21 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// COPY kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   c[i] = a[i] ;
+/// }
+///
 
 #ifndef RAJAPerf_Stream_COPY_HPP
 #define RAJAPerf_Stream_COPY_HPP
+
+
+#define COPY_BODY  \
+  c[i] = a[i] ;
+
 
 #include "common/KernelBase.hpp"
 
@@ -38,6 +50,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_a;

--- a/src/stream/DOT-Cuda.cpp
+++ b/src/stream/DOT-Cuda.cpp
@@ -1,0 +1,180 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DOT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+#define USE_THRUST
+//#undef USE_THRUST
+
+
+#if defined(RAJA_ENABLE_CUDA) && defined(USE_THRUST)
+#include <thrust/device_vector.h>
+#include <thrust/inner_product.h>
+#endif
+
+namespace rajaperf 
+{
+namespace stream
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define DOT_DATA_SETUP_CUDA \
+  Real_ptr a; \
+  Real_ptr b; \
+\
+  allocAndInitCudaDeviceData(a, m_a, iend); \
+  allocAndInitCudaDeviceData(b, m_b, iend);
+
+#define DOT_DATA_TEARDOWN_CUDA \
+  deallocCudaDeviceData(a); \
+  deallocCudaDeviceData(b);
+
+#if defined(USE_THRUST)
+// Nothing to do here...
+#else
+__global__ void dot(Real_ptr a, Real_ptr b,
+                    Real_ptr dprod, Real_type dprod_init,
+                    Index_type iend) 
+{
+  extern __shared__ Real_type pdot[ ];
+
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+
+  pdot[ threadIdx.x ] = dprod_init; 
+  for ( ; i < iend ; i += gridDim.x * blockDim.x ) {
+    pdot[ threadIdx.x ] += a[ i ] * b[i];
+  }
+  __syncthreads();
+
+  for ( i = blockDim.x / 2; i > 0; i /= 2 ) {
+    if ( threadIdx.x < i ) {
+      pdot[ threadIdx.x ] += pdot[ threadIdx.x + i ];
+    }
+     __syncthreads();
+  }
+
+#if 1 // serialized access to shared data;
+  if ( threadIdx.x == 0 ) {
+    RAJA::_atomicAdd( dprod, pdot[ 0 ] );
+  }
+#else // this doesn't work due to data races
+  if ( threadIdx.x == 0 ) {
+    *dprod += pdot[ 0 ];
+  }
+#endif
+
+}
+#endif
+
+
+void DOT::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_CUDA ) {
+
+#if defined(USE_THRUST)
+
+    thrust::device_vector<Real_type> va(m_a, m_a+iend);
+    thrust::device_vector<Real_type> vb(m_b, m_b+iend);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type dprod = thrust::inner_product(va.begin(), va.end(), 
+                                              vb.begin(), m_dot_init);
+
+      m_dot += dprod;
+
+    }
+    stopTimer();
+      
+#else // don't use thrust
+
+    DOT_DATA_SETUP_CUDA;
+
+    Real_ptr dprod;
+    allocAndInitCudaDeviceData(dprod, &m_dot_init, 1);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      initCudaDeviceData(dprod, &m_dot_init, 1);
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      dot<<<grid_size, block_size, 
+            sizeof(Real_type)*block_size>>>( a, b, 
+                                             dprod, m_dot_init,
+                                             iend ); 
+
+      Real_type lprod;
+      Real_ptr plprod = &lprod;
+      getCudaDeviceData(plprod, dprod, 1);
+      m_dot += lprod;  
+
+    }
+    stopTimer();
+
+    DOT_DATA_TEARDOWN_CUDA;
+
+    deallocCudaDeviceData(dprod);
+
+#endif
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    DOT_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::ReduceSum<RAJA::cuda_reduce<block_size>, Real_type> dot(m_dot_init);
+
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         DOT_BODY;
+       });
+
+       m_dot += static_cast<Real_type>(dot.get());
+
+    }
+    stopTimer();
+
+    DOT_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n  DOT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace stream
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/stream/DOT-OMPTarget.cpp
+++ b/src/stream/DOT-OMPTarget.cpp
@@ -1,0 +1,112 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DOT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf 
+{
+namespace stream
+{
+
+#define DOT_DATA \
+  Real_ptr a = m_a; \
+  Real_ptr b = m_b;
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define DOT_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr a; \
+  Real_ptr b; \
+\
+  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid);
+
+#define DOT_DATA_TEARDOWN_OMP_TARGET \
+  deallocOpenMPDeviceData(a, did); \
+  deallocOpenMPDeviceData(b, did);
+
+void DOT::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    DOT_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type dot = m_dot_init;
+
+      #pragma omp target is_device_ptr(a, b) device( did ) map(tofrom:dot)
+      #pragma omp teams distribute parallel for reduction(+:dot) \
+              num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        DOT_BODY;
+      }
+
+      m_dot += dot;
+
+    }
+    stopTimer();
+
+    DOT_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    DOT_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::omp_target_reduce<NUMTEAMS>, Real_type> dot(m_dot_init);
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        DOT_BODY;
+      });
+
+      m_dot += static_cast<Real_type>(dot.get());
+
+    }
+    stopTimer();
+
+    DOT_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  DOT : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace stream
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/stream/DOT-OMPTarget.cpp
+++ b/src/stream/DOT-OMPTarget.cpp
@@ -28,10 +28,6 @@ namespace rajaperf
 namespace stream
 {
 
-#define DOT_DATA \
-  Real_ptr a = m_a; \
-  Real_ptr b = m_b;
-
 //
 // Define thread block size for target execution
 //

--- a/src/stream/DOT.cpp
+++ b/src/stream/DOT.cpp
@@ -14,7 +14,7 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 ///
-/// ADD kernel reference implementation:
+/// DOT kernel reference implementation:
 ///
 /// for (Index_type i = ibegin; i < iend; ++i ) {
 ///   dot += a[i] b b[i];
@@ -24,6 +24,8 @@
 #include "DOT.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 #include "RAJA/policy/cuda.hpp"

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -13,9 +13,21 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// DOT kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   dot += a[i] * b[i];
+/// }
+///
 
 #ifndef RAJAPerf_Stream_DOT_HPP
 #define RAJAPerf_Stream_DOT_HPP
+
+
+#define DOT_BODY  \
+  dot += a[i] * b[i] ;
+
 
 #include "common/KernelBase.hpp"
 
@@ -38,6 +50,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_a;

--- a/src/stream/MUL-Cuda.cpp
+++ b/src/stream/MUL-Cuda.cpp
@@ -13,7 +13,7 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "ADD.hpp"
+#include "MUL.hpp"
 
 #include "RAJA/RAJA.hpp"
 
@@ -23,7 +23,7 @@
 
 #include <iostream>
 
-namespace rajaperf
+namespace rajaperf 
 {
 namespace stream
 {
@@ -34,32 +34,29 @@ namespace stream
   const size_t block_size = 256;
 
 
-#define ADD_DATA_SETUP_CUDA \
-  Real_ptr a; \
+#define MUL_DATA_SETUP_CUDA \
   Real_ptr b; \
   Real_ptr c; \
+  Real_type alpha = m_alpha; \
 \
-  allocAndInitCudaDeviceData(a, m_a, iend); \
   allocAndInitCudaDeviceData(b, m_b, iend); \
   allocAndInitCudaDeviceData(c, m_c, iend);
 
-#define ADD_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_c, c, iend); \
-  deallocCudaDeviceData(a); \
+#define MUL_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_b, b, iend); \
   deallocCudaDeviceData(b); \
-  deallocCudaDeviceData(c);
+  deallocCudaDeviceData(c)
 
-__global__ void add(Real_ptr c, Real_ptr a, Real_ptr b,
-                     Index_type iend)
+__global__ void mul(Real_ptr b, Real_ptr c, Real_type alpha,
+                    Index_type iend) 
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i < iend) {
-     ADD_BODY;
+     MUL_BODY; 
    }
 }
 
-
-void ADD::runCudaVariant(VariantID vid)
+void MUL::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -67,39 +64,39 @@ void ADD::runCudaVariant(VariantID vid)
 
   if ( vid == Base_CUDA ) {
 
-    ADD_DATA_SETUP_CUDA;
+    MUL_DATA_SETUP_CUDA;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      add<<<grid_size, block_size>>>( c, a, b,
-                                      iend );
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       mul<<<grid_size, block_size>>>( b, c, alpha,
+                                       iend ); 
 
     }
     stopTimer();
 
-    ADD_DATA_TEARDOWN_CUDA;
+    MUL_DATA_TEARDOWN_CUDA;
 
   } else if ( vid == RAJA_CUDA ) {
 
-    ADD_DATA_SETUP_CUDA;
+    MUL_DATA_SETUP_CUDA;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-        ADD_BODY;
-      });
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         MUL_BODY;
+       });
 
     }
     stopTimer();
 
-    ADD_DATA_TEARDOWN_CUDA;
+    MUL_DATA_TEARDOWN_CUDA;
 
   } else {
-     std::cout << "\n  ADD : Unknown Cuda variant id = " << vid << std::endl;
+     std::cout << "\n  MUL : Unknown Cuda variant id = " << vid << std::endl;
   }
 }
 
@@ -107,4 +104,3 @@ void ADD::runCudaVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_CUDA
-

--- a/src/stream/MUL-OMPTarget.cpp
+++ b/src/stream/MUL-OMPTarget.cpp
@@ -1,0 +1,99 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+//
+// Produced at the Lawrence Livermore National Laboratory
+//
+// LLNL-CODE-738930
+//
+// All rights reserved.
+//
+// This file is part of the RAJA Performance Suite.
+//
+// For details about use and distribution, please read raja-perfsuite/LICENSE.
+//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MUL.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+namespace rajaperf 
+{
+namespace stream
+{
+
+//
+// Define thread block size for target execution
+//
+#define NUMTEAMS 128
+
+#define MUL_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  Real_ptr b; \
+  Real_ptr c; \
+  Real_type alpha = m_alpha; \
+\
+  allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid); \
+  allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid);
+
+#define MUL_DATA_TEARDOWN_OMP_TARGET \
+  getOpenMPDeviceData(m_b, b, iend, hid, did); \
+  deallocOpenMPDeviceData(b, did); \
+  deallocOpenMPDeviceData(c, did);
+
+void MUL::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getRunSize();
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    MUL_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(b, c) device( did )
+      #pragma omp teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        MUL_BODY;
+      }
+
+    }
+    stopTimer();
+
+    MUL_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    MUL_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        MUL_BODY;
+      });
+
+    }
+    stopTimer();
+
+    MUL_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n  MUL : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace stream
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -13,21 +13,11 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// MUL kernel reference implementation:
-///
-/// for (Index_type i = ibegin; i < iend; ++i ) {
-///   b[i] = alpha * c[i] ;
-/// }
-///
-
 #include "MUL.hpp"
 
-#include "common/DataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
-
 #include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
 
 #include <iostream>
 
@@ -36,47 +26,10 @@ namespace rajaperf
 namespace stream
 {
 
-#define MUL_DATA \
+#define MUL_DATA_SETUP_CPU \
   ResReal_ptr b = m_b; \
   ResReal_ptr c = m_c; \
   Real_type alpha = m_alpha;
-
-#define MUL_BODY  \
-  b[i] = alpha * c[i] ;
-
-
-#if defined(RAJA_ENABLE_CUDA)
-
-  //
-  // Define thread block size for CUDA execution
-  //
-  const size_t block_size = 256;
-
-
-#define MUL_DATA_SETUP_CUDA \
-  Real_ptr b; \
-  Real_ptr c; \
-  Real_type alpha = m_alpha; \
-\
-  allocAndInitCudaDeviceData(b, m_b, iend); \
-  allocAndInitCudaDeviceData(c, m_c, iend);
-
-#define MUL_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_b, b, iend); \
-  deallocCudaDeviceData(b); \
-  deallocCudaDeviceData(c)
-
-__global__ void mul(Real_ptr b, Real_ptr c, Real_type alpha,
-                    Index_type iend) 
-{
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     MUL_BODY; 
-   }
-}
-
-#endif // if defined(RAJA_ENABLE_CUDA)
-
 
 MUL::MUL(const RunParams& params)
   : KernelBase(rajaperf::Stream_MUL, params)
@@ -107,7 +60,7 @@ void MUL::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      MUL_DATA;
+      MUL_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -124,7 +77,7 @@ void MUL::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      MUL_DATA;
+      MUL_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -143,7 +96,7 @@ void MUL::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      MUL_DATA;
+      MUL_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -161,7 +114,7 @@ void MUL::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      MUL_DATA;
+      MUL_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -176,97 +129,22 @@ void MUL::runKernel(VariantID vid)
 
       break;
     }
+#endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-
-#define NUMTEAMS 128
-
-    case Base_OpenMPTarget : {
-
-      MUL_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:b[0:n],c[0:n],alpha)
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        #pragma omp target teams distribute parallel for num_teams(NUMTEAMS) schedule(static, 1) 
-        for (Index_type i = ibegin; i < iend; ++i ) {
-          MUL_BODY;
-        }
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:b[0:n])  map(delete:c[0:n],alpha)
-
+    case Base_OpenMPTarget :
+    case RAJA_OpenMPTarget :
+    {
+      runOpenMPTargetVariant(vid);
       break;
     }
-
-    case RAJA_OpenMPTarget : {
-
-      MUL_DATA;
-
-      int n = getRunSize();
-      #pragma omp target enter data map(to:b[0:n],c[0:n],alpha)
-
-      startTimer();
-      #pragma omp target data use_device_ptr(b,c)
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<NUMTEAMS>>(
-            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          MUL_BODY;
-        });
-
-      }
-      stopTimer();
-
-      #pragma omp target exit data map(from:b[0:n])  map(delete:c[0:n],alpha)
-
-      break;
-    }
-#endif //RAJA_ENABLE_TARGET_OPENMP
-#endif //RAJA_ENABLE_OPENMP
+#endif
 
 #if defined(RAJA_ENABLE_CUDA)
-    case Base_CUDA : {
-
-      MUL_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-         mul<<<grid_size, block_size>>>( b, c, alpha,
-                                         iend ); 
-
-      }
-      stopTimer();
-
-      MUL_DATA_TEARDOWN_CUDA;
-
-      break; 
-    }
-
-    case RAJA_CUDA : {
-
-      MUL_DATA_SETUP_CUDA;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-         RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-           MUL_BODY;
-         });
-
-      }
-      stopTimer();
-
-      MUL_DATA_TEARDOWN_CUDA;
-
+    case Base_CUDA :
+    case RAJA_CUDA :
+    {
+      runCudaVariant(vid);
       break;
     }
 #endif

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -26,10 +26,12 @@ namespace rajaperf
 namespace stream
 {
 
+
 #define MUL_DATA_SETUP_CPU \
   ResReal_ptr b = m_b; \
   ResReal_ptr c = m_c; \
   Real_type alpha = m_alpha;
+
 
 MUL::MUL(const RunParams& params)
   : KernelBase(rajaperf::Stream_MUL, params)

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -24,6 +24,8 @@
 #include "MUL.hpp"
 
 #include "common/DataUtils.hpp"
+#include "common/CudaDataUtils.hpp"
+
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/stream/MUL.hpp
+++ b/src/stream/MUL.hpp
@@ -13,9 +13,21 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// MUL kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   b[i] = alpha * c[i] ;
+/// }
+///
 
 #ifndef RAJAPerf_Stream_MUL_HPP
 #define RAJAPerf_Stream_MUL_HPP
+
+
+#define MUL_BODY  \
+  b[i] = alpha * c[i] ;
+
 
 #include "common/KernelBase.hpp"
 
@@ -38,6 +50,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_b;

--- a/src/stream/TRIAD-Cuda.cpp
+++ b/src/stream/TRIAD-Cuda.cpp
@@ -13,19 +13,17 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "ADD.hpp"
+#include "TRIAD.hpp"
 
 #include "RAJA/RAJA.hpp"
 
 #if defined(RAJA_ENABLE_CUDA)
 
 #include "common/CudaDataUtils.hpp"
-#include "common/CudaDataUtils.hpp"
-
 
 #include <iostream>
 
-namespace rajaperf
+namespace rajaperf 
 {
 namespace stream
 {
@@ -36,32 +34,33 @@ namespace stream
   const size_t block_size = 256;
 
 
-#define ADD_DATA_SETUP_CUDA \
+#define TRIAD_DATA_SETUP_CUDA \
   Real_ptr a; \
   Real_ptr b; \
   Real_ptr c; \
+  Real_type alpha = m_alpha; \
 \
   allocAndInitCudaDeviceData(a, m_a, iend); \
   allocAndInitCudaDeviceData(b, m_b, iend); \
   allocAndInitCudaDeviceData(c, m_c, iend);
 
-#define ADD_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_c, c, iend); \
+#define TRIAD_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_a, a, iend); \
   deallocCudaDeviceData(a); \
   deallocCudaDeviceData(b); \
   deallocCudaDeviceData(c);
 
-__global__ void add(Real_ptr c, Real_ptr a, Real_ptr b,
-                     Index_type iend)
+__global__ void triad(Real_ptr a, Real_ptr b, Real_ptr c, Real_type alpha,
+                      Index_type iend) 
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i < iend) {
-     ADD_BODY;
+     TRIAD_BODY; 
    }
 }
 
 
-void ADD::runCudaVariant(VariantID vid)
+void TRIAD::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -69,44 +68,44 @@ void ADD::runCudaVariant(VariantID vid)
 
   if ( vid == Base_CUDA ) {
 
-    ADD_DATA_SETUP_CUDA;
+    TRIAD_DATA_SETUP_CUDA;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      add<<<grid_size, block_size>>>( c, a, b,
-                                      iend );
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       triad<<<grid_size, block_size>>>( a, b, c, alpha,
+                                         iend ); 
 
     }
     stopTimer();
 
-    ADD_DATA_TEARDOWN_CUDA;
+    TRIAD_DATA_TEARDOWN_CUDA;
 
   } else if ( vid == RAJA_CUDA ) {
 
-    ADD_DATA_SETUP_CUDA;
+    TRIAD_DATA_SETUP_CUDA;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-        ADD_BODY;
-      });
+       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         TRIAD_BODY;
+       });
 
     }
     stopTimer();
 
-    ADD_DATA_TEARDOWN_CUDA;
+    TRIAD_DATA_TEARDOWN_CUDA;
 
   } else {
-     std::cout << "\n  ADD : Unknown Cuda variant id = " << vid << std::endl;
+      std::cout << "\n  TRIAD : Unknown variant id = " << vid << std::endl;
   }
+
 }
 
 } // end namespace stream
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_CUDA
-

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -66,7 +66,7 @@ namespace stream
   getCudaDeviceData(m_a, a, iend); \
   deallocCudaDeviceData(a); \
   deallocCudaDeviceData(b); \
-  deallocCudaDeviceData(c)
+  deallocCudaDeviceData(c);
 
 __global__ void triad(Real_ptr a, Real_ptr b, Real_ptr c, Real_type alpha,
                       Index_type iend) 

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -26,6 +26,12 @@ namespace rajaperf
 namespace stream
 {
 
+#define TRIAD_DATA_SETUP_CPU \
+  ResReal_ptr a = m_a; \
+  ResReal_ptr b = m_b; \
+  ResReal_ptr c = m_c; \
+  Real_type alpha = m_alpha;
+
 TRIAD::TRIAD(const RunParams& params)
   : KernelBase(rajaperf::Stream_TRIAD, params)
 {
@@ -55,7 +61,7 @@ void TRIAD::runKernel(VariantID vid)
 
     case Base_Seq : {
 
-      TRIAD_DATA;
+      TRIAD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -72,7 +78,7 @@ void TRIAD::runKernel(VariantID vid)
 
     case RAJA_Seq : {
 
-      TRIAD_DATA;
+      TRIAD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -91,7 +97,7 @@ void TRIAD::runKernel(VariantID vid)
 #if defined(RAJA_ENABLE_OPENMP)
     case Base_OpenMP : {
 
-      TRIAD_DATA;
+      TRIAD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -109,7 +115,7 @@ void TRIAD::runKernel(VariantID vid)
 
     case RAJA_OpenMP : {
 
-      TRIAD_DATA;
+      TRIAD_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -26,11 +26,13 @@ namespace rajaperf
 namespace stream
 {
 
+
 #define TRIAD_DATA_SETUP_CPU \
   ResReal_ptr a = m_a; \
   ResReal_ptr b = m_b; \
   ResReal_ptr c = m_c; \
   Real_type alpha = m_alpha;
+
 
 TRIAD::TRIAD(const RunParams& params)
   : KernelBase(rajaperf::Stream_TRIAD, params)

--- a/src/stream/TRIAD.hpp
+++ b/src/stream/TRIAD.hpp
@@ -13,6 +13,23 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+///
+/// TRIAD kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   a[i] = b[i] + alpha * c[i] ;
+/// }
+///
+
+#define TRIAD_DATA \
+  ResReal_ptr a = m_a; \
+  ResReal_ptr b = m_b; \
+  ResReal_ptr c = m_c; \
+  Real_type alpha = m_alpha;
+
+#define TRIAD_BODY  \
+  a[i] = b[i] + alpha * c[i] ;
+
 
 #ifndef RAJAPerf_Stream_TRIAD_HPP
 #define RAJAPerf_Stream_TRIAD_HPP
@@ -38,6 +55,9 @@ public:
   void runKernel(VariantID vid); 
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
+
+  void runCudaVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
 
 private:
   Real_ptr m_a;

--- a/src/stream/TRIAD.hpp
+++ b/src/stream/TRIAD.hpp
@@ -21,18 +21,13 @@
 /// }
 ///
 
-#define TRIAD_DATA \
-  ResReal_ptr a = m_a; \
-  ResReal_ptr b = m_b; \
-  ResReal_ptr c = m_c; \
-  Real_type alpha = m_alpha;
+#ifndef RAJAPerf_Stream_TRIAD_HPP
+#define RAJAPerf_Stream_TRIAD_HPP
+
 
 #define TRIAD_BODY  \
   a[i] = b[i] + alpha * c[i] ;
 
-
-#ifndef RAJAPerf_Stream_TRIAD_HPP
-#define RAJAPerf_Stream_TRIAD_HPP
 
 #include "common/KernelBase.hpp"
 


### PR DESCRIPTION
Source files for all kernels are broken apart so CPU, CUDA, and OMP Target variants are in separate translation units. Target data pragmas removed from all OMP Target variants to the extent possible. So temporary OMP Target variants filled in until nested OMP Target collapse is ready to replace them. README documentation updated to reflect current state of builds and file organization.