### PR TITLE
Omp lambda variant

### DIFF
--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -149,6 +149,29 @@ void DEL_DOT_VEC_2D::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      DEL_DOT_VEC_2D_DATA_INDEX;
+
+      auto deldotvec2d_omp_lam = [=](Index_type ii) {
+                                   DEL_DOT_VEC_2D_BODY_INDEX;
+                                   DEL_DOT_VEC_2D_BODY;
+                                 };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type ii = ibegin ; ii < iend ; ++ii ) {
+          deldotvec2d_omp_lam(ii);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -84,22 +84,22 @@ void ENERGY::runKernel(VariantID vid)
 
   ENERGY_DATA_SETUP_CPU;
   
-  auto energy1_lam = [=](int i) {
+  auto energy_lam1 = [=](int i) {
                        ENERGY_BODY1;
                      };
-  auto energy2_lam = [=](int i) {
+  auto energy_lam2 = [=](int i) {
                        ENERGY_BODY2;
                      };
-  auto energy3_lam = [=](int i) {
+  auto energy_lam3 = [=](int i) {
                        ENERGY_BODY3;
                      };
-  auto energy4_lam = [=](int i) {
+  auto energy_lam4 = [=](int i) {
                        ENERGY_BODY4;
                      };
-  auto energy5_lam = [=](int i) {
+  auto energy_lam5 = [=](int i) {
                        ENERGY_BODY5;
                      };
-  auto energy6_lam = [=](int i) {
+  auto energy_lam6 = [=](int i) {
                        ENERGY_BODY6;
                      };
 
@@ -149,22 +149,22 @@ void ENERGY::runKernel(VariantID vid)
         RAJA::region<RAJA::seq_region>( [=]() {
 
           RAJA::forall<RAJA::loop_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy1_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam1);
 
           RAJA::forall<RAJA::loop_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy2_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam2);
 
           RAJA::forall<RAJA::loop_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy3_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam3);
 
           RAJA::forall<RAJA::loop_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy4_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam4);
 
           RAJA::forall<RAJA::loop_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy5_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam5);
 
           RAJA::forall<RAJA::loop_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy6_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam6);
 
         }); // end sequential region (for single-source code)
 
@@ -230,32 +230,32 @@ void ENERGY::runKernel(VariantID vid)
         {
           #pragma omp for nowait
           for (Index_type i = ibegin; i < iend; ++i ) {
-            energy1_lam(i);
+            energy_lam1(i);
           }
 
           #pragma omp for nowait
           for (Index_type i = ibegin; i < iend; ++i ) {
-            energy2_lam(i);
+            energy_lam2(i);
           }
 
           #pragma omp for nowait
           for (Index_type i = ibegin; i < iend; ++i ) {
-            energy3_lam(i);
+            energy_lam3(i);
           }
 
           #pragma omp for nowait
           for (Index_type i = ibegin; i < iend; ++i ) {
-            energy4_lam(i);
+            energy_lam4(i);
           }
 
           #pragma omp for nowait
           for (Index_type i = ibegin; i < iend; ++i ) {
-            energy5_lam(i);
+            energy_lam5(i);
           }
 
           #pragma omp for nowait
           for (Index_type i = ibegin; i < iend; ++i ) {
-            energy6_lam(i);
+            energy_lam6(i);
           }
 
         } // end omp parallel region
@@ -274,22 +274,22 @@ void ENERGY::runKernel(VariantID vid)
         RAJA::region<RAJA::omp_parallel_region>( [=]() {
 
           RAJA::forall<RAJA::omp_for_nowait_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy1_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam1);
 
           RAJA::forall<RAJA::omp_for_nowait_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy2_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam2);
 
           RAJA::forall<RAJA::omp_for_nowait_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy3_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam3);
   
           RAJA::forall<RAJA::omp_for_nowait_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy4_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam4);
   
           RAJA::forall<RAJA::omp_for_nowait_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy5_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam5);
   
           RAJA::forall<RAJA::omp_for_nowait_exec>(
-            RAJA::RangeSegment(ibegin, iend), energy6_lam);
+            RAJA::RangeSegment(ibegin, iend), energy_lam6);
   
         }); // end omp parallel region
 

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -220,6 +220,51 @@ void ENERGY::runKernel(VariantID vid)
 
       break;
     }
+  
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel
+        {
+          #pragma omp for nowait
+          for (Index_type i = ibegin; i < iend; ++i ) {
+            energy1_lam(i);
+          }
+
+          #pragma omp for nowait
+          for (Index_type i = ibegin; i < iend; ++i ) {
+            energy2_lam(i);
+          }
+
+          #pragma omp for nowait
+          for (Index_type i = ibegin; i < iend; ++i ) {
+            energy3_lam(i);
+          }
+
+          #pragma omp for nowait
+          for (Index_type i = ibegin; i < iend; ++i ) {
+            energy4_lam(i);
+          }
+
+          #pragma omp for nowait
+          for (Index_type i = ibegin; i < iend; ++i ) {
+            energy5_lam(i);
+          }
+
+          #pragma omp for nowait
+          for (Index_type i = ibegin; i < iend; ++i ) {
+            energy6_lam(i);
+          }
+
+        } // end omp parallel region
+
+      }
+      stopTimer();
+
+      break;
+    }
 
     case RAJA_OpenMP : {
 

--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -118,6 +118,22 @@ void FIR::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+           fir_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -155,6 +155,33 @@ void LTIMES::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      auto ltimes_omp_lam = [=](Index_type d, Index_type z, 
+                                Index_type g, Index_type m) {
+                              LTIMES_BODY;
+                            };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type z = 0; z < num_z; ++z ) {
+          for (Index_type g = 0; g < num_g; ++g ) {
+            for (Index_type m = 0; m < num_m; ++m ) {
+              for (Index_type d = 0; d < num_d; ++d ) {
+                ltimes_omp_lam(d, z, g, m);
+              }
+            }
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       using EXEC_POL = 

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -70,6 +70,11 @@ void LTIMES::runKernel(VariantID vid)
 
   LTIMES_DATA_SETUP_CPU;
 
+  auto ltimes_base_lam = [=](Index_type d, Index_type z, 
+                             Index_type g, Index_type m) {
+                           LTIMES_BODY;
+                         };
+
   LTIMES_VIEWS_RANGES_RAJA;
 
   auto ltimes_lam = [=](ID d, IZ z, IG g, IM m) {
@@ -157,11 +162,6 @@ void LTIMES::runKernel(VariantID vid)
 
     case OpenMP_Lambda : {
 
-      auto ltimes_omp_lam = [=](Index_type d, Index_type z, 
-                                Index_type g, Index_type m) {
-                              LTIMES_BODY;
-                            };
-
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
@@ -170,7 +170,7 @@ void LTIMES::runKernel(VariantID vid)
           for (Index_type g = 0; g < num_g; ++g ) {
             for (Index_type m = 0; m < num_m; ++m ) {
               for (Index_type d = 0; d < num_d; ++d ) {
-                ltimes_omp_lam(d, z, g, m);
+                ltimes_base_lam(d, z, g, m);
               }
             }
           }

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -154,6 +154,28 @@ void LTIMES_NOVIEW::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type z = 0; z < num_z; ++z ) {
+          for (Index_type g = 0; g < num_g; ++g ) {
+            for (Index_type m = 0; m < num_m; ++m ) {
+              for (Index_type d = 0; d < num_d; ++d ) {
+                ltimesnoview_lam(d, z, g, m);
+              }
+            }
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       using EXEC_POL =

--- a/src/apps/PRESSURE.cpp
+++ b/src/apps/PRESSURE.cpp
@@ -142,6 +142,32 @@ void PRESSURE::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel
+        {
+
+          #pragma omp for nowait
+          for (Index_type i = ibegin; i < iend; ++i ) {
+            pressure1_lam(i);
+          }
+
+          #pragma omp for nowait
+          for (Index_type i = ibegin; i < iend; ++i ) {
+            pressure2_lam(i);
+          }
+
+        } // end omp parallel region
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/apps/PRESSURE.cpp
+++ b/src/apps/PRESSURE.cpp
@@ -64,10 +64,10 @@ void PRESSURE::runKernel(VariantID vid)
 
   PRESSURE_DATA_SETUP_CPU;
 
-  auto pressure1_lam = [=](int i) {
+  auto pressure_lam1 = [=](int i) {
                          PRESSURE_BODY1;
                        };
-  auto pressure2_lam = [=](int i) {
+  auto pressure_lam2 = [=](int i) {
                          PRESSURE_BODY2;
                        };
   
@@ -101,10 +101,10 @@ void PRESSURE::runKernel(VariantID vid)
         RAJA::region<RAJA::seq_region>( [=]() {
 
           RAJA::forall<RAJA::loop_exec>(
-            RAJA::RangeSegment(ibegin, iend), pressure1_lam);
+            RAJA::RangeSegment(ibegin, iend), pressure_lam1);
 
           RAJA::forall<RAJA::loop_exec>(
-            RAJA::RangeSegment(ibegin, iend), pressure2_lam);
+            RAJA::RangeSegment(ibegin, iend), pressure_lam2);
 
         }); // end sequential region (for single-source code)
 
@@ -152,12 +152,12 @@ void PRESSURE::runKernel(VariantID vid)
 
           #pragma omp for nowait
           for (Index_type i = ibegin; i < iend; ++i ) {
-            pressure1_lam(i);
+            pressure_lam1(i);
           }
 
           #pragma omp for nowait
           for (Index_type i = ibegin; i < iend; ++i ) {
-            pressure2_lam(i);
+            pressure_lam2(i);
           }
 
         } // end omp parallel region
@@ -176,10 +176,10 @@ void PRESSURE::runKernel(VariantID vid)
         RAJA::region<RAJA::omp_parallel_region>( [=]() {
 
           RAJA::forall<RAJA::omp_for_nowait_exec>(
-            RAJA::RangeSegment(ibegin, iend), pressure1_lam);
+            RAJA::RangeSegment(ibegin, iend), pressure_lam1);
 
           RAJA::forall<RAJA::omp_for_nowait_exec>(
-            RAJA::RangeSegment(ibegin, iend), pressure2_lam);
+            RAJA::RangeSegment(ibegin, iend), pressure_lam2);
 
         }); // end omp parallel region
 

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -135,6 +135,22 @@ void VOL3D::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin ; i < iend ; ++i ) {
+          vol3d_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/basic/DAXPY.cpp
+++ b/src/basic/DAXPY.cpp
@@ -106,6 +106,22 @@ void DAXPY::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          daxpy_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -109,6 +109,22 @@ void IF_QUAD::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          ifquad_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/basic/INIT3.cpp
+++ b/src/basic/INIT3.cpp
@@ -110,6 +110,22 @@ void INIT3::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          init3_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/basic/INIT_VIEW1D-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D-Cuda.cpp
@@ -31,11 +31,7 @@ namespace basic
   Real_ptr a; \
   const Real_type v = m_val; \
 \
-  allocAndInitCudaDeviceData(a, m_a, iend); \
-\
-  using ViewType = RAJA::View<Real_type, RAJA::Layout<1, Index_type, 0> >; \
-  const RAJA::Layout<1> my_layout(iend); \
-  ViewType view(a, my_layout);
+  allocAndInitCudaDeviceData(a, m_a, iend);
 
 #define INIT_VIEW1D_DATA_TEARDOWN_CUDA \
   getCudaDeviceData(m_a, a, iend); \
@@ -78,6 +74,8 @@ void INIT_VIEW1D::runCudaVariant(VariantID vid)
   } else if ( vid == RAJA_CUDA ) {
 
     INIT_VIEW1D_DATA_SETUP_CUDA;
+
+    INIT_VIEW1D_VIEW_RAJA;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/basic/INIT_VIEW1D-OMPTarget.cpp
+++ b/src/basic/INIT_VIEW1D-OMPTarget.cpp
@@ -33,11 +33,7 @@ namespace basic
   Real_ptr a; \
   const Real_type v = m_val; \
 \
-  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
-\
-  using ViewType = RAJA::View<Real_type, RAJA::Layout<1, Index_type, 0> >; \
-  const RAJA::Layout<1> my_layout(iend); \
-  ViewType view(a, my_layout);
+  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid);
 
 #define INIT_VIEW1D_DATA_TEARDOWN_OMP_TARGET \
   getOpenMPDeviceData(m_a, a, iend, hid, did); \
@@ -70,7 +66,9 @@ void INIT_VIEW1D::runOpenMPTargetVariant(VariantID vid)
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-     INIT_VIEW1D_DATA_SETUP_OMP_TARGET
+     INIT_VIEW1D_DATA_SETUP_OMP_TARGET;
+
+     INIT_VIEW1D_VIEW_RAJA;
 
      startTimer();
      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -22,11 +22,7 @@ namespace basic
 
 #define INIT_VIEW1D_DATA_SETUP_CPU \
   Real_ptr a = m_a; \
-  const Real_type v = m_val; \
-\
-  using ViewType = RAJA::View<Real_type, RAJA::Layout<1, Index_type, 0> >; \
-  const RAJA::Layout<1> my_layout(iend); \
-  ViewType view(a, my_layout);
+  const Real_type v = m_val;
 
 
 INIT_VIEW1D::INIT_VIEW1D(const RunParams& params)
@@ -53,6 +49,12 @@ void INIT_VIEW1D::runKernel(VariantID vid)
   const Index_type iend = getRunSize();
 
   INIT_VIEW1D_DATA_SETUP_CPU;
+
+  auto initview1d_base_lam = [=](Index_type i) {
+                               INIT_VIEW1D_BODY;
+                             };
+
+  INIT_VIEW1D_VIEW_RAJA;
 
   auto initview1d_lam = [=](Index_type i) {
                           INIT_VIEW1D_BODY_RAJA;
@@ -115,7 +117,7 @@ void INIT_VIEW1D::runKernel(VariantID vid)
 
         #pragma omp parallel for
         for (Index_type i = ibegin; i < iend; ++i ) {
-          initview1d_lam(i);
+          initview1d_base_lam(i);
         }
 
       }

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -108,6 +108,22 @@ void INIT_VIEW1D::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          initview1d_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/basic/INIT_VIEW1D.hpp
+++ b/src/basic/INIT_VIEW1D.hpp
@@ -30,6 +30,11 @@
 #define INIT_VIEW1D_BODY_RAJA  \
   view(i) = v;
 
+#define INIT_VIEW1D_VIEW_RAJA \
+  using ViewType = RAJA::View<Real_type, RAJA::Layout<1, Index_type, 0> >; \
+  const RAJA::Layout<1> my_layout(iend); \
+  ViewType view(a, my_layout);
+
 
 #include "common/KernelBase.hpp"
 

--- a/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
@@ -31,10 +31,7 @@ namespace basic
   Real_ptr a; \
   const Real_type v = m_val; \
 \
-  allocAndInitCudaDeviceData(a, m_a, iend); \
-\
-  using ViewType = RAJA::View<Real_type, RAJA::OffsetLayout<1> >; \
-  ViewType view(a, RAJA::make_offset_layout<1>({{1}}, {{iend+1}}));
+  allocAndInitCudaDeviceData(a, m_a, iend);
 
 #define INIT_VIEW1D_OFFSET_DATA_TEARDOWN_CUDA \
   getCudaDeviceData(m_a, a, iend); \
@@ -78,6 +75,8 @@ void INIT_VIEW1D_OFFSET::runCudaVariant(VariantID vid)
   } else if ( vid == RAJA_CUDA ) {
 
     INIT_VIEW1D_OFFSET_DATA_SETUP_CUDA;
+
+    INIT_VIEW1D_OFFSET_VIEW_RAJA;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
@@ -33,10 +33,7 @@ namespace basic
   Real_ptr a; \
   const Real_type v = m_val; \
 \
-  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
-\
-  using ViewType = RAJA::View<Real_type, RAJA::OffsetLayout<1> >; \
-  ViewType view(a, RAJA::make_offset_layout<1>({{1}}, {{iend+1}}));
+  allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid);
 
 #define INIT_VIEW1D_OFFSET_DATA_TEARDOWN_OMP_TARGET \
   getOpenMPDeviceData(m_a, a, iend, hid, did); \
@@ -70,6 +67,8 @@ void INIT_VIEW1D_OFFSET::runOpenMPTargetVariant(VariantID vid)
   } else if ( vid == RAJA_OpenMPTarget ) {
 
      INIT_VIEW1D_OFFSET_DATA_SETUP_OMP_TARGET;
+
+     INIT_VIEW1D_OFFSET_VIEW_RAJA;
 
      startTimer();
      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -21,10 +21,7 @@ namespace basic
 
 #define INIT_VIEW1D_OFFSET_DATA_SETUP_CPU \
   Real_ptr a = m_a; \
-  const Real_type v = m_val; \
-\
-  using ViewType = RAJA::View<Real_type, RAJA::OffsetLayout<1> >; \
-  ViewType view(a, RAJA::make_offset_layout<1>({{1}}, {{iend+1}}));
+  const Real_type v = m_val;
 
 
 INIT_VIEW1D_OFFSET::INIT_VIEW1D_OFFSET(const RunParams& params)
@@ -51,6 +48,12 @@ void INIT_VIEW1D_OFFSET::runKernel(VariantID vid)
   const Index_type iend = getRunSize()+1;
 
   INIT_VIEW1D_OFFSET_DATA_SETUP_CPU;
+
+  auto initview1doffset_base_lam = [=](Index_type i) {
+                                     INIT_VIEW1D_OFFSET_BODY;
+                                   };
+
+  INIT_VIEW1D_OFFSET_VIEW_RAJA;
 
   auto initview1doffset_lam = [=](Index_type i) {
                                 INIT_VIEW1D_OFFSET_BODY_RAJA;
@@ -113,7 +116,7 @@ void INIT_VIEW1D_OFFSET::runKernel(VariantID vid)
 
         #pragma omp parallel for
         for (Index_type i = ibegin; i < iend; ++i ) {
-          initview1doffset_lam(i);
+          initview1doffset_base_lam(i);
         }
 
       }

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -106,6 +106,22 @@ void INIT_VIEW1D_OFFSET::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          initview1doffset_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/basic/INIT_VIEW1D_OFFSET.hpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.hpp
@@ -30,6 +30,10 @@
 #define INIT_VIEW1D_OFFSET_BODY_RAJA  \
   view(i) = v;
 
+#define INIT_VIEW1D_OFFSET_VIEW_RAJA  \
+  using ViewType = RAJA::View<Real_type, RAJA::OffsetLayout<1> >; \
+  ViewType view(a, RAJA::make_offset_layout<1>({{1}}, {{iend+1}}));
+
 
 #include "common/KernelBase.hpp"
 

--- a/src/basic/MULADDSUB.cpp
+++ b/src/basic/MULADDSUB.cpp
@@ -110,6 +110,22 @@ void MULADDSUB::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          mas_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -137,6 +137,31 @@ void NESTED_INIT::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+#if 0
+// using collapse here doesn't appear to yield a performance benefit
+          #pragma omp parallel for collapse(3)
+#else
+          #pragma omp parallel for
+#endif
+          for (Index_type k = 0; k < nk; ++k ) {
+            for (Index_type j = 0; j < nj; ++j ) {
+              for (Index_type i = 0; i < ni; ++i ) {
+                nestedinit_lam(i, j, k);
+              }
+            }
+          }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
 #if 0

--- a/src/basic/TRAP_INT.cpp
+++ b/src/basic/TRAP_INT.cpp
@@ -142,6 +142,31 @@ void TRAP_INT::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        Real_type sumx = m_sumx_init;
+
+        auto trapint_lam = [=](Index_type i) -> Real_type {
+                             Real_type x = x0 + i*h;
+                             return trap_int_func(x, y, xp, yp);
+                           };
+
+        #pragma omp parallel for reduction(+:sumx)
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          sumx += trapint_lam(i);
+        }
+
+        m_sumx += sumx * h;
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/basic/TRAP_INT.cpp
+++ b/src/basic/TRAP_INT.cpp
@@ -78,6 +78,11 @@ void TRAP_INT::runKernel(VariantID vid)
 
   TRAP_INT_DATA_SETUP_CPU;
 
+  auto trapint_base_lam = [=](Index_type i) -> Real_type {
+                            Real_type x = x0 + i*h;
+                            return trap_int_func(x, y, xp, yp);
+                          };
+
   switch ( vid ) {
 
     case Base_Seq : {
@@ -149,14 +154,9 @@ void TRAP_INT::runKernel(VariantID vid)
 
         Real_type sumx = m_sumx_init;
 
-        auto trapint_lam = [=](Index_type i) -> Real_type {
-                             Real_type x = x0 + i*h;
-                             return trap_int_func(x, y, xp, yp);
-                           };
-
         #pragma omp parallel for reduction(+:sumx)
         for (Index_type i = ibegin; i < iend; ++i ) {
-          sumx += trapint_lam(i);
+          sumx += trapint_base_lam(i);
         }
 
         m_sumx += sumx * h;

--- a/src/common/DataUtils.cpp
+++ b/src/common/DataUtils.cpp
@@ -122,6 +122,7 @@ void initData(Int_ptr& ptr, int len, VariantID vid)
 // First touch...
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
   if ( vid == Base_OpenMP ||
+       vid == OpenMP_Lambda ||
        vid == RAJA_OpenMP ) {
     #pragma omp parallel for
     for (int i = 0; i < len; ++i) {
@@ -164,6 +165,7 @@ void initData(Real_ptr& ptr, int len, VariantID vid)
 // first touch...
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
   if ( vid == Base_OpenMP || 
+       vid == OpenMP_Lambda ||
        vid == RAJA_OpenMP ) {
     #pragma omp parallel for
     for (int i = 0; i < len; ++i) { 
@@ -189,6 +191,7 @@ void initDataConst(Real_ptr& ptr, int len, Real_type val,
 // first touch...
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
   if ( vid == Base_OpenMP ||
+       vid == OpenMP_Lambda ||
        vid == RAJA_OpenMP ) {
     #pragma omp parallel for
     for (int i = 0; i < len; ++i) {
@@ -216,6 +219,7 @@ void initDataRandSign(Real_ptr& ptr, int len, VariantID vid)
 // First touch...
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
   if ( vid == Base_OpenMP ||
+       vid == OpenMP_Lambda ||
        vid == RAJA_OpenMP ) {
     #pragma omp parallel for
     for (int i = 0; i < len; ++i) {
@@ -249,6 +253,7 @@ void initData(Complex_ptr& ptr, int len, VariantID vid)
 
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
   if ( vid == Base_OpenMP ||
+       vid == OpenMP_Lambda || 
        vid == RAJA_OpenMP ) {
     #pragma omp parallel for
     for (int i = 0; i < len; ++i) { 

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -208,6 +208,7 @@ static const std::string VariantNames [] =
 
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
   std::string("Base_OpenMP"),
+  std::string("OpenMP_Lambda"),
   std::string("RAJA_OpenMP"),
 #endif
 

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -183,6 +183,7 @@ enum VariantID {
 
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
   Base_OpenMP,
+  OpenMP_Lambda,
   RAJA_OpenMP,
 #endif
 

--- a/src/lcals/DIFF_PREDICT.cpp
+++ b/src/lcals/DIFF_PREDICT.cpp
@@ -108,6 +108,22 @@ void DIFF_PREDICT::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          diffpredict_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/lcals/FIRST_DIFF.cpp
+++ b/src/lcals/FIRST_DIFF.cpp
@@ -105,6 +105,22 @@ void FIRST_DIFF::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          firstdiff_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -116,6 +116,22 @@ void HYDRO_1D::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          hydro1d_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -86,6 +86,16 @@ void HYDRO_2D::runKernel(VariantID vid)
 
   HYDRO_2D_DATA_SETUP_CPU;
 
+  auto hydro2d_base_lam1 = [=] (Index_type k, Index_type j) {
+                             HYDRO_2D_BODY1;
+                           };
+  auto hydro2d_base_lam2 = [=] (Index_type k, Index_type j) {
+                             HYDRO_2D_BODY2;
+                           };
+  auto hydro2d_base_lam3 = [=] (Index_type k, Index_type j) {
+                             HYDRO_2D_BODY3;
+                           };
+
   HYDRO_2D_VIEWS_RAJA;
 
   auto hydro2d_lam1 = [=] (Index_type k, Index_type j) {
@@ -215,21 +225,21 @@ void HYDRO_2D::runKernel(VariantID vid)
           #pragma omp for nowait
           for (Index_type k = kbeg; k < kend; ++k ) {
             for (Index_type j = jbeg; j < jend; ++j ) {
-              hydro2d_lam1(k, j);
+              hydro2d_base_lam1(k, j);
             }
           }
 
           #pragma omp for nowait
           for (Index_type k = kbeg; k < kend; ++k ) {
             for (Index_type j = jbeg; j < jend; ++j ) {
-              hydro2d_lam2(k, j);
+              hydro2d_base_lam2(k, j);
             }
           }
 
           #pragma omp for nowait
           for (Index_type k = kbeg; k < kend; ++k ) {
             for (Index_type j = jbeg; j < jend; ++j ) {
-              hydro2d_lam3(k, j);
+              hydro2d_base_lam3(k, j);
             }
           }
 

--- a/src/lcals/INT_PREDICT.cpp
+++ b/src/lcals/INT_PREDICT.cpp
@@ -115,6 +115,22 @@ void INT_PREDICT::runKernel(VariantID vid)
 
         #pragma omp parallel for
         for (Index_type i = ibegin; i < iend; ++i ) {
+          intpredict_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
           INT_PREDICT_BODY;
         }
 

--- a/src/lcals/PLANCKIAN.cpp
+++ b/src/lcals/PLANCKIAN.cpp
@@ -111,6 +111,22 @@ void PLANCKIAN::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          planckian_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/polybench/POLYBENCH_2MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_2MM-Cuda.cpp
@@ -30,6 +30,11 @@ namespace polybench
   Real_type alpha = m_alpha; \
   Real_type beta = m_beta; \
 \
+  const Index_type ni = m_ni; \
+  const Index_type nj = m_nj; \
+  const Index_type nk = m_nk; \
+  const Index_type nl = m_nl; \
+\
   allocAndInitCudaDeviceData(tmp, m_tmp, m_ni * m_nj); \
   allocAndInitCudaDeviceData(A, m_A, m_ni * m_nk); \
   allocAndInitCudaDeviceData(B, m_B, m_nk * m_nj); \
@@ -78,11 +83,6 @@ __global__ void poly_2mm_2(Real_ptr tmp, Real_ptr C, Real_ptr D,
 void POLYBENCH_2MM::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type ni = m_ni;
-  const Index_type nj = m_nj;
-  const Index_type nk = m_nk;
-  const Index_type nl = m_nl;
-
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_2MM-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_2MM-OMPTarget.cpp
@@ -33,6 +33,11 @@ namespace polybench
   Real_type alpha = m_alpha; \
   Real_type beta = m_beta; \
 \
+  const Index_type ni = m_ni; \
+  const Index_type nj = m_nj; \
+  const Index_type nk = m_nk; \
+  const Index_type nl = m_nl; \
+\
   allocAndInitOpenMPDeviceData(tmp, m_tmp, m_ni * m_nj, did, hid); \
   allocAndInitOpenMPDeviceData(A, m_A, m_ni * m_nk, did, hid); \
   allocAndInitOpenMPDeviceData(B, m_B, m_nk * m_nj, did, hid); \
@@ -52,10 +57,6 @@ namespace polybench
 void POLYBENCH_2MM::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type ni = m_ni;
-  const Index_type nj = m_nj;
-  const Index_type nk = m_nk;
-  const Index_type nl = m_nl;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -33,7 +33,12 @@ namespace polybench
   ResReal_ptr C = m_C; \
   ResReal_ptr D = m_D; \
   Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; 
+  Real_type beta = m_beta; \
+\
+  const Index_type ni = m_ni; \
+  const Index_type nj = m_nj; \
+  const Index_type nk = m_nk; \
+  const Index_type nl = m_nl;
 
   
 POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
@@ -93,10 +98,6 @@ void POLYBENCH_2MM::setUp(VariantID vid)
 void POLYBENCH_2MM::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
-  const Index_type ni = m_ni;
-  const Index_type nj = m_nj;
-  const Index_type nk = m_nk;
-  const Index_type nl = m_nl;
 
   POLYBENCH_2MM_DATA_SETUP_CPU;
 

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -100,6 +100,23 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
 
   POLYBENCH_2MM_DATA_SETUP_CPU;
 
+  auto poly_2mm_base_lam2 = [=](Index_type i, Index_type j,
+                                Index_type k, Real_type &dot) {
+                              POLYBENCH_2MM_BODY2;
+                            };
+  auto poly_2mm_base_lam3 = [=](Index_type i, Index_type j,
+                                Real_type &dot) {
+                              POLYBENCH_2MM_BODY3;
+                            };
+  auto poly_2mm_base_lam5 = [=](Index_type i, Index_type l,
+                                Index_type j, Real_type &dot) {
+                              POLYBENCH_2MM_BODY5;
+                            };
+  auto poly_2mm_base_lam6 = [=](Index_type i, Index_type l,
+                                Real_type &dot) {
+                              POLYBENCH_2MM_BODY6;
+                            };
+
   POLYBENCH_2MM_VIEWS_RAJA;
 
   auto poly_2mm_lam1 = [=](Index_type /*i*/, Index_type /*j*/, Index_type /*k*/,                           Real_type &dot) {
@@ -253,23 +270,6 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
 
     case OpenMP_Lambda : {
 
-      auto poly_2mm_omp_lam2 = [=](Index_type i, Index_type j, 
-                                   Index_type k, Real_type &dot) {
-                                 POLYBENCH_2MM_BODY2;
-                               };
-      auto poly_2mm_omp_lam3 = [=](Index_type i, Index_type j, 
-                                   Real_type &dot) {
-                                 POLYBENCH_2MM_BODY3;
-                               };
-      auto poly_2mm_omp_lam5 = [=](Index_type i, Index_type l, 
-                                   Index_type j, Real_type &dot) {
-                                 POLYBENCH_2MM_BODY5;
-                               };
-      auto poly_2mm_omp_lam6 = [=](Index_type i, Index_type l, 
-                                   Real_type &dot) {
-                                 POLYBENCH_2MM_BODY6;
-                               };
-
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
@@ -282,9 +282,9 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
           for(Index_type j = 0; j < nj; j++) {
             POLYBENCH_2MM_BODY1;
             for (Index_type k = 0; k < nk; k++) {
-              poly_2mm_omp_lam2(i, j, k, dot);
+              poly_2mm_base_lam2(i, j, k, dot);
             }
-            poly_2mm_omp_lam3(i, j, dot);
+            poly_2mm_base_lam3(i, j, dot);
           }
         }
 
@@ -297,9 +297,9 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
           for(Index_type l = 0; l < nl; l++) {
             POLYBENCH_2MM_BODY4;
             for (Index_type j = 0; j < nj; j++) {
-              poly_2mm_omp_lam5(i, l, j, dot);
+              poly_2mm_base_lam5(i, l, j, dot);
             }
-            poly_2mm_omp_lam6(i, l, dot);
+            poly_2mm_base_lam6(i, l, dot);
           }
         }
 

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -251,6 +251,64 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      auto poly_2mm_omp_lam2 = [=](Index_type i, Index_type j, 
+                                   Index_type k, Real_type &dot) {
+                                 POLYBENCH_2MM_BODY2;
+                               };
+      auto poly_2mm_omp_lam3 = [=](Index_type i, Index_type j, 
+                                   Real_type &dot) {
+                                 POLYBENCH_2MM_BODY3;
+                               };
+      auto poly_2mm_omp_lam5 = [=](Index_type i, Index_type l, 
+                                   Index_type j, Real_type &dot) {
+                                 POLYBENCH_2MM_BODY5;
+                               };
+      auto poly_2mm_omp_lam6 = [=](Index_type i, Index_type l, 
+                                   Real_type &dot) {
+                                 POLYBENCH_2MM_BODY6;
+                               };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+#if defined(USE_OMP_COLLAPSE)
+        #pragma omp parallel for collapse(2)
+#else
+        #pragma omp parallel for
+#endif
+        for (Index_type i = 0; i < ni; i++ ) {
+          for(Index_type j = 0; j < nj; j++) {
+            POLYBENCH_2MM_BODY1;
+            for (Index_type k = 0; k < nk; k++) {
+              poly_2mm_omp_lam2(i, j, k, dot);
+            }
+            poly_2mm_omp_lam3(i, j, dot);
+          }
+        }
+
+#if defined(USE_OMP_COLLAPSE)
+        #pragma omp parallel for collapse(2)
+#else
+        #pragma omp parallel for
+#endif
+        for(Index_type i = 0; i < ni; i++) {
+          for(Index_type l = 0; l < nl; l++) {
+            POLYBENCH_2MM_BODY4;
+            for (Index_type j = 0; j < nj; j++) {
+              poly_2mm_omp_lam5(i, l, j, dot);
+            }
+            poly_2mm_omp_lam6(i, l, dot);
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
 #if defined(USE_RAJA_OMP_COLLAPSE)

--- a/src/polybench/POLYBENCH_3MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_3MM-Cuda.cpp
@@ -30,6 +30,12 @@ namespace polybench
   Real_ptr F = m_F; \
   Real_ptr G = m_G; \
 \
+  const Index_type ni = m_ni; \
+  const Index_type nj = m_nj; \
+  const Index_type nk = m_nk; \
+  const Index_type nl = m_nl; \
+  const Index_type nm = m_nm; \
+\
   allocAndInitCudaDeviceData(A, m_A, m_ni * m_nk); \
   allocAndInitCudaDeviceData(B, m_B, m_nk * m_nj); \
   allocAndInitCudaDeviceData(C, m_C, m_nj * m_nm); \
@@ -92,12 +98,6 @@ __global__ void poly_3mm_3(Real_ptr G, Real_ptr E, Real_ptr F,
 void POLYBENCH_3MM::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type ni = m_ni;
-  const Index_type nj = m_nj;
-  const Index_type nk = m_nk;
-  const Index_type nl = m_nl;
-  const Index_type nm = m_nm;
-
   
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_3MM-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_3MM-OMPTarget.cpp
@@ -33,6 +33,12 @@ namespace polybench
   Real_ptr F; \
   Real_ptr G; \
 \
+  const Index_type ni = m_ni; \
+  const Index_type nj = m_nj; \
+  const Index_type nk = m_nk; \
+  const Index_type nl = m_nl; \
+  const Index_type nm = m_nm; \
+\
   allocAndInitOpenMPDeviceData(A, m_A, m_ni * m_nk, did, hid); \
   allocAndInitOpenMPDeviceData(B, m_B, m_nk * m_nj, did, hid); \
   allocAndInitOpenMPDeviceData(C, m_C, m_nj * m_nm, did, hid); \

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -34,7 +34,13 @@ namespace polybench
   ResReal_ptr D = m_D; \
   ResReal_ptr E = m_E; \
   ResReal_ptr F = m_F; \
-  ResReal_ptr G = m_G; 
+  ResReal_ptr G = m_G; \
+\
+  const Index_type ni = m_ni; \
+  const Index_type nj = m_nj; \
+  const Index_type nk = m_nk; \
+  const Index_type nl = m_nl; \
+  const Index_type nm = m_nm;
   
   
 POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
@@ -91,11 +97,6 @@ void POLYBENCH_3MM::setUp(VariantID vid)
 void POLYBENCH_3MM::runKernel(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type ni = m_ni;
-  const Index_type nj = m_nj;
-  const Index_type nk = m_nk;
-  const Index_type nl = m_nl;
-  const Index_type nm = m_nm;
 
   POLYBENCH_3MM_DATA_SETUP_CPU;
 

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -301,6 +301,87 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      auto poly_3mm_omp_lam2 = [=] (Index_type i, Index_type j, Index_type k,
+                                    Real_type &dot) {
+                                 POLYBENCH_3MM_BODY2_RAJA;
+                               };
+      auto poly_3mm_omp_lam3 = [=] (Index_type i, Index_type j,
+                                    Real_type &dot) {
+                                 POLYBENCH_3MM_BODY3_RAJA;
+                               };
+      auto poly_3mm_omp_lam5 = [=] (Index_type j, Index_type l, Index_type m,
+                                    Real_type &dot) {
+                                  POLYBENCH_3MM_BODY5_RAJA;
+                               };
+      auto poly_3mm_omp_lam6 = [=] (Index_type j, Index_type l,
+                                    Real_type &dot) {
+                                 POLYBENCH_3MM_BODY6_RAJA;
+                               };
+      auto poly_3mm_omp_lam8 = [=] (Index_type i, Index_type l, Index_type j,
+                                    Real_type &dot) {
+                                 POLYBENCH_3MM_BODY8_RAJA;
+                               };
+      auto poly_3mm_omp_lam9 = [=] (Index_type i, Index_type l,
+                                    Real_type &dot) {
+                                 POLYBENCH_3MM_BODY9_RAJA;
+                               };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+#if defined(USE_OMP_COLLAPSE)
+        #pragma omp parallel for collapse(2)
+#else
+        #pragma omp parallel for
+#endif
+        for (Index_type i = 0; i < ni; i++ )  {
+          for (Index_type j = 0; j < nj; j++) {
+            POLYBENCH_3MM_BODY1;
+            for (Index_type k = 0; k < nk; k++) {
+              poly_3mm_omp_lam2(i, j, k, dot);
+            }
+            poly_3mm_omp_lam3(i, j, dot);
+          }
+        }
+
+#if defined(USE_OMP_COLLAPSE)
+        #pragma omp parallel for collapse(2)
+#else
+        #pragma omp parallel for
+#endif
+        for (Index_type j = 0; j < nj; j++) {
+          for (Index_type l = 0; l < nl; l++) {
+            POLYBENCH_3MM_BODY4;
+            for (Index_type m = 0; m < nm; m++) {
+              poly_3mm_omp_lam5(j, l, m, dot);
+            }
+            poly_3mm_omp_lam6(j, l, dot);
+          }
+        }
+
+#if defined(USE_OMP_COLLAPSE)
+        #pragma omp parallel for collapse(2)
+#else
+        #pragma omp parallel for
+#endif
+        for (Index_type i = 0; i < ni; i++) {
+          for (Index_type l = 0; l < nl; l++) {
+            POLYBENCH_3MM_BODY7;
+            for (Index_type j = 0; j < nj; j++) {
+              poly_3mm_omp_lam8(i, l, j, dot);
+            }
+            poly_3mm_omp_lam9(i, l, dot);
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
 #if defined(USE_RAJA_OMP_COLLAPSE)

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -99,6 +99,31 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
 
   POLYBENCH_3MM_DATA_SETUP_CPU;
 
+  auto poly_3mm_base_lam2 = [=] (Index_type i, Index_type j, Index_type k,
+                                 Real_type &dot) {
+                              POLYBENCH_3MM_BODY2;
+                            };
+  auto poly_3mm_base_lam3 = [=] (Index_type i, Index_type j,
+                                 Real_type &dot) {
+                              POLYBENCH_3MM_BODY3;
+                            };
+  auto poly_3mm_base_lam5 = [=] (Index_type j, Index_type l, Index_type m,
+                                 Real_type &dot) {
+                               POLYBENCH_3MM_BODY5;
+                            };
+  auto poly_3mm_base_lam6 = [=] (Index_type j, Index_type l,
+                                 Real_type &dot) {
+                              POLYBENCH_3MM_BODY6;
+                            };
+  auto poly_3mm_base_lam8 = [=] (Index_type i, Index_type l, Index_type j,
+                                 Real_type &dot) {
+                              POLYBENCH_3MM_BODY8;
+                            };
+  auto poly_3mm_base_lam9 = [=] (Index_type i, Index_type l,
+                                 Real_type &dot) {
+                              POLYBENCH_3MM_BODY9;
+                            };
+
   POLYBENCH_3MM_VIEWS_RAJA;
 
   auto poly_3mm_lam1 = [=] (Index_type /*i*/, Index_type /*j*/, Index_type /*k*/,
@@ -303,31 +328,6 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
 
     case OpenMP_Lambda : {
 
-      auto poly_3mm_omp_lam2 = [=] (Index_type i, Index_type j, Index_type k,
-                                    Real_type &dot) {
-                                 POLYBENCH_3MM_BODY2_RAJA;
-                               };
-      auto poly_3mm_omp_lam3 = [=] (Index_type i, Index_type j,
-                                    Real_type &dot) {
-                                 POLYBENCH_3MM_BODY3_RAJA;
-                               };
-      auto poly_3mm_omp_lam5 = [=] (Index_type j, Index_type l, Index_type m,
-                                    Real_type &dot) {
-                                  POLYBENCH_3MM_BODY5_RAJA;
-                               };
-      auto poly_3mm_omp_lam6 = [=] (Index_type j, Index_type l,
-                                    Real_type &dot) {
-                                 POLYBENCH_3MM_BODY6_RAJA;
-                               };
-      auto poly_3mm_omp_lam8 = [=] (Index_type i, Index_type l, Index_type j,
-                                    Real_type &dot) {
-                                 POLYBENCH_3MM_BODY8_RAJA;
-                               };
-      auto poly_3mm_omp_lam9 = [=] (Index_type i, Index_type l,
-                                    Real_type &dot) {
-                                 POLYBENCH_3MM_BODY9_RAJA;
-                               };
-
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
@@ -340,9 +340,9 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
           for (Index_type j = 0; j < nj; j++) {
             POLYBENCH_3MM_BODY1;
             for (Index_type k = 0; k < nk; k++) {
-              poly_3mm_omp_lam2(i, j, k, dot);
+              poly_3mm_base_lam2(i, j, k, dot);
             }
-            poly_3mm_omp_lam3(i, j, dot);
+            poly_3mm_base_lam3(i, j, dot);
           }
         }
 
@@ -355,9 +355,9 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
           for (Index_type l = 0; l < nl; l++) {
             POLYBENCH_3MM_BODY4;
             for (Index_type m = 0; m < nm; m++) {
-              poly_3mm_omp_lam5(j, l, m, dot);
+              poly_3mm_base_lam5(j, l, m, dot);
             }
-            poly_3mm_omp_lam6(j, l, dot);
+            poly_3mm_base_lam6(j, l, dot);
           }
         }
 
@@ -370,9 +370,9 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
           for (Index_type l = 0; l < nl; l++) {
             POLYBENCH_3MM_BODY7;
             for (Index_type j = 0; j < nj; j++) {
-              poly_3mm_omp_lam8(i, l, j, dot);
+              poly_3mm_base_lam8(i, l, j, dot);
             }
-            poly_3mm_omp_lam9(i, l, dot);
+            poly_3mm_base_lam9(i, l, dot);
           }
         }
 

--- a/src/polybench/POLYBENCH_ADI-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ADI-Cuda.cpp
@@ -30,10 +30,19 @@ const size_t block_size = 256;
   const Index_type n = m_n; \
   const Index_type tsteps = m_tsteps; \
 \
-  Real_type DX,DY,DT; \
-  Real_type B1,B2; \
-  Real_type mul1,mul2; \
-  Real_type a,b,c,d,e,f; \
+  Real_type DX = 1.0/(Real_type)n; \
+  Real_type DY = 1.0/(Real_type)n; \
+  Real_type DT = 1.0/(Real_type)tsteps; \
+  Real_type B1 = 2.0; \
+  Real_type B2 = 1.0; \
+  Real_type mul1 = B1 * DT / (DX * DX); \
+  Real_type mul2 = B2 * DT / (DY * DY); \
+  Real_type a = -mul1 / 2.0; \
+  Real_type b = 1.0 + mul1; \
+  Real_type c = a; \
+  Real_type d = -mul2 /2.0; \
+  Real_type e = 1.0 + mul2; \
+  Real_type f = d; \
 \
   Real_ptr U; \
   Real_ptr V; \
@@ -44,7 +53,6 @@ const size_t block_size = 256;
   allocAndInitCudaDeviceData(V, m_V, m_n * m_n); \
   allocAndInitCudaDeviceData(P, m_P, m_n * m_n); \
   allocAndInitCudaDeviceData(Q, m_Q, m_n * m_n); 
-
 
 #define POLYBENCH_ADI_TEARDOWN_CUDA \
   getCudaDeviceData(m_U, U, m_n * m_n); \
@@ -104,8 +112,6 @@ void POLYBENCH_ADI::runCudaVariant(VariantID vid)
 
       for (Index_type t = 1; t <= tsteps; ++t) {
 
-        POLYBENCH_ADI_BODY1;
-
         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(n-1, block_size);
 
         adi1<<<grid_size, block_size>>>(n,
@@ -150,8 +156,6 @@ void POLYBENCH_ADI::runCudaVariant(VariantID vid)
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-      POLYBENCH_ADI_BODY1;
 
       for (Index_type t = 1; t <= tsteps; ++t) {
 

--- a/src/polybench/POLYBENCH_ADI-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_ADI-OMPTarget.cpp
@@ -32,10 +32,19 @@ namespace polybench
   const Index_type n = m_n; \
   const Index_type tsteps = m_tsteps; \
 \
-  Real_type DX,DY,DT; \
-  Real_type B1,B2; \
-  Real_type mul1,mul2; \
-  Real_type a,b,c,d,e,f; \
+  Real_type DX = 1.0/(Real_type)n; \
+  Real_type DY = 1.0/(Real_type)n; \
+  Real_type DT = 1.0/(Real_type)tsteps; \
+  Real_type B1 = 2.0; \
+  Real_type B2 = 1.0; \
+  Real_type mul1 = B1 * DT / (DX * DX); \
+  Real_type mul2 = B2 * DT / (DY * DY); \
+  Real_type a = -mul1 / 2.0; \
+  Real_type b = 1.0 + mul1; \
+  Real_type c = a; \
+  Real_type d = -mul2 /2.0; \
+  Real_type e = 1.0 + mul2; \
+  Real_type f = d; \
 \
   Real_ptr U = m_U; \
   Real_ptr V = m_V; \
@@ -65,8 +74,6 @@ void POLYBENCH_ADI::runOpenMPTargetVariant(VariantID vid)
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-      POLYBENCH_ADI_BODY1;
 
       for (Index_type t = 1; t <= tsteps; ++t) { 
 
@@ -125,8 +132,6 @@ void POLYBENCH_ADI::runOpenMPTargetVariant(VariantID vid)
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-      POLYBENCH_ADI_BODY1;
 
       for (Index_type t = 1; t <= tsteps; ++t) {
 

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -96,6 +96,31 @@ void POLYBENCH_ADI::runKernel(VariantID vid)
 
   POLYBENCH_ADI_DATA_SETUP_CPU;
 
+  auto poly_adi_base_lam2 = [=](Index_type i) {
+                              POLYBENCH_ADI_BODY2;
+                            };
+  auto poly_adi_base_lam3 = [=](Index_type i, Index_type j) {
+                              POLYBENCH_ADI_BODY3;
+                            };
+  auto poly_adi_base_lam4 = [=](Index_type i) {
+                              POLYBENCH_ADI_BODY4;
+                            };
+  auto poly_adi_base_lam5 = [=](Index_type i, Index_type k) {
+                              POLYBENCH_ADI_BODY5;
+                            };
+  auto poly_adi_base_lam6 = [=](Index_type i) {
+                              POLYBENCH_ADI_BODY6;
+                            };
+  auto poly_adi_base_lam7 = [=](Index_type i, Index_type j) {
+                              POLYBENCH_ADI_BODY7;
+                            };
+  auto poly_adi_base_lam8 = [=](Index_type i) {
+                              POLYBENCH_ADI_BODY8;
+                            };
+  auto poly_adi_base_lam9 = [=](Index_type i, Index_type k) {
+                              POLYBENCH_ADI_BODY9;
+                            };
+
   POLYBENCH_ADI_VIEWS_RAJA;
 
   auto poly_adi_lam2 = [=](Index_type i, Index_type /*j*/, Index_type /*k*/) {
@@ -247,6 +272,45 @@ void POLYBENCH_ADI::runKernel(VariantID vid)
             for (Index_type k = n-2; k >= 1; --k) {
               POLYBENCH_ADI_BODY9;
             }  
+          }
+
+        }  // tstep loop
+
+      }  // run_reps
+      stopTimer();
+
+      break;
+    }
+
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        for (Index_type t = 1; t <= tsteps; ++t) {
+
+          #pragma omp parallel for
+          for (Index_type i = 1; i < n-1; ++i) {
+            poly_adi_base_lam2(i);
+            for (Index_type j = 1; j < n-1; ++j) {
+              poly_adi_base_lam3(i, j);
+            }
+            poly_adi_base_lam4(i);
+            for (Index_type k = n-2; k >= 1; --k) {
+              poly_adi_base_lam5(i, k);
+            }
+          }
+
+          #pragma omp parallel for
+          for (Index_type i = 1; i < n-1; ++i) {
+            poly_adi_base_lam6(i);
+            for (Index_type j = 1; j < n-1; ++j) {
+              poly_adi_base_lam7(i, j);
+            }
+            poly_adi_base_lam8(i);
+            for (Index_type k = n-2; k >= 1; --k) {
+              poly_adi_base_lam9(i, k);
+            }
           }
 
         }  // tstep loop

--- a/src/polybench/POLYBENCH_ADI.hpp
+++ b/src/polybench/POLYBENCH_ADI.hpp
@@ -64,21 +64,6 @@
 #define RAJAPerf_POLYBENCH_ADI_HPP
 
 
-#define POLYBENCH_ADI_BODY1 \
-  DX = 1.0/(Real_type)n; \
-  DY = 1.0/(Real_type)n; \
-  DT = 1.0/(Real_type)tsteps; \
-  B1 = 2.0; \
-  B2 = 1.0; \
-  mul1 = B1 * DT / (DX * DX); \
-  mul2 = B2 * DT / (DY * DY); \
-  a = -mul1 / 2.0; \
-  b = 1.0 + mul1; \
-  c = a; \
-  d = -mul2 /2.0; \
-  e = 1.0 + mul2; \
-  f = d; 
-
 #define POLYBENCH_ADI_BODY2 \
   V[0 * n + i] = 1.0; \
   P[i * n + 0] = 0.0; \

--- a/src/polybench/POLYBENCH_ATAX-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Cuda.cpp
@@ -32,6 +32,8 @@ namespace polybench
   Real_ptr x; \
   Real_ptr A; \
 \
+  const Index_type N = m_N; \
+\
   allocAndInitCudaDeviceData(tmp, m_tmp, N); \
   allocAndInitCudaDeviceData(y, m_y, N); \
   allocAndInitCudaDeviceData(x, m_x, N); \
@@ -78,7 +80,6 @@ __global__ void poly_atax_2(Real_ptr A, Real_ptr tmp, Real_ptr y,
 void POLYBENCH_ATAX::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_ATAX-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_ATAX-OMPTarget.cpp
@@ -35,6 +35,8 @@ namespace polybench
   Real_ptr x; \
   Real_ptr A; \
 \
+  const Index_type N = m_N; \
+\
   allocAndInitOpenMPDeviceData(tmp, m_tmp, N, did, hid); \
   allocAndInitOpenMPDeviceData(y, m_y, N, did, hid); \
   allocAndInitOpenMPDeviceData(x, m_x, N, did, hid); \
@@ -52,7 +54,6 @@ namespace polybench
 void POLYBENCH_ATAX::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
@@ -25,6 +25,8 @@ namespace polybench
   Real_ptr pin; \
   Real_ptr pout; \
 \
+  const Index_type N = m_N; \
+\
   allocAndInitCudaDeviceData(pin, m_pin, m_N * m_N); \
   allocAndInitCudaDeviceData(pout, m_pout, m_N * m_N);
 
@@ -49,8 +51,6 @@ __global__ void poly_floyd_warshall(Real_ptr pout, Real_ptr pin,
 void POLYBENCH_FLOYD_WARSHALL::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
-
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-OMPTarget.cpp
@@ -27,6 +27,7 @@ namespace polybench
 \
   Real_ptr pin; \
   Real_ptr pout; \
+  const Index_type N = m_N; \
 \
   allocAndInitOpenMPDeviceData(pin, m_pin, m_N * m_N, did, hid); \
   allocAndInitOpenMPDeviceData(pout, m_pout, m_N * m_N, did, hid);
@@ -41,8 +42,6 @@ namespace polybench
 void POLYBENCH_FLOYD_WARSHALL::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
-
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_GEMM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Cuda.cpp
@@ -53,10 +53,11 @@ __global__ void poly_gemm(Real_ptr C, Real_ptr A, Real_ptr B,
    Index_type j = threadIdx.x;
 
    POLYBENCH_GEMM_BODY1;
+   POLYBENCH_GEMM_BODY2;
    for (Index_type k = 0; k < nk; ++k ) {
-     POLYBENCH_GEMM_BODY2;
+     POLYBENCH_GEMM_BODY3;
    }
-   POLYBENCH_GEMM_BODY3;
+   POLYBENCH_GEMM_BODY4;
 }
 
 
@@ -95,10 +96,11 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
           RAJA::statement::For<0, RAJA::cuda_block_y_loop,
             RAJA::statement::For<1, RAJA::cuda_thread_x_loop,
               RAJA::statement::Lambda<0>,
+              RAJA::statement::Lambda<1>,
               RAJA::statement::For<2, RAJA::seq_exec,
-                RAJA::statement::Lambda<1>
+                RAJA::statement::Lambda<2>
               >,
-              RAJA::statement::Lambda<2>
+              RAJA::statement::Lambda<3>
             >
           >
         >
@@ -115,17 +117,21 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
 
           RAJA::make_tuple(static_cast<Real_type>(0.0)),  // variable for dot
 
-          [=] __device__ (Index_type i, Index_type j, Index_type /*k*/, 
+          [=] __device__ (Index_type /*i*/, Index_type /*j*/, Index_type /*k*/, 
                           Real_type& dot) {
             POLYBENCH_GEMM_BODY1_RAJA;
           },
-          [=] __device__ (Index_type i, Index_type j, Index_type k, 
+          [=] __device__ (Index_type i, Index_type j, Index_type /*k*/, 
                           Real_type& dot) {
             POLYBENCH_GEMM_BODY2_RAJA;
           },
-          [=] __device__ (Index_type i, Index_type j, Index_type /*k*/, 
+          [=] __device__ (Index_type i, Index_type j, Index_type k, 
                           Real_type& dot) {
             POLYBENCH_GEMM_BODY3_RAJA;
+          },
+          [=] __device__ (Index_type i, Index_type j, Index_type /*k*/, 
+                          Real_type& dot) {
+            POLYBENCH_GEMM_BODY4_RAJA;
           }
         );
 

--- a/src/polybench/POLYBENCH_GEMM-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_GEMM-OMPTarget.cpp
@@ -64,10 +64,11 @@ void POLYBENCH_GEMM::runOpenMPTargetVariant(VariantID vid)
       for (Index_type i = 0; i < ni; ++i ) {
         for (Index_type j = 0; j < nj; ++j ) {
           POLYBENCH_GEMM_BODY1;
+          POLYBENCH_GEMM_BODY2;
           for (Index_type k = 0; k < nk; ++k ) {
-             POLYBENCH_GEMM_BODY2;
+             POLYBENCH_GEMM_BODY3;
           }
-          POLYBENCH_GEMM_BODY3;
+          POLYBENCH_GEMM_BODY4;
         }
       }
 
@@ -87,10 +88,11 @@ void POLYBENCH_GEMM::runOpenMPTargetVariant(VariantID vid)
         RAJA::statement::Collapse<RAJA::omp_target_parallel_collapse_exec,
                                   RAJA::ArgList<0, 1>,
           RAJA::statement::Lambda<0>,
+          RAJA::statement::Lambda<1>,
           RAJA::statement::For<2, RAJA::seq_exec,
-            RAJA::statement::Lambda<1>
+            RAJA::statement::Lambda<2>
           >,
-          RAJA::statement::Lambda<2>
+          RAJA::statement::Lambda<3>
         >
       >;
 
@@ -104,14 +106,17 @@ void POLYBENCH_GEMM::runOpenMPTargetVariant(VariantID vid)
                             RAJA::RangeSegment{0, nk} ),
           RAJA::make_tuple(static_cast<Real_type>(0.0)),  // variable for dot
 
-          [=] (Index_type i, Index_type j, Index_type /*k*/, Real_type& dot) {
+          [=] (Index_type /*i*/, Index_type /*j*/, Index_type /*k*/, Real_type& dot) {
             POLYBENCH_GEMM_BODY1_RAJA;
           },
-          [=] (Index_type i, Index_type j, Index_type k, Real_type& dot) {
+          [=] (Index_type i, Index_type j, Index_type /*k*/, Real_type& dot) {
             POLYBENCH_GEMM_BODY2_RAJA;
           },
-          [=] (Index_type i, Index_type j, Index_type /*k*/, Real_type& dot) {
+          [=] (Index_type i, Index_type j, Index_type k, Real_type& dot) {
             POLYBENCH_GEMM_BODY3_RAJA;
+          },
+          [=] (Index_type i, Index_type j, Index_type /*k*/, Real_type& dot) {
+            POLYBENCH_GEMM_BODY4_RAJA;
           }
         );
 

--- a/src/polybench/POLYBENCH_GEMM.hpp
+++ b/src/polybench/POLYBENCH_GEMM.hpp
@@ -25,24 +25,28 @@
 #define RAJAPerf_POLYBENCH_GEMM_HPP
 
 #define POLYBENCH_GEMM_BODY1 \
-  C[j + i*nj] *= beta; \
   Real_type dot = 0.0;
 
 #define POLYBENCH_GEMM_BODY2 \
-  dot += alpha * A[k + i*nk] * B[j + k*nj];  
+  C[j + i*nj] *= beta;
 
 #define POLYBENCH_GEMM_BODY3 \
+  dot += alpha * A[k + i*nk] * B[j + k*nj];  
+
+#define POLYBENCH_GEMM_BODY4 \
   C[j + i*nj] = dot;
 
 
 #define POLYBENCH_GEMM_BODY1_RAJA \
-  Cview(i, j) *= beta; \
   dot = 0.0;
 
 #define POLYBENCH_GEMM_BODY2_RAJA \
-  dot += alpha * Aview(i, k) * Bview(k, j);  
+  Cview(i, j) *= beta;
 
 #define POLYBENCH_GEMM_BODY3_RAJA \
+  dot += alpha * Aview(i, k) * Bview(k, j);  
+
+#define POLYBENCH_GEMM_BODY4_RAJA \
   Cview(i, j) = dot;
 
 

--- a/src/polybench/POLYBENCH_GEMVER-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-OMPTarget.cpp
@@ -70,7 +70,6 @@ namespace polybench
 void POLYBENCH_GEMVER::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type n = m_n;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_GESUMMV.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV.cpp
@@ -90,6 +90,15 @@ void POLYBENCH_GESUMMV::runKernel(VariantID vid)
 
   POLYBENCH_GESUMMV_DATA_SETUP_CPU;
 
+  auto poly_gesummv_base_lam2 = [=](Index_type i, Index_type j, 
+                                    Real_type& tmpdot, Real_type& ydot) {
+                                  POLYBENCH_GESUMMV_BODY2;
+                                };
+  auto poly_gesummv_base_lam3 = [=](Index_type i,
+                                    Real_type& tmpdot, Real_type& ydot) {
+                                  POLYBENCH_GESUMMV_BODY3;
+                                };
+
   POLYBENCH_GESUMMV_VIEWS_RAJA;
 
   auto poly_gesummv_lam1 = [=](Index_type /*i*/, Index_type /*j*/, 
@@ -177,6 +186,26 @@ void POLYBENCH_GESUMMV::runKernel(VariantID vid)
             POLYBENCH_GESUMMV_BODY2;
           }
           POLYBENCH_GESUMMV_BODY3;
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = 0; i < N; ++i ) {
+          POLYBENCH_GESUMMV_BODY1;
+          for (Index_type j = 0; j < N; ++j ) {
+            poly_gesummv_base_lam2(i, j, tmpdot, ydot);
+          }
+          poly_gesummv_base_lam3(i, tmpdot, ydot);
         }
 
       }

--- a/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
@@ -24,6 +24,8 @@ namespace polybench
 #define POLYBENCH_HEAT_3D_DATA_SETUP_CUDA \
   Real_ptr A; \
   Real_ptr B; \
+  const Index_type N = m_N; \
+  const Index_type tsteps = m_tsteps; \
 \
   allocAndInitCudaDeviceData(A, m_Ainit, m_N*m_N*m_N); \
   allocAndInitCudaDeviceData(B, m_Binit, m_N*m_N*m_N);
@@ -62,8 +64,6 @@ __global__ void poly_heat_3D_2(Real_ptr A, Real_ptr B, Index_type N)
 void POLYBENCH_HEAT_3D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
-  const Index_type tsteps = m_tsteps;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_HEAT_3D-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-OMPTarget.cpp
@@ -27,6 +27,8 @@ namespace polybench
 \
   Real_ptr A; \
   Real_ptr B; \
+  const Index_type N = m_N; \
+  const Index_type tsteps = m_tsteps; \
 \
   allocAndInitOpenMPDeviceData(A, m_Ainit, m_N*m_N*m_N, did, hid); \
   allocAndInitOpenMPDeviceData(B, m_Binit, m_N*m_N*m_N, did, hid);
@@ -42,8 +44,6 @@ namespace polybench
 void POLYBENCH_HEAT_3D::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
-  const Index_type tsteps = m_tsteps;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -21,7 +21,9 @@ namespace polybench
 
 #define POLYBENCH_HEAT_3D_DATA_SETUP_CPU \
   ResReal_ptr A = m_Ainit; \
-  ResReal_ptr B = m_Binit;
+  ResReal_ptr B = m_Binit; \
+  const Index_type N = m_N; \
+  const Index_type tsteps = m_tsteps;
 
 #define POLYBENCH_HEAT_3D_DATA_RESET_CPU \
   m_Ainit = m_A; \
@@ -98,10 +100,15 @@ void POLYBENCH_HEAT_3D::setUp(VariantID vid)
 void POLYBENCH_HEAT_3D::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
-  const Index_type N = m_N;
-  const Index_type tsteps = m_tsteps;
 
   POLYBENCH_HEAT_3D_DATA_SETUP_CPU;
+
+  auto poly_heat3d_base_lam1 = [=](Index_type i, Index_type j, Index_type k) {
+                                 POLYBENCH_HEAT_3D_BODY1;
+                               };
+  auto poly_heat3d_base_lam2 = [=](Index_type i, Index_type j, Index_type k) {
+                                 POLYBENCH_HEAT_3D_BODY2;
+                               };
 
   POLYBENCH_HEAT_3D_VIEWS_RAJA;
 
@@ -197,6 +204,41 @@ void POLYBENCH_HEAT_3D::runKernel(VariantID vid)
 
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
     case Base_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        for (Index_type t = 0; t < tsteps; ++t) {
+
+          #pragma omp parallel for collapse(2)
+          for (Index_type i = 1; i < N-1; ++i ) {
+            for (Index_type j = 1; j < N-1; ++j ) {
+              for (Index_type k = 1; k < N-1; ++k ) {
+                poly_heat3d_base_lam1(i, j, k);
+              }
+            }
+          }
+
+          #pragma omp parallel for collapse(2)
+          for (Index_type i = 1; i < N-1; ++i ) {
+            for (Index_type j = 1; j < N-1; ++j ) {
+              for (Index_type k = 1; k < N-1; ++k ) {
+                poly_heat3d_base_lam2(i, j, k);
+              }
+            }
+          }
+
+        }
+
+      }
+      stopTimer();
+
+      POLYBENCH_HEAT_3D_DATA_RESET_CPU;
+
+      break;
+    }
+
+    case OpenMP_Lambda : {
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/polybench/POLYBENCH_JACOBI_1D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-Cuda.cpp
@@ -29,6 +29,8 @@ namespace polybench
 #define POLYBENCH_JACOBI_1D_DATA_SETUP_CUDA \
   Real_ptr A; \
   Real_ptr B; \
+  const Index_type N = m_N; \
+  const Index_type tsteps = m_tsteps; \
 \
   allocAndInitCudaDeviceData(A, m_Ainit, m_N); \
   allocAndInitCudaDeviceData(B, m_Binit, m_N);
@@ -63,8 +65,6 @@ __global__ void poly_jacobi_1D_2(Real_ptr A, Real_ptr B, Index_type N)
 void POLYBENCH_JACOBI_1D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
-  const Index_type tsteps = m_tsteps;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_JACOBI_1D-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-OMPTarget.cpp
@@ -32,6 +32,8 @@ namespace polybench
 \
   Real_ptr A; \
   Real_ptr B; \
+  const Index_type N = m_N; \
+  const Index_type tsteps = m_tsteps; \
 \
   allocAndInitOpenMPDeviceData(A, m_Ainit, m_N, did, hid); \
   allocAndInitOpenMPDeviceData(B, m_Binit, m_N, did, hid);
@@ -47,8 +49,6 @@ namespace polybench
 void POLYBENCH_JACOBI_1D::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
-  const Index_type tsteps = m_tsteps;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_JACOBI_1D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.cpp
@@ -21,7 +21,9 @@ namespace polybench
 
 #define POLYBENCH_JACOBI_1D_DATA_SETUP_CPU \
   ResReal_ptr A = m_Ainit; \
-  ResReal_ptr B = m_Binit;
+  ResReal_ptr B = m_Binit; \
+  const Index_type N = m_N; \
+  const Index_type tsteps = m_tsteps;
 
 #define POLYBENCH_JACOBI_1D_DATA_RESET_CPU \
   m_Ainit = m_A; \
@@ -88,8 +90,6 @@ void POLYBENCH_JACOBI_1D::setUp(VariantID vid)
 void POLYBENCH_JACOBI_1D::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
-  const Index_type N = m_N;
-  const Index_type tsteps = m_tsteps;
 
   POLYBENCH_JACOBI_1D_DATA_SETUP_CPU;
 
@@ -168,6 +168,30 @@ void POLYBENCH_JACOBI_1D::runKernel(VariantID vid)
           #pragma omp parallel for
           for (Index_type i = 1; i < N-1; ++i ) {
             POLYBENCH_JACOBI_1D_BODY2;
+          }
+        }
+
+      }
+      stopTimer();
+
+      POLYBENCH_JACOBI_1D_DATA_RESET_CPU;
+
+      break;
+    }
+
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        for (Index_type t = 0; t < tsteps; ++t) {
+          #pragma omp parallel for
+          for (Index_type i = 1; i < N-1; ++i ) {
+            poly_jacobi1d_lam1(i);
+          }
+          #pragma omp parallel for
+          for (Index_type i = 1; i < N-1; ++i ) {
+            poly_jacobi1d_lam2(i);
           }
         }
 

--- a/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
@@ -24,6 +24,8 @@ namespace polybench
 #define POLYBENCH_JACOBI_2D_DATA_SETUP_CUDA \
   Real_ptr A; \
   Real_ptr B; \
+  const Index_type N = m_N; \
+  const Index_type tsteps = m_tsteps; \
 \
   allocAndInitCudaDeviceData(A, m_Ainit, m_N*m_N); \
   allocAndInitCudaDeviceData(B, m_Binit, m_N*m_N);
@@ -60,8 +62,6 @@ __global__ void poly_jacobi_2D_2(Real_ptr A, Real_ptr B, Index_type N)
 void POLYBENCH_JACOBI_2D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
-  const Index_type tsteps = m_tsteps;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_JACOBI_2D-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-OMPTarget.cpp
@@ -27,6 +27,8 @@ namespace polybench
 \
   Real_ptr A; \
   Real_ptr B; \
+  const Index_type N = m_N; \
+  const Index_type tsteps = m_tsteps; \
 \
   allocAndInitOpenMPDeviceData(A, m_Ainit, m_N*m_N, did, hid); \
   allocAndInitOpenMPDeviceData(B, m_Binit, m_N*m_N, did, hid);
@@ -42,8 +44,6 @@ namespace polybench
 void POLYBENCH_JACOBI_2D::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
-  const Index_type tsteps = m_tsteps;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_MVT-Cuda.cpp
+++ b/src/polybench/POLYBENCH_MVT-Cuda.cpp
@@ -32,6 +32,7 @@ namespace polybench
   Real_ptr y1; \
   Real_ptr y2; \
   Real_ptr A; \
+  const Index_type N = m_N; \
 \
   allocAndInitCudaDeviceData(x1, m_x1, N); \
   allocAndInitCudaDeviceData(x2, m_x2, N); \
@@ -82,7 +83,6 @@ __global__ void poly_mvt_2(Real_ptr A, Real_ptr x2, Real_ptr y2,
 void POLYBENCH_MVT::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_MVT-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_MVT-OMPTarget.cpp
@@ -35,6 +35,7 @@ namespace polybench
   Real_ptr y1; \
   Real_ptr y2; \
   Real_ptr A; \
+  const Index_type N = m_N; \
 \
   allocAndInitOpenMPDeviceData(x1, m_x1, N, did, hid); \
   allocAndInitOpenMPDeviceData(x2, m_x2, N, did, hid); \
@@ -56,7 +57,6 @@ namespace polybench
 void POLYBENCH_MVT::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type N = m_N;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -106,6 +106,22 @@ void ADD::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          add_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -104,6 +104,22 @@ void COPY::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          copy_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/stream/DOT.cpp
+++ b/src/stream/DOT.cpp
@@ -117,6 +117,30 @@ void DOT::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        Real_type dot = m_dot_init;
+
+        auto dot_lam = [=](Index_type i) -> Real_type {
+                         return a[i] * b[i];
+                       };
+
+        #pragma omp parallel for reduction(+:dot)
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          dot += dot_lam(i);
+        }
+
+        m_dot += dot;
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/stream/DOT.cpp
+++ b/src/stream/DOT.cpp
@@ -53,6 +53,10 @@ void DOT::runKernel(VariantID vid)
 
   DOT_DATA_SETUP_CPU;
 
+  auto dot_base_lam = [=](Index_type i) -> Real_type {
+                        return a[i] * b[i];
+                      };
+
   switch ( vid ) {
 
     case Base_Seq : {
@@ -124,13 +128,9 @@ void DOT::runKernel(VariantID vid)
 
         Real_type dot = m_dot_init;
 
-        auto dot_lam = [=](Index_type i) -> Real_type {
-                         return a[i] * b[i];
-                       };
-
         #pragma omp parallel for reduction(+:dot)
         for (Index_type i = ibegin; i < iend; ++i ) {
-          dot += dot_lam(i);
+          dot += dot_base_lam(i);
         }
 
         m_dot += dot;

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -107,6 +107,22 @@ void MUL::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          mul_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -108,6 +108,22 @@ void TRIAD::runKernel(VariantID vid)
       break;
     }
 
+    case OpenMP_Lambda : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          triad_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
     case RAJA_OpenMP : {
 
       startTimer();


### PR DESCRIPTION
This PR adds a variant of each kernel that uses OpenMP with C++ lambdas, but no RAJA. I will follow this one up with a similar sequential variant. Then, there will be a PR after that which breaks the files apart in preparation for the "uber perf suite" recently discussed via email.