### PR TITLE
changed TARGET_OPENMP string names to avoid redundant generation of R…

### DIFF
--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -193,8 +193,8 @@ static const std::string VariantNames [] =
   std::string("RAJA_OpenMP"),
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)  
-  std::string("Base_OpenMPTarget"),
-  std::string("RAJA_OpenMPTarget"),
+  std::string("Base_OMPTarget"),
+  std::string("RAJA_OMPTarget"),
 #endif
 
 #endif


### PR DESCRIPTION
Bug reported that FOM output file had a redundant RAJA_OpenMPTarget column. FOM groups are parsed wrt to baseline implementation for a given model variant. However substring searches proceeding xxxx_  need to be unique for each compute model, otherwise we can get a RAJA_OpenMPTarget associated with Base_OpenMP and another RAJA_OpenMPTarget associated with Base_OpenMPTarget.

Just changing the string names from Base_OpenMPTarget and RAJA_OpenMPTarget to Base_OMPTarget and RAJA_OMPTarget now generate this FOM header:

FOM Report : signed speedup(-)/slowdown(+) for each PM (base vs. RAJA) -> (T_RAJA - T_base) / T_base ) ,  ,  ,  ,  ,  , 
'OVER_TOL' in column to right if RAJA speedup is over tolerance ,  ,  ,  ,  ,  , 
Kernel                    , RAJA_Seq        ,         , RAJA_OpenMP     ,         , RAJA_OMPTarget 

Just an FYI: PR has been generated against master just for convenience.
