### PR TITLE
Unify macros

### DIFF
--- a/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
@@ -30,21 +30,6 @@ namespace apps
 
 
 #define DEL_DOT_VEC_2D_DATA_SETUP_CUDA \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr xdot; \
-  Real_ptr ydot; \
-  Real_ptr div; \
-  Index_ptr real_zones; \
-\
-  const Real_type ptiny = m_ptiny; \
-  const Real_type half = m_half; \
-\
-  Real_ptr x1,x2,x3,x4 ; \
-  Real_ptr y1,y2,y3,y4 ; \
-  Real_ptr fx1,fx2,fx3,fx4 ; \
-  Real_ptr fy1,fy2,fy3,fy4 ; \
-\
   allocAndInitCudaDeviceData(x, m_x, m_array_length); \
   allocAndInitCudaDeviceData(y, m_y, m_array_length); \
   allocAndInitCudaDeviceData(xdot, m_xdot, m_array_length); \
@@ -86,6 +71,8 @@ void DEL_DOT_VEC_2D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type iend = m_domain->n_real_zones;
+
+  DEL_DOT_VEC_2D_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/apps/DEL_DOT_VEC_2D-OMPTarget.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-OMPTarget.cpp
@@ -32,21 +32,6 @@ namespace apps
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr x = m_x; \
-  Real_ptr y = m_y; \
-  Real_ptr xdot = m_xdot; \
-  Real_ptr ydot = m_ydot; \
-  Real_ptr div = m_div; \
-  Index_ptr real_zones; \
-\
-  const Real_type ptiny = m_ptiny; \
-  const Real_type half = m_half; \
-\
-  Real_ptr x1,x2,x3,x4 ; \
-  Real_ptr y1,y2,y3,y4 ; \
-  Real_ptr fx1,fx2,fx3,fx4 ; \
-  Real_ptr fy1,fy2,fy3,fy4 ; \
-\
   allocAndInitOpenMPDeviceData(x, m_x, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(y, m_y, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(xdot, m_xdot, m_array_length, did, hid); \
@@ -69,6 +54,8 @@ void DEL_DOT_VEC_2D::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = m_domain->n_real_zones;
+
+  DEL_DOT_VEC_2D_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -20,21 +20,6 @@ namespace rajaperf
 namespace apps
 {
 
-#define DEL_DOT_VEC_2D_DATA_SETUP_CPU \
-  ResReal_ptr x = m_x; \
-  ResReal_ptr y = m_y; \
-  ResReal_ptr xdot = m_xdot; \
-  ResReal_ptr ydot = m_ydot; \
-  ResReal_ptr div = m_div; \
-\
-  const Real_type ptiny = m_ptiny; \
-  const Real_type half = m_half; \
-\
-  ResReal_ptr x1,x2,x3,x4 ; \
-  ResReal_ptr y1,y2,y3,y4 ; \
-  ResReal_ptr fx1,fx2,fx3,fx4 ; \
-  ResReal_ptr fy1,fy2,fy3,fy4 ;
-
 
 DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
   : KernelBase(rajaperf::Apps_DEL_DOT_VEC_2D, params)
@@ -81,14 +66,12 @@ void DEL_DOT_VEC_2D::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = m_domain->n_real_zones;
 
-  DEL_DOT_VEC_2D_DATA_SETUP_CPU;
+  DEL_DOT_VEC_2D_DATA_SETUP;
 
   NDSET2D(m_domain->jp, x,x1,x2,x3,x4) ;
   NDSET2D(m_domain->jp, y,y1,y2,y3,y4) ;
   NDSET2D(m_domain->jp, xdot,fx1,fx2,fx3,fx4) ;
   NDSET2D(m_domain->jp, ydot,fy1,fy2,fy3,fy4) ;
-
-  DEL_DOT_VEC_2D_DATA_INDEX;
 
   auto deldotvec2d_base_lam = [=](Index_type ii) {
                                 DEL_DOT_VEC_2D_BODY_INDEX;

--- a/src/apps/DEL_DOT_VEC_2D.hpp
+++ b/src/apps/DEL_DOT_VEC_2D.hpp
@@ -40,8 +40,21 @@
 #ifndef RAJAPerf_Apps_DEL_DOT_VEC_2D_HPP
 #define RAJAPerf_Apps_DEL_DOT_VEC_2D_HPP
 
-
-#define DEL_DOT_VEC_2D_DATA_INDEX \
+#define DEL_DOT_VEC_2D_DATA_SETUP \
+  Real_ptr x = m_x; \
+  Real_ptr y = m_y; \
+  Real_ptr xdot = m_xdot; \
+  Real_ptr ydot = m_ydot; \
+  Real_ptr div = m_div; \
+\
+  const Real_type ptiny = m_ptiny; \
+  const Real_type half = m_half; \
+\
+  Real_ptr x1,x2,x3,x4 ; \
+  Real_ptr y1,y2,y3,y4 ; \
+  Real_ptr fx1,fx2,fx3,fx4 ; \
+  Real_ptr fy1,fy2,fy3,fy4 ; \
+\
   Index_ptr real_zones = m_domain->real_zones;
 
 #define DEL_DOT_VEC_2D_BODY_INDEX \

--- a/src/apps/ENERGY-Cuda.cpp
+++ b/src/apps/ENERGY-Cuda.cpp
@@ -28,26 +28,6 @@ namespace apps
 
 
 #define ENERGY_DATA_SETUP_CUDA \
-  Real_ptr e_new; \
-  Real_ptr e_old; \
-  Real_ptr delvc; \
-  Real_ptr p_new; \
-  Real_ptr p_old; \
-  Real_ptr q_new; \
-  Real_ptr q_old; \
-  Real_ptr work; \
-  Real_ptr compHalfStep; \
-  Real_ptr pHalfStep; \
-  Real_ptr bvc; \
-  Real_ptr pbvc; \
-  Real_ptr ql_old; \
-  Real_ptr qq_old; \
-  Real_ptr vnewc; \
-  const Real_type rho0 = m_rho0; \
-  const Real_type e_cut = m_e_cut; \
-  const Real_type emin = m_emin; \
-  const Real_type q_cut = m_q_cut; \
-\
   allocAndInitCudaDeviceData(e_new, m_e_new, iend); \
   allocAndInitCudaDeviceData(e_old, m_e_old, iend); \
   allocAndInitCudaDeviceData(delvc, m_delvc, iend); \
@@ -162,6 +142,8 @@ void ENERGY::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  ENERGY_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
     

--- a/src/apps/ENERGY-OMPTarget.cpp
+++ b/src/apps/ENERGY-OMPTarget.cpp
@@ -30,26 +30,6 @@ namespace apps
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr e_new; \
-  Real_ptr e_old; \
-  Real_ptr delvc; \
-  Real_ptr p_new; \
-  Real_ptr p_old; \
-  Real_ptr q_new; \
-  Real_ptr q_old; \
-  Real_ptr work; \
-  Real_ptr compHalfStep; \
-  Real_ptr pHalfStep; \
-  Real_ptr bvc; \
-  Real_ptr pbvc; \
-  Real_ptr ql_old; \
-  Real_ptr qq_old; \
-  Real_ptr vnewc; \
-  const Real_type rho0 = m_rho0; \
-  const Real_type e_cut = m_e_cut; \
-  const Real_type emin = m_emin; \
-  const Real_type q_cut = m_q_cut; \
-\
   allocAndInitOpenMPDeviceData(e_new, m_e_new, iend, did, hid); \
   allocAndInitOpenMPDeviceData(e_old, m_e_old, iend, did, hid); \
   allocAndInitOpenMPDeviceData(delvc, m_delvc, iend, did, hid); \
@@ -90,6 +70,8 @@ void ENERGY::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  ENERGY_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -19,27 +19,6 @@ namespace rajaperf
 namespace apps
 {
 
-#define ENERGY_DATA_SETUP_CPU \
-  ResReal_ptr e_new = m_e_new; \
-  ResReal_ptr e_old = m_e_old; \
-  ResReal_ptr delvc = m_delvc; \
-  ResReal_ptr p_new = m_p_new; \
-  ResReal_ptr p_old = m_p_old; \
-  ResReal_ptr q_new = m_q_new; \
-  ResReal_ptr q_old = m_q_old; \
-  ResReal_ptr work = m_work; \
-  ResReal_ptr compHalfStep = m_compHalfStep; \
-  ResReal_ptr pHalfStep = m_pHalfStep; \
-  ResReal_ptr bvc = m_bvc; \
-  ResReal_ptr pbvc = m_pbvc; \
-  ResReal_ptr ql_old = m_ql_old; \
-  ResReal_ptr qq_old = m_qq_old; \
-  ResReal_ptr vnewc = m_vnewc; \
-  const Real_type rho0 = m_rho0; \
-  const Real_type e_cut = m_e_cut; \
-  const Real_type emin = m_emin; \
-  const Real_type q_cut = m_q_cut;
-
 
 ENERGY::ENERGY(const RunParams& params)
   : KernelBase(rajaperf::Apps_ENERGY, params)
@@ -82,7 +61,7 @@ void ENERGY::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  ENERGY_DATA_SETUP_CPU;
+  ENERGY_DATA_SETUP;
   
   auto energy_lam1 = [=](Index_type i) {
                        ENERGY_BODY1;

--- a/src/apps/ENERGY.hpp
+++ b/src/apps/ENERGY.hpp
@@ -87,6 +87,26 @@
 #ifndef RAJAPerf_Apps_ENERGY_HPP
 #define RAJAPerf_Apps_ENERGY_HPP
 
+#define ENERGY_DATA_SETUP \
+  Real_ptr e_new = m_e_new; \
+  Real_ptr e_old = m_e_old; \
+  Real_ptr delvc = m_delvc; \
+  Real_ptr p_new = m_p_new; \
+  Real_ptr p_old = m_p_old; \
+  Real_ptr q_new = m_q_new; \
+  Real_ptr q_old = m_q_old; \
+  Real_ptr work = m_work; \
+  Real_ptr compHalfStep = m_compHalfStep; \
+  Real_ptr pHalfStep = m_pHalfStep; \
+  Real_ptr bvc = m_bvc; \
+  Real_ptr pbvc = m_pbvc; \
+  Real_ptr ql_old = m_ql_old; \
+  Real_ptr qq_old = m_qq_old; \
+  Real_ptr vnewc = m_vnewc; \
+  const Real_type rho0 = m_rho0; \
+  const Real_type e_cut = m_e_cut; \
+  const Real_type emin = m_emin; \
+  const Real_type q_cut = m_q_cut;
 
 #define ENERGY_BODY1 \
   e_new[i] = e_old[i] - 0.5 * delvc[i] * \

--- a/src/apps/FIR-Cuda.cpp
+++ b/src/apps/FIR-Cuda.cpp
@@ -36,11 +36,6 @@ namespace apps
 __constant__ Real_type coeff[FIR_COEFFLEN];
 
 #define FIR_DATA_SETUP_CUDA \
-  Real_ptr in; \
-  Real_ptr out; \
-\
-  const Index_type coefflen = m_coefflen; \
-\
   allocAndInitCudaDeviceData(in, m_in, getRunSize()); \
   allocAndInitCudaDeviceData(out, m_out, getRunSize()); \
   cudaMemcpyToSymbol(coeff, coeff_array, FIR_COEFFLEN * sizeof(Real_type));
@@ -64,11 +59,7 @@ __global__ void fir(Real_ptr out, Real_ptr in,
 #else  // use global memry for coefficients 
 
 #define FIR_DATA_SETUP_CUDA \
-  Real_ptr in; \
-  Real_ptr out; \
   Real_ptr coeff; \
-\
-  const Index_type coefflen = m_coefflen; \
 \
   allocAndInitCudaDeviceData(in, m_in, getRunSize()); \
   allocAndInitCudaDeviceData(out, m_out, getRunSize()); \
@@ -101,6 +92,8 @@ void FIR::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize() - m_coefflen;
+
+  FIR_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/apps/FIR-OMPTarget.cpp
+++ b/src/apps/FIR-OMPTarget.cpp
@@ -31,11 +31,7 @@ namespace apps
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr in; \
-  Real_ptr out; \
   Real_ptr coeff; \
-\
-  const Index_type coefflen = m_coefflen; \
 \
   allocAndInitOpenMPDeviceData(in, m_in, getRunSize(), did, hid); \
   allocAndInitOpenMPDeviceData(out, m_out, getRunSize(), did, hid); \
@@ -55,6 +51,8 @@ void FIR::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize() - m_coefflen;
+
+  FIR_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -21,16 +21,6 @@ namespace apps
 {
 
 
-#define FIR_DATA_SETUP_CPU \
-  ResReal_ptr in = m_in; \
-  ResReal_ptr out = m_out; \
-\
-  Real_type coeff[FIR_COEFFLEN]; \
-  std::copy(std::begin(coeff_array), std::end(coeff_array), std::begin(coeff));\
-\
-  const Index_type coefflen = m_coefflen;
-
-
 FIR::FIR(const RunParams& params)
   : KernelBase(rajaperf::Apps_FIR, params)
 {
@@ -62,7 +52,10 @@ void FIR::runKernel(VariantID vid)
 
   FIR_COEFF;
 
-  FIR_DATA_SETUP_CPU;
+  FIR_DATA_SETUP;
+
+  Real_type coeff[FIR_COEFFLEN];
+  std::copy(std::begin(coeff_array), std::end(coeff_array), std::begin(coeff));
 
   auto fir_lam = [=](Index_type i) {
                    FIR_BODY;

--- a/src/apps/FIR.hpp
+++ b/src/apps/FIR.hpp
@@ -31,6 +31,12 @@
 
 #define FIR_COEFFLEN (16)
 
+#define FIR_DATA_SETUP \
+  Real_ptr in = m_in; \
+  Real_ptr out = m_out; \
+\
+  const Index_type coefflen = m_coefflen;
+
 #define FIR_COEFF \
   Real_type coeff_array[FIR_COEFFLEN] = { 3.0, -1.0, -1.0, -1.0, \
                                          -1.0, 3.0, -1.0, -1.0, \

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -23,15 +23,6 @@ namespace apps
 
 
 #define LTIMES_DATA_SETUP_CUDA \
-  Real_ptr phidat; \
-  Real_ptr elldat; \
-  Real_ptr psidat; \
-\
-  Index_type num_d = m_num_d; \
-  Index_type num_z = m_num_z; \
-  Index_type num_g = m_num_g; \
-  Index_type num_m = m_num_m; \
-\
   allocAndInitCudaDeviceData(phidat, m_phidat, m_philen); \
   allocAndInitCudaDeviceData(elldat, m_elldat, m_elllen); \
   allocAndInitCudaDeviceData(psidat, m_psidat, m_psilen);
@@ -58,6 +49,8 @@ __global__ void ltimes(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
 void LTIMES::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  LTIMES_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/apps/LTIMES-OMPTarget.cpp
+++ b/src/apps/LTIMES-OMPTarget.cpp
@@ -25,15 +25,6 @@ namespace apps
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr phidat; \
-  Real_ptr elldat; \
-  Real_ptr psidat; \
-\
-  Index_type num_d = m_num_d; \
-  Index_type num_z = m_num_z; \
-  Index_type num_g = m_num_g; \
-  Index_type num_m = m_num_m; \
-\
   allocAndInitOpenMPDeviceData(phidat, m_phidat, m_philen, did, hid); \
   allocAndInitOpenMPDeviceData(elldat, m_elldat, m_elllen, did, hid); \
   allocAndInitOpenMPDeviceData(psidat, m_psidat, m_psilen, did, hid);
@@ -48,6 +39,8 @@ namespace apps
 void LTIMES::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  LTIMES_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -20,17 +20,6 @@ namespace apps
 {
 
 
-#define LTIMES_DATA_SETUP_CPU \
-  ResReal_ptr phidat = m_phidat; \
-  ResReal_ptr elldat = m_elldat; \
-  ResReal_ptr psidat = m_psidat; \
-\
-  Index_type num_d = m_num_d; \
-  Index_type num_z = m_num_z; \
-  Index_type num_g = m_num_g; \
-  Index_type num_m = m_num_m;
-
-
 LTIMES::LTIMES(const RunParams& params)
   : KernelBase(rajaperf::Apps_LTIMES, params)
 {
@@ -68,7 +57,7 @@ void LTIMES::runKernel(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
-  LTIMES_DATA_SETUP_CPU;
+  LTIMES_DATA_SETUP;
 
   auto ltimes_base_lam = [=](Index_type d, Index_type z, 
                              Index_type g, Index_type m) {

--- a/src/apps/LTIMES.hpp
+++ b/src/apps/LTIMES.hpp
@@ -30,6 +30,15 @@
 #ifndef RAJAPerf_Apps_LTIMES_HPP
 #define RAJAPerf_Apps_LTIMES_HPP
 
+#define LTIMES_DATA_SETUP \
+  Real_ptr phidat = m_phidat; \
+  Real_ptr elldat = m_elldat; \
+  Real_ptr psidat = m_psidat; \
+\
+  Index_type num_d = m_num_d; \
+  Index_type num_z = m_num_z; \
+  Index_type num_g = m_num_g; \
+  Index_type num_m = m_num_m;
 
 #define LTIMES_BODY \
   phidat[m+ (g * num_m) + (z * num_m * num_g)] += \

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -23,14 +23,6 @@ namespace apps
 
 
 #define LTIMES_NOVIEW_DATA_SETUP_CUDA \
-  Real_ptr phidat; \
-  Real_ptr elldat; \
-  Real_ptr psidat; \
-\
-  Index_type num_d = m_num_d; \
-  Index_type num_z = m_num_z; \
-  Index_type num_g = m_num_g; \
-  Index_type num_m = m_num_m; \
 \
   allocAndInitCudaDeviceData(phidat, m_phidat, m_philen); \
   allocAndInitCudaDeviceData(elldat, m_elldat, m_elllen); \
@@ -58,6 +50,8 @@ __global__ void ltimes_noview(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
 void LTIMES_NOVIEW::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  LTIMES_NOVIEW_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/apps/LTIMES_NOVIEW-OMPTarget.cpp
+++ b/src/apps/LTIMES_NOVIEW-OMPTarget.cpp
@@ -25,15 +25,6 @@ namespace apps
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr phidat; \
-  Real_ptr elldat; \
-  Real_ptr psidat; \
-\
-  Index_type num_d = m_num_d; \
-  Index_type num_z = m_num_z; \
-  Index_type num_g = m_num_g; \
-  Index_type num_m = m_num_m; \
-\
   allocAndInitOpenMPDeviceData(phidat, m_phidat, m_philen, did, hid); \
   allocAndInitOpenMPDeviceData(elldat, m_elldat, m_elllen, did, hid); \
   allocAndInitOpenMPDeviceData(psidat, m_psidat, m_psilen, did, hid);
@@ -48,6 +39,8 @@ namespace apps
 void LTIMES_NOVIEW::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  LTIMES_NOVIEW_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -20,17 +20,6 @@ namespace apps
 {
 
 
-#define LTIMES_NOVIEW_DATA_SETUP_CPU \
-  ResReal_ptr phidat = m_phidat; \
-  ResReal_ptr elldat = m_elldat; \
-  ResReal_ptr psidat = m_psidat; \
-\
-  Index_type num_d = m_num_d; \
-  Index_type num_z = m_num_z; \
-  Index_type num_g = m_num_g; \
-  Index_type num_m = m_num_m;
-
-
 LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   : KernelBase(rajaperf::Apps_LTIMES_NOVIEW, params)
 {
@@ -68,7 +57,7 @@ void LTIMES_NOVIEW::runKernel(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
-  LTIMES_NOVIEW_DATA_SETUP_CPU;
+  LTIMES_NOVIEW_DATA_SETUP;
  
   auto ltimesnoview_lam = [=](Index_type d, Index_type z, 
                               Index_type g, Index_type m) {

--- a/src/apps/LTIMES_NOVIEW.hpp
+++ b/src/apps/LTIMES_NOVIEW.hpp
@@ -26,6 +26,15 @@
 #ifndef RAJAPerf_Apps_LTIMES_NOVIEW_HPP
 #define RAJAPerf_Apps_LTIMES_NOVIEW_HPP
 
+#define LTIMES_NOVIEW_DATA_SETUP \
+  Real_ptr phidat = m_phidat; \
+  Real_ptr elldat = m_elldat; \
+  Real_ptr psidat = m_psidat; \
+\
+  Index_type num_d = m_num_d; \
+  Index_type num_z = m_num_z; \
+  Index_type num_g = m_num_g; \
+  Index_type num_m = m_num_m;
 
 #define LTIMES_NOVIEW_BODY \
   phidat[m+ (g * num_m) + (z * num_m * num_g)] += \

--- a/src/apps/PRESSURE-Cuda.cpp
+++ b/src/apps/PRESSURE-Cuda.cpp
@@ -28,16 +28,6 @@ namespace apps
 
 
 #define PRESSURE_DATA_SETUP_CUDA \
-  Real_ptr compression; \
-  Real_ptr bvc; \
-  Real_ptr p_new; \
-  Real_ptr e_old; \
-  Real_ptr vnewc; \
-  const Real_type cls = m_cls; \
-  const Real_type p_cut = m_p_cut; \
-  const Real_type pmin = m_pmin; \
-  const Real_type eosvmax = m_eosvmax; \
-\
   allocAndInitCudaDeviceData(compression, m_compression, iend); \
   allocAndInitCudaDeviceData(bvc, m_bvc, iend); \
   allocAndInitCudaDeviceData(p_new, m_p_new, iend); \
@@ -80,6 +70,8 @@ void PRESSURE::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  PRESSURE_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/apps/PRESSURE-OMPTarget.cpp
+++ b/src/apps/PRESSURE-OMPTarget.cpp
@@ -30,16 +30,6 @@ namespace apps
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr compression; \
-  Real_ptr bvc; \
-  Real_ptr p_new; \
-  Real_ptr e_old; \
-  Real_ptr vnewc; \
-  const Real_type cls = m_cls; \
-  const Real_type p_cut = m_p_cut; \
-  const Real_type pmin = m_pmin; \
-  const Real_type eosvmax = m_eosvmax; \
-\
   allocAndInitOpenMPDeviceData(compression, m_compression, iend, did, hid); \
   allocAndInitOpenMPDeviceData(bvc, m_bvc, iend, did, hid); \
   allocAndInitOpenMPDeviceData(p_new, m_p_new, iend, did, hid); \
@@ -60,7 +50,9 @@ void PRESSURE::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
-
+  
+  PRESSURE_DATA_SETUP;
+  
   if ( vid == Base_OpenMPTarget ) {
 
     PRESSURE_DATA_SETUP_OMP_TARGET;

--- a/src/apps/PRESSURE.cpp
+++ b/src/apps/PRESSURE.cpp
@@ -19,17 +19,6 @@ namespace rajaperf
 namespace apps
 {
 
-#define PRESSURE_DATA_SETUP_CPU \
-  ResReal_ptr compression = m_compression; \
-  ResReal_ptr bvc = m_bvc; \
-  ResReal_ptr p_new = m_p_new; \
-  ResReal_ptr e_old  = m_e_old; \
-  ResReal_ptr vnewc  = m_vnewc; \
-  const Real_type cls = m_cls; \
-  const Real_type p_cut = m_p_cut; \
-  const Real_type pmin = m_pmin; \
-  const Real_type eosvmax = m_eosvmax; 
-   
 
 PRESSURE::PRESSURE(const RunParams& params)
   : KernelBase(rajaperf::Apps_PRESSURE, params)
@@ -62,7 +51,7 @@ void PRESSURE::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  PRESSURE_DATA_SETUP_CPU;
+  PRESSURE_DATA_SETUP;
 
   auto pressure_lam1 = [=](Index_type i) {
                          PRESSURE_BODY1;

--- a/src/apps/PRESSURE.hpp
+++ b/src/apps/PRESSURE.hpp
@@ -24,6 +24,17 @@
 #ifndef RAJAPerf_Apps_PRESSURE_HPP
 #define RAJAPerf_Apps_PRESSURE_HPP
 
+#define PRESSURE_DATA_SETUP \
+  Real_ptr compression = m_compression; \
+  Real_ptr bvc = m_bvc; \
+  Real_ptr p_new = m_p_new; \
+  Real_ptr e_old  = m_e_old; \
+  Real_ptr vnewc  = m_vnewc; \
+  const Real_type cls = m_cls; \
+  const Real_type p_cut = m_p_cut; \
+  const Real_type pmin = m_pmin; \
+  const Real_type eosvmax = m_eosvmax;
+
 
 #define PRESSURE_BODY1 \
   bvc[i] = cls * (compression[i] + 1.0);

--- a/src/apps/VOL3D-Cuda.cpp
+++ b/src/apps/VOL3D-Cuda.cpp
@@ -30,17 +30,6 @@ namespace apps
 
 
 #define VOL3D_DATA_SETUP_CUDA \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr z; \
-  Real_ptr vol; \
-\
-  const Real_type vnormq = m_vnormq; \
-\
-  Real_ptr x0,x1,x2,x3,x4,x5,x6,x7 ; \
-  Real_ptr y0,y1,y2,y3,y4,y5,y6,y7 ; \
-  Real_ptr z0,z1,z2,z3,z4,z5,z6,z7 ; \
-\
   allocAndInitCudaDeviceData(x, m_x, m_array_length); \
   allocAndInitCudaDeviceData(y, m_y, m_array_length); \
   allocAndInitCudaDeviceData(z, m_z, m_array_length); \
@@ -82,6 +71,8 @@ void VOL3D::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = m_domain->fpz;
   const Index_type iend = m_domain->lpz+1;
+
+  VOL3D_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/apps/VOL3D-OMPTarget.cpp
+++ b/src/apps/VOL3D-OMPTarget.cpp
@@ -32,17 +32,6 @@ namespace apps
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr z; \
-  Real_ptr vol; \
-\
-  const Real_type vnormq = m_vnormq; \
-\
-  Real_ptr x0,x1,x2,x3,x4,x5,x6,x7 ; \
-  Real_ptr y0,y1,y2,y3,y4,y5,y6,y7 ; \
-  Real_ptr z0,z1,z2,z3,z4,z5,z6,z7 ; \
-\
   allocAndInitOpenMPDeviceData(x, m_x, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(y, m_y, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(z, m_z, m_array_length, did, hid); \
@@ -61,6 +50,8 @@ void VOL3D::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = m_domain->fpz;
   const Index_type iend = m_domain->lpz+1;
+
+  VOL3D_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -20,18 +20,6 @@ namespace rajaperf
 namespace apps
 {
 
-#define VOL3D_DATA_SETUP_CPU \
-  Real_ptr x = m_x; \
-  Real_ptr y = m_y; \
-  Real_ptr z = m_z; \
-  ResReal_ptr vol = m_vol; \
-\
-  const Real_type vnormq = m_vnormq;
-\
-  Real_ptr x0,x1,x2,x3,x4,x5,x6,x7 ; \
-  Real_ptr y0,y1,y2,y3,y4,y5,y6,y7 ; \
-  Real_ptr z0,z1,z2,z3,z4,z5,z6,z7 ;
-
 
 VOL3D::VOL3D(const RunParams& params)
   : KernelBase(rajaperf::Apps_VOL3D, params)
@@ -75,7 +63,7 @@ void VOL3D::runKernel(VariantID vid)
   const Index_type ibegin = m_domain->fpz;
   const Index_type iend = m_domain->lpz+1;
 
-  VOL3D_DATA_SETUP_CPU;
+  VOL3D_DATA_SETUP;
 
   NDPTRSET(m_domain->jp, m_domain->kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
   NDPTRSET(m_domain->jp, m_domain->kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;

--- a/src/apps/VOL3D.hpp
+++ b/src/apps/VOL3D.hpp
@@ -69,6 +69,17 @@
 #ifndef RAJAPerf_Apps_VOL3D_HPP
 #define RAJAPerf_Apps_VOL3D_HPP
 
+#define VOL3D_DATA_SETUP \
+  Real_ptr x = m_x; \
+  Real_ptr y = m_y; \
+  Real_ptr z = m_z; \
+  Real_ptr vol = m_vol; \
+\
+  const Real_type vnormq = m_vnormq; \
+\
+  Real_ptr x0,x1,x2,x3,x4,x5,x6,x7 ; \
+  Real_ptr y0,y1,y2,y3,y4,y5,y6,y7 ; \
+  Real_ptr z0,z1,z2,z3,z4,z5,z6,z7 ;
 
 #define VOL3D_BODY \
   Real_type x71 = x7[i] - x1[i] ; \

--- a/src/apps/WIP-COUPLE.cpp
+++ b/src/apps/WIP-COUPLE.cpp
@@ -20,26 +20,6 @@ namespace rajaperf
 namespace apps
 {
 
-#define COUPLE_DATA_SETUP_CPU \
-  ResComplex_ptr t0 = m_t0; \
-  ResComplex_ptr t1 = m_t1; \
-  ResComplex_ptr t2 = m_t2; \
-  ResComplex_ptr denac = m_denac; \
-  ResComplex_ptr denlw = m_denlw; \
-  const Real_type dt = m_dt; \
-  const Real_type c10 = m_c10; \
-  const Real_type fratio = m_fratio; \
-  const Real_type r_fratio = m_r_fratio; \
-  const Real_type c20 = m_c20; \
-  const Complex_type ireal = m_ireal; \
- \
-  const Index_type imin = m_imin; \
-  const Index_type imax = m_imax; \
-  const Index_type jmin = m_jmin; \
-  const Index_type jmax = m_jmax; \
-  const Index_type kmin = m_kmin; \
-  const Index_type kmax = m_kmax;
-
 
 COUPLE::COUPLE(const RunParams& params)
   : KernelBase(rajaperf::Apps_COUPLE, params)
@@ -93,11 +73,11 @@ void COUPLE::runKernel(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
+  COUPLE_DATA_SETUP;
+
   switch ( vid ) {
 
     case Base_Seq : {
-
-      COUPLE_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -114,8 +94,6 @@ void COUPLE::runKernel(VariantID vid)
 
 #if defined(RUN_RAJA_SEQ)
     case RAJA_Seq : {
-
-      COUPLE_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -134,7 +112,6 @@ void COUPLE::runKernel(VariantID vid)
 
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
     case Base_OpenMP : {
-      COUPLE_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -150,8 +127,6 @@ void COUPLE::runKernel(VariantID vid)
     }
 
     case RAJA_OpenMP : {
-
-      COUPLE_DATA_SETUP_CPU;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/apps/WIP-COUPLE.hpp
+++ b/src/apps/WIP-COUPLE.hpp
@@ -68,6 +68,25 @@
 #ifndef RAJAPerf_Apps_COUPLE_HPP
 #define RAJAPerf_Apps_COUPLE_HPP
 
+#define COUPLE_DATA_SETUP \
+  Complex_ptr t0 = m_t0; \
+  Complex_ptr t1 = m_t1; \
+  Complex_ptr t2 = m_t2; \
+  Complex_ptr denac = m_denac; \
+  Complex_ptr denlw = m_denlw; \
+  const Real_type dt = m_dt; \
+  const Real_type c10 = m_c10; \
+  const Real_type fratio = m_fratio; \
+  const Real_type r_fratio = m_r_fratio; \
+  const Real_type c20 = m_c20; \
+  const Complex_type ireal = m_ireal; \
+ \
+  const Index_type imin = m_imin; \
+  const Index_type imax = m_imax; \
+  const Index_type jmin = m_jmin; \
+  const Index_type jmax = m_jmax; \
+  const Index_type kmin = m_kmin; \
+  const Index_type kmax = m_kmax;
 
 #define COUPLE_BODY \
 for (Index_type j = jmin; j < jmax; j++) { \

--- a/src/basic/DAXPY-Cuda.cpp
+++ b/src/basic/DAXPY-Cuda.cpp
@@ -28,10 +28,6 @@ namespace basic
 
 
 #define DAXPY_DATA_SETUP_CUDA \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_type a = m_a; \
-\
   allocAndInitCudaDeviceData(x, m_x, iend); \
   allocAndInitCudaDeviceData(y, m_y, iend);
 
@@ -56,6 +52,8 @@ void DAXPY::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  DAXPY_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/basic/DAXPY-OMPTarget.cpp
+++ b/src/basic/DAXPY-OMPTarget.cpp
@@ -30,10 +30,6 @@ namespace basic
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_type a = m_a; \
-\
   allocAndInitOpenMPDeviceData(x, m_x, iend, did, hid); \
   allocAndInitOpenMPDeviceData(y, m_y, iend, did, hid);
 
@@ -48,6 +44,8 @@ void DAXPY::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  DAXPY_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/basic/DAXPY.cpp
+++ b/src/basic/DAXPY.cpp
@@ -20,12 +20,6 @@ namespace basic
 {
 
 
-#define DAXPY_DATA_SETUP_CPU \
-  ResReal_ptr x = m_x; \
-  ResReal_ptr y = m_y; \
-  Real_type a = m_a; 
-
-
 DAXPY::DAXPY(const RunParams& params)
   : KernelBase(rajaperf::Basic_DAXPY, params)
 {
@@ -50,7 +44,7 @@ void DAXPY::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  DAXPY_DATA_SETUP_CPU;
+  DAXPY_DATA_SETUP;
 
   auto daxpy_lam = [=](Index_type i) {
                      DAXPY_BODY;

--- a/src/basic/DAXPY.hpp
+++ b/src/basic/DAXPY.hpp
@@ -17,6 +17,10 @@
 #ifndef RAJAPerf_Basic_DAXPY_HPP
 #define RAJAPerf_Basic_DAXPY_HPP
 
+#define DAXPY_DATA_SETUP \
+  Real_ptr x = m_x; \
+  Real_ptr y = m_y; \
+  Real_type a = m_a;
 
 #define DAXPY_BODY  \
   y[i] += a * x[i] ;

--- a/src/basic/IF_QUAD-Cuda.cpp
+++ b/src/basic/IF_QUAD-Cuda.cpp
@@ -28,12 +28,6 @@ namespace basic
 
 
 #define IF_QUAD_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  Real_ptr b; \
-  Real_ptr c; \
-  Real_ptr x1; \
-  Real_ptr x2; \
-\
   allocAndInitCudaDeviceData(a, m_a, iend); \
   allocAndInitCudaDeviceData(b, m_b, iend); \
   allocAndInitCudaDeviceData(c, m_c, iend); \
@@ -65,6 +59,8 @@ void IF_QUAD::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  IF_QUAD_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/basic/IF_QUAD-OMPTarget.cpp
+++ b/src/basic/IF_QUAD-OMPTarget.cpp
@@ -30,12 +30,6 @@ namespace basic
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr a; \
-  Real_ptr b; \
-  Real_ptr c; \
-  Real_ptr x1; \
-  Real_ptr x2; \
-\
   allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
   allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid); \
   allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid); \
@@ -56,6 +50,8 @@ void IF_QUAD::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  IF_QUAD_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -20,14 +20,6 @@ namespace basic
 {
 
 
-#define IF_QUAD_DATA_SETUP_CPU \
-  ResReal_ptr a = m_a; \
-  ResReal_ptr b = m_b; \
-  ResReal_ptr c = m_c; \
-  ResReal_ptr x1 = m_x1; \
-  ResReal_ptr x2 = m_x2;
-
-
 IF_QUAD::IF_QUAD(const RunParams& params)
   : KernelBase(rajaperf::Basic_IF_QUAD, params)
 {
@@ -54,7 +46,7 @@ void IF_QUAD::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  IF_QUAD_DATA_SETUP_CPU;
+  IF_QUAD_DATA_SETUP;
 
   auto ifquad_lam = [=](Index_type i) {
                       IF_QUAD_BODY;

--- a/src/basic/IF_QUAD.hpp
+++ b/src/basic/IF_QUAD.hpp
@@ -25,8 +25,12 @@
 #ifndef RAJAPerf_Basic_IF_QUAD_HPP
 #define RAJAPerf_Basic_IF_QUAD_HPP
 
-#include "common/KernelBase.hpp"
-
+#define IF_QUAD_DATA_SETUP \
+  Real_ptr a = m_a; \
+  Real_ptr b = m_b; \
+  Real_ptr c = m_c; \
+  Real_ptr x1 = m_x1; \
+  Real_ptr x2 = m_x2;
 
 #define IF_QUAD_BODY  \
   Real_type s = b[i]*b[i] - 4.0*a[i]*c[i]; \
@@ -39,6 +43,7 @@
     x1[i] = 0.0; \
   }
 
+#include "common/KernelBase.hpp"
 
 namespace rajaperf 
 {

--- a/src/basic/INIT3-Cuda.cpp
+++ b/src/basic/INIT3-Cuda.cpp
@@ -28,12 +28,6 @@ namespace basic
 
 
 #define INIT3_DATA_SETUP_CUDA \
-  Real_ptr out1; \
-  Real_ptr out2; \
-  Real_ptr out3; \
-  Real_ptr in1; \
-  Real_ptr in2; \
-\
   allocAndInitCudaDeviceData(out1, m_out1, iend); \
   allocAndInitCudaDeviceData(out2, m_out2, iend); \
   allocAndInitCudaDeviceData(out3, m_out3, iend); \
@@ -66,6 +60,8 @@ void INIT3::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  INIT3_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/basic/INIT3-OMPTarget.cpp
+++ b/src/basic/INIT3-OMPTarget.cpp
@@ -30,12 +30,6 @@ namespace basic
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr out1; \
-  Real_ptr out2; \
-  Real_ptr out3; \
-  Real_ptr in1; \
-  Real_ptr in2; \
-\
   allocAndInitOpenMPDeviceData(out1, m_out1, iend, did, hid); \
   allocAndInitOpenMPDeviceData(out2, m_out2, iend, did, hid); \
   allocAndInitOpenMPDeviceData(out3, m_out3, iend, did, hid); \
@@ -58,6 +52,8 @@ void INIT3::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  INIT3_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/basic/INIT3.cpp
+++ b/src/basic/INIT3.cpp
@@ -20,14 +20,6 @@ namespace basic
 {
 
 
-#define INIT3_DATA_SETUP_CPU \
-  ResReal_ptr out1 = m_out1; \
-  ResReal_ptr out2 = m_out2; \
-  ResReal_ptr out3 = m_out3; \
-  ResReal_ptr in1 = m_in1; \
-  ResReal_ptr in2 = m_in2;
-
-
 INIT3::INIT3(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT3, params)
 {
@@ -54,7 +46,7 @@ void INIT3::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  INIT3_DATA_SETUP_CPU;
+  INIT3_DATA_SETUP;
 
   auto init3_lam = [=](Index_type i) {
                      INIT3_BODY;

--- a/src/basic/INIT3.hpp
+++ b/src/basic/INIT3.hpp
@@ -18,6 +18,13 @@
 #define RAJAPerf_Basic_INIT3_HPP
 
 
+#define INIT3_DATA_SETUP \
+  Real_ptr out1 = m_out1; \
+  Real_ptr out2 = m_out2; \
+  Real_ptr out3 = m_out3; \
+  Real_ptr in1 = m_in1; \
+  Real_ptr in2 = m_in2;
+
 #define INIT3_BODY  \
   out1[i] = out2[i] = out3[i] = - in1[i] - in2[i] ;
 

--- a/src/basic/INIT_VIEW1D-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D-Cuda.cpp
@@ -28,9 +28,6 @@ namespace basic
 
 
 #define INIT_VIEW1D_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  const Real_type v = m_val; \
-\
   allocAndInitCudaDeviceData(a, m_a, iend);
 
 #define INIT_VIEW1D_DATA_TEARDOWN_CUDA \
@@ -53,6 +50,8 @@ void INIT_VIEW1D::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  INIT_VIEW1D_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/basic/INIT_VIEW1D-OMPTarget.cpp
+++ b/src/basic/INIT_VIEW1D-OMPTarget.cpp
@@ -30,9 +30,6 @@ namespace basic
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr a; \
-  const Real_type v = m_val; \
-\
   allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid);
 
 #define INIT_VIEW1D_DATA_TEARDOWN_OMP_TARGET \
@@ -45,6 +42,8 @@ void INIT_VIEW1D::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  INIT_VIEW1D_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -20,11 +20,6 @@ namespace basic
 {
 
 
-#define INIT_VIEW1D_DATA_SETUP_CPU \
-  Real_ptr a = m_a; \
-  const Real_type v = m_val;
-
-
 INIT_VIEW1D::INIT_VIEW1D(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT_VIEW1D, params)
 {
@@ -48,7 +43,7 @@ void INIT_VIEW1D::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  INIT_VIEW1D_DATA_SETUP_CPU;
+  INIT_VIEW1D_DATA_SETUP;
 
   auto initview1d_base_lam = [=](Index_type i) {
                                INIT_VIEW1D_BODY;

--- a/src/basic/INIT_VIEW1D.hpp
+++ b/src/basic/INIT_VIEW1D.hpp
@@ -24,6 +24,10 @@
 #define RAJAPerf_Basic_INIT_VIEW1D_HPP
 
 
+#define INIT_VIEW1D_DATA_SETUP \
+  Real_ptr a = m_a; \
+  const Real_type v = m_val;
+
 #define INIT_VIEW1D_BODY  \
   a[i] = v;
 

--- a/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
@@ -28,9 +28,6 @@ namespace basic
 
 
 #define INIT_VIEW1D_OFFSET_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  const Real_type v = m_val; \
-\
   allocAndInitCudaDeviceData(a, m_a, iend);
 
 #define INIT_VIEW1D_OFFSET_DATA_TEARDOWN_CUDA \
@@ -54,6 +51,8 @@ void INIT_VIEW1D_OFFSET::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize()+1;
+
+  INIT_VIEW1D_OFFSET_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
@@ -30,9 +30,6 @@ namespace basic
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr a; \
-  const Real_type v = m_val; \
-\
   allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid);
 
 #define INIT_VIEW1D_OFFSET_DATA_TEARDOWN_OMP_TARGET \
@@ -45,6 +42,8 @@ void INIT_VIEW1D_OFFSET::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 1;
   const Index_type iend = getRunSize()+1;
+
+  INIT_VIEW1D_OFFSET_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -19,10 +19,6 @@ namespace rajaperf
 namespace basic
 {
 
-#define INIT_VIEW1D_OFFSET_DATA_SETUP_CPU \
-  Real_ptr a = m_a; \
-  const Real_type v = m_val;
-
 
 INIT_VIEW1D_OFFSET::INIT_VIEW1D_OFFSET(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT_VIEW1D_OFFSET, params)
@@ -47,7 +43,7 @@ void INIT_VIEW1D_OFFSET::runKernel(VariantID vid)
   const Index_type ibegin = 1;
   const Index_type iend = getRunSize()+1;
 
-  INIT_VIEW1D_OFFSET_DATA_SETUP_CPU;
+  INIT_VIEW1D_OFFSET_DATA_SETUP;
 
   auto initview1doffset_base_lam = [=](Index_type i) {
                                      INIT_VIEW1D_OFFSET_BODY;

--- a/src/basic/INIT_VIEW1D_OFFSET.hpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.hpp
@@ -24,6 +24,10 @@
 #define RAJAPerf_Basic_INIT_VIEW1D_OFFSET_HPP
 
 
+#define INIT_VIEW1D_OFFSET_DATA_SETUP \
+  Real_ptr a = m_a; \
+  const Real_type v = m_val;
+
 #define INIT_VIEW1D_OFFSET_BODY  \
   a[i-ibegin] = v;
 

--- a/src/basic/MULADDSUB-Cuda.cpp
+++ b/src/basic/MULADDSUB-Cuda.cpp
@@ -28,12 +28,6 @@ namespace basic
 
 
 #define MULADDSUB_DATA_SETUP_CUDA \
-  Real_ptr out1; \
-  Real_ptr out2; \
-  Real_ptr out3; \
-  Real_ptr in1; \
-  Real_ptr in2; \
-\
   allocAndInitCudaDeviceData(out1, m_out1, iend); \
   allocAndInitCudaDeviceData(out2, m_out2, iend); \
   allocAndInitCudaDeviceData(out3, m_out3, iend); \
@@ -66,6 +60,8 @@ void MULADDSUB::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  MULADDSUB_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/basic/MULADDSUB-OMPTarget.cpp
+++ b/src/basic/MULADDSUB-OMPTarget.cpp
@@ -30,12 +30,6 @@ namespace basic
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr out1; \
-  Real_ptr out2; \
-  Real_ptr out3; \
-  Real_ptr in1; \
-  Real_ptr in2; \
-\
   allocAndInitOpenMPDeviceData(out1, m_out1, iend, did, hid); \
   allocAndInitOpenMPDeviceData(out2, m_out2, iend, did, hid); \
   allocAndInitOpenMPDeviceData(out3, m_out3, iend, did, hid); \
@@ -58,6 +52,8 @@ void MULADDSUB::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  MULADDSUB_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/basic/MULADDSUB.cpp
+++ b/src/basic/MULADDSUB.cpp
@@ -20,14 +20,6 @@ namespace basic
 {
 
 
-#define MULADDSUB_DATA_SETUP_CPU \
-  ResReal_ptr out1 = m_out1; \
-  ResReal_ptr out2 = m_out2; \
-  ResReal_ptr out3 = m_out3; \
-  ResReal_ptr in1 = m_in1; \
-  ResReal_ptr in2 = m_in2;
-
-
 MULADDSUB::MULADDSUB(const RunParams& params)
   : KernelBase(rajaperf::Basic_MULADDSUB, params)
 {
@@ -54,7 +46,7 @@ void MULADDSUB::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  MULADDSUB_DATA_SETUP_CPU;
+  MULADDSUB_DATA_SETUP;
 
   auto mas_lam = [=](Index_type i) {
                    MULADDSUB_BODY;

--- a/src/basic/MULADDSUB.hpp
+++ b/src/basic/MULADDSUB.hpp
@@ -19,6 +19,12 @@
 #ifndef RAJAPerf_Basic_MULADDSUB_HPP
 #define RAJAPerf_Basic_MULADDSUB_HPP
 
+#define MULADDSUB_DATA_SETUP \
+  Real_ptr out1 = m_out1; \
+  Real_ptr out2 = m_out2; \
+  Real_ptr out3 = m_out3; \
+  Real_ptr in1 = m_in1; \
+  Real_ptr in2 = m_in2;
 
 #define MULADDSUB_BODY  \
   out1[i] = in1[i] * in2[i] ; \

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -22,11 +22,6 @@ namespace basic
 {
 
 #define NESTED_INIT_DATA_SETUP_CUDA \
-  Real_ptr array; \
-  Index_type ni = m_ni; \
-  Index_type nj = m_nj; \
-  Index_type nk = m_nk; \
-\
   allocAndInitCudaDeviceData(array, m_array, m_array_length);
 
 #define NESTED_INIT_DATA_TEARDOWN_CUDA \
@@ -47,6 +42,8 @@ __global__ void nested_init(Real_ptr array,
 void NESTED_INIT::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  NESTED_INIT_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/basic/NESTED_INIT-OMPTarget.cpp
+++ b/src/basic/NESTED_INIT-OMPTarget.cpp
@@ -25,11 +25,6 @@ namespace basic
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr array = m_array; \
-  Index_type ni = m_ni; \
-  Index_type nj = m_nj; \
-  Index_type nk = m_nk; \
-\
   allocAndInitOpenMPDeviceData(array, m_array, m_array_length, did, hid);
 
 #define NESTED_INIT_DATA_TEARDOWN_OMP_TARGET \
@@ -40,6 +35,8 @@ namespace basic
 void NESTED_INIT::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  NESTED_INIT_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -23,13 +23,6 @@ namespace basic
 #undef USE_OMP_COLLAPSE
 
 
-#define NESTED_INIT_DATA_SETUP_CPU \
-  ResReal_ptr array = m_array; \
-  Index_type ni = m_ni; \
-  Index_type nj = m_nj; \
-  Index_type nk = m_nk;
-
-
 NESTED_INIT::NESTED_INIT(const RunParams& params)
   : KernelBase(rajaperf::Basic_NESTED_INIT, params)
 {
@@ -57,7 +50,7 @@ void NESTED_INIT::runKernel(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
-  NESTED_INIT_DATA_SETUP_CPU;
+  NESTED_INIT_DATA_SETUP;
 
   auto nestedinit_lam = [=](Index_type i, Index_type j, Index_type k) {
                           NESTED_INIT_BODY;

--- a/src/basic/NESTED_INIT.hpp
+++ b/src/basic/NESTED_INIT.hpp
@@ -22,6 +22,12 @@
 #define RAJAPerf_Basic_NESTED_INIT_HPP
 
 
+#define NESTED_INIT_DATA_SETUP \
+  Real_ptr array = m_array; \
+  Index_type ni = m_ni; \
+  Index_type nj = m_nj; \
+  Index_type nk = m_nk;
+
 #define NESTED_INIT_BODY  \
   array[i+ni*(j+nj*k)] = 0.00000001 * i * j * k ;
 

--- a/src/basic/REDUCE3_INT-Cuda.cpp
+++ b/src/basic/REDUCE3_INT-Cuda.cpp
@@ -28,8 +28,6 @@ namespace basic
 
 
 #define REDUCE3_INT_DATA_SETUP_CUDA \
-  Int_ptr vec; \
-\
   allocAndInitCudaDeviceData(vec, m_vec, iend);
 
 #define REDUCE3_INT_DATA_TEARDOWN_CUDA \
@@ -71,8 +69,8 @@ __global__ void reduce3int(Int_ptr vec,
 #if 1 // serialized access to shared data;
   if ( threadIdx.x == 0 ) {
     RAJA::atomicAdd<RAJA::cuda_atomic>( vsum, psum[ 0 ] );
-    RAJA::atomicAdd<RAJA::cuda_atomic>( vmin, pmin[ 0 ] );
-    RAJA::atomicAdd<RAJA::cuda_atomic>( vmax, pmax[ 0 ] );
+    RAJA::atomicMin<RAJA::cuda_atomic>( vmin, pmin[ 0 ] );
+    RAJA::atomicMax<RAJA::cuda_atomic>( vmax, pmax[ 0 ] );
   }
 #else // this doesn't work due to data races
   if ( threadIdx.x == 0 ) {
@@ -89,6 +87,8 @@ void REDUCE3_INT::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  REDUCE3_INT_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/basic/REDUCE3_INT-OMPTarget.cpp
+++ b/src/basic/REDUCE3_INT-OMPTarget.cpp
@@ -30,8 +30,6 @@ namespace basic
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Int_ptr vec; \
-\
   allocAndInitOpenMPDeviceData(vec, m_vec, iend, did, hid);
 
 #define REDUCE3_INT_DATA_TEARDOWN_OMP_TARGET \
@@ -43,6 +41,8 @@ void REDUCE3_INT::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  REDUCE3_INT_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/basic/REDUCE3_INT.cpp
+++ b/src/basic/REDUCE3_INT.cpp
@@ -21,10 +21,6 @@ namespace basic
 {
 
 
-#define REDUCE3_INT_DATA_SETUP_CPU \
-  Int_ptr vec = m_vec; \
-
-
 REDUCE3_INT::REDUCE3_INT(const RunParams& params)
   : KernelBase(rajaperf::Basic_REDUCE3_INT, params)
 {
@@ -57,7 +53,7 @@ void REDUCE3_INT::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  REDUCE3_INT_DATA_SETUP_CPU;
+  REDUCE3_INT_DATA_SETUP;
 
   auto init3_base_lam = [&](Index_type i) -> Int_type {
                           return vec[i];

--- a/src/basic/REDUCE3_INT.hpp
+++ b/src/basic/REDUCE3_INT.hpp
@@ -30,6 +30,9 @@
 #define RAJAPerf_Basic_REDUCE3_INT_HPP
 
 
+#define REDUCE3_INT_DATA_SETUP \
+  Int_ptr vec = m_vec; \
+
 #define REDUCE3_INT_BODY  \
   vsum += vec[i] ; \
   vmin = RAJA_MIN(vmin, vec[i]) ; \

--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -43,12 +43,7 @@ Real_type trap_int_func(Real_type x,
   const size_t block_size = 256;
 
 
-#define TRAP_INT_DATA_SETUP_CUDA \
-  Real_type x0 = m_x0; \
-  Real_type xp = m_xp; \
-  Real_type y = m_y; \
-  Real_type yp = m_yp; \
-  Real_type h = m_h;
+#define TRAP_INT_DATA_SETUP_CUDA  // nothing to do here...
 
 #define TRAP_INT_DATA_TEARDOWN_CUDA // nothing to do here...
 
@@ -96,6 +91,8 @@ void TRAP_INT::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  TRAP_INT_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/basic/TRAP_INT-OMPTarget.cpp
+++ b/src/basic/TRAP_INT-OMPTarget.cpp
@@ -40,12 +40,8 @@ Real_type trap_int_func(Real_type x,
   //
   const size_t threads_per_team = 256;
 
-#define TRAP_INT_DATA_SETUP_OMP_TARGET \
-  Real_type x0 = m_x0; \
-  Real_type xp = m_xp; \
-  Real_type y = m_y; \
-  Real_type yp = m_yp; \
-  Real_type h = m_h;
+
+#define TRAP_INT_DATA_SETUP_OMP_TARGET  // nothing to do here...
 
 #define TRAP_INT_DATA_TEARDOWN_OMP_TARGET // nothing to do here...
 
@@ -55,6 +51,8 @@ void TRAP_INT::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  TRAP_INT_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/basic/TRAP_INT.cpp
+++ b/src/basic/TRAP_INT.cpp
@@ -34,14 +34,6 @@ Real_type trap_int_func(Real_type x,
 }
 
 
-#define TRAP_INT_DATA_SETUP_CPU \
-  Real_type x0 = m_x0; \
-  Real_type xp = m_xp; \
-  Real_type y = m_y; \
-  Real_type yp = m_yp; \
-  Real_type h = m_h;
-
-
 TRAP_INT::TRAP_INT(const RunParams& params)
   : KernelBase(rajaperf::Basic_TRAP_INT, params)
 {
@@ -76,7 +68,7 @@ void TRAP_INT::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  TRAP_INT_DATA_SETUP_CPU;
+  TRAP_INT_DATA_SETUP;
 
   auto trapint_base_lam = [=](Index_type i) -> Real_type {
                             Real_type x = x0 + i*h;

--- a/src/basic/TRAP_INT.hpp
+++ b/src/basic/TRAP_INT.hpp
@@ -29,6 +29,13 @@
 #define RAJAPerf_Basic_TRAP_INT_HPP
 
 
+#define TRAP_INT_DATA_SETUP \
+  Real_type x0 = m_x0; \
+  Real_type xp = m_xp; \
+  Real_type y = m_y; \
+  Real_type yp = m_yp; \
+  Real_type h = m_h;
+
 #define TRAP_INT_BODY \
   Real_type x = x0 + i*h; \
   sumx += trap_int_func(x, y, xp, yp);

--- a/src/common/RPTypes.hpp
+++ b/src/common/RPTypes.hpp
@@ -20,6 +20,7 @@
 // 
 #define RP_USE_DOUBLE
 //#undef RP_USE_DOUBLE
+
 //#define RP_USE_FLOAT
 #undef RP_USE_FLOAT
 
@@ -103,15 +104,10 @@ using Real_type = float;
 #endif
 
 using Real_ptr = Real_type*;
-typedef Real_type* RAJA_RESTRICT ResReal_ptr;
-
 
 #if defined(RP_USE_COMPLEX)
 ///
 using Complex_type = std::complex<Real_type>;
-
-using Complex_ptr = Complex_type*;
-typedef Complex_type* RAJA_RESTRICT ResComplex_ptr;
 #endif
 
 

--- a/src/lcals/DIFF_PREDICT-Cuda.cpp
+++ b/src/lcals/DIFF_PREDICT-Cuda.cpp
@@ -28,10 +28,6 @@ namespace lcals
 
 
 #define DIFF_PREDICT_DATA_SETUP_CUDA \
-  Real_ptr px; \
-  Real_ptr cx; \
-  const Index_type offset = m_offset; \
-\
   allocAndInitCudaDeviceData(px, m_px, m_array_length); \
   allocAndInitCudaDeviceData(cx, m_cx, m_array_length);
 
@@ -56,6 +52,8 @@ void DIFF_PREDICT::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  DIFF_PREDICT_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/lcals/DIFF_PREDICT-OMPTarget.cpp
+++ b/src/lcals/DIFF_PREDICT-OMPTarget.cpp
@@ -30,10 +30,6 @@ namespace lcals
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr px; \
-  Real_ptr cx; \
-  const Index_type offset = m_offset; \
-\
   allocAndInitOpenMPDeviceData(px, m_px, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(cx, m_cx, m_array_length, did, hid);
 
@@ -48,6 +44,8 @@ void DIFF_PREDICT::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  DIFF_PREDICT_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/lcals/DIFF_PREDICT.cpp
+++ b/src/lcals/DIFF_PREDICT.cpp
@@ -20,12 +20,6 @@ namespace lcals
 {
 
 
-#define DIFF_PREDICT_DATA_SETUP_CPU \
-  ResReal_ptr px = m_px; \
-  ResReal_ptr cx = m_cx; \
-  const Index_type offset = m_offset;
-
-
 DIFF_PREDICT::DIFF_PREDICT(const RunParams& params)
   : KernelBase(rajaperf::Lcals_DIFF_PREDICT, params)
 {
@@ -52,7 +46,7 @@ void DIFF_PREDICT::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  DIFF_PREDICT_DATA_SETUP_CPU;
+  DIFF_PREDICT_DATA_SETUP;
 
   auto diffpredict_lam = [=](Index_type i) {
                            DIFF_PREDICT_BODY;

--- a/src/lcals/DIFF_PREDICT.hpp
+++ b/src/lcals/DIFF_PREDICT.hpp
@@ -38,6 +38,11 @@
 #define RAJAPerf_Basic_DIFF_PREDICT_HPP
 
 
+#define DIFF_PREDICT_DATA_SETUP \
+  Real_ptr px = m_px; \
+  Real_ptr cx = m_cx; \
+  const Index_type offset = m_offset;
+
 #define DIFF_PREDICT_BODY  \
   Real_type ar, br, cr; \
 \

--- a/src/lcals/EOS-Cuda.cpp
+++ b/src/lcals/EOS-Cuda.cpp
@@ -28,14 +28,6 @@ namespace lcals
 
 
 #define EOS_DATA_SETUP_CUDA \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr z; \
-  Real_ptr u; \
-  const Real_type q = m_q; \
-  const Real_type r = m_r; \
-  const Real_type t = m_t; \
-\
   allocAndInitCudaDeviceData(x, m_x, m_array_length); \
   allocAndInitCudaDeviceData(y, m_y, m_array_length); \
   allocAndInitCudaDeviceData(z, m_z, m_array_length); \
@@ -64,6 +56,8 @@ void EOS::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  EOS_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/lcals/EOS-OMPTarget.cpp
+++ b/src/lcals/EOS-OMPTarget.cpp
@@ -30,14 +30,6 @@ namespace lcals
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr z; \
-  Real_ptr u; \
-  const Real_type q = m_q; \
-  const Real_type r = m_r; \
-  const Real_type t = m_t; \
-\
   allocAndInitOpenMPDeviceData(x, m_x, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(y, m_y, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(z, m_z, m_array_length, did, hid); \
@@ -56,6 +48,8 @@ void EOS::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  EOS_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -20,17 +20,6 @@ namespace lcals
 {
 
 
-#define EOS_DATA_SETUP_CPU \
-  ResReal_ptr x = m_x; \
-  ResReal_ptr y = m_y; \
-  ResReal_ptr z = m_z; \
-  ResReal_ptr u = m_u; \
-\
-  const Real_type q = m_q; \
-  const Real_type r = m_r; \
-  const Real_type t = m_t;
-
-
 EOS::EOS(const RunParams& params)
   : KernelBase(rajaperf::Lcals_EOS, params)
 {
@@ -62,7 +51,7 @@ void EOS::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  EOS_DATA_SETUP_CPU;
+  EOS_DATA_SETUP;
 
   auto eos_lam = [=](Index_type i) {
                    EOS_BODY;

--- a/src/lcals/EOS.hpp
+++ b/src/lcals/EOS.hpp
@@ -20,6 +20,16 @@
 #define RAJAPerf_Basic_EOS_HPP
 
 
+#define EOS_DATA_SETUP \
+  Real_ptr x = m_x; \
+  Real_ptr y = m_y; \
+  Real_ptr z = m_z; \
+  Real_ptr u = m_u; \
+\
+  const Real_type q = m_q; \
+  const Real_type r = m_r; \
+  const Real_type t = m_t;
+
 #define EOS_BODY  \
   x[i] = u[i] + r*( z[i] + r*y[i] ) + \
                 t*( u[i+3] + r*( u[i+2] + r*u[i+1] ) + \

--- a/src/lcals/FIRST_DIFF-Cuda.cpp
+++ b/src/lcals/FIRST_DIFF-Cuda.cpp
@@ -28,9 +28,6 @@ namespace lcals
 
 
 #define FIRST_DIFF_DATA_SETUP_CUDA \
-  Real_ptr x; \
-  Real_ptr y; \
-\
   allocAndInitCudaDeviceData(x, m_x, m_array_length); \
   allocAndInitCudaDeviceData(y, m_y, m_array_length);
 
@@ -54,6 +51,8 @@ void FIRST_DIFF::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  FIRST_DIFF_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/lcals/FIRST_DIFF-OMPTarget.cpp
+++ b/src/lcals/FIRST_DIFF-OMPTarget.cpp
@@ -30,9 +30,6 @@ namespace lcals
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr x; \
-  Real_ptr y; \
-\
   allocAndInitOpenMPDeviceData(x, m_x, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(y, m_y, m_array_length, did, hid);
 
@@ -48,6 +45,8 @@ void FIRST_DIFF::runOpenMPTargetVariant(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
+  FIRST_DIFF_DATA_SETUP;
+ 
   if ( vid == Base_OpenMPTarget ) {
 
     FIRST_DIFF_DATA_SETUP_OMP_TARGET;

--- a/src/lcals/FIRST_DIFF.cpp
+++ b/src/lcals/FIRST_DIFF.cpp
@@ -20,11 +20,6 @@ namespace lcals
 {
 
 
-#define FIRST_DIFF_DATA_SETUP_CPU \
-  ResReal_ptr x = m_x; \
-  ResReal_ptr y = m_y;
-
-
 FIRST_DIFF::FIRST_DIFF(const RunParams& params)
   : KernelBase(rajaperf::Lcals_FIRST_DIFF, params)
 {
@@ -49,7 +44,7 @@ void FIRST_DIFF::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  FIRST_DIFF_DATA_SETUP_CPU;
+  FIRST_DIFF_DATA_SETUP;
 
   auto firstdiff_lam = [=](Index_type i) {
                          FIRST_DIFF_BODY;

--- a/src/lcals/FIRST_DIFF.hpp
+++ b/src/lcals/FIRST_DIFF.hpp
@@ -18,6 +18,10 @@
 #define RAJAPerf_Basic_FIRST_DIFF_HPP
 
 
+#define FIRST_DIFF_DATA_SETUP \
+  Real_ptr x = m_x; \
+  Real_ptr y = m_y;
+
 #define FIRST_DIFF_BODY  \
   x[i] = y[i+1] - y[i];
 

--- a/src/lcals/HYDRO_1D-Cuda.cpp
+++ b/src/lcals/HYDRO_1D-Cuda.cpp
@@ -28,13 +28,6 @@ namespace lcals
 
 
 #define HYDRO_1D_DATA_SETUP_CUDA \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr z; \
-  const Real_type q = m_q; \
-  const Real_type r = m_r; \
-  const Real_type t = m_t; \
-\
   allocAndInitCudaDeviceData(x, m_x, m_array_length); \
   allocAndInitCudaDeviceData(y, m_y, m_array_length); \
   allocAndInitCudaDeviceData(z, m_z, m_array_length);
@@ -61,6 +54,8 @@ void HYDRO_1D::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  HYDRO_1D_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/lcals/HYDRO_1D-OMPTarget.cpp
+++ b/src/lcals/HYDRO_1D-OMPTarget.cpp
@@ -30,13 +30,6 @@ namespace lcals
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr z; \
-  const Real_type q = m_q; \
-  const Real_type r = m_r; \
-  const Real_type t = m_t; \
-\
   allocAndInitOpenMPDeviceData(x, m_x, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(y, m_y, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(z, m_z, m_array_length, did, hid);
@@ -53,6 +46,8 @@ void HYDRO_1D::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  HYDRO_1D_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -20,16 +20,6 @@ namespace lcals
 {
 
 
-#define HYDRO_1D_DATA_SETUP_CPU \
-  ResReal_ptr x = m_x; \
-  ResReal_ptr y = m_y; \
-  ResReal_ptr z = m_z; \
-\
-  const Real_type q = m_q; \
-  const Real_type r = m_r; \
-  const Real_type t = m_t;
-
-
 HYDRO_1D::HYDRO_1D(const RunParams& params)
   : KernelBase(rajaperf::Lcals_HYDRO_1D, params)
 {
@@ -60,7 +50,7 @@ void HYDRO_1D::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  HYDRO_1D_DATA_SETUP_CPU;
+  HYDRO_1D_DATA_SETUP;
 
   auto hydro1d_lam = [=](Index_type i) {
                        HYDRO_1D_BODY;

--- a/src/lcals/HYDRO_1D.hpp
+++ b/src/lcals/HYDRO_1D.hpp
@@ -18,6 +18,15 @@
 #define RAJAPerf_Basic_HYDRO_1D_HPP
 
 
+#define HYDRO_1D_DATA_SETUP \
+  Real_ptr x = m_x; \
+  Real_ptr y = m_y; \
+  Real_ptr z = m_z; \
+\
+  const Real_type q = m_q; \
+  const Real_type r = m_r; \
+  const Real_type t = m_t;
+
 #define HYDRO_1D_BODY  \
   x[i] = q + y[i]*( r*z[i+10] + t*z[i+11] );
 

--- a/src/lcals/HYDRO_2D-Cuda.cpp
+++ b/src/lcals/HYDRO_2D-Cuda.cpp
@@ -22,24 +22,6 @@ namespace lcals
 {
 
 #define HYDRO_2D_DATA_SETUP_CUDA \
-  Real_ptr zadat; \
-  Real_ptr zbdat; \
-  Real_ptr zmdat; \
-  Real_ptr zpdat; \
-  Real_ptr zqdat; \
-  Real_ptr zrdat; \
-  Real_ptr zudat; \
-  Real_ptr zvdat; \
-  Real_ptr zzdat; \
-\
-  Real_ptr zroutdat; \
-  Real_ptr zzoutdat; \
-\
-  const Real_type s = m_s; \
-  const Real_type t = m_t; \
-\
-  const Index_type jn = m_jn; \
-  const Index_type kn = m_kn; \
 \
   allocAndInitCudaDeviceData(zadat, m_za, m_array_length); \
   allocAndInitCudaDeviceData(zbdat, m_zb, m_array_length); \
@@ -114,6 +96,8 @@ void HYDRO_2D::runCudaVariant(VariantID vid)
   const Index_type kend = m_kn - 1;
   const Index_type jbeg = 1;
   const Index_type jend = m_jn - 1;
+
+  HYDRO_2D_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/lcals/HYDRO_2D-OMPTarget.cpp
+++ b/src/lcals/HYDRO_2D-OMPTarget.cpp
@@ -25,25 +25,6 @@ namespace lcals
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr zadat; \
-  Real_ptr zbdat; \
-  Real_ptr zmdat; \
-  Real_ptr zpdat; \
-  Real_ptr zqdat; \
-  Real_ptr zrdat; \
-  Real_ptr zudat; \
-  Real_ptr zvdat; \
-  Real_ptr zzdat; \
-\
-  Real_ptr zroutdat; \
-  Real_ptr zzoutdat; \
-\
-  const Real_type s = m_s; \
-  const Real_type t = m_t; \
-\
-  const Index_type jn = m_jn; \
-  const Index_type kn = m_kn; \
-\
   allocAndInitOpenMPDeviceData(zadat, m_za, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(zbdat, m_zb, m_array_length, did, hid); \
   allocAndInitOpenMPDeviceData(zmdat, m_zm, m_array_length, did, hid); \
@@ -80,6 +61,8 @@ void HYDRO_2D::runOpenMPTargetVariant(VariantID vid)
   const Index_type kend = m_kn - 1;
   const Index_type jbeg = 1;
   const Index_type jend = m_jn - 1;
+
+  HYDRO_2D_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -20,27 +20,6 @@ namespace lcals
 {
 
 
-#define HYDRO_2D_DATA_SETUP_CPU \
-  ResReal_ptr zadat = m_za; \
-  ResReal_ptr zbdat = m_zb; \
-  ResReal_ptr zmdat = m_zm; \
-  ResReal_ptr zpdat = m_zp; \
-  ResReal_ptr zqdat = m_zq; \
-  ResReal_ptr zrdat = m_zr; \
-  ResReal_ptr zudat = m_zu; \
-  ResReal_ptr zvdat = m_zv; \
-  ResReal_ptr zzdat = m_zz; \
-\
-  ResReal_ptr zroutdat = m_zrout; \
-  ResReal_ptr zzoutdat = m_zzout; \
-\
-  const Real_type s = m_s; \
-  const Real_type t = m_t; \
-\
-  const Index_type kn = m_kn; \
-  const Index_type jn = m_jn;
-
-
 HYDRO_2D::HYDRO_2D(const RunParams& params)
   : KernelBase(rajaperf::Lcals_HYDRO_2D, params)
 {
@@ -84,7 +63,7 @@ void HYDRO_2D::runKernel(VariantID vid)
   const Index_type jbeg = 1;
   const Index_type jend = m_jn - 1;
 
-  HYDRO_2D_DATA_SETUP_CPU;
+  HYDRO_2D_DATA_SETUP;
 
   auto hydro2d_base_lam1 = [=] (Index_type k, Index_type j) {
                              HYDRO_2D_BODY1;

--- a/src/lcals/HYDRO_2D.hpp
+++ b/src/lcals/HYDRO_2D.hpp
@@ -43,6 +43,26 @@
 #define RAJAPerf_Basic_HYDRO_2D_HPP
 
 
+#define HYDRO_2D_DATA_SETUP \
+  Real_ptr zadat = m_za; \
+  Real_ptr zbdat = m_zb; \
+  Real_ptr zmdat = m_zm; \
+  Real_ptr zpdat = m_zp; \
+  Real_ptr zqdat = m_zq; \
+  Real_ptr zrdat = m_zr; \
+  Real_ptr zudat = m_zu; \
+  Real_ptr zvdat = m_zv; \
+  Real_ptr zzdat = m_zz; \
+\
+  Real_ptr zroutdat = m_zrout; \
+  Real_ptr zzoutdat = m_zzout; \
+\
+  const Real_type s = m_s; \
+  const Real_type t = m_t; \
+\
+  const Index_type kn = m_kn; \
+  const Index_type jn = m_jn;
+
 #define HYDRO_2D_BODY1  \
   zadat[j+k*jn] = ( zpdat[j-1+(k+1)*jn] + zqdat[j-1+(k+1)*jn] - \
                     zpdat[j-1+k*jn] - zqdat[j-1+k*jn] ) * \

--- a/src/lcals/INT_PREDICT-Cuda.cpp
+++ b/src/lcals/INT_PREDICT-Cuda.cpp
@@ -28,17 +28,6 @@ namespace lcals
 
 
 #define INT_PREDICT_DATA_SETUP_CUDA \
-  Real_ptr px; \
-  Real_type dm22 = m_dm22; \
-  Real_type dm23 = m_dm23; \
-  Real_type dm24 = m_dm24; \
-  Real_type dm25 = m_dm25; \
-  Real_type dm26 = m_dm26; \
-  Real_type dm27 = m_dm27; \
-  Real_type dm28 = m_dm28; \
-  Real_type c0 = m_c0; \
-  const Index_type offset = m_offset; \
-\
   allocAndInitCudaDeviceData(px, m_px, m_array_length);
 
 #define INT_PREDICT_DATA_TEARDOWN_CUDA \
@@ -64,6 +53,8 @@ void INT_PREDICT::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  INT_PREDICT_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/lcals/INT_PREDICT-OMPTarget.cpp
+++ b/src/lcals/INT_PREDICT-OMPTarget.cpp
@@ -30,17 +30,6 @@ namespace lcals
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr px; \
-  Real_type dm22 = m_dm22; \
-  Real_type dm23 = m_dm23; \
-  Real_type dm24 = m_dm24; \
-  Real_type dm25 = m_dm25; \
-  Real_type dm26 = m_dm26; \
-  Real_type dm27 = m_dm27; \
-  Real_type dm28 = m_dm28; \
-  Real_type c0 = m_c0; \
-  const Index_type offset = m_offset; \
-\
   allocAndInitOpenMPDeviceData(px, m_px, m_array_length, did, hid);
 
 #define INT_PREDICT_DATA_TEARDOWN_OMP_TARGET \
@@ -53,6 +42,8 @@ void INT_PREDICT::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  INT_PREDICT_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/lcals/INT_PREDICT.cpp
+++ b/src/lcals/INT_PREDICT.cpp
@@ -20,19 +20,6 @@ namespace lcals
 {
 
 
-#define INT_PREDICT_DATA_SETUP_CPU \
-  ResReal_ptr px = m_px; \
-  Real_type dm22 = m_dm22; \
-  Real_type dm23 = m_dm23; \
-  Real_type dm24 = m_dm24; \
-  Real_type dm25 = m_dm25; \
-  Real_type dm26 = m_dm26; \
-  Real_type dm27 = m_dm27; \
-  Real_type dm28 = m_dm28; \
-  Real_type c0 = m_c0; \
-  const Index_type offset = m_offset;
-
-
 INT_PREDICT::INT_PREDICT(const RunParams& params)
   : KernelBase(rajaperf::Lcals_INT_PREDICT, params)
 {
@@ -68,7 +55,7 @@ void INT_PREDICT::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  INT_PREDICT_DATA_SETUP_CPU;
+  INT_PREDICT_DATA_SETUP;
 
   auto intpredict_lam = [=](Index_type i) {
                           INT_PREDICT_BODY;

--- a/src/lcals/INT_PREDICT.hpp
+++ b/src/lcals/INT_PREDICT.hpp
@@ -25,6 +25,18 @@
 #define RAJAPerf_Basic_INT_PREDICT_HPP
 
 
+#define INT_PREDICT_DATA_SETUP \
+  Real_ptr px = m_px; \
+  Real_type dm22 = m_dm22; \
+  Real_type dm23 = m_dm23; \
+  Real_type dm24 = m_dm24; \
+  Real_type dm25 = m_dm25; \
+  Real_type dm26 = m_dm26; \
+  Real_type dm27 = m_dm27; \
+  Real_type dm28 = m_dm28; \
+  Real_type c0 = m_c0; \
+  const Index_type offset = m_offset;
+
 #define INT_PREDICT_BODY  \
   px[i] = dm28*px[i + offset * 12] + dm27*px[i + offset * 11] + \
           dm26*px[i + offset * 10] + dm25*px[i + offset *  9] + \

--- a/src/lcals/PLANCKIAN-Cuda.cpp
+++ b/src/lcals/PLANCKIAN-Cuda.cpp
@@ -29,12 +29,6 @@ namespace lcals
 
 
 #define PLANCKIAN_DATA_SETUP_CUDA \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr u; \
-  Real_ptr v; \
-  Real_ptr w; \
-\
   allocAndInitCudaDeviceData(x, m_x, iend); \
   allocAndInitCudaDeviceData(y, m_y, iend); \
   allocAndInitCudaDeviceData(u, m_u, iend); \
@@ -65,6 +59,8 @@ void PLANCKIAN::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  PLANCKIAN_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/lcals/PLANCKIAN-OMPTarget.cpp
+++ b/src/lcals/PLANCKIAN-OMPTarget.cpp
@@ -31,12 +31,6 @@ namespace lcals
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr u; \
-  Real_ptr v; \
-  Real_ptr w; \
-\
   allocAndInitOpenMPDeviceData(x, m_x, iend, did, hid); \
   allocAndInitOpenMPDeviceData(y, m_y, iend, did, hid); \
   allocAndInitOpenMPDeviceData(u, m_u, iend, did, hid); \
@@ -57,6 +51,8 @@ void PLANCKIAN::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  PLANCKIAN_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/lcals/PLANCKIAN.cpp
+++ b/src/lcals/PLANCKIAN.cpp
@@ -21,14 +21,6 @@ namespace lcals
 {
 
 
-#define PLANCKIAN_DATA_SETUP_CPU \
-  ResReal_ptr x = m_x; \
-  ResReal_ptr y = m_y; \
-  ResReal_ptr u = m_u; \
-  ResReal_ptr v = m_v; \
-  ResReal_ptr w = m_w;
-
-
 PLANCKIAN::PLANCKIAN(const RunParams& params)
   : KernelBase(rajaperf::Lcals_PLANCKIAN, params)
 {
@@ -55,7 +47,7 @@ void PLANCKIAN::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  PLANCKIAN_DATA_SETUP_CPU;
+  PLANCKIAN_DATA_SETUP;
 
   auto planckian_lam = [=](Index_type i) {
                          PLANCKIAN_BODY;

--- a/src/lcals/PLANCKIAN.hpp
+++ b/src/lcals/PLANCKIAN.hpp
@@ -19,6 +19,13 @@
 #define RAJAPerf_Basic_PLANCKIAN_HPP
 
 
+#define PLANCKIAN_DATA_SETUP \
+  Real_ptr x = m_x; \
+  Real_ptr y = m_y; \
+  Real_ptr u = m_u; \
+  Real_ptr v = m_v; \
+  Real_ptr w = m_w;
+
 #define PLANCKIAN_BODY  \
   y[i] = u[i] / v[i]; \
   w[i] = x[i] / ( exp( y[i] ) - 1.0 );

--- a/src/polybench/POLYBENCH_2MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_2MM-Cuda.cpp
@@ -22,19 +22,6 @@ namespace polybench
 {
 
 #define POLYBENCH_2MM_DATA_SETUP_CUDA \
-  Real_ptr tmp; \
-  Real_ptr A; \
-  Real_ptr B; \
-  Real_ptr C; \
-  Real_ptr D; \
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-\
-  const Index_type ni = m_ni; \
-  const Index_type nj = m_nj; \
-  const Index_type nk = m_nk; \
-  const Index_type nl = m_nl; \
-\
   allocAndInitCudaDeviceData(tmp, m_tmp, m_ni * m_nj); \
   allocAndInitCudaDeviceData(A, m_A, m_ni * m_nk); \
   allocAndInitCudaDeviceData(B, m_B, m_nk * m_nj); \
@@ -83,6 +70,8 @@ __global__ void poly_2mm_2(Real_ptr tmp, Real_ptr C, Real_ptr D,
 void POLYBENCH_2MM::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_2MM_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_2MM-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_2MM-OMPTarget.cpp
@@ -25,19 +25,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr tmp; \
-  Real_ptr A; \
-  Real_ptr B; \
-  Real_ptr C; \
-  Real_ptr D; \
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-\
-  const Index_type ni = m_ni; \
-  const Index_type nj = m_nj; \
-  const Index_type nk = m_nk; \
-  const Index_type nl = m_nl; \
-\
   allocAndInitOpenMPDeviceData(tmp, m_tmp, m_ni * m_nj, did, hid); \
   allocAndInitOpenMPDeviceData(A, m_A, m_ni * m_nk, did, hid); \
   allocAndInitOpenMPDeviceData(B, m_B, m_nk * m_nj, did, hid); \
@@ -57,6 +44,8 @@ namespace polybench
 void POLYBENCH_2MM::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_2MM_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -26,21 +26,6 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_2MM_DATA_SETUP_CPU \
-  ResReal_ptr tmp = m_tmp; \
-  ResReal_ptr A = m_A; \
-  ResReal_ptr B = m_B; \
-  ResReal_ptr C = m_C; \
-  ResReal_ptr D = m_D; \
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-\
-  const Index_type ni = m_ni; \
-  const Index_type nj = m_nj; \
-  const Index_type nk = m_nk; \
-  const Index_type nl = m_nl;
-
-  
 POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_2MM, params)
 {
@@ -99,7 +84,7 @@ void POLYBENCH_2MM::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
 
-  POLYBENCH_2MM_DATA_SETUP_CPU;
+  POLYBENCH_2MM_DATA_SETUP;
 
   auto poly_2mm_base_lam2 = [=](Index_type i, Index_type j,
                                 Index_type k, Real_type &dot) {

--- a/src/polybench/POLYBENCH_2MM.hpp
+++ b/src/polybench/POLYBENCH_2MM.hpp
@@ -32,9 +32,24 @@
 ///
 
 
-
 #ifndef RAJAPerf_POLYBENCH_2MM_HPP
 #define RAJAPerf_POLYBENCH_2MM_HPP
+
+
+#define POLYBENCH_2MM_DATA_SETUP \
+  Real_ptr tmp = m_tmp; \
+  Real_ptr A = m_A; \
+  Real_ptr B = m_B; \
+  Real_ptr C = m_C; \
+  Real_ptr D = m_D; \
+  Real_type alpha = m_alpha; \
+  Real_type beta = m_beta; \
+\
+  const Index_type ni = m_ni; \
+  const Index_type nj = m_nj; \
+  const Index_type nk = m_nk; \
+  const Index_type nl = m_nl;
+
 
 #define POLYBENCH_2MM_BODY1 \
   Real_type dot = 0.0;

--- a/src/polybench/POLYBENCH_3MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_3MM-Cuda.cpp
@@ -22,20 +22,6 @@ namespace polybench
 {
 
 #define POLYBENCH_3MM_DATA_SETUP_CUDA \
-  Real_ptr A = m_A; \
-  Real_ptr B = m_B; \
-  Real_ptr C = m_C; \
-  Real_ptr D = m_D; \
-  Real_ptr E = m_E; \
-  Real_ptr F = m_F; \
-  Real_ptr G = m_G; \
-\
-  const Index_type ni = m_ni; \
-  const Index_type nj = m_nj; \
-  const Index_type nk = m_nk; \
-  const Index_type nl = m_nl; \
-  const Index_type nm = m_nm; \
-\
   allocAndInitCudaDeviceData(A, m_A, m_ni * m_nk); \
   allocAndInitCudaDeviceData(B, m_B, m_nk * m_nj); \
   allocAndInitCudaDeviceData(C, m_C, m_nj * m_nm); \
@@ -98,6 +84,8 @@ __global__ void poly_3mm_3(Real_ptr G, Real_ptr E, Real_ptr F,
 void POLYBENCH_3MM::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_3MM_DATA_SETUP;
   
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_3MM-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_3MM-OMPTarget.cpp
@@ -25,20 +25,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr A; \
-  Real_ptr B; \
-  Real_ptr C; \
-  Real_ptr D; \
-  Real_ptr E; \
-  Real_ptr F; \
-  Real_ptr G; \
-\
-  const Index_type ni = m_ni; \
-  const Index_type nj = m_nj; \
-  const Index_type nk = m_nk; \
-  const Index_type nl = m_nl; \
-  const Index_type nm = m_nm; \
-\
   allocAndInitOpenMPDeviceData(A, m_A, m_ni * m_nk, did, hid); \
   allocAndInitOpenMPDeviceData(B, m_B, m_nk * m_nj, did, hid); \
   allocAndInitOpenMPDeviceData(C, m_C, m_nj * m_nm, did, hid); \
@@ -61,11 +47,8 @@ namespace polybench
 void POLYBENCH_3MM::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type ni = m_ni;
-  const Index_type nj = m_nj;
-  const Index_type nk = m_nk;
-  const Index_type nl = m_nl;
-  const Index_type nm = m_nm;
+
+  POLYBENCH_3MM_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -27,21 +27,6 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_3MM_DATA_SETUP_CPU \
-  ResReal_ptr A = m_A; \
-  ResReal_ptr B = m_B; \
-  ResReal_ptr C = m_C; \
-  ResReal_ptr D = m_D; \
-  ResReal_ptr E = m_E; \
-  ResReal_ptr F = m_F; \
-  ResReal_ptr G = m_G; \
-\
-  const Index_type ni = m_ni; \
-  const Index_type nj = m_nj; \
-  const Index_type nk = m_nk; \
-  const Index_type nl = m_nl; \
-  const Index_type nm = m_nm;
-  
   
 POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_3MM, params)
@@ -98,7 +83,7 @@ void POLYBENCH_3MM::runKernel(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
-  POLYBENCH_3MM_DATA_SETUP_CPU;
+  POLYBENCH_3MM_DATA_SETUP;
 
   auto poly_3mm_base_lam2 = [=] (Index_type i, Index_type j, Index_type k,
                                  Real_type &dot) {

--- a/src/polybench/POLYBENCH_3MM.hpp
+++ b/src/polybench/POLYBENCH_3MM.hpp
@@ -42,6 +42,22 @@
 #ifndef RAJAPerf_POLYBENCH_3MM_HPP
 #define RAJAPerf_POLYBENCH_3MM_HPP
 
+#define POLYBENCH_3MM_DATA_SETUP \
+  Real_ptr A = m_A; \
+  Real_ptr B = m_B; \
+  Real_ptr C = m_C; \
+  Real_ptr D = m_D; \
+  Real_ptr E = m_E; \
+  Real_ptr F = m_F; \
+  Real_ptr G = m_G; \
+\
+  const Index_type ni = m_ni; \
+  const Index_type nj = m_nj; \
+  const Index_type nk = m_nk; \
+  const Index_type nl = m_nl; \
+  const Index_type nm = m_nm;
+
+
 #define POLYBENCH_3MM_BODY1 \
   Real_type dot = 0.0;
 

--- a/src/polybench/POLYBENCH_ADI-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ADI-Cuda.cpp
@@ -27,28 +27,6 @@ namespace polybench
 const size_t block_size = 256;
 
 #define POLYBENCH_ADI_DATA_SETUP_CUDA \
-  const Index_type n = m_n; \
-  const Index_type tsteps = m_tsteps; \
-\
-  Real_type DX = 1.0/(Real_type)n; \
-  Real_type DY = 1.0/(Real_type)n; \
-  Real_type DT = 1.0/(Real_type)tsteps; \
-  Real_type B1 = 2.0; \
-  Real_type B2 = 1.0; \
-  Real_type mul1 = B1 * DT / (DX * DX); \
-  Real_type mul2 = B2 * DT / (DY * DY); \
-  Real_type a = -mul1 / 2.0; \
-  Real_type b = 1.0 + mul1; \
-  Real_type c = a; \
-  Real_type d = -mul2 /2.0; \
-  Real_type e = 1.0 + mul2; \
-  Real_type f = d; \
-\
-  Real_ptr U; \
-  Real_ptr V; \
-  Real_ptr P; \
-  Real_ptr Q; \
-\
   allocAndInitCudaDeviceData(U, m_U, m_n * m_n); \
   allocAndInitCudaDeviceData(V, m_V, m_n * m_n); \
   allocAndInitCudaDeviceData(P, m_P, m_n * m_n); \
@@ -102,6 +80,8 @@ __global__ void adi2(const Index_type n,
 void POLYBENCH_ADI::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_ADI_DATA_SETUP;
   
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_ADI-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_ADI-OMPTarget.cpp
@@ -29,27 +29,6 @@ namespace polybench
 #define POLYBENCH_ADI_DATA_SETUP_OMP_TARGET \
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
-  const Index_type n = m_n; \
-  const Index_type tsteps = m_tsteps; \
-\
-  Real_type DX = 1.0/(Real_type)n; \
-  Real_type DY = 1.0/(Real_type)n; \
-  Real_type DT = 1.0/(Real_type)tsteps; \
-  Real_type B1 = 2.0; \
-  Real_type B2 = 1.0; \
-  Real_type mul1 = B1 * DT / (DX * DX); \
-  Real_type mul2 = B2 * DT / (DY * DY); \
-  Real_type a = -mul1 / 2.0; \
-  Real_type b = 1.0 + mul1; \
-  Real_type c = a; \
-  Real_type d = -mul2 /2.0; \
-  Real_type e = 1.0 + mul2; \
-  Real_type f = d; \
-\
-  Real_ptr U = m_U; \
-  Real_ptr V = m_V; \
-  Real_ptr P = m_P; \
-  Real_ptr Q = m_Q; \
 \
   allocAndInitOpenMPDeviceData(U, m_U, m_n * m_n, did, hid); \
   allocAndInitOpenMPDeviceData(V, m_V, m_n * m_n, did, hid); \
@@ -67,6 +46,8 @@ namespace polybench
 void POLYBENCH_ADI::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_ADI_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -19,28 +19,6 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_ADI_DATA_SETUP_CPU \
-  const Index_type n = m_n; \
-  const Index_type tsteps = m_tsteps; \
-\
-  Real_type DX = 1.0/(Real_type)n; \
-  Real_type DY = 1.0/(Real_type)n; \
-  Real_type DT = 1.0/(Real_type)tsteps; \
-  Real_type B1 = 2.0; \
-  Real_type B2 = 1.0; \
-  Real_type mul1 = B1 * DT / (DX * DX); \
-  Real_type mul2 = B2 * DT / (DY * DY); \
-  Real_type a = -mul1 / 2.0; \
-  Real_type b = 1.0 + mul1; \
-  Real_type c = a; \
-  Real_type d = -mul2 /2.0; \
-  Real_type e = 1.0 + mul2; \
-  Real_type f = d; \
-\
-  ResReal_ptr U = m_U; \
-  ResReal_ptr V = m_V; \
-  ResReal_ptr P = m_P; \
-  ResReal_ptr Q = m_Q; 
 
 POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
   : KernelBase(rajaperf::Polybench_ADI, params)
@@ -94,7 +72,7 @@ void POLYBENCH_ADI::runKernel(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
-  POLYBENCH_ADI_DATA_SETUP_CPU;
+  POLYBENCH_ADI_DATA_SETUP;
 
   auto poly_adi_base_lam2 = [=](Index_type i) {
                               POLYBENCH_ADI_BODY2;

--- a/src/polybench/POLYBENCH_ADI.hpp
+++ b/src/polybench/POLYBENCH_ADI.hpp
@@ -64,6 +64,30 @@
 #define RAJAPerf_POLYBENCH_ADI_HPP
 
 
+#define POLYBENCH_ADI_DATA_SETUP \
+  const Index_type n = m_n; \
+  const Index_type tsteps = m_tsteps; \
+\
+  Real_type DX = 1.0/(Real_type)n; \
+  Real_type DY = 1.0/(Real_type)n; \
+  Real_type DT = 1.0/(Real_type)tsteps; \
+  Real_type B1 = 2.0; \
+  Real_type B2 = 1.0; \
+  Real_type mul1 = B1 * DT / (DX * DX); \
+  Real_type mul2 = B2 * DT / (DY * DY); \
+  Real_type a = -mul1 / 2.0; \
+  Real_type b = 1.0 + mul1; \
+  Real_type c = a; \
+  Real_type d = -mul2 /2.0; \
+  Real_type e = 1.0 + mul2; \
+  Real_type f = d; \
+\
+  Real_ptr U = m_U; \
+  Real_ptr V = m_V; \
+  Real_ptr P = m_P; \
+  Real_ptr Q = m_Q;
+
+
 #define POLYBENCH_ADI_BODY2 \
   V[0 * n + i] = 1.0; \
   P[i * n + 0] = 0.0; \

--- a/src/polybench/POLYBENCH_ATAX-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Cuda.cpp
@@ -27,13 +27,6 @@ namespace polybench
   const size_t block_size = 256;
 
 #define POLYBENCH_ATAX_DATA_SETUP_CUDA \
-  Real_ptr tmp; \
-  Real_ptr y; \
-  Real_ptr x; \
-  Real_ptr A; \
-\
-  const Index_type N = m_N; \
-\
   allocAndInitCudaDeviceData(tmp, m_tmp, N); \
   allocAndInitCudaDeviceData(y, m_y, N); \
   allocAndInitCudaDeviceData(x, m_x, N); \
@@ -80,6 +73,8 @@ __global__ void poly_atax_2(Real_ptr A, Real_ptr tmp, Real_ptr y,
 void POLYBENCH_ATAX::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_ATAX_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_ATAX-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_ATAX-OMPTarget.cpp
@@ -30,13 +30,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr tmp; \
-  Real_ptr y; \
-  Real_ptr x; \
-  Real_ptr A; \
-\
-  const Index_type N = m_N; \
-\
   allocAndInitOpenMPDeviceData(tmp, m_tmp, N, did, hid); \
   allocAndInitOpenMPDeviceData(y, m_y, N, did, hid); \
   allocAndInitOpenMPDeviceData(x, m_x, N, did, hid); \
@@ -54,6 +47,8 @@ namespace polybench
 void POLYBENCH_ATAX::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_ATAX_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_ATAX.cpp
+++ b/src/polybench/POLYBENCH_ATAX.cpp
@@ -19,14 +19,6 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_ATAX_DATA_SETUP_CPU \
-  ResReal_ptr tmp = m_tmp; \
-  ResReal_ptr y = m_y; \
-  ResReal_ptr x = m_x; \
-  ResReal_ptr A = m_A; \
-\
-  const Index_type N = m_N;
-
 
 POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
   : KernelBase(rajaperf::Polybench_ATAX, params)
@@ -82,7 +74,7 @@ void POLYBENCH_ATAX::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
 
-  POLYBENCH_ATAX_DATA_SETUP_CPU;
+  POLYBENCH_ATAX_DATA_SETUP;
 
   auto poly_atax_base_lam2 = [=] (Index_type i, Index_type j, Real_type &dot) {
                                POLYBENCH_ATAX_BODY2;

--- a/src/polybench/POLYBENCH_ATAX.hpp
+++ b/src/polybench/POLYBENCH_ATAX.hpp
@@ -26,6 +26,14 @@
 #ifndef RAJAPerf_POLYBENCH_ATAX_HPP
 #define RAJAPerf_POLYBENCH_ATAX_HPP
 
+#define POLYBENCH_ATAX_DATA_SETUP \
+  Real_ptr tmp = m_tmp; \
+  Real_ptr y = m_y; \
+  Real_ptr x = m_x; \
+  Real_ptr A = m_A; \
+\
+  const Index_type N = m_N;
+
 
 #define POLYBENCH_ATAX_BODY1 \
   y[i] = 0.0; \

--- a/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
@@ -27,16 +27,6 @@ namespace polybench
   const size_t block_size = 256;
 
 #define POLYBENCH_FDTD_2D_DATA_SETUP_CUDA \
-  Index_type t = 0; \
-  const Index_type nx = m_nx; \
-  const Index_type ny = m_ny; \
-  const Index_type tsteps = m_tsteps; \
-\
-  Real_ptr fict; \
-  Real_ptr ex; \
-  Real_ptr ey; \
-  Real_ptr hz; \
-\
   allocAndInitCudaDeviceData(hz, m_hz, m_nx * m_ny); \
   allocAndInitCudaDeviceData(ex, m_ex, m_nx * m_ny); \
   allocAndInitCudaDeviceData(ey, m_ey, m_nx * m_ny); \
@@ -96,6 +86,8 @@ __global__ void poly_fdtd2d_4(Real_ptr hz, Real_ptr ex, Real_ptr ey,
 void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_FDTD_2D_DATA_SETUP; 
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_FDTD_2D-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-OMPTarget.cpp
@@ -30,16 +30,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Index_type t = 0; \
-  const Index_type nx = m_nx; \
-  const Index_type ny = m_ny; \
-  const Index_type tsteps = m_tsteps; \
-\
-  Real_ptr fict; \
-  Real_ptr ex; \
-  Real_ptr ey; \
-  Real_ptr hz; \
-\
   allocAndInitOpenMPDeviceData(hz, m_hz, m_nx * m_ny, did, hid); \
   allocAndInitOpenMPDeviceData(ex, m_ex, m_nx * m_ny, did, hid); \
   allocAndInitOpenMPDeviceData(ey, m_ey, m_nx * m_ny, did, hid); \
@@ -56,6 +46,8 @@ namespace polybench
 void POLYBENCH_FDTD_2D::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_FDTD_2D_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_FDTD_2D.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.cpp
@@ -19,16 +19,6 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_FDTD_2D_DATA_SETUP_CPU \
-  Index_type t = 0; \
-  const Index_type nx = m_nx; \
-  const Index_type ny = m_ny; \
-  const Index_type tsteps = m_tsteps; \
-\
-  ResReal_ptr fict = m_fict; \
-  ResReal_ptr ex = m_ex; \
-  ResReal_ptr ey = m_ey; \
-  ResReal_ptr hz = m_hz; 
 
 POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_FDTD_2D, params)
@@ -82,7 +72,7 @@ void POLYBENCH_FDTD_2D::runKernel(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
-  POLYBENCH_FDTD_2D_DATA_SETUP_CPU;
+  POLYBENCH_FDTD_2D_DATA_SETUP;
 
   // IMPORTANT: This first lambda definition must use capture by reference to
   //            get the correct result (the scalar vaiable 't' used in

--- a/src/polybench/POLYBENCH_FDTD_2D.hpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.hpp
@@ -36,6 +36,19 @@
 #ifndef RAJAPerf_POLYBENCH_FDTD_2D_HPP
 #define RAJAPerf_POLYBENCH_FDTD_2D_HPP
 
+
+#define POLYBENCH_FDTD_2D_DATA_SETUP \
+  Index_type t = 0; \
+  const Index_type nx = m_nx; \
+  const Index_type ny = m_ny; \
+  const Index_type tsteps = m_tsteps; \
+\
+  Real_ptr fict = m_fict; \
+  Real_ptr ex = m_ex; \
+  Real_ptr ey = m_ey; \
+  Real_ptr hz = m_hz;
+
+
 #define POLYBENCH_FDTD_2D_BODY1 \
   ey[j + 0*ny] = fict[t];
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
@@ -22,11 +22,6 @@ namespace polybench
 {
 
 #define POLYBENCH_FLOYD_WARSHALL_DATA_SETUP_CUDA \
-  Real_ptr pin; \
-  Real_ptr pout; \
-\
-  const Index_type N = m_N; \
-\
   allocAndInitCudaDeviceData(pin, m_pin, m_N * m_N); \
   allocAndInitCudaDeviceData(pout, m_pout, m_N * m_N);
 
@@ -51,6 +46,8 @@ __global__ void poly_floyd_warshall(Real_ptr pout, Real_ptr pin,
 void POLYBENCH_FLOYD_WARSHALL::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_FLOYD_WARSHALL_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-OMPTarget.cpp
@@ -25,10 +25,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr pin; \
-  Real_ptr pout; \
-  const Index_type N = m_N; \
-\
   allocAndInitOpenMPDeviceData(pin, m_pin, m_N * m_N, did, hid); \
   allocAndInitOpenMPDeviceData(pout, m_pout, m_N * m_N, did, hid);
 
@@ -42,6 +38,8 @@ namespace polybench
 void POLYBENCH_FLOYD_WARSHALL::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_FLOYD_WARSHALL_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
@@ -24,12 +24,7 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_FLOYD_WARSHALL_DATA_SETUP_CPU \
-  ResReal_ptr pin = m_pin; \
-  ResReal_ptr pout = m_pout; \
-  const Index_type N = m_N;
-
-  
+ 
 POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
   : KernelBase(rajaperf::Polybench_FLOYD_WARSHALL, params)
 {
@@ -82,7 +77,7 @@ void POLYBENCH_FLOYD_WARSHALL::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
 
-  POLYBENCH_FLOYD_WARSHALL_DATA_SETUP_CPU;
+  POLYBENCH_FLOYD_WARSHALL_DATA_SETUP;
 
   auto poly_floydwarshall_base_lam = [=](Index_type k, Index_type i, 
                                          Index_type j) {

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.hpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.hpp
@@ -25,6 +25,12 @@
 #ifndef RAJAPerf_POLYBENCH_FLOYD_WARSHALL_HPP
 #define RAJAPerf_POLYBENCH_FLOYD_WARSHALL_HPP
 
+#define POLYBENCH_FLOYD_WARSHALL_DATA_SETUP \
+  Real_ptr pin = m_pin; \
+  Real_ptr pout = m_pout; \
+  const Index_type N = m_N;
+
+
 #define POLYBENCH_FLOYD_WARSHALL_BODY \
   pout[j + i*N] = pin[j + i*N] < pin[k + i*N] + pin[j + k*N] ? \
                   pin[j + i*N] : pin[k + i*N] + pin[j + k*N];

--- a/src/polybench/POLYBENCH_GEMM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Cuda.cpp
@@ -22,17 +22,6 @@ namespace polybench
 {
 
 #define POLYBENCH_GEMM_DATA_SETUP_CUDA \
-  const Index_type ni = m_ni; \
-  const Index_type nj = m_nj; \
-  const Index_type nk = m_nk; \
-\
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-\
-  Real_ptr A; \
-  Real_ptr B; \
-  Real_ptr C; \
-\
   allocAndInitCudaDeviceData(A, m_A, ni*nk); \
   allocAndInitCudaDeviceData(B, m_B, nk*nj); \
   allocAndInitCudaDeviceData(C, m_C, ni*nj);
@@ -64,6 +53,8 @@ __global__ void poly_gemm(Real_ptr C, Real_ptr A, Real_ptr B,
 void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_GEMM_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_GEMM-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_GEMM-OMPTarget.cpp
@@ -25,17 +25,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  const Index_type ni = m_ni; \
-  const Index_type nj = m_nj; \
-  const Index_type nk = m_nk; \
-\
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-\
-  Real_ptr A; \
-  Real_ptr B; \
-  Real_ptr C; \
-\
   allocAndInitOpenMPDeviceData(A, m_A, ni*nk, did, hid); \
   allocAndInitOpenMPDeviceData(B, m_B, nk*nj, did, hid); \
   allocAndInitOpenMPDeviceData(C, m_C, ni*nj, did, hid);
@@ -51,6 +40,8 @@ namespace polybench
 void POLYBENCH_GEMM::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_GEMM_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_GEMM.cpp
+++ b/src/polybench/POLYBENCH_GEMM.cpp
@@ -19,19 +19,7 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_GEMM_DATA_SETUP_CPU \
-  const Index_type ni = m_ni; \
-  const Index_type nj = m_nj; \
-  const Index_type nk = m_nk; \
-\
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-\
-  ResReal_ptr A = m_A; \
-  ResReal_ptr B = m_B; \
-  ResReal_ptr C = m_C;
 
-  
 POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GEMM, params)
 {
@@ -88,7 +76,7 @@ void POLYBENCH_GEMM::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
 
-  POLYBENCH_GEMM_DATA_SETUP_CPU;
+  POLYBENCH_GEMM_DATA_SETUP;
 
   auto poly_gemm_base_lam2 = [=](Index_type i, Index_type j) {
                                POLYBENCH_GEMM_BODY2;

--- a/src/polybench/POLYBENCH_GEMM.hpp
+++ b/src/polybench/POLYBENCH_GEMM.hpp
@@ -24,6 +24,19 @@
 #ifndef RAJAPerf_POLYBENCH_GEMM_HPP
 #define RAJAPerf_POLYBENCH_GEMM_HPP
 
+#define POLYBENCH_GEMM_DATA_SETUP \
+  const Index_type ni = m_ni; \
+  const Index_type nj = m_nj; \
+  const Index_type nk = m_nk; \
+\
+  Real_type alpha = m_alpha; \
+  Real_type beta = m_beta; \
+\
+  Real_ptr A = m_A; \
+  Real_ptr B = m_B; \
+  Real_ptr C = m_C;
+
+
 #define POLYBENCH_GEMM_BODY1 \
   Real_type dot = 0.0;
 

--- a/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
@@ -27,19 +27,6 @@ namespace polybench
 const size_t block_size = 256;
 
 #define POLYBENCH_GEMVER_DATA_SETUP_CUDA \
-  Index_type n = m_n; \
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-  Real_ptr A; \
-  Real_ptr u1; \
-  Real_ptr v1; \
-  Real_ptr u2; \
-  Real_ptr v2; \
-  Real_ptr w; \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr z; \
-\
   allocAndInitCudaDeviceData(A, m_A, m_n * m_n); \
   allocAndInitCudaDeviceData(u1, m_u1, m_n); \
   allocAndInitCudaDeviceData(v1, m_v1, m_n); \
@@ -117,6 +104,8 @@ __global__ void poly_gemmver_4(Real_ptr A,
 void POLYBENCH_GEMVER::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_GEMVER_DATA_SETUP; 
   
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_GEMVER-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-OMPTarget.cpp
@@ -30,19 +30,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Index_type n = m_n; \
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-  Real_ptr A; \
-  Real_ptr u1; \
-  Real_ptr v1; \
-  Real_ptr u2; \
-  Real_ptr v2; \
-  Real_ptr w; \
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr z; \
-\
   allocAndInitOpenMPDeviceData(A, m_A, m_n * m_n, did, hid); \
   allocAndInitOpenMPDeviceData(u1, m_u1, m_n, did, hid); \
   allocAndInitOpenMPDeviceData(v1, m_v1, m_n, did, hid); \
@@ -70,6 +57,8 @@ namespace polybench
 void POLYBENCH_GEMVER::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_GEMVER_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_GEMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMVER.cpp
@@ -20,22 +20,7 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_GEMVER_DATA_SETUP_CPU \
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-  ResReal_ptr A = m_A; \
-  ResReal_ptr u1 = m_u1; \
-  ResReal_ptr v1 = m_v1; \
-  ResReal_ptr u2 = m_u2; \
-  ResReal_ptr v2 = m_v2; \
-  ResReal_ptr w = m_w; \
-  ResReal_ptr x = m_x; \
-  ResReal_ptr y = m_y; \
-  ResReal_ptr z = m_z; \
-\
-  const Index_type n = m_n;
 
-  
 POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GEMVER, params)
 {
@@ -96,10 +81,9 @@ void POLYBENCH_GEMVER::setUp(VariantID vid)
 
 void POLYBENCH_GEMVER::runKernel(VariantID vid)
 {
-
   const Index_type run_reps = getRunReps();
 
-  POLYBENCH_GEMVER_DATA_SETUP_CPU;
+  POLYBENCH_GEMVER_DATA_SETUP;
 
   auto poly_gemver_base_lam1 = [=](Index_type i, Index_type j) {
                                  POLYBENCH_GEMVER_BODY1;

--- a/src/polybench/POLYBENCH_GEMVER.hpp
+++ b/src/polybench/POLYBENCH_GEMVER.hpp
@@ -37,6 +37,22 @@
 #ifndef RAJAPerf_POLYBENCH_GEMVER_HPP
 #define RAJAPerf_POLYBENCH_GEMVER_HPP
 
+#define POLYBENCH_GEMVER_DATA_SETUP \
+  Real_type alpha = m_alpha; \
+  Real_type beta = m_beta; \
+  Real_ptr A = m_A; \
+  Real_ptr u1 = m_u1; \
+  Real_ptr v1 = m_v1; \
+  Real_ptr u2 = m_u2; \
+  Real_ptr v2 = m_v2; \
+  Real_ptr w = m_w; \
+  Real_ptr x = m_x; \
+  Real_ptr y = m_y; \
+  Real_ptr z = m_z; \
+\
+  const Index_type n = m_n;
+
+
 #define POLYBENCH_GEMVER_BODY1 \
   A[j + i*n] += u1[i] * v1[j] + u2[i] * v2[j];
 

--- a/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
@@ -27,16 +27,6 @@ namespace polybench
   const size_t block_size = 256;
 
 #define POLYBENCH_GESUMMV_DATA_SETUP_CUDA \
-  const Index_type N = m_N; \
-\
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-\
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr A; \
-  Real_ptr B; \
-\
   allocAndInitCudaDeviceData(x, m_x, N); \
   allocAndInitCudaDeviceData(y, m_y, N); \
   allocAndInitCudaDeviceData(A, m_A, N*N); \
@@ -71,6 +61,8 @@ __global__ void poly_gesummv(Real_ptr x, Real_ptr y,
 void POLYBENCH_GESUMMV::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_GESUMMV_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_GESUMMV-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-OMPTarget.cpp
@@ -30,16 +30,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  const Index_type N = m_N; \
-\
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-\
-  Real_ptr x; \
-  Real_ptr y; \
-  Real_ptr A; \
-  Real_ptr B; \
-\
   allocAndInitOpenMPDeviceData(x, m_x, N, did, hid); \
   allocAndInitOpenMPDeviceData(y, m_y, N, did, hid); \
   allocAndInitOpenMPDeviceData(A, m_A, N*N, did, hid); \
@@ -57,6 +47,8 @@ namespace polybench
 void POLYBENCH_GESUMMV::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_GESUMMV_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_GESUMMV.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV.cpp
@@ -19,18 +19,7 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_GESUMMV_DATA_SETUP_CPU \
-  const Index_type N = m_N; \
-\
-  Real_type alpha = m_alpha; \
-  Real_type beta = m_beta; \
-\
-  ResReal_ptr x = m_x; \
-  ResReal_ptr y = m_y; \
-  ResReal_ptr A = m_A; \
-  ResReal_ptr B = m_B;
-
-  
+ 
 POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GESUMMV, params)
 {
@@ -88,7 +77,7 @@ void POLYBENCH_GESUMMV::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
 
-  POLYBENCH_GESUMMV_DATA_SETUP_CPU;
+  POLYBENCH_GESUMMV_DATA_SETUP;
 
   auto poly_gesummv_base_lam2 = [=](Index_type i, Index_type j, 
                                     Real_type& tmpdot, Real_type& ydot) {

--- a/src/polybench/POLYBENCH_GESUMMV.hpp
+++ b/src/polybench/POLYBENCH_GESUMMV.hpp
@@ -23,6 +23,18 @@
 #ifndef RAJAPerf_POLYBENCH_GESUMMV_HPP
 #define RAJAPerf_POLYBENCH_GESUMMV_HPP
 
+#define POLYBENCH_GESUMMV_DATA_SETUP \
+  const Index_type N = m_N; \
+\
+  Real_type alpha = m_alpha; \
+  Real_type beta = m_beta; \
+\
+  Real_ptr x = m_x; \
+  Real_ptr y = m_y; \
+  Real_ptr A = m_A; \
+  Real_ptr B = m_B;
+
+
 #define POLYBENCH_GESUMMV_BODY1 \
   Real_type tmpdot = 0.0; \
   Real_type ydot = 0.0;

--- a/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
@@ -22,11 +22,6 @@ namespace polybench
 {
 
 #define POLYBENCH_HEAT_3D_DATA_SETUP_CUDA \
-  Real_ptr A; \
-  Real_ptr B; \
-  const Index_type N = m_N; \
-  const Index_type tsteps = m_tsteps; \
-\
   allocAndInitCudaDeviceData(A, m_Ainit, m_N*m_N*m_N); \
   allocAndInitCudaDeviceData(B, m_Binit, m_N*m_N*m_N);
 
@@ -64,6 +59,8 @@ __global__ void poly_heat_3D_2(Real_ptr A, Real_ptr B, Index_type N)
 void POLYBENCH_HEAT_3D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_HEAT_3D_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_HEAT_3D-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-OMPTarget.cpp
@@ -25,11 +25,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr A; \
-  Real_ptr B; \
-  const Index_type N = m_N; \
-  const Index_type tsteps = m_tsteps; \
-\
   allocAndInitOpenMPDeviceData(A, m_Ainit, m_N*m_N*m_N, did, hid); \
   allocAndInitOpenMPDeviceData(B, m_Binit, m_N*m_N*m_N, did, hid);
 
@@ -44,6 +39,8 @@ namespace polybench
 void POLYBENCH_HEAT_3D::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_HEAT_3D_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -19,18 +19,7 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_HEAT_3D_DATA_SETUP_CPU \
-  ResReal_ptr A = m_Ainit; \
-  ResReal_ptr B = m_Binit; \
-  const Index_type N = m_N; \
-  const Index_type tsteps = m_tsteps;
-
-#define POLYBENCH_HEAT_3D_DATA_RESET_CPU \
-  m_Ainit = m_A; \
-  m_Binit = m_B; \
-  m_A = A; \
-  m_B = B; 
-  
+ 
 POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_HEAT_3D, params)
 {
@@ -101,7 +90,7 @@ void POLYBENCH_HEAT_3D::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
 
-  POLYBENCH_HEAT_3D_DATA_SETUP_CPU;
+  POLYBENCH_HEAT_3D_DATA_SETUP;
 
   auto poly_heat3d_base_lam1 = [=](Index_type i, Index_type j, Index_type k) {
                                  POLYBENCH_HEAT_3D_BODY1;
@@ -149,7 +138,7 @@ void POLYBENCH_HEAT_3D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_HEAT_3D_DATA_RESET_CPU;
+      POLYBENCH_HEAT_3D_DATA_RESET;
 
       break;
     }
@@ -183,7 +172,7 @@ void POLYBENCH_HEAT_3D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_HEAT_3D_DATA_RESET_CPU;
+      POLYBENCH_HEAT_3D_DATA_RESET;
 
       break;
     }
@@ -226,7 +215,7 @@ void POLYBENCH_HEAT_3D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_HEAT_3D_DATA_RESET_CPU;
+      POLYBENCH_HEAT_3D_DATA_RESET;
 
       break;
     }
@@ -264,7 +253,7 @@ void POLYBENCH_HEAT_3D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_HEAT_3D_DATA_RESET_CPU;
+      POLYBENCH_HEAT_3D_DATA_RESET;
 
       break;
     }
@@ -299,7 +288,7 @@ void POLYBENCH_HEAT_3D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_HEAT_3D_DATA_RESET_CPU;
+      POLYBENCH_HEAT_3D_DATA_RESET;
 
       break;
     }
@@ -340,7 +329,7 @@ void POLYBENCH_HEAT_3D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_HEAT_3D_DATA_RESET_CPU;
+      POLYBENCH_HEAT_3D_DATA_RESET;
       
       break;
     }

--- a/src/polybench/POLYBENCH_HEAT_3D.hpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.hpp
@@ -40,6 +40,18 @@
 #ifndef RAJAPerf_POLYBENCH_HEAT_3D_HPP
 #define RAJAPerf_POLYBENCH_HEAT_3D_HPP
 
+#define POLYBENCH_HEAT_3D_DATA_SETUP \
+  Real_ptr A = m_Ainit; \
+  Real_ptr B = m_Binit; \
+  const Index_type N = m_N; \
+  const Index_type tsteps = m_tsteps;
+
+#define POLYBENCH_HEAT_3D_DATA_RESET \
+  m_Ainit = m_A; \
+  m_Binit = m_B; \
+  m_A = A; \
+  m_B = B;
+
 
 #define POLYBENCH_HEAT_3D_BODY1 \
   B[k + N*(j + N*i)] = \

--- a/src/polybench/POLYBENCH_JACOBI_1D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-Cuda.cpp
@@ -27,11 +27,6 @@ namespace polybench
   const size_t block_size = 256;
 
 #define POLYBENCH_JACOBI_1D_DATA_SETUP_CUDA \
-  Real_ptr A; \
-  Real_ptr B; \
-  const Index_type N = m_N; \
-  const Index_type tsteps = m_tsteps; \
-\
   allocAndInitCudaDeviceData(A, m_Ainit, m_N); \
   allocAndInitCudaDeviceData(B, m_Binit, m_N);
 
@@ -65,6 +60,8 @@ __global__ void poly_jacobi_1D_2(Real_ptr A, Real_ptr B, Index_type N)
 void POLYBENCH_JACOBI_1D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_JACOBI_1D_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_JACOBI_1D-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-OMPTarget.cpp
@@ -30,11 +30,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr A; \
-  Real_ptr B; \
-  const Index_type N = m_N; \
-  const Index_type tsteps = m_tsteps; \
-\
   allocAndInitOpenMPDeviceData(A, m_Ainit, m_N, did, hid); \
   allocAndInitOpenMPDeviceData(B, m_Binit, m_N, did, hid);
 
@@ -49,6 +44,8 @@ namespace polybench
 void POLYBENCH_JACOBI_1D::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_JACOBI_1D_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_JACOBI_1D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.cpp
@@ -19,18 +19,7 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_JACOBI_1D_DATA_SETUP_CPU \
-  ResReal_ptr A = m_Ainit; \
-  ResReal_ptr B = m_Binit; \
-  const Index_type N = m_N; \
-  const Index_type tsteps = m_tsteps;
-
-#define POLYBENCH_JACOBI_1D_DATA_RESET_CPU \
-  m_Ainit = m_A; \
-  m_Binit = m_B; \
-  m_A = A; \
-  m_B = B; 
-  
+ 
 POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_JACOBI_1D, params)
 {
@@ -91,7 +80,7 @@ void POLYBENCH_JACOBI_1D::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
 
-  POLYBENCH_JACOBI_1D_DATA_SETUP_CPU;
+  POLYBENCH_JACOBI_1D_DATA_SETUP;
 
   auto poly_jacobi1d_lam1 = [=] (Index_type i) {
                               POLYBENCH_JACOBI_1D_BODY1;
@@ -121,7 +110,7 @@ void POLYBENCH_JACOBI_1D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_1D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_1D_DATA_RESET;
 
       break;
     }
@@ -147,7 +136,7 @@ void POLYBENCH_JACOBI_1D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_1D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_1D_DATA_RESET;
 
       break;
     }
@@ -172,7 +161,7 @@ void POLYBENCH_JACOBI_1D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_1D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_1D_DATA_RESET;
 
       break;
     }
@@ -202,7 +191,7 @@ void POLYBENCH_JACOBI_1D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_1D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_1D_DATA_RESET;
 
       break;
     }
@@ -228,7 +217,7 @@ void POLYBENCH_JACOBI_1D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_1D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_1D_DATA_RESET;
 
       break;
     }
@@ -253,7 +242,7 @@ void POLYBENCH_JACOBI_1D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_1D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_1D_DATA_RESET;
 
       break;
     }

--- a/src/polybench/POLYBENCH_JACOBI_1D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.hpp
@@ -23,6 +23,19 @@
 #ifndef RAJAPerf_POLYBENCH_JACOBI_1D_HPP
 #define RAJAPerf_POLYBENCH_JACOBI_1D_HPP
 
+#define POLYBENCH_JACOBI_1D_DATA_SETUP \
+  Real_ptr A = m_Ainit; \
+  Real_ptr B = m_Binit; \
+  const Index_type N = m_N; \
+  const Index_type tsteps = m_tsteps;
+
+#define POLYBENCH_JACOBI_1D_DATA_RESET \
+  m_Ainit = m_A; \
+  m_Binit = m_B; \
+  m_A = A; \
+  m_B = B;
+
+
 #define POLYBENCH_JACOBI_1D_BODY1 \
   B[i] = 0.33333 * (A[i-1] + A[i] + A[i + 1]);  
 

--- a/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
@@ -22,11 +22,6 @@ namespace polybench
 {
 
 #define POLYBENCH_JACOBI_2D_DATA_SETUP_CUDA \
-  Real_ptr A; \
-  Real_ptr B; \
-  const Index_type N = m_N; \
-  const Index_type tsteps = m_tsteps; \
-\
   allocAndInitCudaDeviceData(A, m_Ainit, m_N*m_N); \
   allocAndInitCudaDeviceData(B, m_Binit, m_N*m_N);
 
@@ -62,6 +57,8 @@ __global__ void poly_jacobi_2D_2(Real_ptr A, Real_ptr B, Index_type N)
 void POLYBENCH_JACOBI_2D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_JACOBI_2D_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_JACOBI_2D-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-OMPTarget.cpp
@@ -25,11 +25,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr A; \
-  Real_ptr B; \
-  const Index_type N = m_N; \
-  const Index_type tsteps = m_tsteps; \
-\
   allocAndInitOpenMPDeviceData(A, m_Ainit, m_N*m_N, did, hid); \
   allocAndInitOpenMPDeviceData(B, m_Binit, m_N*m_N, did, hid);
 
@@ -44,6 +39,8 @@ namespace polybench
 void POLYBENCH_JACOBI_2D::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_JACOBI_2D_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -19,18 +19,7 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_JACOBI_2D_DATA_SETUP_CPU \
-  ResReal_ptr A = m_Ainit; \
-  ResReal_ptr B = m_Binit; \
-  const Index_type N = m_N; \
-  const Index_type tsteps = m_tsteps;
 
-#define POLYBENCH_JACOBI_2D_DATA_RESET_CPU \
-  m_Ainit = m_A; \
-  m_Binit = m_B; \
-  m_A = A; \
-  m_B = B; 
-  
 POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_JACOBI_2D, params)
 {
@@ -90,7 +79,7 @@ void POLYBENCH_JACOBI_2D::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
 
-  POLYBENCH_JACOBI_2D_DATA_SETUP_CPU;
+  POLYBENCH_JACOBI_2D_DATA_SETUP;
 
   auto poly_jacobi2d_base_lam1 = [=](Index_type i, Index_type j) {
                                    POLYBENCH_JACOBI_2D_BODY1;
@@ -133,7 +122,7 @@ void POLYBENCH_JACOBI_2D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_2D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_2D_DATA_RESET;
 
       break;
     }
@@ -164,7 +153,7 @@ void POLYBENCH_JACOBI_2D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_2D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_2D_DATA_RESET;
 
       break;
     }
@@ -202,7 +191,7 @@ void POLYBENCH_JACOBI_2D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_2D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_2D_DATA_RESET;
 
       break;
     }
@@ -237,7 +226,7 @@ void POLYBENCH_JACOBI_2D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_2D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_2D_DATA_RESET;
 
       break;
     }
@@ -268,7 +257,7 @@ void POLYBENCH_JACOBI_2D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_2D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_2D_DATA_RESET;
 
       break;
     }
@@ -306,7 +295,7 @@ void POLYBENCH_JACOBI_2D::runKernel(VariantID vid)
       }
       stopTimer();
 
-      POLYBENCH_JACOBI_2D_DATA_RESET_CPU;
+      POLYBENCH_JACOBI_2D_DATA_RESET;
 
       break;
     }

--- a/src/polybench/POLYBENCH_JACOBI_2D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.hpp
@@ -27,6 +27,20 @@
 #ifndef RAJAPerf_POLYBENCH_JACOBI_2D_HPP
 #define RAJAPerf_POLYBENCH_JACOBI_2D_HPP
 
+#define POLYBENCH_JACOBI_2D_DATA_SETUP \
+  Real_ptr A = m_Ainit; \
+  Real_ptr B = m_Binit; \
+\
+  const Index_type N = m_N; \
+  const Index_type tsteps = m_tsteps;
+
+#define POLYBENCH_JACOBI_2D_DATA_RESET \
+  m_Ainit = m_A; \
+  m_Binit = m_B; \
+  m_A = A; \
+  m_B = B;
+
+
 #define POLYBENCH_JACOBI_2D_BODY1 \
   B[j + i*N] = 0.2 * (A[j + i*N] + A[j-1 + i*N] + A[j+1 + i*N] + A[j + (i+1)*N] + A[j + (i-1)*N]);
 

--- a/src/polybench/POLYBENCH_MVT-Cuda.cpp
+++ b/src/polybench/POLYBENCH_MVT-Cuda.cpp
@@ -27,13 +27,6 @@ namespace polybench
   const size_t block_size = 256;
 
 #define POLYBENCH_MVT_DATA_SETUP_CUDA \
-  Real_ptr x1; \
-  Real_ptr x2; \
-  Real_ptr y1; \
-  Real_ptr y2; \
-  Real_ptr A; \
-  const Index_type N = m_N; \
-\
   allocAndInitCudaDeviceData(x1, m_x1, N); \
   allocAndInitCudaDeviceData(x2, m_x2, N); \
   allocAndInitCudaDeviceData(y1, m_y1, N); \
@@ -83,6 +76,8 @@ __global__ void poly_mvt_2(Real_ptr A, Real_ptr x2, Real_ptr y2,
 void POLYBENCH_MVT::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_MVT_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/polybench/POLYBENCH_MVT-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_MVT-OMPTarget.cpp
@@ -30,13 +30,6 @@ namespace polybench
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr x1; \
-  Real_ptr x2; \
-  Real_ptr y1; \
-  Real_ptr y2; \
-  Real_ptr A; \
-  const Index_type N = m_N; \
-\
   allocAndInitOpenMPDeviceData(x1, m_x1, N, did, hid); \
   allocAndInitOpenMPDeviceData(x2, m_x2, N, did, hid); \
   allocAndInitOpenMPDeviceData(y1, m_y1, N, did, hid); \
@@ -57,6 +50,8 @@ namespace polybench
 void POLYBENCH_MVT::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+
+  POLYBENCH_MVT_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/polybench/POLYBENCH_MVT.cpp
+++ b/src/polybench/POLYBENCH_MVT.cpp
@@ -19,15 +19,7 @@ namespace rajaperf
 namespace polybench
 {
 
-#define POLYBENCH_MVT_DATA_SETUP_CPU \
-  ResReal_ptr x1 = m_x1; \
-  ResReal_ptr x2 = m_x2; \
-  ResReal_ptr y1 = m_y1; \
-  ResReal_ptr y2 = m_y2; \
-  ResReal_ptr A = m_A; \
-  const Index_type N = m_N;
-
-  
+ 
 POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
   : KernelBase(rajaperf::Polybench_MVT, params)
 {
@@ -83,7 +75,7 @@ void POLYBENCH_MVT::runKernel(VariantID vid)
 {
   const Index_type run_reps= getRunReps();
 
-  POLYBENCH_MVT_DATA_SETUP_CPU;
+  POLYBENCH_MVT_DATA_SETUP;
 
   auto poly_mvt_base_lam2 = [=] (Index_type i, Index_type j, Real_type &dot) {
                               POLYBENCH_MVT_BODY2;

--- a/src/polybench/POLYBENCH_MVT.hpp
+++ b/src/polybench/POLYBENCH_MVT.hpp
@@ -24,6 +24,15 @@
 #ifndef RAJAPerf_POLYBENCH_MVT_HPP
 #define RAJAPerf_POLYBENCH_MVT_HPP
 
+#define POLYBENCH_MVT_DATA_SETUP \
+  Real_ptr x1 = m_x1; \
+  Real_ptr x2 = m_x2; \
+  Real_ptr y1 = m_y1; \
+  Real_ptr y2 = m_y2; \
+  Real_ptr A = m_A; \
+  const Index_type N = m_N;
+
+
 #define POLYBENCH_MVT_BODY1 \
   Real_type dot = 0.0;
 

--- a/src/stream/ADD-Cuda.cpp
+++ b/src/stream/ADD-Cuda.cpp
@@ -28,10 +28,6 @@ namespace stream
 
 
 #define ADD_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  Real_ptr b; \
-  Real_ptr c; \
-\
   allocAndInitCudaDeviceData(a, m_a, iend); \
   allocAndInitCudaDeviceData(b, m_b, iend); \
   allocAndInitCudaDeviceData(c, m_c, iend);
@@ -57,6 +53,8 @@ void ADD::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  ADD_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/stream/ADD-OMPTarget.cpp
+++ b/src/stream/ADD-OMPTarget.cpp
@@ -30,10 +30,6 @@ namespace stream
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr a; \
-  Real_ptr b; \
-  Real_ptr c; \
-\
   allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
   allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid); \
   allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid);
@@ -49,6 +45,8 @@ void ADD::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  ADD_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -20,12 +20,6 @@ namespace stream
 {
 
  
-#define ADD_DATA_SETUP_CPU \
-  ResReal_ptr a = m_a; \
-  ResReal_ptr b = m_b; \
-  ResReal_ptr c = m_c;
-
-
 ADD::ADD(const RunParams& params)
   : KernelBase(rajaperf::Stream_ADD, params)
 {
@@ -50,7 +44,7 @@ void ADD::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  ADD_DATA_SETUP_CPU;
+  ADD_DATA_SETUP;
 
   auto add_lam = [=](Index_type i) {
                    ADD_BODY;

--- a/src/stream/ADD.hpp
+++ b/src/stream/ADD.hpp
@@ -17,6 +17,10 @@
 #ifndef RAJAPerf_Stream_ADD_HPP
 #define RAJAPerf_Stream_ADD_HPP
 
+#define ADD_DATA_SETUP \
+  Real_ptr a = m_a; \
+  Real_ptr b = m_b; \
+  Real_ptr c = m_c;
 
 #define ADD_BODY  \
   c[i] = a[i] + b[i]; 

--- a/src/stream/COPY-Cuda.cpp
+++ b/src/stream/COPY-Cuda.cpp
@@ -28,9 +28,6 @@ namespace stream
 
 
 #define COPY_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  Real_ptr c; \
-\
   allocAndInitCudaDeviceData(a, m_a, iend); \
   allocAndInitCudaDeviceData(c, m_c, iend);
 
@@ -54,6 +51,8 @@ void COPY::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  COPY_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/stream/COPY-OMPTarget.cpp
+++ b/src/stream/COPY-OMPTarget.cpp
@@ -30,9 +30,6 @@ namespace stream
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr a; \
-  Real_ptr c; \
-\
   allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
   allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid);
 
@@ -47,6 +44,8 @@ void COPY::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  COPY_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -20,11 +20,6 @@ namespace stream
 {
 
 
-#define COPY_DATA_SETUP_CPU \
-  ResReal_ptr a = m_a; \
-  ResReal_ptr c = m_c;
-
-
 COPY::COPY(const RunParams& params)
   : KernelBase(rajaperf::Stream_COPY, params)
 {
@@ -48,7 +43,7 @@ void COPY::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  COPY_DATA_SETUP_CPU;
+  COPY_DATA_SETUP;
 
   auto copy_lam = [=](Index_type i) {
                     COPY_BODY;

--- a/src/stream/COPY.hpp
+++ b/src/stream/COPY.hpp
@@ -17,6 +17,9 @@
 #ifndef RAJAPerf_Stream_COPY_HPP
 #define RAJAPerf_Stream_COPY_HPP
 
+#define COPY_DATA_SETUP \
+  Real_ptr a = m_a; \
+  Real_ptr c = m_c;
 
 #define COPY_BODY  \
   c[i] = a[i] ;

--- a/src/stream/DOT-Cuda.cpp
+++ b/src/stream/DOT-Cuda.cpp
@@ -29,9 +29,6 @@ namespace stream
 
 
 #define DOT_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  Real_ptr b; \
-\
   allocAndInitCudaDeviceData(a, m_a, iend); \
   allocAndInitCudaDeviceData(b, m_b, iend);
 
@@ -78,6 +75,8 @@ void DOT::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  DOT_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/stream/DOT-OMPTarget.cpp
+++ b/src/stream/DOT-OMPTarget.cpp
@@ -30,9 +30,6 @@ namespace stream
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr a; \
-  Real_ptr b; \
-\
   allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
   allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid);
 
@@ -45,6 +42,8 @@ void DOT::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  DOT_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/stream/DOT.cpp
+++ b/src/stream/DOT.cpp
@@ -20,11 +20,6 @@ namespace stream
 {
 
 
-#define DOT_DATA_SETUP_CPU \
-  ResReal_ptr a = m_a; \
-  ResReal_ptr b = m_b;
-
-
 DOT::DOT(const RunParams& params)
   : KernelBase(rajaperf::Stream_DOT, params)
 {
@@ -51,7 +46,7 @@ void DOT::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  DOT_DATA_SETUP_CPU;
+  DOT_DATA_SETUP;
 
   auto dot_base_lam = [=](Index_type i) -> Real_type {
                         return a[i] * b[i];

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -17,6 +17,9 @@
 #ifndef RAJAPerf_Stream_DOT_HPP
 #define RAJAPerf_Stream_DOT_HPP
 
+#define DOT_DATA_SETUP \
+  Real_ptr a = m_a; \
+  Real_ptr b = m_b;
 
 #define DOT_BODY  \
   dot += a[i] * b[i] ;

--- a/src/stream/MUL-Cuda.cpp
+++ b/src/stream/MUL-Cuda.cpp
@@ -28,10 +28,6 @@ namespace stream
 
 
 #define MUL_DATA_SETUP_CUDA \
-  Real_ptr b; \
-  Real_ptr c; \
-  Real_type alpha = m_alpha; \
-\
   allocAndInitCudaDeviceData(b, m_b, iend); \
   allocAndInitCudaDeviceData(c, m_c, iend);
 
@@ -54,6 +50,8 @@ void MUL::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  MUL_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/stream/MUL-OMPTarget.cpp
+++ b/src/stream/MUL-OMPTarget.cpp
@@ -30,10 +30,6 @@ namespace stream
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr b; \
-  Real_ptr c; \
-  Real_type alpha = m_alpha; \
-\
   allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid); \
   allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid);
 
@@ -47,6 +43,8 @@ void MUL::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  MUL_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -20,12 +20,6 @@ namespace stream
 {
 
 
-#define MUL_DATA_SETUP_CPU \
-  ResReal_ptr b = m_b; \
-  ResReal_ptr c = m_c; \
-  Real_type alpha = m_alpha;
-
-
 MUL::MUL(const RunParams& params)
   : KernelBase(rajaperf::Stream_MUL, params)
 {
@@ -51,7 +45,7 @@ void MUL::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  MUL_DATA_SETUP_CPU;
+  MUL_DATA_SETUP;
 
   auto mul_lam = [=](Index_type i) {
                    MUL_BODY;

--- a/src/stream/MUL.hpp
+++ b/src/stream/MUL.hpp
@@ -17,6 +17,10 @@
 #ifndef RAJAPerf_Stream_MUL_HPP
 #define RAJAPerf_Stream_MUL_HPP
 
+#define MUL_DATA_SETUP \
+  Real_ptr b = m_b; \
+  Real_ptr c = m_c; \
+  Real_type alpha = m_alpha;
 
 #define MUL_BODY  \
   b[i] = alpha * c[i] ;

--- a/src/stream/TRIAD-Cuda.cpp
+++ b/src/stream/TRIAD-Cuda.cpp
@@ -28,11 +28,6 @@ namespace stream
 
 
 #define TRIAD_DATA_SETUP_CUDA \
-  Real_ptr a; \
-  Real_ptr b; \
-  Real_ptr c; \
-  Real_type alpha = m_alpha; \
-\
   allocAndInitCudaDeviceData(a, m_a, iend); \
   allocAndInitCudaDeviceData(b, m_b, iend); \
   allocAndInitCudaDeviceData(c, m_c, iend);
@@ -58,6 +53,8 @@ void TRIAD::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  TRIAD_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 

--- a/src/stream/TRIAD-OMPTarget.cpp
+++ b/src/stream/TRIAD-OMPTarget.cpp
@@ -30,11 +30,6 @@ namespace stream
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  Real_ptr a; \
-  Real_ptr b; \
-  Real_ptr c; \
-  Real_type alpha = m_alpha; \
-\
   allocAndInitOpenMPDeviceData(a, m_a, iend, did, hid); \
   allocAndInitOpenMPDeviceData(b, m_b, iend, did, hid); \
   allocAndInitOpenMPDeviceData(c, m_c, iend, did, hid);
@@ -50,6 +45,8 @@ void TRIAD::runOpenMPTargetVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
+
+  TRIAD_DATA_SETUP;
 
   if ( vid == Base_OpenMPTarget ) {
 

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -20,13 +20,6 @@ namespace stream
 {
 
 
-#define TRIAD_DATA_SETUP_CPU \
-  ResReal_ptr a = m_a; \
-  ResReal_ptr b = m_b; \
-  ResReal_ptr c = m_c; \
-  Real_type alpha = m_alpha;
-
-
 TRIAD::TRIAD(const RunParams& params)
   : KernelBase(rajaperf::Stream_TRIAD, params)
 {
@@ -52,7 +45,7 @@ void TRIAD::runKernel(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getRunSize();
 
-  TRIAD_DATA_SETUP_CPU;
+  TRIAD_DATA_SETUP;
 
   auto triad_lam = [=](Index_type i) {
                      TRIAD_BODY;

--- a/src/stream/TRIAD.hpp
+++ b/src/stream/TRIAD.hpp
@@ -17,6 +17,11 @@
 #ifndef RAJAPerf_Stream_TRIAD_HPP
 #define RAJAPerf_Stream_TRIAD_HPP
 
+#define TRIAD_DATA_SETUP \
+  Real_ptr a = m_a; \
+  Real_ptr b = m_b; \
+  Real_ptr c = m_c; \
+  Real_type alpha = m_alpha;
 
 #define TRIAD_BODY  \
   a[i] = b[i] + alpha * c[i] ;


### PR DESCRIPTION
This PR cleans up and unifies macros used in the kernels so it will be easier to break the files apart, which will be done in my next PR.

The same pattern of macro reorg is done for each kernel. So if you look at changes for one, you've pretty much seen them all.