### PR TITLE
Fix timers and policy changes

### DIFF
--- a/scripts/update_copyright.sh
+++ b/scripts/update_copyright.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2017-18, Lawrence Livermore National Security, LLC.
+#
+# Produced at the Lawrence Livermore National Laboratory
+#
+# LLNL-CODE-738930
+#
+# All rights reserved.
+#
+# This file is part of the RAJA Performance Suite.
+#
+# For details about use and distribution, please read RAJAPerf/LICENSE.
+#
+###############################################################################
+
+#=============================================================================
+# Change the copyright date in all files that contain the text
+# "RAJA Performance Suite". We restrict to this subset of files
+# since we do not want to modify files we do not own (e.g., other repos
+# included as submodules). Note that this file and *.git files are omitted
+# as well.
+#
+# IMPORTANT: Since this file is not modified (it is running the shell 
+# script commands), you must EDIT THE COPYRIGHT DATES ABOVE MANUALLY.
+#
+# Edit the 'find' command below to change the set of files that will be
+# modified.
+#
+# Change the 'sed' command below to change the content that is changed
+# in each file and what it is changed to.
+#
+#=============================================================================
+#
+# If you need to modify this script, you may want to run each of these 
+# commands individual from the command line to make sure things are doing 
+# what you think they should be doing. This is why they are seperated into 
+# steps here.
+# 
+#=============================================================================
+
+#=============================================================================
+# First find all the files we want to modify
+#=============================================================================
+find . -type f ! -name \*.git\*  ! -name \*update_copyright\* -exec grep -l "RAJA Performance Suite" {} \; > files2change
+
+#=============================================================================
+# Replace the old copyright dates with new dates
+#=============================================================================
+for i in `cat files2change`
+do
+    echo $i
+    cp $i $i.sed.bak
+    sed "s/Copyright (c) 2017-18/Copyright (c) 2017-19/" $i.sed.bak > $i
+done
+
+#=============================================================================
+# Remove temporary files created in the process
+#=============================================================================
+find . -name \*.sed.bak -exec rm {} \;
+rm files2change

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -135,32 +135,32 @@ void ENERGY::runKernel(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::simd_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](int i) {
           ENERGY_BODY1;
         }); 
 
-        RAJA::forall<RAJA::simd_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](int i) {
           ENERGY_BODY2;
         }); 
 
-        RAJA::forall<RAJA::simd_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](int i) {
           ENERGY_BODY3;
         }); 
 
-        RAJA::forall<RAJA::simd_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](int i) {
           ENERGY_BODY4;
         }); 
 
-        RAJA::forall<RAJA::simd_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](int i) {
           ENERGY_BODY5;
         }); 
 
-        RAJA::forall<RAJA::simd_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](int i) {
           ENERGY_BODY6;
         }); 

--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -97,7 +97,7 @@ void FIR::runKernel(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::seq_exec>(
+        RAJA::forall<RAJA::simd_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](int i) {
           FIR_BODY;
         }); 

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -107,10 +107,10 @@ void LTIMES::runKernel(VariantID vid)
       LTIMES_VIEWS_RANGES_RAJA;
 
       using EXEC_POL = RAJA::nested::Policy<
-                             RAJA::nested::For<1, RAJA::seq_exec>,
-                             RAJA::nested::For<2, RAJA::seq_exec>,
-                             RAJA::nested::For<3, RAJA::seq_exec>,
-                             RAJA::nested::For<0, RAJA::seq_exec> >;
+                             RAJA::nested::For<1, RAJA::loop_exec>,
+                             RAJA::nested::For<2, RAJA::loop_exec>,
+                             RAJA::nested::For<3, RAJA::loop_exec>,
+                             RAJA::nested::For<0, RAJA::loop_exec> >;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -163,9 +163,9 @@ void LTIMES::runKernel(VariantID vid)
 
       using EXEC_POL = RAJA::nested::Policy<
                      RAJA::nested::For<1, RAJA::omp_parallel_for_exec>,
-                     RAJA::nested::For<2, RAJA::seq_exec>,
-                     RAJA::nested::For<3, RAJA::seq_exec>,
-                     RAJA::nested::For<0, RAJA::seq_exec> >;
+                     RAJA::nested::For<2, RAJA::loop_exec>,
+                     RAJA::nested::For<3, RAJA::loop_exec>,
+                     RAJA::nested::For<0, RAJA::loop_exec> >;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -107,10 +107,10 @@ void LTIMES_NOVIEW::runKernel(VariantID vid)
       LTIMES_NOVIEW_RANGES_RAJA;
 
       using EXEC_POL = RAJA::nested::Policy<
-                             RAJA::nested::For<1, RAJA::seq_exec>,
-                             RAJA::nested::For<2, RAJA::seq_exec>,
-                             RAJA::nested::For<3, RAJA::seq_exec>,
-                             RAJA::nested::For<0, RAJA::seq_exec> >;
+                             RAJA::nested::For<1, RAJA::loop_exec>,
+                             RAJA::nested::For<2, RAJA::loop_exec>,
+                             RAJA::nested::For<3, RAJA::loop_exec>,
+                             RAJA::nested::For<0, RAJA::loop_exec> >;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -163,9 +163,9 @@ void LTIMES_NOVIEW::runKernel(VariantID vid)
 
       using EXEC_POL = RAJA::nested::Policy<
                      RAJA::nested::For<1, RAJA::omp_parallel_for_exec>,
-                     RAJA::nested::For<2, RAJA::seq_exec>,
-                     RAJA::nested::For<3, RAJA::seq_exec>,
-                     RAJA::nested::For<0, RAJA::seq_exec> >;
+                     RAJA::nested::For<2, RAJA::loop_exec>,
+                     RAJA::nested::For<3, RAJA::loop_exec>,
+                     RAJA::nested::For<0, RAJA::loop_exec> >;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/apps/PRESSURE.cpp
+++ b/src/apps/PRESSURE.cpp
@@ -99,12 +99,12 @@ void PRESSURE::runKernel(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::simd_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](int i) {
           PRESSURE_BODY1;
         }); 
 
-        RAJA::forall<RAJA::simd_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](int i) {
           PRESSURE_BODY2;
         }); 

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -116,7 +116,7 @@ void VOL3D::runKernel(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::simd_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
           VOL3D_BODY;
         }); 

--- a/src/apps/WIP-COUPLE.cpp
+++ b/src/apps/WIP-COUPLE.cpp
@@ -126,7 +126,7 @@ void COUPLE::runKernel(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::seq_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(kmin, kmax), [=](int k) {
           COUPLE_BODY;
         }); 

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -87,7 +87,7 @@ void IF_QUAD::runKernel(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::simd_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](int i) {
           IF_QUAD_BODY;
         });

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -89,8 +89,8 @@ void NESTED_INIT::runKernel(VariantID vid)
       NESTED_INIT_DATA_SETUP_CPU;
 
       using EXEC_POL = RAJA::nested::Policy<
-                             RAJA::nested::For<2, RAJA::seq_exec>,    // k
-                             RAJA::nested::For<1, RAJA::seq_exec>,    // j
+                             RAJA::nested::For<2, RAJA::loop_exec>,    // k
+                             RAJA::nested::For<1, RAJA::loop_exec>,    // j
                              RAJA::nested::For<0, RAJA::simd_exec> >; // i
 
       startTimer();
@@ -141,7 +141,7 @@ void NESTED_INIT::runKernel(VariantID vid)
 
       using EXEC_POL = RAJA::nested::Policy<
                            RAJA::nested::For<2, RAJA::omp_parallel_for_exec>,//k
-                           RAJA::nested::For<1, RAJA::seq_exec>,             //j
+                           RAJA::nested::For<1, RAJA::loop_exec>,            //j
                            RAJA::nested::For<0, RAJA::simd_exec> >;          //i
 
       startTimer();

--- a/src/basic/REDUCE3_INT.cpp
+++ b/src/basic/REDUCE3_INT.cpp
@@ -102,7 +102,7 @@ void REDUCE3_INT::runKernel(VariantID vid)
         RAJA::ReduceMin<RAJA::seq_reduce, Int_type> vmin(m_vmin_init);
         RAJA::ReduceMax<RAJA::seq_reduce, Int_type> vmax(m_vmax_init);
 
-        RAJA::forall<RAJA::simd_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
           REDUCE3_INT_BODY_RAJA;
         });

--- a/src/basic/TRAP_INT.cpp
+++ b/src/basic/TRAP_INT.cpp
@@ -115,7 +115,7 @@ void TRAP_INT::runKernel(VariantID vid)
 
         RAJA::ReduceSum<RAJA::seq_reduce, Real_type> sumx(m_sumx_init);
 
-        RAJA::forall<RAJA::seq_exec>(
+        RAJA::forall<RAJA::loop_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](int i) {
           TRAP_INT_BODY;
         });

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -67,8 +67,27 @@ public:
   Checksum_type getChecksum(VariantID vid) const { return checksum[vid]; }
 
   void execute(VariantID vid);
-  void startTimer() { timer.start(); }
-  void stopTimer()  { timer.stop(); recordExecTime(); }
+
+  void startTimer() 
+  { 
+#if defined(RAJA_ENABLE_CUDA)
+    if ( running_variant == Base_CUDA || running_variant == RAJA_CUDA ) {
+      cudaDeviceSynchronize();
+    }
+#endif
+    timer.start(); 
+  }
+
+  void stopTimer()  
+  { 
+#if defined(RAJA_ENABLE_CUDA)
+    if ( running_variant == Base_CUDA || running_variant == RAJA_CUDA ) {
+      cudaDeviceSynchronize();
+    }
+#endif
+    timer.stop(); recordExecTime(); 
+  }
+
   void resetTimer() { timer.reset(); }
 
   //

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -335,7 +335,7 @@ void RunParams::printHelpMessage(std::ostream& str) const
   str << "\t --sizefact <double> [default is 1.0]\n"
       << "\t      (fraction of default kernel iteration space size to run)\n";
   str << "\t\t Example...\n"
-      << "\t\t --repfact 2.0 (kernel loops will be twice as long as default)\n\n";
+      << "\t\t --sizefact 2.0 (kernel size will be twice the default)\n\n";
 
   str << "\t --sizespec <string> [one of : mini,small,medium,large,extralarge (anycase) -- default is medium]\n"
       << "\t      (used to set specific sizes for certain kernels : e.g. polybench)\n\n"; 

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -335,7 +335,7 @@ void RunParams::printHelpMessage(std::ostream& str) const
   str << "\t --sizefact <double> [default is 1.0]\n"
       << "\t      (fraction of default kernel iteration space size to run)\n";
   str << "\t\t Example...\n"
-      << "\t\t --sizefact 2.0 (kernel size will be twice the default)\n\n";
+      << "\t\t --sizefact 2.0 (iteration space size is twice the default)\n\n";
 
   str << "\t --sizespec <string> [one of : mini,small,medium,large,extralarge (anycase) -- default is medium]\n"
       << "\t      (used to set specific sizes for certain kernels : e.g. polybench)\n\n"; 

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -13,30 +13,6 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// POLYBENCH_2MM kernel reference implementation:
-///
-/// D := alpha*A*B*C + beta*D
-///
-/// for (Index_type i = 0; i < m_ni; i++) {
-///   for (Index_type j = 0; j < m_nj; j++) {
-///     m_tmp[i][j] = 0.0;
-///     for (Index_type k = 0; k < m_nk; ++k) {
-///       m_tmp[i][j] += m_alpha * m_A[i][k] * m_B[k][j];
-///     }
-///   }
-/// } 
-/// for (Index_type i = 0; i < m_ni; i++) {
-///   for (Index_type j = 0; j < m_nl; j++) {
-///     m_D[i][j] *= m_beta;
-///     for (Index_type k = 0; k < m_nj; ++k) {
-///       m_D[i][j] += m_tmp[i][k] * m_C[k][j];
-///     } 
-///   }
-/// } 
-///
-
-
 #include "POLYBENCH_2MM.hpp"
 
 #include "RAJA/RAJA.hpp"
@@ -164,8 +140,8 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
       POLYBENCH_2MM_DATA_SETUP_CPU;
 
       using EXEC_POL = RAJA::nested::Policy<
-        RAJA::nested::For<1, RAJA::seq_exec>,
-        RAJA::nested::For<0, RAJA::seq_exec> >;
+        RAJA::nested::For<1, RAJA::loop_exec>,
+        RAJA::nested::For<0, RAJA::loop_exec> >;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -176,7 +152,7 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
             [=](Index_type i, Index_type j) {     
             POLYBENCH_2MM_BODY1;
 
-            RAJA::forall<RAJA::seq_exec> (
+            RAJA::forall<RAJA::loop_exec> (
               RAJA::RangeSegment{0, nk}, [=] (int k) {
               POLYBENCH_2MM_BODY2; 
             });
@@ -190,7 +166,7 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
             [=](Index_type i, Index_type l) {     
             POLYBENCH_2MM_BODY3;
 
-            RAJA::forall<RAJA::seq_exec> (
+            RAJA::forall<RAJA::loop_exec> (
               RAJA::RangeSegment{0, nj}, [=] (int j) {
               POLYBENCH_2MM_BODY4; 
             });
@@ -244,7 +220,7 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
 
       using EXEC_POL = RAJA::nested::Policy<
         RAJA::nested::For<1, RAJA::omp_parallel_for_exec>,
-        RAJA::nested::For<0, RAJA::seq_exec> >;
+        RAJA::nested::For<0, RAJA::loop_exec> >;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -255,7 +231,7 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
             [=](Index_type i, Index_type j) {     
             POLYBENCH_2MM_BODY1;
 
-            RAJA::forall<RAJA::seq_exec> (
+            RAJA::forall<RAJA::loop_exec> (
               RAJA::RangeSegment{0, nk}, [=] (int k) {
               POLYBENCH_2MM_BODY2; 
             });
@@ -269,7 +245,7 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
             [=](Index_type i, Index_type l) {     
             POLYBENCH_2MM_BODY3;
 
-            RAJA::forall<RAJA::seq_exec> (
+            RAJA::forall<RAJA::loop_exec> (
               RAJA::RangeSegment{0, nj}, [=] (int j) {
               POLYBENCH_2MM_BODY4; 
             });

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -13,39 +13,6 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// POLYBENCH_3MM kernel reference implementation:
-///
-/// E := A*B 
-/// F := C*D 
-/// G := E*F 
-///
-/// for (Index_type i = 0; i < _PB_NI; i++) {
-///   for (Index_type j = 0; j < _PB_NJ; j++) {
-///     E[i][j] = SCALAR_VAL(0.0);
-///     for (Index_type k = 0; k < _PB_NK; ++k) {
-///       E[i][j] += A[i][k] * B[k][j];
-///     }
-///   }
-/// } 
-/// for (Index_type i = 0; i < _PB_NJ; i++) {
-///   for (Index_type j = 0; j < _PB_NL; j++) {
-///	F[i][j] = SCALAR_VAL(0.0);
-///	for (Index_type k = 0; k < _PB_NM; ++k) {
-///	  F[i][j] += C[i][k] * D[k][j];
-///     }
-///   }
-/// }
-/// for (Index_type i = 0; i < _PB_NI; i++) {
-///   for (Index_type j = 0; j < _PB_NL; j++) {
-///     G[i][j] = SCALAR_VAL(0.0);
-///     for (Index_type k = 0; k < _PB_NJ; ++k) {
-///	  G[i][j] += E[i][k] * F[k][j];
-///     }
-///   }
-/// }
-///
-
 #include "POLYBENCH_3MM.hpp"
 
 #include "RAJA/RAJA.hpp"
@@ -178,8 +145,8 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
       POLYBENCH_3MM_DATA_SETUP_CPU;
       
       using EXEC_POL = RAJA::nested::Policy<
-        RAJA::nested::For<1, RAJA::seq_exec>,
-        RAJA::nested::For<0, RAJA::seq_exec> >;
+        RAJA::nested::For<1, RAJA::loop_exec>,
+        RAJA::nested::For<0, RAJA::loop_exec> >;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -190,7 +157,7 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
             [=](Index_type i, Index_type j) {     
             POLYBENCH_3MM_BODY1;
 
-            RAJA::forall<RAJA::seq_exec> (
+            RAJA::forall<RAJA::loop_exec> (
               RAJA::RangeSegment{0, nk}, [=] (int k) {
               POLYBENCH_3MM_BODY2; 
             });
@@ -202,7 +169,7 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
             [=](Index_type j, Index_type l) {     
             POLYBENCH_3MM_BODY3;
 
-            RAJA::forall<RAJA::seq_exec> (
+            RAJA::forall<RAJA::loop_exec> (
               RAJA::RangeSegment{0, nm}, [=] (int m) {
               POLYBENCH_3MM_BODY4; 
             });
@@ -214,7 +181,7 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
             [=](Index_type i, Index_type l) {     
             POLYBENCH_3MM_BODY5;
 
-            RAJA::forall<RAJA::seq_exec> (
+            RAJA::forall<RAJA::loop_exec> (
               RAJA::RangeSegment{0, nj}, [=] (int j) {
               POLYBENCH_3MM_BODY6; 
             });
@@ -276,7 +243,7 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
 
       using EXEC_POL = RAJA::nested::Policy<
         RAJA::nested::For<1, RAJA::omp_parallel_for_exec>,
-        RAJA::nested::For<0, RAJA::seq_exec> >;
+        RAJA::nested::For<0, RAJA::loop_exec> >;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -288,7 +255,7 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
 
           POLYBENCH_3MM_BODY1;
 
-          RAJA::forall<RAJA::seq_exec> (
+          RAJA::forall<RAJA::loop_exec> (
           RAJA::RangeSegment{0, nk}, [=] (int k) {
             POLYBENCH_3MM_BODY2; 
           });
@@ -302,7 +269,7 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
 
           POLYBENCH_3MM_BODY3;
 
-          RAJA::forall<RAJA::seq_exec> (
+          RAJA::forall<RAJA::loop_exec> (
           RAJA::RangeSegment{0, nm}, [=] (int m) {
             POLYBENCH_3MM_BODY4;
           });
@@ -316,7 +283,7 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
 
             POLYBENCH_3MM_BODY5;
 
-            RAJA::forall<RAJA::seq_exec> (
+            RAJA::forall<RAJA::loop_exec> (
               RAJA::RangeSegment{0, nj}, [=] (int j) {
               POLYBENCH_3MM_BODY6;
           });

--- a/src/polybench/POLYBENCH_GEMMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMMVER.cpp
@@ -13,33 +13,6 @@
 //
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-///
-/// POLYBENCH_GEMMVER kernel reference implementation:
-///
-/// for (Index_type i = 0; i < _PB_N; i++) {
-///   for (Index_type j = 0; j < _PB_N; j++) {
-///     A[i][j] = A[i][j] + u1[i] * v1[j] + u2[i] * v2[j];
-///   }
-/// }
-///
-/// for (Index_type i = 0; i < _PB_N; i++) {
-///   for (Index_type j = 0; j < _PB_N; j++) {
-///     x[i] = x[i] + beta * A[j][i] * y[j];
-///   }
-/// }
-///
-/// for (Index_type i = 0; i < _PB_N; i++) {
-///   x[i] = x[i] + z[i];
-/// }
-///
-/// for (Index_type i = 0; i < _PB_N; i++) {
-///   for (Index_type j = 0; j < _PB_N; j++) {
-///     w[i] = w[i] +  alpha * A[i][j] * x[j];
-///   }
-/// }
-///
-
-
 #include "POLYBENCH_GEMMVER.hpp"
 
 #include "RAJA/RAJA.hpp"
@@ -175,8 +148,8 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
       POLYBENCH_GEMMVER_DATA_SETUP_CPU;
 
       using EXEC_POL = RAJA::nested::Policy<
-        RAJA::nested::For<1, RAJA::seq_exec>,
-        RAJA::nested::For<0, RAJA::seq_exec> >;
+        RAJA::nested::For<1, RAJA::loop_exec>,
+        RAJA::nested::For<0, RAJA::loop_exec> >;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -195,7 +168,7 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
             POLYBENCH_GEMMVER_BODY2;
         });
 
-        RAJA::forall<RAJA::seq_exec> (
+        RAJA::forall<RAJA::loop_exec> (
           RAJA::RangeSegment{0, n}, [=] (int i) {
           POLYBENCH_GEMMVER_BODY3; 
         });
@@ -260,7 +233,7 @@ void POLYBENCH_GEMMVER::runKernel(VariantID vid)
       POLYBENCH_GEMMVER_DATA_SETUP_CPU;
 
       using EXEC_POL = RAJA::nested::Policy<
-        RAJA::nested::For<1, RAJA::seq_exec>,
+        RAJA::nested::For<1, RAJA::loop_exec>,
         RAJA::nested::For<0, RAJA::omp_parallel_for_exec> >;
 
       startTimer();


### PR DESCRIPTION
Fixed timers so that we are correctly timing CUDA async kernel launches.

Modified policies to use loop_exec in place of all seq_exec usage, and in place of simd_exec when simd_exec is questionable.