### PR TITLE
Bug fix for CUDA version of INIT_VIEW1D_OFFSET.

### DIFF
--- a/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
@@ -61,7 +61,7 @@ __global__ void initview1d_offset(Real_ptr a,
 void INIT_VIEW1D_OFFSET::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type ibegin = 1;
+  const Index_type ibegin = 0;
   const Index_type iend = getRunSize()+1;
 
   if ( vid == Base_CUDA ) {


### PR DESCRIPTION
Starting index should be 0, due to CUDA thread indexing. Mat Colgrove (PGI) was experiencing seg faults on x86+V100 platforms, and reported this issue.

__global__ void initview1d_offset(Real_ptr a, 
                                  Real_type v,
                                  const Index_type ibegin,
                                  const Index_type iend) 
{
   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < iend) {
     INIT_VIEW1D_OFFSET_BODY;   // a[i-ibegin] = v;
   }
}

In the body of the "if" statement, "ibegin" needs to start at 0 for proper CUDA indexing. Otherwise, we incur -1 index accesses.