### PR TITLE
Feature/variant output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,34 @@ RAJA Performance Suite
 
 [![Build Status](https://travis-ci.org/LLNL/RAJAPerf.svg?branch=develop)](https://travis-ci.org/LLNL/RAJAPerf)
 
-The RAJA performance suite is developed to explore performance of loop-based 
-computational kernels found in HPC applications. Specifically, it
-is used to assess, monitor, and compare runtime performance of kernels 
-implemented using RAJA and variants implemented using standard or 
-vendor-supported parallel programming models directly. Each kernel in the 
-suite appears in multiple RAJA and non-RAJA (i.e., baseline) variants using 
-parallel programming models such as OpenMP and CUDA.
+The RAJA Performance Suite is designed to explore performance of loop-based 
+computational kernels found in HPC applications. Specifically, it can be
+used to assess and monitor runtime performance of kernels implemented using 
+[RAJA] C++ performance portability abstractions and compare those to variants 
+implemented using common parallel programming models, such as OpenMP and CUDA, 
+directly. Some important terminology used in the Suite includes:
 
-The kernels originate from various HPC benchmark suites and applications. 
-Kernels are partitioned into "groups" --  each group
-indicates the origin of its kernels, the algorithm patterns they represent, 
-etc. For example, the "Apps" group contains a collection of kernels extracted 
-from real scientific computing applications, the "Basic" group contains 
-kernels that are small and simple, but exhibit challenges for compiler 
-optimization, and so forth.
+  * `Kernel` is a distinct loop-based computation that appears in the Suite in
+    multiple variants, each of which performs the same computation. 
+  * `Variant` is a particular implementation of a kernel in the Suite, 
+    such as baseline OpenMP, RAJA OpenMP, etc.
+  * `Group` is a collection of kernels in the Suite that are grouped together
+    because they originate from the same source; e.g., benchmark suite.
+
+Each kernel in the Suite appears in multiple RAJA and non-RAJA (i.e., baseline)
+variants using parallel programming models that RAJA supports. The kernels 
+originate from various HPC benchmark suites and applications. For example,
+the "Stream" group contains kernels from the Babel Stream benchmark, the "Apps"
+group contains kernels extracted from real scientific computing applications,
+and so forth.
 
 * * *
 
 Table of Contents
 =================
 
-1. [Building the suite](#building-the-suite)
-2. [Running the suite](#running-the-suite)
+1. [Building the Suite](#building-the-suite)
+2. [Running the Suite](#running-the-suite)
 3. [Generated output](#generated-output)
 4. [Adding kernels and variants](#adding-kernels-and-variants)
 5. [Contributions](#contributions)
@@ -43,34 +48,34 @@ Table of Contents
 
 * * *
 
-# Building the suite
+# Building the Suite
 
-To build the suite, you must first obtain a copy of the code by cloning the
+To build the Suite, you must first obtain a copy of the code by cloning the
 source repository. For example,
 
 ```
 > mkdir RAJA-PERFSUITE
 > cd RAJA-PERFSUITE
 > git clone --recursive https://github.com/llnl/RAJAPerf.git
-> ls 
-RAJAPerf
 ```
 
-The Performance Suite has [RAJA] and the CMake-based [BLT] build system
-as Git submodules. The `--recursive` argument will clone the appropriate
-version of the submodules into the Performance Suite source code. So
-if you switch to a different branch, you will have to update the 
-submodules. For example,
+The repository will reside in a `RAJAPerf` directory in the directory into 
+which is was cloned.
+
+The Performance Suite has two Git submodules, [RAJA] and the CMake-based [BLT] 
+build system. The `--recursive` option tells Git to clone the submodules
+as well as any submodules that they use. If you switch to a different branch
+in the repository, you should update the submodules to make sure you have 
+the right versions of them. For example,
 
 ```
 > cd RAJAPerf
 > git checkout <some branch name>
-> git submodule init
 > git submodule update --recursive
 ```
 
-Note that the `--recursive` will update submodules within submodules, similar
-to usage with the `git clone` as described above.
+Note that the `--recursive` option will update submodules within submodules, 
+similar to usage with the `git clone` as described above.
 
 RAJA and the Performance Suite are built together using the same CMake
 configuration. For convenience, we include scripts in the `scripts`
@@ -84,13 +89,17 @@ compilers used. After CMake completes, enter the build directory and type
 `make` (or `make -j <N>` for a parallel build) to compile the code. For example,
 
 ```
-> ./scripts/blueos_nvcc8.0_clang-coral.sh
-> cd build_blueos_nvcc8.0_clang-coral
+> ./scripts/blueos_nvcc11_clang10.0.1.sh
+> cd build_blueos_nvcc11_clang10.0.1
 > make -j
 ```
 
+The build scripts and associated CMake `host-config` files in RAJA are 
+useful sources of information for building the Suite on various platforms.
+For example, they show how to enable specific back-end variants.
+
 You can also create your own build directory and run CMake with your own
-arguments from there; e.g., :
+options from there; e.g., :
 
 ```
 > mkdir my-build
@@ -101,8 +110,8 @@ arguments from there; e.g., :
 
 The provided configurations will only build the Performance Suite code by
 default; i.e., it will not build any RAJA test or example codes. If you
-want to build the RAJA tests for example and verify your build of RAJA is 
-working properly, just add the `-DENABLE_TESTS=On` option to CMake, either
+want to build the RAJA tests, for example, to verify your build of RAJA is 
+working properly, just pass the `-DENABLE_TESTS=On` option to CMake, either
 on the command line if you run CMake directly or edit the script you are 
 running to do this. Then, when the build completes, you can type `make test`
 to run the tests.
@@ -110,26 +119,24 @@ to run the tests.
 
 * * *
 
-# Running the suite
+# Running the Suite
 
-The suite is run by invoking the executable in the `bin` directory in the 
-build space. For example, giving it no options:
+The Suite is run by invoking the executable in the `bin` sub-directory in the 
+build space directory. For example, giving it no command line options:
 
 ```
 > ./bin/raja-perf.exe
 ```
 
-will run the entire suite (all kernels and variants) in their default 
+will run the entire Suite (all kernels and variants) in their default 
 configurations.
 
-The suite can be run in a variety of ways by passing options to the executable.
+The Suite can be run in a variety of ways by passing options to the executable.
 For example, you can run subsets of kernels by specifying variants, groups, or
-listing individual kernels explicitly. Other configuration options to set 
-problem sizes, number of kernel repetitions, etc. can also be specified. The 
-goal is to build the code once and use scripts or other mechanisms to run the 
-suite in different ways.
-
-Note: most options appear in a long or short form for ease of use.
+individual kernels explicitly. Other configuration options to set 
+problem sizes, number of times each kernel is run, etc. can also be specified. 
+The idea is that you  build the code once and use scripts or other mechanisms 
+to run the Suite in different ways for analyses you want to do.
 
 To see available options along with a brief description of each, pass the 
 `--help` or `-h` option:
@@ -144,57 +151,62 @@ or
 > ./bin/raja-perf.exe -h
 ```
 
-Lastly, the program will emit a summary of provided input if it is given 
+Lastly, the program will generate a summary of provided input if it is given 
 input that the code does not know how to parse. Hopefully, this will make it 
 easy for users to correct erroneous usage.
 
 # Important notes
 
+ * Some options appear in a single character short form for ease of use.
  * The OpenMP target offload variants of the kernels in the Suite are a 
-   work-in-progress. Depending on the compiler you have available, you 
-   may not be able to compile them. If you can build them, they will 
-   appear in an executable named `./bin/raja-perf-omptarget.exe` which is
-   distinct from the one named above. The build system will be reworked in 
-   the future so that the OpenMP target variants can be run from the same 
+   work-in-progress since the RAJA OpenMP target offload back-end is also
+   a work-in-progress. If you configure them to build, they will appear in 
+   an the executable `./bin/raja-perf-omptarget.exe` which is distinct from 
+   the one described above. At the time the OpenMP target offload variants were
+   developed, it was not possible for them to co-exist in the same executable
+   as the CUDA variants, for example. In the future, the build system may
+   be reworked so that the OpenMP target variants can be run from the same 
    executable as the other variants.
 
 * * *
 
 # Generated output
 
-Running the suite will generate several output files whose name starts with
-the specified file prefix in the specified  out put directory. If no such
-preferences are provided, files will be located in the current directory
-and be named `RAJAPerf*`.
+When the Suite is run, several output files are generated that contain 
+data describing the run. The file names start with the file prefix 
+provided via a command line option in the output directory, also specified
+on the command line. If no such options are provided, files will be located 
+in the current directory and be named `RAJAPerf-*`.
 
 Currently, there are up to four files generated:
 
-1. Timing -- execution time (sec.) of each loop kernel and variant
-2. Checksum -- checksum value from results of each loop kernel and variant
-3. Speedup -- runtime speedup of each loop kernel and variant with respect to reference variant. Reference variant can be set with command line option.
-4. Figure of Merit (FOM) -- basic statistics about speedup of RAJA variant vs. baseline for each programming model run. PASS/FAIL tolerance can be set with command line option.
+1. Timing -- execution time (sec.) of each loop kernel and variant run
+2. Checksum -- checksum values for each loop kernel and variant run to ensure they are producing the same results
+3. Speedup -- runtime speedup of each loop kernel and variant with respect to a reference variant. The reference variant can be set with a command line option. If not specified, the first variant run will be used as the reference. The reference variant used will be noted in the file.
+4. Figure of Merit (FOM) -- basic statistics about speedup of RAJA variant vs. baseline for each programming model run. Also, when a RAJA variant timing differs from the corresponding baseline variant timing by more than some tolerance, this will be noted in the file with `OVER_TOL`. By default the tolerance is 10%. This can be changed via a command line option.
 
 The name of each file is indicative of its contents. All files are text files. 
 Other than the checksum file, all are in 'csv' format for easy processing 
-by various tools.
+by tools and generating plots.
 
 * * *
 
 # Adding kernels and variants
 
-This section describes how to add new kernels and/or kernel variants to the
-RAJA Performance Suite. Group modifications are not required unless a new
-group is added. The information in this section also provides insight into 
-how the performance suite operates.
+This section describes how to add new kernels and/or variants to the Suite.
+Group modifications are not required unless a new group is added. The 
+information in this section also provides insight into how the performance 
+Suite operates.
 
 It is essential that the appropriate targets are updated in the appropriate
-`CMakeLists.txt` files when files are added to the suite.
+`CMakeLists.txt` files when files are added to the Suite so that they will
+be compiled.
 
 ## Adding a kernel
 
-Adding a new kernel to the suite involves three main steps:
+Adding a new kernel to the Suite involves three main steps:
 
-1. Add unique kernel ID and unique name to the suite. 
+1. Add a unique kernel ID and a unique kernel name to the Suite. 
 2. If the kernel is part of a new kernel group, also add a unique group ID and name for the group.
 3. Implement a kernel class that contains all operations needed to run it, with source files organized as described below.
 
@@ -204,25 +216,26 @@ These steps are described in the following sections.
 
 Two key pieces of information identify a kernel: the group in which it 
 resides and the name of the kernel itself. For concreteness, we describe
-how to add a kernel "Foo" that lives in the kernel group "Bar". The files 
-`RAJAPerfSuite.hpp` and `RAJAPerfSuite.cpp` define enumeration 
-values and arrays of string names for the kernels, respectively. 
+how to add a kernel "FOO" that lives in the kernel group "Basic". The files 
+`RAJAPerfSuite.hpp` and `RAJAPerfSuite.cpp` in the `src/common` directory
+define enumeration values and arrays of string names for the kernels, 
+respectively. 
 
 First, add an enumeration value identifier for the kernel, that is unique 
-among all kernels, in the enum 'KerneID' in the header file `RAJAPerfSuite.hpp`:
+among all kernels, in the enum 'KernelID' in the header file `RAJAPerfSuite.hpp`:
 
 ```cpp
 enum KernelID {
 ..
-  Bar_Foo,
+  Basic_FOO,
 ..
 };
 ```
 
 Note: the enumeration value for the kernel is the group name followed
 by the kernel name, separated by an underscore. It is important to follow
-this convention so that the kernel works with existing performance
-suite machinery. 
+this convention so that the kernel works properly with the Performance
+Suite machinery. 
 
 Second, add the kernel name to the array of strings 'KernelNames' in the file
 `RAJAPerfSuite.cpp`:
@@ -231,58 +244,66 @@ Second, add the kernel name to the array of strings 'KernelNames' in the file
 static const std::string KernelNames [] =
 {
 ..
-  std::string("Bar_Foo"),
+  std::string("Biasci_FOO"),
 ..
 };
 ```
 
 Note: the kernel string name is just a string version of the kernel ID.
-This convention must be followed so that the kernel works with existing 
-performance suite machinery. Also, the values in the KernelID enum and the
+This convention must be followed so that the kernel works properly with the
+Performance Suite machinery. Also, the values in the KernelID enum and the
 strings in the KernelNames array must be kept consistent (i.e., same order
 and matching one-to-one).
 
 
 ### Add new group if needed
 
-If a kernel is added as part of a new group of kernels in the suite, a
+If a kernel is added as part of a new group of kernels in the Suite, a
 new value must be added to the 'GroupID' enum in the header file 
 `RAJAPerfSuite.hpp` and an associated group string name must be added to
 the 'GroupNames' array of strings in the file `RAJAPerfSuite.cpp`. Again,
 the enumeration values and items in the string array must be kept
-consistent.
+consistent (same order and matching one-to-one).
 
 
 ### Add the kernel class
 
-Each kernel in the suite is implemented in a class whose header and 
+Each kernel in the Suite is implemented in a class whose header and 
 implementation files live in the directory named for the group
 in which the kernel lives. The kernel class is responsible for implementing
-all operations needed to manage data, execute and record execution timing and 
-result checksum information for each variant of the kernel. 
-To properly plug in to the Perf Suite framework, the kernel class must 
-inherit from the `KernelBase` base class that defines the interface for 
-a kernel in the suite.
+all operations needed to manage data, execute, and record execution timing and 
+checksum information for each variant of the kernel. To properly plug in to 
+the Performance Suite framework, the kernel class must be a subclass of the
+`KernelBase` base class that defines the interface for kernels in the Suite.
 
-Continuing with our example, we add a 'Foo' class header file 'Foo.hpp', 
+Continuing with our example, we add a 'FOO' class header file `FOO.hpp`, 
 and multiple implementation files described in the following sections: 
-  * 'Foo.cpp' contains the methods to setup and teardown the memory for the
-    'Foo kernel, and compute and record a checksum on the result after it 
-    executes;
-  * 'Foo-Seq.cpp' contains CPU variants of the kernel;
-  * 'Foo-OMP.cpp' contains OpenMP CPU multithreading variants of the kernel;
-  * 'Foo-Cuda.cpp' contains CUDA GPU variants of the kernel; and
-  * 'Foo-OMPTarget.cpp' contains OpenMP target offload variants of the kernel.
-
+  * `FOO.cpp` contains the methods to setup and teardown the memory for the
+    `FOO kernel, and compute and record a checksum on the result after it 
+    executes
+  * `FOO-Seq.cpp` contains sequential CPU variants of the kernel
+  * `FOO-OMP.cpp` contains OpenMP CPU multithreading variants of the kernel
+  * `FOO-OMPTarget.cpp` contains OpenMP target offload variants of the kernel
+  * `FOO-Cuda.cpp` contains CUDA GPU variants of the kernel
+  * `FOO-Hip.cpp` contains HIP GPU variants of the kernel
+  
+Note: if a new execution back-end variant is added that is not listed here,
+that variant should go in the file `FOO-<backend-name>.cpp`. Keeping the 
+back-end variants in separate files helps to understand compiler optimizations
+when looking at generated assembly code, for example.
 
 #### Kernel class header
 
-Here is what the header file for the Foo kernel object may look like:
+Here is what a header file for the FOO kernel object should look like:
 
 ```cpp
-#ifndef RAJAPerf_Bar_Foo_HXX
-#define RAJAPerf_Bar_Foo_HXX
-
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 ///
 /// Foo kernel reference implementation:
@@ -290,6 +311,8 @@ Here is what the header file for the Foo kernel object may look like:
 /// Describe it here...
 ///
 
+#ifndef RAJAPerf_Basic_FOO_HPP
+#define RAJAPerf_Basic_FOO_HPP
 
 #include "common/KernelBase.hpp"
 
@@ -297,16 +320,16 @@ namespace rajaperf
 {
 class RunParams; // Forward declaration for ctor arg.
 
-namespace bar   
+namespace basic   
 {
 
-class Foo : public KernelBase
+class FOO : public KernelBase
 {
 public:
 
-  Foo(const RunParams& params);
+  FOO(const RunParams& params);
 
-  ~Foo();
+  ~FOO();
 
   void setUp(VariantID vid);
   void updateChecksum(VariantID vid);
@@ -315,40 +338,41 @@ public:
   void runSeqVariant(VariantID vid);
   void runOpenMPVariant(VariantID vid);
   void runCudaVariant(VariantID vid);
+  void runHipVariant(VariantID vid);
   void runOpenMPTargetVariant(VariantID vid); 
 
 private:
-  // Kernel-specific data (pointers, scalars, etc.) used in kernel...
+  // Kernel-specific data (pointers, scalars, etc.) as needed...
 };
 
-} // end namespace bar
+} // end namespace basic
 } // end namespace rajaperf
 
 #endif // closing endif for header file include guard
 ```
 
 The kernel object header has a uniquely-named header file include guard and
-the class is nested within the 'rajaperf' and 'bar' namespaces. The 
+the class is nested within the 'rajaperf' and 'basic' namespaces. The 
 constructor takes a reference to a 'RunParams' object, which contains the
-input parameters for running the suite -- we'll say more about this later. 
-The seven methods that take a variant ID argument must be provided as they are
+input parameters for running the Suite -- we'll say more about this later. 
+The methods that take a variant ID argument must be provided as they are
 pure virtual in the KernelBase class. Their names are descriptive of what they
-do and we'll provide more details when we describe the class implementation
-next.
+do and we'll provide more details about them when we describe the class 
+implementation next.
 
 #### Kernel class implementation
 
-All kernels in the suite follow a similar implementation pattern for 
+Each kernel in the Suite follows a similar implementation pattern for 
 consistency and ease of analysis and understanding. Here, we describe several 
-steps and conventions that must be followed to ensure that all kernels 
-interact with the performance suite machinery in the same way:
+key steps and conventions that must be followed to ensure that all kernels 
+interact with the performance Suite machinery in the same way:
 
-1. Initialize the 'KernelBase' class object with KernelID, default size, and default repetition count in the `class constructor`.
-2. Implement data allocation and initialization operations for each kernel variant in the `setUp` method.
-3. Implement kernel execution for the associated variants in the `run` methods.
+1. Initialize the `KernelBase` class object with `KernelID` and `RunParams` object passed to the FOO class constructor.
+2. Set the default size, and default run repetition count in the FOO class constructor. Then, set the variants which are defined, also in the constructor.
+3. Implement data allocation and initialization operations for each kernel variant in the `setUp` method.
 4. Compute the checksum for each variant in the `updateChecksum` method.
 5. Deallocate and reset any data that will be allocated and/or initialized in subsequent kernel executions in the `tearDown` method.
-
+6. Implement kernel execution for the associated variants in the `run*Variant` methods in the proper source files.
 
 ##### Constructor and destructor
 
@@ -358,47 +382,56 @@ destructor must only perform operations that are non-specific to any kernel
 variant.
 
 The constructor must pass the kernel ID and RunParams object to the base
-class 'KernelBase' constructor. The body of the constructor must also call
+class `KernelBase` constructor. The body of the constructor must also call
 base class methods to set the default size for the iteration space of the 
 kernel (e.g., typically the number of loop iterations, but can be 
 kernel-dependent) and the number of times to repeat (i.e., execute) the kernel 
-with each pass through the suite to generate adequate timing information. 
-These values will be modified based on input parameters to define the actual 
-size and number of reps applied when the suite is run. Here is how this 
-typically looks:
+with each pass through the Suite to generate adequate timing information.
+Different kernel size and kernel repetition values may be applied when the 
+Suite is run based on input options provided. Also, the variants that are 
+defined in the kernel implementation must be specified in the constructor 
+so the Suite machinery knows what it has available to run.
+Here is how this typically looks:
 
 ```cpp
-Foo::Foo(const RunParams& params)
-  : Foo(rajaperf::Bar_Foo, params),
+FOO::FOO(const RunParams& params)
+  : KernelBase(rajaperf::Basic_Foo, params),
     // default initialization of class members
 {
-   setDefaultSize(100000);
-   setDefaultReps(1000);
+  setDefaultSize(100000);
+  setDefaultReps(1000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  // etc.
 }
 ```
 
 The class destructor doesn't have any requirements beyond freeing memory
-owned by the class object as needed.
+owned by the class object as needed. Typically, it is empty.
 
 ##### setUp() method
 
-The 'setUp()' method is responsible for allocating and initializing data 
+The `setUp()` method is responsible for allocating and initializing data 
 necessary to run the kernel for the variant specified by its variant ID 
 argument. For example, a baseline variant may have aligned data allocation
 to help enable SIMD optimizations, an OpenMP variant may initialize arrays
 following a pattern of "first touch" based on how memory and threads are 
-mapped to CPU cores, a CUDA variant may initialize data in host memory and 
-copy it into device memory, etc.
+mapped to CPU cores, a CUDA variant may initialize data in host memory, 
+which will be copied to device memory when a CUDA variant executes, etc.
 
 It is important to use the same data allocation and initialization operations
-for RAJA and non-RAJA variants that are related. Also, the state of all 
-input data for the kernel should be the same for all variants so that 
+for RAJA and non-RAJA variants that use the same back-end. Also, the state of 
+all input data for the kernel should be the same for all variants so that 
 checksums can be compared at the end of a run.
 
 Note: to simplify these operations and help ensure consistency, there exist 
 utility methods to allocate, initialize, deallocate, and copy data, and compute
-checksums defined in the `DataUtils.hpp` `CudaDataUtils.hpp`, and 
-`OpenMPTargetDataUtils.hpp` header files in the 'common' directory.
+checksums defined in the `DataUtils.hpp` `CudaDataUtils.hpp`,
+`OpenMPTargetDataUtils.hpp`, etc. header files in the 'common' directory.
 
 ##### run methods
 
@@ -419,15 +452,13 @@ void Foo::runSeqVariant(VariantID vid)
 
     case Base_Seq : {
 
-      // Declare data for baseline sequential variant of kernel...
-
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
          // Implementation of Base_Seq kernel variant...
+
       }
       stopTimer();
-
-      // ...
 
       break; 
     }
@@ -437,7 +468,9 @@ void Foo::runSeqVariant(VariantID vid)
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
         // Implementation of Lambda_Seq kernel variant... 
+
       }
       stopTimer();
 
@@ -448,7 +481,9 @@ void Foo::runSeqVariant(VariantID vid)
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
         // Implementation of RAJA_Seq kernel variant...
+
       }
       stopTimer();
 
@@ -467,21 +502,24 @@ void Foo::runSeqVariant(VariantID vid)
 All kernel implementation files are organized in this way. So following this
 pattern will keep all new additions consistent. 
 
-Note: As described earlier, there are five source files for each kernel.
-The reason for this is that it makes it easier to apply unique compiler flags 
-to different variants and to manage compilation and linking issues that arise 
-when some kernel variants are combined in the same translation unit.
+Important notes:
 
-Note: for convenience, we make heavy use of macros to define data 
-declarations and kernel bodies in the suite. This significantly reduces
-the amount of redundant code required to implement multiple variants
-of each kernel and make sure things are the same as much as possible. 
-The kernel class implementation files in the suite provide many examples of 
-the basic pattern we use.
+  * As mentioned earlier, there are multiple source files for each kernel.  
+    The reason for this is that it makes it easier to apply unique compiler 
+    flags to different variants and to manage compilation and linking issues 
+    that arise when some kernel variants are combined in the same translation 
+    unit.
+
+  * For convenience, we make heavy use of macros to define data declarations 
+    and kernel bodies in the Suite. While seemingly cryptic, this significantly
+    reduces the amount of redundant code required to implement multiple variants
+    for each kernel and make sure things are the same as much as possible. The 
+    kernel class implementation files in the Suite provide many examples of 
+    the basic pattern we use.
 
 ##### updateChecksum() method
 
-The 'updateChecksum()' method is responsible for adding the checksum
+The `updateChecksum()` method is responsible for adding the checksum
 for the current kernel (based on the data the kernel computes) to the 
 checksum value for the variant of the kernel just executed, which is held 
 in the KernelBase base class object. 
@@ -492,30 +530,30 @@ compared to help identify differences, and potentially errors, in
 implementations, compiler optimizations, programming model execution, etc.
 
 Note: to simplify checksum computations and help ensure consistency, there 
-are methods to compute checksums defined in the `DataUtils.hpp` header file 
-in the 'common' directory.
+are methods to compute checksums, a weighted sum of array values for example,
+are defined in the `DataUtils.hpp` header file in the `common` directory.
 
 ##### tearDown() method
 
-The 'tearDown()' method free and/or reset all kernel data that is
-allocated and/or initialized in the 'setUp' method execution to prepare for 
+The `tearDown()` method frees and/or resets all kernel data that is
+allocated and/or initialized in the `setUp()` method execution to prepare for 
 other kernel variants run subsequently.
 
 
 ### Add object construction operation
 
-The 'Executor' class object is responsible for creating kernel objects 
-for the kernels to be run based on the suite input options. To ensure a new
-kernel object will be created properly, add a call to its class constructor 
-based on its 'KernelID' in the 'getKernelObject()' method in the 
-`RAJAPerfSuite.cpp` file.
+The `Executor` class in the `common` directory is responsible for creating 
+kernel objects for the kernels to be run based on the Suite input options. 
+To ensure a new kernel object will be created properly, add a call to its 
+class constructor based on its `KernelID` in the `getKernelObject()` 
+method in the `RAJAPerfSuite.cpp` file.
 
   
 ## Adding a variant
 
 Each variant in the RAJA Performance Suite is identified by an enumeration
 value and a string name. Adding a new variant requires adding these two
-items similar to adding a kernel as described above. 
+items similarly to adding those for a kernel as described above. 
 
 ### Add the variant ID and name
 
@@ -544,8 +582,8 @@ static const std::string VariantNames [] =
 ```
 
 Note that the variant string name is just a string version of the variant ID.
-This convention must be followed so that the variant works with existing
-performance suite machinery. Also, the values in the VariantID enum and the
+This convention must be followed so that the variant works properly with the
+Performance Suite machinery. Also, the values in the VariantID enum and the
 strings in the VariantNames array must be kept consistent (i.e., same order
 and matching one-to-one).
 
@@ -553,26 +591,30 @@ and matching one-to-one).
 
 In the classes containing kernels to which the new variant applies, 
 add implementations for the variant in the setup, kernel execution, 
-checksum computation, and teardown methods. These operations are described
-in earlier sections for adding a new kernel above.
+checksum computation, and teardown methods as needed. Also, make sure to 
+define the variant for those kernels in the kernel class constructors by 
+calling `setVariantDefined(NewVariant)` so that the variant can be run. 
+These operations are described in earlier sections for adding a new kernel 
+above.
 
 * * *
 
 # Contributions
 
-The RAJA Performance Suite is intended to be a work-in-progress, with new
-kernels and variants added over time. We encourage interested parties to 
-contribute to it so that C++ compiler optimizations and support for programming
-models like RAJA continue to improve. 
+The RAJA Performance Suite is a work-in-progress, with new kernels and variants 
+added over time as new features and back-end support are developed in RAJA. 
+We encourage interested parties to contribute to it so that C++ compiler 
+optimizations and support for programming models like RAJA continue to improve. 
 
-The Suite developers follow the [GitFlow](http://nvie.com/posts/a-successful-git-branching-model/) development model. Folks wishing to contribute to the Suite, should include their work in a feature branch created from the RAJA `develop` 
-branch. Then, create a pull request with the `develop` branch as the 
+The Suite developers follow the [GitFlow](http://nvie.com/posts/a-successful-git-branching-model/) development model. Folks wishing to contribute to the Suite,
+should include their work in a feature branch created from the Performance Suite 
+`develop` branch. Then, create a pull request with the `develop` branch as the 
 destination when it is ready to be reviewed. The `develop` branch contains the 
 latest work in RAJA Performance Suite. Periodically, we will merge the
 develop branch into the `main` branch and tag a new release.
 
-If you would like to contribute to the RAJA Performance Suitea, or have 
-questions about doing so, please contact one of its developers. See below.
+If you would like to contribute to the RAJA Performance Suite, or have 
+questions about doing so, please contact the primary developer listed  below.
 
 * * *
 

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -28,6 +28,23 @@ DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
   m_domain = new ADomain(getRunSize(), /* ndims = */ 2);
 
   m_array_length = m_domain->nnalls;
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 DEL_DOT_VEC_2D::~DEL_DOT_VEC_2D() 

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -23,6 +23,23 @@ ENERGY::ENERGY(const RunParams& params)
 {
   setDefaultSize(100000);
   setDefaultReps(1300);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 ENERGY::~ENERGY() 

--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -25,6 +25,23 @@ FIR::FIR(const RunParams& params)
   setDefaultReps(1600);
 
   m_coefflen = FIR_COEFFLEN;
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 FIR::~FIR() 

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -29,6 +29,23 @@ LTIMES::LTIMES(const RunParams& params)
   setDefaultSize(m_num_d_default * m_num_m_default * 
                  m_num_g_default * m_num_z_default);
   setDefaultReps(50);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 LTIMES::~LTIMES() 

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -29,6 +29,23 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   setDefaultSize(m_num_d_default * m_num_m_default * 
                  m_num_g_default * m_num_z_default);
   setDefaultReps(50);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 LTIMES_NOVIEW::~LTIMES_NOVIEW() 

--- a/src/apps/PRESSURE.cpp
+++ b/src/apps/PRESSURE.cpp
@@ -23,6 +23,23 @@ PRESSURE::PRESSURE(const RunParams& params)
 {
   setDefaultSize(100000);
   setDefaultReps(7000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 PRESSURE::~PRESSURE() 

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -27,7 +27,24 @@ VOL3D::VOL3D(const RunParams& params)
 
   m_domain = new ADomain(getRunSize(), /* ndims = */ 3);
 
-  m_array_length = m_domain->nnalls;;
+  m_array_length = m_domain->nnalls;
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 VOL3D::~VOL3D() 

--- a/src/basic/ATOMIC_PI.cpp
+++ b/src/basic/ATOMIC_PI.cpp
@@ -21,8 +21,25 @@ namespace basic
 ATOMIC_PI::ATOMIC_PI(const RunParams& params)
   : KernelBase(rajaperf::Basic_ATOMIC_PI, params)
 {
-   setDefaultSize(3000);
-   setDefaultReps(10000);
+  setDefaultSize(3000);
+  setDefaultReps(10000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 ATOMIC_PI::~ATOMIC_PI() 

--- a/src/basic/DAXPY.cpp
+++ b/src/basic/DAXPY.cpp
@@ -21,8 +21,25 @@ namespace basic
 DAXPY::DAXPY(const RunParams& params)
   : KernelBase(rajaperf::Basic_DAXPY, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(5000);
+  setDefaultSize(100000);
+  setDefaultReps(5000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 DAXPY::~DAXPY() 

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -21,8 +21,25 @@ namespace basic
 IF_QUAD::IF_QUAD(const RunParams& params)
   : KernelBase(rajaperf::Basic_IF_QUAD, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(1800);
+  setDefaultSize(100000);
+  setDefaultReps(1800);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 IF_QUAD::~IF_QUAD() 

--- a/src/basic/INIT3.cpp
+++ b/src/basic/INIT3.cpp
@@ -21,8 +21,25 @@ namespace basic
 INIT3::INIT3(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT3, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(5000);
+  setDefaultSize(100000);
+  setDefaultReps(5000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 INIT3::~INIT3() 

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -21,8 +21,25 @@ namespace basic
 INIT_VIEW1D::INIT_VIEW1D(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT_VIEW1D, params)
 {
-   setDefaultSize(500000);
-   setDefaultReps(5000);
+  setDefaultSize(500000);
+  setDefaultReps(5000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 INIT_VIEW1D::~INIT_VIEW1D() 

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -21,8 +21,25 @@ namespace basic
 INIT_VIEW1D_OFFSET::INIT_VIEW1D_OFFSET(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT_VIEW1D_OFFSET, params)
 {
-   setDefaultSize(500000);
-   setDefaultReps(5000);
+  setDefaultSize(500000);
+  setDefaultReps(5000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 INIT_VIEW1D_OFFSET::~INIT_VIEW1D_OFFSET() 

--- a/src/basic/MULADDSUB.cpp
+++ b/src/basic/MULADDSUB.cpp
@@ -21,8 +21,25 @@ namespace basic
 MULADDSUB::MULADDSUB(const RunParams& params)
   : KernelBase(rajaperf::Basic_MULADDSUB, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(3500);
+  setDefaultSize(100000);
+  setDefaultReps(3500);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 MULADDSUB::~MULADDSUB() 

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -30,6 +30,23 @@ NESTED_INIT::NESTED_INIT(const RunParams& params)
 
   setDefaultSize(m_ni * m_nj * m_nk);
   setDefaultReps(100);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 NESTED_INIT::~NESTED_INIT() 

--- a/src/basic/REDUCE3_INT.cpp
+++ b/src/basic/REDUCE3_INT.cpp
@@ -23,11 +23,28 @@ namespace basic
 REDUCE3_INT::REDUCE3_INT(const RunParams& params)
   : KernelBase(rajaperf::Basic_REDUCE3_INT, params)
 {
-   setDefaultSize(1000000);
-// setDefaultReps(5000);
+  setDefaultSize(1000000);
+//setDefaultReps(5000);
 // Set reps to low value until we resolve RAJA omp-target 
 // reduction performance issues
-   setDefaultReps(100);
+  setDefaultReps(100);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 REDUCE3_INT::~REDUCE3_INT() 

--- a/src/basic/TRAP_INT.cpp
+++ b/src/basic/TRAP_INT.cpp
@@ -21,8 +21,25 @@ namespace basic
 TRAP_INT::TRAP_INT(const RunParams& params)
   : KernelBase(rajaperf::Basic_TRAP_INT, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(2000);
+  setDefaultSize(100000);
+  setDefaultReps(2000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 TRAP_INT::~TRAP_INT() 

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -56,10 +56,10 @@ void Executor::setupSuite()
 
   cout << "\nSetting up suite based on input..." << endl;
 
-  typedef list<string> Slist;
-  typedef vector<string> Svector;
-  typedef set<KernelID> KIDset;
-  typedef set<VariantID> VIDset;
+  using Slist = list<string>;
+  using Svector = vector<string>;
+  using KIDset = set<KernelID>;
+  using VIDset = set<VariantID>;
 
   //
   // Determine which kernels to execute from input.
@@ -146,6 +146,18 @@ void Executor::setupSuite()
 
 
   //
+  // Assemble set of available variants to run 
+  // (based on compile-time configuration).
+  //
+  VIDset available_var;
+  for (size_t iv = 0; iv < NumVariants; ++iv) {
+    VariantID vid = static_cast<VariantID>(iv);
+    if ( isVariantAvailable( vid ) ) {
+       available_var.insert( vid );
+    }
+  }
+
+  //
   // Determine variants to execute from input.
   // run_var will be non-duplicated ordered set of IDs of variants to run.
   //
@@ -156,11 +168,12 @@ void Executor::setupSuite()
   if ( variant_input.empty() ) {
 
     //
-    // No variants specified in input options, run them all.
+    // No variants specified in input options, run all available.
     // Also, set reference variant if specified.
     //
-    for (size_t iv = 0; iv < NumVariants; ++iv) {
-      VariantID vid = static_cast<VariantID>(iv);
+    for (VIDset::iterator vid_it = available_var.begin();
+         vid_it != available_var.end(); ++vid_it) {
+      VariantID vid = *vid_it;
       run_var.insert( vid );
       if ( getVariantName(vid) == run_params.getReferenceVariant() ) {
         reference_vid = vid;
@@ -170,46 +183,47 @@ void Executor::setupSuite()
     //
     // Set reference variant if not specified.
     //
-    if ( run_params.getReferenceVariant().empty() ) {
-      reference_vid = VariantID::Base_Seq;
+    if ( run_params.getReferenceVariant().empty() && !run_var.empty() ) {
+      reference_vid = *run_var.begin();
     }
 
   } else {
 
     //
-    // Add reference variant to run variants if specified
-    //
-    for (size_t iv = 0; iv < NumVariants; ++iv) {
-      VariantID vid = static_cast<VariantID>(iv);
-      if ( getVariantName(vid) == run_params.getReferenceVariant() ) {
-        run_var.insert(vid);
-        reference_vid = vid; 
-      }
-    }
-
-    //
-    // Need to parse input to determine which variants to run
+    // Parse input to determine which variants to run:
+    //   - variants to run will be the intersection of available variants
+    //     and those specified in input
+    //   - reference variant will be set to specified input if available
+    //     and variant will be run; else first variant that will be run.
     // 
-
-    //
-    // Search input for matching variant names.
-    //
     // Assemble invalid input for warning message.
     //
+
     Svector invalid;
 
     for (size_t it = 0; it < variant_input.size(); ++it) {
       bool found_it = false;
 
-      for (size_t iv = 0; iv < NumVariants && !found_it; ++iv) {
-        VariantID vid = static_cast<VariantID>(iv);
+      for (VIDset::iterator vid_it = available_var.begin();
+         vid_it != available_var.end(); ++vid_it) {
+        VariantID vid = *vid_it;
         if ( getVariantName(vid) == variant_input[it] ) {
           run_var.insert(vid);
+          if ( getVariantName(vid) == run_params.getReferenceVariant() ) {
+            reference_vid = vid;
+          }
           found_it = true;
         }
       }
 
       if ( !found_it )  invalid.push_back(variant_input[it]);
+    }
+
+    //
+    // Set reference variant if not specified.
+    //
+    if ( run_params.getReferenceVariant().empty() && !run_var.empty() ) {
+      reference_vid = *run_var.begin();
     }
 
     run_params.setInvalidVariantInput(invalid);
@@ -316,7 +330,7 @@ void Executor::reportRunSummary(ostream& str) const
     str << "\t Kernel rep factor = " << run_params.getRepFactor() << endl;
     str << "\t Output files will be named " << ofiles << endl;
 
-    str << "\nThe following kernels and variants will be run:\n"; 
+    str << "\nThe following kernels and variants (when available) will be run:\n"; 
 
     str << "\nVariants"
         << "\n--------\n";
@@ -346,15 +360,23 @@ void Executor::runSuite()
     return;
   }
 
-  cout << "\n\nRunning warmup kernel variants...\n";
+  cout << "\n\nRun warmup kernel...\n";
 
   KernelBase* warmup_kernel = new basic::DAXPY(run_params);
 
   for (size_t iv = 0; iv < variant_ids.size(); ++iv) {
+    VariantID vid = variant_ids[iv];
     if ( run_params.showProgress() ) {
-      cout << "Warmup Kernel " <<  getVariantName(variant_ids[iv]) << endl;
+      if ( warmup_kernel->hasVariantToRun(vid) ) {
+        cout << "   Running ";
+      } else {
+        cout << "   No ";
+      }
+      cout << getVariantName(vid) << " variant" << endl;
     }
-    warmup_kernel->execute( variant_ids[iv] );
+    if ( warmup_kernel->hasVariantToRun(vid) ) {
+      warmup_kernel->execute(vid);
+    }
   }
 
   delete warmup_kernel;
@@ -371,15 +393,23 @@ void Executor::runSuite()
     for (size_t ik = 0; ik < kernels.size(); ++ik) {
       KernelBase* kernel = kernels[ik];
       if ( run_params.showProgress() ) {
-        std::cout << "\n   Running kernel -- " << kernel->getName() << "\n"; 
+        std::cout << "\nRun kernel -- " << kernel->getName() << "\n"; 
       }
 
       for (size_t iv = 0; iv < variant_ids.size(); ++iv) {
+         VariantID vid = variant_ids[iv];
          KernelBase* kern = kernels[ik];
          if ( run_params.showProgress() ) {
-           cout << kern->getName() << " " <<  getVariantName(variant_ids[iv]) << endl;
-         }  
-         kernels[ik]->execute( variant_ids[iv] );
+           if ( kern->hasVariantToRun(vid) ) {
+             cout << "   Running ";
+           } else {
+             cout << "   No ";
+           }
+           cout << getVariantName(vid) << " variant" << endl;
+         }
+         if ( kern->hasVariantToRun(vid) ) {
+           kernels[ik]->execute(vid);
+         }
       } // loop over variants 
 
     } // loop over kernels
@@ -483,8 +513,18 @@ void Executor::writeCSVReport(const string& filename, CSVRepMode mode,
       file <<left<< setw(kercol_width) << kern->getName();
       for (size_t iv = 0; iv < variant_ids.size(); ++iv) {
         VariantID vid = variant_ids[iv];
-        file << sepchr <<right<< setw(varcol_width[iv]) << setprecision(prec) 
-             << std::fixed << getReportDataEntry(mode, kern, vid);
+        file << sepchr <<right<< setw(varcol_width[iv]);
+        if ( (mode == CSVRepMode::Speedup) &&
+             (!kern->hasVariantToRun(reference_vid) || 
+              !kern->hasVariantToRun(vid)) ) {
+          file << "Not run";
+        } else if ( (mode == CSVRepMode::Timing) && 
+                    !kern->hasVariantToRun(vid) ) {
+          file << "Not run";
+        } else {
+          file << setprecision(prec) << std::fixed 
+               << getReportDataEntry(mode, kern, vid);
+        }
       }
       file << endl;
     }
@@ -809,7 +849,12 @@ void Executor::writeChecksumReport(const string& filename)
                << showpoint << setprecision(prec) 
                <<left<< setw(checksum_width) << vcheck_sum
                <<left<< setw(checksum_width) << diff << endl;
+        } else {
+          file <<left<< setw(namecol_width) << getVariantName(vid) 
+               <<left<< setw(checksum_width) << "Not Run" 
+               <<left<< setw(checksum_width) << "Not Run" << endl;
         }
+
       }
 
       file << endl;
@@ -855,8 +900,13 @@ long double Executor::getReportDataEntry(CSVRepMode mode,
     }
     case CSVRepMode::Speedup : { 
       if ( haveReferenceVariant() ) {
-        retval = kern->getTotTime(reference_vid) / kern->getTotTime(vid);
-#if 0 // RDH DEBUG
+        if ( kern->hasVariantToRun(reference_vid) && 
+             kern->hasVariantToRun(vid) ) {
+          retval = kern->getTotTime(reference_vid) / kern->getTotTime(vid);
+        } else {
+          retval = 0.0;
+        }
+#if 0 // RDH DEBUG  (leave this here, it's useful for debugging!)
         cout << "Kernel(iv): " << kern->getName() << "(" << vid << ")" << endl;
         cout << "\tref_time, tot_time, retval = " 
              << kern->getTotTime(reference_vid) << " , "
@@ -902,7 +952,7 @@ void Executor::getFOMGroups(vector<FOMGroup>& fom_groups)
 
   }  // iterate over variant ids to run
 
-#if 0 // RDH for debugging...
+#if 0 //  RDH DEBUG   (leave this here, it's useful for debugging!)
   cout << "\nFOMGroups..." << endl;
   for (size_t ifg = 0; ifg < fom_groups.size(); ++ifg) {
     const FOMGroup& group = fom_groups[ifg];

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -23,11 +23,12 @@ KernelBase::KernelBase(KernelID kid, const RunParams& params)
     running_variant(NumVariants)
 {
   for (size_t ivar = 0; ivar < NumVariants; ++ivar) {
+     checksum[ivar] = 0.0;
      num_exec[ivar] = 0;
      min_time[ivar] = std::numeric_limits<double>::max();
      max_time[ivar] = -std::numeric_limits<double>::max();
      tot_time[ivar] = 0.0;
-     checksum[ivar] = 0.0;
+     has_variant_to_run[ivar] = false;
   }
 }
 
@@ -49,6 +50,11 @@ Index_type KernelBase::getRunReps() const
   } else {
     return static_cast<Index_type>(default_reps*run_params.getRepFactor()); 
   } 
+}
+
+void KernelBase::setVariantDefined(VariantID vid) 
+{
+  has_variant_to_run[vid] = isVariantAvailable(vid); 
 }
 
 
@@ -82,58 +88,64 @@ void KernelBase::recordExecTime()
 
 void KernelBase::runKernel(VariantID vid)
 {
+  if ( !has_variant_to_run[vid] ) {
+    return;
+  }
+
   switch ( vid ) {
 
     case Base_Seq :
-#if defined(RUN_RAJA_SEQ)
     case Lambda_Seq :
     case RAJA_Seq :
-#endif
     {
+#if defined(RUN_RAJA_SEQ)
       runSeqVariant(vid);
+#endif
       break;
     }
 
-#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
     case Base_OpenMP :
     case Lambda_OpenMP :
     case RAJA_OpenMP :
     {
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
       runOpenMPVariant(vid);
+#endif
       break;
     }
-#endif
 
-#if defined(RAJA_ENABLE_TARGET_OPENMP)
     case Base_OpenMPTarget :
     case RAJA_OpenMPTarget :
     {
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
       runOpenMPTargetVariant(vid);
+#endif
       break;
     }
-#endif
 
-#if defined(RAJA_ENABLE_CUDA)
     case Base_CUDA :
     case RAJA_CUDA :
     {
+#if defined(RAJA_ENABLE_CUDA)
       runCudaVariant(vid);
+#endif
       break;
     }
-#endif
 
-#if defined(RAJA_ENABLE_HIP)
     case Base_HIP :
     case RAJA_HIP :
     {
+#if defined(RAJA_ENABLE_HIP)
       runHipVariant(vid);
+#endif
       break;
     }
-#endif
 
     default : {
+#if 0
       std::cout << "\n  " << getName() 
                 << " : Unknown variant id = " << vid << std::endl;
+#endif
     }
 
   }

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -58,6 +58,10 @@ public:
   double getTotTime(VariantID vid) { return tot_time[vid]; }
   Checksum_type getChecksum(VariantID vid) const { return checksum[vid]; }
 
+  bool hasVariantToRun(VariantID vid) const { return has_variant_to_run[vid]; }
+
+  void setVariantDefined(VariantID vid);
+
   void execute(VariantID vid);
 
   void startTimer() 
@@ -122,16 +126,9 @@ public:
 #endif
 
 protected:
-  int num_exec[NumVariants];
-
   const RunParams& run_params;
 
-  RAJA::Timer::ElapsedType min_time[NumVariants];
-  RAJA::Timer::ElapsedType max_time[NumVariants];
-  RAJA::Timer::ElapsedType tot_time[NumVariants];
-
   Checksum_type checksum[NumVariants];
-
 
 private:
   KernelBase() = delete;
@@ -141,12 +138,20 @@ private:
   KernelID    kernel_id;
   std::string name;
 
-  RAJA::Timer timer;
-
   Index_type default_size;
   Index_type default_reps;
 
   VariantID running_variant; 
+
+  int num_exec[NumVariants];
+
+  RAJA::Timer timer;
+
+  RAJA::Timer::ElapsedType min_time[NumVariants];
+  RAJA::Timer::ElapsedType max_time[NumVariants];
+  RAJA::Timer::ElapsedType tot_time[NumVariants];
+
+  bool has_variant_to_run[NumVariants];
 };
 
 }  // closing brace for rajaperf namespace

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -211,31 +211,21 @@ static const std::string VariantNames [] =
 {
 
   std::string("Base_Seq"),
-#if defined(RUN_RAJA_SEQ)
   std::string("Lambda_Seq"),
   std::string("RAJA_Seq"),
-#endif
 
-#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
   std::string("Base_OpenMP"),
   std::string("Lambda_OpenMP"),
   std::string("RAJA_OpenMP"),
-#endif
 
-#if defined(RAJA_ENABLE_TARGET_OPENMP)  
   std::string("Base_OMPTarget"),
   std::string("RAJA_OMPTarget"),
-#endif
 
-#if defined(RAJA_ENABLE_CUDA)
   std::string("Base_CUDA"),
   std::string("RAJA_CUDA"),
-#endif
 
-#if defined(RAJA_ENABLE_HIP)
   std::string("Base_HIP"),
   std::string("RAJA_HIP"),
-#endif
 
   std::string("Unknown Variant")  // Keep this at the end and DO NOT remove....
 
@@ -245,7 +235,7 @@ static const std::string VariantNames [] =
 /*
  *******************************************************************************
  *
- * \brief Return group name associated with GroupID enum value.
+ * Return group name associated with GroupID enum value.
  *
  *******************************************************************************
  */
@@ -258,7 +248,7 @@ const std::string& getGroupName(GroupID sid)
 /*
  *******************************************************************************
  *
- * \brief Return kernel name associated with KernelID enum value.
+ * Return kernel name associated with KernelID enum value.
  *
  *******************************************************************************
  */
@@ -273,7 +263,7 @@ std::string getKernelName(KernelID kid)
 /*
  *******************************************************************************
  *
- * \brief Return full kernel name associated with KernelID enum value.
+ * Return full kernel name associated with KernelID enum value.
  *
  *******************************************************************************
  */
@@ -286,13 +276,67 @@ const std::string& getFullKernelName(KernelID kid)
 /*
  *******************************************************************************
  *
- * \brief Return variant name associated with VariantID enum value.
+ * Return variant name associated with VariantID enum value.
  *
  *******************************************************************************
  */
 const std::string& getVariantName(VariantID vid)
 {
   return VariantNames[vid];
+}
+
+/*!
+ *******************************************************************************
+ *
+ * Return true if variant associated with VariantID enum value is available 
+ * to run; else false.
+ *
+ *******************************************************************************
+ */
+bool isVariantAvailable(VariantID vid)
+{
+  bool ret_val = false;
+
+  if ( vid == Base_Seq ) {
+    ret_val = true;
+  }
+#if defined(RUN_RAJA_SEQ)
+  if ( vid == Lambda_Seq || 
+       vid == RAJA_Seq ) {
+    ret_val = true;
+  }
+#endif
+
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+  if ( vid == Base_OpenMP || 
+       vid == Lambda_OpenMP || 
+       vid == RAJA_OpenMP ) {
+    ret_val = true;
+  }
+#endif
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+  if ( vid == Base_OpenMPTarget || 
+       vid == RAJA_OpenMPTarget ) {
+    ret_val = true;
+  }
+#endif
+
+#if defined(RAJA_ENABLE_CUDA)
+  if ( vid == Base_CUDA || 
+       vid == RAJA_CUDA ) {
+    ret_val = true;
+  }
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+  if ( vid == Base_HIP || 
+       vid == RAJA_HIP ) {
+    ret_val = true;
+  }
+#endif
+
+  return ret_val;
 }
 
 /*

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -182,31 +182,21 @@ enum KernelID {
 enum VariantID {
 
   Base_Seq = 0,
-#if defined(RUN_RAJA_SEQ)
   Lambda_Seq,
   RAJA_Seq,
-#endif
 
-#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
   Base_OpenMP,
   Lambda_OpenMP,
   RAJA_OpenMP,
-#endif
 
-#if defined(RAJA_ENABLE_TARGET_OPENMP)  
   Base_OpenMPTarget,
   RAJA_OpenMPTarget,
-#endif
 
-#if defined(RAJA_ENABLE_CUDA)
   Base_CUDA,
   RAJA_CUDA,
-#endif
 
-#if defined(RAJA_ENABLE_HIP)
   Base_HIP,
   RAJA_HIP,
-#endif
 
   NumVariants // Keep this one last and NEVER comment out (!!)
 
@@ -252,6 +242,16 @@ const std::string& getFullKernelName(KernelID kid);
  *******************************************************************************
  */
 const std::string& getVariantName(VariantID vid); 
+
+/*!
+ *******************************************************************************
+ *
+ * \brief Return true if variant associated with VariantID enum value is 
+ *        available * to run; else false.
+ *
+ *******************************************************************************
+ */
+bool isVariantAvailable(VariantID vid);
 
 /*!
  *******************************************************************************

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -8,8 +8,6 @@
 
 #include "RunParams.hpp"
 
-#include "RAJAPerfSuite.hpp"
-
 #include <cstdlib>
 #include <cstdio>
 #include <iostream>

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -13,8 +13,7 @@
 #include <vector>
 #include <iosfwd>
 
-
-#include "common/DataUtils.hpp"
+#include "RAJAPerfSuite.hpp"
 
 namespace rajaperf
 {

--- a/src/lcals/DIFF_PREDICT.cpp
+++ b/src/lcals/DIFF_PREDICT.cpp
@@ -21,8 +21,25 @@ namespace lcals
 DIFF_PREDICT::DIFF_PREDICT(const RunParams& params)
   : KernelBase(rajaperf::Lcals_DIFF_PREDICT, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(2000);
+  setDefaultSize(100000);
+  setDefaultReps(2000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 DIFF_PREDICT::~DIFF_PREDICT() 

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -21,8 +21,25 @@ namespace lcals
 EOS::EOS(const RunParams& params)
   : KernelBase(rajaperf::Lcals_EOS, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(5000);
+  setDefaultSize(100000);
+  setDefaultReps(5000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 EOS::~EOS() 

--- a/src/lcals/FIRST_DIFF.cpp
+++ b/src/lcals/FIRST_DIFF.cpp
@@ -21,8 +21,25 @@ namespace lcals
 FIRST_DIFF::FIRST_DIFF(const RunParams& params)
   : KernelBase(rajaperf::Lcals_FIRST_DIFF, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(16000);
+  setDefaultSize(100000);
+  setDefaultReps(16000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 FIRST_DIFF::~FIRST_DIFF() 

--- a/src/lcals/FIRST_MIN.cpp
+++ b/src/lcals/FIRST_MIN.cpp
@@ -21,11 +21,28 @@ namespace lcals
 FIRST_MIN::FIRST_MIN(const RunParams& params)
   : KernelBase(rajaperf::Lcals_FIRST_MIN, params)
 {
-   setDefaultSize(1000000);
-// setDefaultReps(1000);
+  setDefaultSize(1000000);
+//setDefaultReps(1000);
 // Set reps to low value until we resolve RAJA omp-target
 // reduction performance issues
-   setDefaultReps(100);
+  setDefaultReps(100);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 FIRST_MIN::~FIRST_MIN() 

--- a/src/lcals/FIRST_SUM.cpp
+++ b/src/lcals/FIRST_SUM.cpp
@@ -21,8 +21,25 @@ namespace lcals
 FIRST_SUM::FIRST_SUM(const RunParams& params)
   : KernelBase(rajaperf::Lcals_FIRST_SUM, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(16000);
+  setDefaultSize(100000);
+  setDefaultReps(16000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP ); 
 }
 
 FIRST_SUM::~FIRST_SUM() 

--- a/src/lcals/GEN_LIN_RECUR.cpp
+++ b/src/lcals/GEN_LIN_RECUR.cpp
@@ -21,8 +21,25 @@ namespace lcals
 GEN_LIN_RECUR::GEN_LIN_RECUR(const RunParams& params)
   : KernelBase(rajaperf::Lcals_GEN_LIN_RECUR, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(5000);
+  setDefaultSize(100000);
+  setDefaultReps(5000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 GEN_LIN_RECUR::~GEN_LIN_RECUR() 

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -21,8 +21,25 @@ namespace lcals
 HYDRO_1D::HYDRO_1D(const RunParams& params)
   : KernelBase(rajaperf::Lcals_HYDRO_1D, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(12500);
+  setDefaultSize(100000);
+  setDefaultReps(12500);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 HYDRO_1D::~HYDRO_1D() 

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -21,14 +21,31 @@ namespace lcals
 HYDRO_2D::HYDRO_2D(const RunParams& params)
   : KernelBase(rajaperf::Lcals_HYDRO_2D, params)
 {
-   m_jn = 1000;
-   m_kn = 1000;
+  m_jn = 1000;
+  m_kn = 1000;
 
-   m_s = 0.0041;
-   m_t = 0.0037;
+  m_s = 0.0041;
+  m_t = 0.0037;
 
-   setDefaultSize(m_jn);
-   setDefaultReps(200);
+  setDefaultSize(m_jn);
+  setDefaultReps(200);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 HYDRO_2D::~HYDRO_2D() 

--- a/src/lcals/INT_PREDICT.cpp
+++ b/src/lcals/INT_PREDICT.cpp
@@ -21,8 +21,25 @@ namespace lcals
 INT_PREDICT::INT_PREDICT(const RunParams& params)
   : KernelBase(rajaperf::Lcals_INT_PREDICT, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(4000);
+  setDefaultSize(100000);
+  setDefaultReps(4000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 INT_PREDICT::~INT_PREDICT() 

--- a/src/lcals/PLANCKIAN.cpp
+++ b/src/lcals/PLANCKIAN.cpp
@@ -21,8 +21,25 @@ namespace lcals
 PLANCKIAN::PLANCKIAN(const RunParams& params)
   : KernelBase(rajaperf::Lcals_PLANCKIAN, params)
 {
-   setDefaultSize(100000);
-   setDefaultReps(460);
+  setDefaultSize(100000);
+  setDefaultReps(460);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 PLANCKIAN::~PLANCKIAN() 

--- a/src/lcals/TRIDIAG_ELIM.cpp
+++ b/src/lcals/TRIDIAG_ELIM.cpp
@@ -21,8 +21,25 @@ namespace lcals
 TRIDIAG_ELIM::TRIDIAG_ELIM(const RunParams& params)
   : KernelBase(rajaperf::Lcals_TRIDIAG_ELIM, params)
 {
-   setDefaultSize(200000);
-   setDefaultReps(5000);
+  setDefaultSize(200000);
+  setDefaultReps(5000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 TRIDIAG_ELIM::~TRIDIAG_ELIM() 

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -54,6 +54,23 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
 
   m_alpha = 1.5;
   m_beta = 1.2;
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_2MM::~POLYBENCH_2MM() 

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -51,6 +51,23 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
 
   setDefaultSize(m_ni*m_nj*(1+m_nk) + m_nj*m_nl*(1+m_nm) + m_ni*m_nl*(1+m_nj));
   setDefaultReps(m_run_reps);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_3MM::~POLYBENCH_3MM() 

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -48,8 +48,26 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
       run_reps = 20;
       break;
   }
+
   setDefaultSize( m_tsteps * 2*m_n*(m_n+m_n) );
   setDefaultReps(run_reps);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_ADI::~POLYBENCH_ADI() 

--- a/src/polybench/POLYBENCH_ATAX.cpp
+++ b/src/polybench/POLYBENCH_ATAX.cpp
@@ -52,6 +52,23 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
 
   setDefaultSize( m_N + m_N*2*m_N );
   setDefaultReps(run_reps);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_ATAX::~POLYBENCH_ATAX()

--- a/src/polybench/POLYBENCH_FDTD_2D.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.cpp
@@ -51,8 +51,26 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
       run_reps = 10;
       break;
   }
+
   setDefaultSize( m_tsteps * (m_ny + 3 * m_nx*m_ny) );
   setDefaultReps(run_reps);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_FDTD_2D::~POLYBENCH_FDTD_2D() 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
@@ -52,6 +52,23 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
 
   setDefaultSize( m_N*m_N*m_N );
   setDefaultReps(run_reps);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_FLOYD_WARSHALL::~POLYBENCH_FLOYD_WARSHALL() 

--- a/src/polybench/POLYBENCH_GEMM.cpp
+++ b/src/polybench/POLYBENCH_GEMM.cpp
@@ -55,6 +55,23 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
 
   m_alpha = 0.62;
   m_beta = 1.002;
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_GEMM::~POLYBENCH_GEMM() 

--- a/src/polybench/POLYBENCH_GEMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMVER.cpp
@@ -55,6 +55,23 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
 
   m_alpha = 1.5;
   m_beta = 1.2;
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_GEMVER::~POLYBENCH_GEMVER() 

--- a/src/polybench/POLYBENCH_GESUMMV.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV.cpp
@@ -55,6 +55,23 @@ POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
 
   m_alpha = 0.62;
   m_beta = 1.002;
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_GESUMMV::~POLYBENCH_GESUMMV() 

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -69,6 +69,23 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
 
   setDefaultSize( m_tsteps * 2 * m_N * m_N * m_N);
   setDefaultReps(run_reps);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_HEAT_3D::~POLYBENCH_HEAT_3D() 

--- a/src/polybench/POLYBENCH_JACOBI_1D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.cpp
@@ -58,6 +58,23 @@ POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
 
   setDefaultSize( m_tsteps * 2 * m_N );
   setDefaultReps(run_reps);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_JACOBI_1D::~POLYBENCH_JACOBI_1D() 

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -58,6 +58,23 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
 
   setDefaultSize( m_tsteps * 2 * m_N * m_N );
   setDefaultReps(run_reps);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_JACOBI_2D::~POLYBENCH_JACOBI_2D() 

--- a/src/polybench/POLYBENCH_MVT.cpp
+++ b/src/polybench/POLYBENCH_MVT.cpp
@@ -52,6 +52,23 @@ POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
 
   setDefaultSize( 2*m_N*m_N );
   setDefaultReps(run_reps);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 POLYBENCH_MVT::~POLYBENCH_MVT() 

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -21,8 +21,25 @@ namespace stream
 ADD::ADD(const RunParams& params)
   : KernelBase(rajaperf::Stream_ADD, params)
 {
-   setDefaultSize(1000000);
-   setDefaultReps(1000);
+  setDefaultSize(1000000);
+  setDefaultReps(1000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 ADD::~ADD() 

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -21,8 +21,25 @@ namespace stream
 COPY::COPY(const RunParams& params)
   : KernelBase(rajaperf::Stream_COPY, params)
 {
-   setDefaultSize(1000000);
-   setDefaultReps(1800);
+  setDefaultSize(1000000);
+  setDefaultReps(1800);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 COPY::~COPY() 

--- a/src/stream/DOT.cpp
+++ b/src/stream/DOT.cpp
@@ -21,8 +21,25 @@ namespace stream
 DOT::DOT(const RunParams& params)
   : KernelBase(rajaperf::Stream_DOT, params)
 {
-   setDefaultSize(1000000);
-   setDefaultReps(2000);
+  setDefaultSize(1000000);
+  setDefaultReps(2000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 DOT::~DOT() 

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -21,8 +21,25 @@ namespace stream
 MUL::MUL(const RunParams& params)
   : KernelBase(rajaperf::Stream_MUL, params)
 {
-   setDefaultSize(1000000);
-   setDefaultReps(1800);
+  setDefaultSize(1000000);
+  setDefaultReps(1800);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 MUL::~MUL() 

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -21,8 +21,25 @@ namespace stream
 TRIAD::TRIAD(const RunParams& params)
   : KernelBase(rajaperf::Stream_TRIAD, params)
 {
-   setDefaultSize(1000000);
-   setDefaultReps(1000);
+  setDefaultSize(1000000);
+  setDefaultReps(1000);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+                     
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+  
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+      
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+        
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
 }
 
 TRIAD::~TRIAD() 


### PR DESCRIPTION
This PR fixes the mechanics of how Perf Suite variants work so we can add variants that apply to only a subset of kernels and add kernels that don't implement all variants. Specifically,

- it makes explicit how each kernel indicates which variants it provides
- it reports at run time when there is no variant for a kernel to run, when appropriate
- it makes clear in the generated reports, which variants where not run
- it updates the README file documentation to the new process.