### PR TITLE
Idea check for Kokkos implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "tpl/RAJA"]
 	path = tpl/RAJA
 	url = https://github.com/LLNL/RAJA.git
+[submodule "tpl/kokkos"]
+	path = tpl/kokkos
+	url = https://github.com/kokkos/kokkos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ cmake_minimum_required(VERSION 3.9)
 
 option(ENABLE_RAJA_SEQUENTIAL "Run sequential variants of RAJA kernels. Disable
 this, and all other variants, to run _only_ raw C loops." On)
+option(ENABLE_KOKKOS "Include Kokkos implementations of the kernels in the RAJA Perfsuite" Off)
 
 #
 # Initialize the BLT build system
@@ -104,6 +105,17 @@ configure_file(${CMAKE_SOURCE_DIR}/src/rajaperf_config.hpp.in
 
 # Make sure RAJA flag propagate
 set (CUDA_NVCC_FLAGS ${RAJA_NVCC_FLAGS})
+
+if(ENABLE_KOKKOS)
+  add_definitions(-DRUN_KOKKOS)
+
+  add_subdirectory(tpl/kokkos)
+
+  get_property(KOKKOS_INCLUDE_DIRS DIRECTORY tpl/kokkos PROPERTY INCLUDE_DIRECTORIES)
+  include_directories(${KOKKOS_INCLUDE_DIRS})
+  list(APPEND RAJA_PERFSUITE_DEPENDS kokkos)
+endif()
+
 
 #
 # Each directory in the perf suite has its own CMakeLists.txt file.

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -259,7 +259,9 @@ void Executor::setupSuite()
       }
 
     } // kernel and variant input both look good
-
+#if defined(RUN_KOKKOS)
+    Kokkos::initialize(); 
+#endif
   } // if kernel input looks good
 
 }
@@ -422,6 +424,9 @@ void Executor::outputRunData()
 
   filename = out_fprefix + "-fom.csv";
   writeFOMReport(filename);
+#if defined(RUN_KOKKOS)
+    Kokkos::finalize(); // TODO DZP: should this be here? 
+#endif
 }
 
 

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -232,6 +232,29 @@ static const std::string VariantNames [] =
   std::string("RAJA_CUDA"),
 #endif
 
+#if defined(RUN_KOKKOS)
+#if defined(RUN_RAJA_SEQ)
+  std::string("Kokkos_Lambda_Seq"),
+  std::string("Kokkos_Functor_Seq"),
+#endif
+
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+  std::string("Kokkos_Lambda_OpenMP"),
+  std::string("Kokkos_Functor_OpenMP"),
+#endif
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)  
+  std::string("Kokkos_Lambda_OMPTarget"),
+  std::string("Kokkos_Functor_OMPTarget"),
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+  std::string("Kokkos_Lambda_CUDA"),
+  std::string("Kokkos_Functor_CUDA"),
+#endif
+
+#endif // RUN_KOKKOS
+
   std::string("Unknown Variant")  // Keep this at the end and DO NOT remove....
 
 }; // END VariantNames

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -15,6 +15,10 @@
 
 #include "RAJA/config.hpp"
 
+#if defined(RUN_KOKKOS)
+#include "Kokkos_Core.hpp"
+#endif
+
 #include <string>
 
 namespace rajaperf
@@ -203,6 +207,27 @@ enum VariantID {
   RAJA_CUDA,
 #endif
 
+#if defined(RUN_KOKKOS)
+#if defined(RUN_RAJA_SEQ)
+  Kokkos_Lambda_Seq,
+  Kokkos_Functor_Seq,
+#endif
+
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+  Kokkos_Lambda_OpenMP,
+  Kokkos_Functor_OpenMP,
+#endif
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)  
+  Kokkos_Lambda_OMPTarget,
+  Kokkos_Functor_OMPTarget,
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+  Kokkos_Lambda_CUDA,
+  Kokkos_Functor_CUDA,
+#endif
+#endif // RUN_KOKKOS
   NumVariants // Keep this one last and NEVER comment out (!!)
 
 };


### PR DESCRIPTION
Hey folks, I finally got a few free cycles, wanted to spin this up. Before I start going after all the kernels, I wanted to make sure that this methodology was kosher, don't merge this, but do let me know if the way it's done need work. 

Essentially, RAJA is always on, you have the option (default off) to enable Kokkos. Initialization and finalization of Kokkos happen as part of the Executor, and you get the following variants: `Kokkos_Lambda_[Model]` and `Kokkos_Functor_[Model]`. All Kokkos'isms are hidden behind `#if defined` blocks, and RAJA or the Perfsuite handle the memory management and such.

Obviously as we get past the Basic kernels, things might get a little trickier, but I think we can take those as we get to them.

If you notice any changes that should be made let me know, otherwise if you say it looks good to you I'll tackle the other kernels. Shockingly even with the "whimsical" Kokkos build system BLT just works, which was good news.