### PR TITLE
Add halo exchange message packing and unpacking "loop"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,9 @@ blt_add_executable(
   apps/PRESSURE.cpp
   apps/PRESSURE-Seq.cpp
   apps/PRESSURE-OMPTarget.cpp
+  apps/HALOEXCHANGE.cpp
+  apps/HALOEXCHANGE-Seq.cpp
+  apps/HALOEXCHANGE-OMPTarget.cpp
   apps/LTIMES.cpp
   apps/LTIMES-Seq.cpp
   apps/LTIMES-OMPTarget.cpp

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -27,6 +27,12 @@ blt_add_library(
           FIR-Cuda.cpp
           FIR-OMP.cpp
           FIR-OMPTarget.cpp
+          HALOEXCHANGE.cpp
+          HALOEXCHANGE-Seq.cpp
+          HALOEXCHANGE-Hip.cpp
+          HALOEXCHANGE-Cuda.cpp
+          HALOEXCHANGE-OMP.cpp
+          HALOEXCHANGE-OMPTarget.cpp
           LTIMES.cpp
           LTIMES-Seq.cpp
           LTIMES-Hip.cpp

--- a/src/apps/HALOEXCHANGE-Cuda.cpp
+++ b/src/apps/HALOEXCHANGE-Cuda.cpp
@@ -125,51 +125,45 @@ void HALOEXCHANGE::runCudaVariant(VariantID vid)
 
     using EXEC_POL = RAJA::cuda_exec<block_size, true /*async*/>;
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        // packing
-        for (Index_type l = 0; l < num_neighbors; ++l) {
-          Real_ptr buffer = buffers[l];
-          Int_ptr list = pack_index_lists[l];
-          Index_type  len  = pack_index_list_lengths[l];
-          // pack
-          for (Index_type v = 0; v < num_vars; ++v) {
-            Real_ptr var = vars[v];
-            auto haloexchange_pack_base_lam = [=] __device__ (Index_type i) {
-                  HALOEXCHANGE_PACK_BODY;
-                };
-            RAJA::forall<EXEC_POL>(
-                RAJA::TypedRangeSegment<Index_type>(0, len),
-                haloexchange_pack_base_lam );
-            buffer += len;
-          }
-          // send single message
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = pack_index_lists[l];
+        Index_type  len  = pack_index_list_lengths[l];
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          auto haloexchange_pack_base_lam = [=] __device__ (Index_type i) {
+                HALOEXCHANGE_PACK_BODY;
+              };
+          RAJA::forall<EXEC_POL>(
+              RAJA::TypedRangeSegment<Index_type>(0, len),
+              haloexchange_pack_base_lam );
+          buffer += len;
         }
-
-        // unpacking
-        for (Index_type l = 0; l < num_neighbors; ++l) {
-          // recv single message
-          Real_ptr buffer = buffers[l];
-          Int_ptr list = unpack_index_lists[l];
-          Index_type  len  = unpack_index_list_lengths[l];
-          // unpack
-          for (Index_type v = 0; v < num_vars; ++v) {
-            Real_ptr var = vars[v];
-            auto haloexchange_unpack_base_lam = [=] __device__ (Index_type i) {
-                  HALOEXCHANGE_UNPACK_BODY;
-                };
-            RAJA::forall<EXEC_POL>(
-                RAJA::TypedRangeSegment<Index_type>(0, len),
-                haloexchange_unpack_base_lam );
-            buffer += len;
-          }
-        }
-
       }
-      stopTimer();
 
-      HALOEXCHANGE_DATA_TEARDOWN_CUDA;
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = unpack_index_lists[l];
+        Index_type  len  = unpack_index_list_lengths[l];
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          auto haloexchange_unpack_base_lam = [=] __device__ (Index_type i) {
+                HALOEXCHANGE_UNPACK_BODY;
+              };
+          RAJA::forall<EXEC_POL>(
+              RAJA::TypedRangeSegment<Index_type>(0, len),
+              haloexchange_unpack_base_lam );
+          buffer += len;
+        }
+      }
+
+    }
+    stopTimer();
+
+    HALOEXCHANGE_DATA_TEARDOWN_CUDA;
 
   } else {
      std::cout << "\n HALOEXCHANGE : Unknown Cuda variant id = " << vid << std::endl;

--- a/src/apps/HALOEXCHANGE-Cuda.cpp
+++ b/src/apps/HALOEXCHANGE-Cuda.cpp
@@ -1,0 +1,182 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "HALOEXCHANGE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace apps
+{
+
+  //
+  // Define thread block size for CUDA execution
+  //
+  const size_t block_size = 256;
+
+
+#define HALOEXCHANGE_DATA_SETUP_CUDA \
+  for (Index_type v = 0; v < m_num_vars; ++v) { \
+    allocAndInitCudaDeviceData(vars[v], m_vars[v], m_var_size); \
+  } \
+  for (Index_type l = 0; l < num_neighbors; ++l) { \
+    allocAndInitCudaDeviceData(buffers[l], m_buffers[l], m_num_vars*m_pack_index_list_lengths[l]); \
+    allocAndInitCudaDeviceData(pack_index_lists[l], m_pack_index_lists[l], m_pack_index_list_lengths[l]); \
+    allocAndInitCudaDeviceData(unpack_index_lists[l], m_unpack_index_lists[l], m_unpack_index_list_lengths[l]); \
+  }
+
+#define HALOEXCHANGE_DATA_TEARDOWN_CUDA \
+  for (Index_type l = 0; l < num_neighbors; ++l) { \
+    deallocCudaDeviceData(unpack_index_lists[l]); \
+    deallocCudaDeviceData(pack_index_lists[l]); \
+    deallocCudaDeviceData(buffers[l]); \
+  } \
+  for (Index_type v = 0; v < m_num_vars; ++v) { \
+    getCudaDeviceData(m_vars[v], vars[v], m_var_size); \
+    deallocCudaDeviceData(vars[v]); \
+  }
+
+__global__ void haloexchange_pack(Real_ptr buffer, Int_ptr list, Real_ptr var,
+                                  Index_type len)
+{
+   Index_type i = threadIdx.x + blockIdx.x * blockDim.x;
+
+   if (i < len) {
+     HALOEXCHANGE_PACK_BODY;
+   }
+}
+
+__global__ void haloexchange_unpack(Real_ptr buffer, Int_ptr list, Real_ptr var,
+                                    Index_type len)
+{
+   Index_type i = threadIdx.x + blockIdx.x * blockDim.x;
+
+   if (i < len) {
+     HALOEXCHANGE_UNPACK_BODY;
+   }
+}
+
+
+void HALOEXCHANGE::runCudaVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  HALOEXCHANGE_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    HALOEXCHANGE_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      // packing
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = pack_index_lists[l];
+        Index_type  len  = pack_index_list_lengths[l];
+        // pack
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          dim3 nthreads_per_block(block_size);
+          dim3 nblocks((len + block_size-1) / block_size);
+          haloexchange_pack<<<nblocks, nthreads_per_block>>>(buffer, list, var, len);
+          buffer += len;
+        }
+        // send single message
+      }
+
+      // unpacking
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        // recv single message
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = unpack_index_lists[l];
+        Index_type  len  = unpack_index_list_lengths[l];
+        // unpack
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          dim3 nthreads_per_block(block_size);
+          dim3 nblocks((len + block_size-1) / block_size);
+          haloexchange_unpack<<<nblocks, nthreads_per_block>>>(buffer, list, var, len);
+          buffer += len;
+        }
+      }
+
+    }
+    stopTimer();
+
+    HALOEXCHANGE_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    HALOEXCHANGE_DATA_SETUP_CUDA;
+
+    using EXEC_POL = RAJA::cuda_exec<block_size, true /*async*/>;
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        // packing
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = pack_index_lists[l];
+          Index_type  len  = pack_index_list_lengths[l];
+          // pack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            auto haloexchange_pack_base_lam = [=] __device__ (Index_type i) {
+                  HALOEXCHANGE_PACK_BODY;
+                };
+            RAJA::forall<EXEC_POL>(
+                RAJA::TypedRangeSegment<Index_type>(0, len),
+                haloexchange_pack_base_lam );
+            buffer += len;
+          }
+          // send single message
+        }
+
+        // unpacking
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          // recv single message
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = unpack_index_lists[l];
+          Index_type  len  = unpack_index_list_lengths[l];
+          // unpack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            auto haloexchange_unpack_base_lam = [=] __device__ (Index_type i) {
+                  HALOEXCHANGE_UNPACK_BODY;
+                };
+            RAJA::forall<EXEC_POL>(
+                RAJA::TypedRangeSegment<Index_type>(0, len),
+                haloexchange_unpack_base_lam );
+            buffer += len;
+          }
+        }
+
+      }
+      stopTimer();
+
+      HALOEXCHANGE_DATA_TEARDOWN_CUDA;
+
+  } else {
+     std::cout << "\n HALOEXCHANGE : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/apps/HALOEXCHANGE-Cuda.cpp
+++ b/src/apps/HALOEXCHANGE-Cuda.cpp
@@ -94,6 +94,7 @@ void HALOEXCHANGE::runCudaVariant(VariantID vid)
           buffer += len;
         }
       }
+      synchronize();
 
       for (Index_type l = 0; l < num_neighbors; ++l) {
         Real_ptr buffer = buffers[l];
@@ -107,6 +108,7 @@ void HALOEXCHANGE::runCudaVariant(VariantID vid)
           buffer += len;
         }
       }
+      synchronize();
 
     }
     stopTimer();
@@ -137,6 +139,7 @@ void HALOEXCHANGE::runCudaVariant(VariantID vid)
           buffer += len;
         }
       }
+      synchronize();
 
       for (Index_type l = 0; l < num_neighbors; ++l) {
         Real_ptr buffer = buffers[l];
@@ -153,6 +156,7 @@ void HALOEXCHANGE::runCudaVariant(VariantID vid)
           buffer += len;
         }
       }
+      synchronize();
 
     }
     stopTimer();

--- a/src/apps/HALOEXCHANGE-Cuda.cpp
+++ b/src/apps/HALOEXCHANGE-Cuda.cpp
@@ -82,12 +82,10 @@ void HALOEXCHANGE::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      // packing
       for (Index_type l = 0; l < num_neighbors; ++l) {
         Real_ptr buffer = buffers[l];
         Int_ptr list = pack_index_lists[l];
         Index_type  len  = pack_index_list_lengths[l];
-        // pack
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           dim3 nthreads_per_block(block_size);
@@ -95,16 +93,12 @@ void HALOEXCHANGE::runCudaVariant(VariantID vid)
           haloexchange_pack<<<nblocks, nthreads_per_block>>>(buffer, list, var, len);
           buffer += len;
         }
-        // send single message
       }
 
-      // unpacking
       for (Index_type l = 0; l < num_neighbors; ++l) {
-        // recv single message
         Real_ptr buffer = buffers[l];
         Int_ptr list = unpack_index_lists[l];
         Index_type  len  = unpack_index_list_lengths[l];
-        // unpack
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           dim3 nthreads_per_block(block_size);

--- a/src/apps/HALOEXCHANGE-Hip.cpp
+++ b/src/apps/HALOEXCHANGE-Hip.cpp
@@ -95,6 +95,7 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
           buffer += len;
         }
       }
+      synchronize();
 
       for (Index_type l = 0; l < num_neighbors; ++l) {
         Real_ptr buffer = buffers[l];
@@ -109,6 +110,7 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
           buffer += len;
         }
       }
+      synchronize();
 
     }
     stopTimer();
@@ -139,6 +141,7 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
           buffer += len;
         }
       }
+      synchronize();
 
       for (Index_type l = 0; l < num_neighbors; ++l) {
         Real_ptr buffer = buffers[l];
@@ -155,6 +158,7 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
           buffer += len;
         }
       }
+      synchronize();
 
     }
     stopTimer();

--- a/src/apps/HALOEXCHANGE-Hip.cpp
+++ b/src/apps/HALOEXCHANGE-Hip.cpp
@@ -1,0 +1,184 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "HALOEXCHANGE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+#include "common/HipDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace apps
+{
+
+  //
+  // Define thread block size for HIP execution
+  //
+  const size_t block_size = 256;
+
+
+#define HALOEXCHANGE_DATA_SETUP_HIP \
+  for (Index_type v = 0; v < m_num_vars; ++v) { \
+    allocAndInitHipDeviceData(vars[v], m_vars[v], m_var_size); \
+  } \
+  for (Index_type l = 0; l < num_neighbors; ++l) { \
+    allocAndInitHipDeviceData(buffers[l], m_buffers[l], m_num_vars*m_pack_index_list_lengths[l]); \
+    allocAndInitHipDeviceData(pack_index_lists[l], m_pack_index_lists[l], m_pack_index_list_lengths[l]); \
+    allocAndInitHipDeviceData(unpack_index_lists[l], m_unpack_index_lists[l], m_unpack_index_list_lengths[l]); \
+  }
+
+#define HALOEXCHANGE_DATA_TEARDOWN_HIP \
+  for (Index_type l = 0; l < num_neighbors; ++l) { \
+    deallocHipDeviceData(unpack_index_lists[l]); \
+    deallocHipDeviceData(pack_index_lists[l]); \
+    deallocHipDeviceData(buffers[l]); \
+  } \
+  for (Index_type v = 0; v < m_num_vars; ++v) { \
+    getHipDeviceData(m_vars[v], vars[v], m_var_size); \
+    deallocHipDeviceData(vars[v]); \
+  }
+
+__global__ void haloexchange_pack(Real_ptr buffer, Int_ptr list, Real_ptr var,
+                                  Index_type len)
+{
+   Index_type i = threadIdx.x + blockIdx.x * blockDim.x;
+
+   if (i < len) {
+     HALOEXCHANGE_PACK_BODY;
+   }
+}
+
+__global__ void haloexchange_unpack(Real_ptr buffer, Int_ptr list, Real_ptr var,
+                                    Index_type len)
+{
+   Index_type i = threadIdx.x + blockIdx.x * blockDim.x;
+
+   if (i < len) {
+     HALOEXCHANGE_UNPACK_BODY;
+   }
+}
+
+
+void HALOEXCHANGE::runHipVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  HALOEXCHANGE_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    HALOEXCHANGE_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      // packing
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = pack_index_lists[l];
+        Index_type  len  = pack_index_list_lengths[l];
+        // pack
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          dim3 nthreads_per_block(block_size);
+          dim3 nblocks((len + block_size-1) / block_size);
+          hipLaunchKernelGGL((haloexchange_pack), nblocks, nthreads_per_block, 0, 0,
+              buffer, list, var, len);
+          buffer += len;
+        }
+        // send single message
+      }
+
+      // unpacking
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        // recv single message
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = unpack_index_lists[l];
+        Index_type  len  = unpack_index_list_lengths[l];
+        // unpack
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          dim3 nthreads_per_block(block_size);
+          dim3 nblocks((len + block_size-1) / block_size);
+          hipLaunchKernelGGL((haloexchange_unpack), nblocks, nthreads_per_block, 0, 0,
+              buffer, list, var, len);
+          buffer += len;
+        }
+      }
+
+    }
+    stopTimer();
+
+    HALOEXCHANGE_DATA_TEARDOWN_HIP;
+
+  } else if ( vid == RAJA_HIP ) {
+
+    HALOEXCHANGE_DATA_SETUP_HIP;
+
+    using EXEC_POL = RAJA::hip_exec<block_size, true /*async*/>;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      // packing
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = pack_index_lists[l];
+        Index_type  len  = pack_index_list_lengths[l];
+        // pack
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          auto haloexchange_pack_base_lam = [=] __device__ (Index_type i) {
+                HALOEXCHANGE_PACK_BODY;
+              };
+          RAJA::forall<EXEC_POL>(
+              RAJA::TypedRangeSegment<Index_type>(0, len),
+              haloexchange_pack_base_lam );
+          buffer += len;
+        }
+        // send single message
+      }
+
+      // unpacking
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        // recv single message
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = unpack_index_lists[l];
+        Index_type  len  = unpack_index_list_lengths[l];
+        // unpack
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          auto haloexchange_unpack_base_lam = [=] __device__ (Index_type i) {
+                HALOEXCHANGE_UNPACK_BODY;
+              };
+          RAJA::forall<EXEC_POL>(
+              RAJA::TypedRangeSegment<Index_type>(0, len),
+              haloexchange_unpack_base_lam );
+          buffer += len;
+        }
+      }
+
+    }
+    stopTimer();
+
+    HALOEXCHANGE_DATA_TEARDOWN_HIP;
+
+  } else {
+     std::cout << "\n HALOEXCHANGE : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_HIP

--- a/src/apps/HALOEXCHANGE-Hip.cpp
+++ b/src/apps/HALOEXCHANGE-Hip.cpp
@@ -82,12 +82,10 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      // packing
       for (Index_type l = 0; l < num_neighbors; ++l) {
         Real_ptr buffer = buffers[l];
         Int_ptr list = pack_index_lists[l];
         Index_type  len  = pack_index_list_lengths[l];
-        // pack
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           dim3 nthreads_per_block(block_size);
@@ -96,16 +94,12 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
               buffer, list, var, len);
           buffer += len;
         }
-        // send single message
       }
 
-      // unpacking
       for (Index_type l = 0; l < num_neighbors; ++l) {
-        // recv single message
         Real_ptr buffer = buffers[l];
         Int_ptr list = unpack_index_lists[l];
         Index_type  len  = unpack_index_list_lengths[l];
-        // unpack
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           dim3 nthreads_per_block(block_size);
@@ -130,12 +124,10 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      // packing
       for (Index_type l = 0; l < num_neighbors; ++l) {
         Real_ptr buffer = buffers[l];
         Int_ptr list = pack_index_lists[l];
         Index_type  len  = pack_index_list_lengths[l];
-        // pack
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           auto haloexchange_pack_base_lam = [=] __device__ (Index_type i) {
@@ -146,16 +138,12 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
               haloexchange_pack_base_lam );
           buffer += len;
         }
-        // send single message
       }
 
-      // unpacking
       for (Index_type l = 0; l < num_neighbors; ++l) {
-        // recv single message
         Real_ptr buffer = buffers[l];
         Int_ptr list = unpack_index_lists[l];
         Index_type  len  = unpack_index_list_lengths[l];
-        // unpack
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           auto haloexchange_unpack_base_lam = [=] __device__ (Index_type i) {

--- a/src/apps/HALOEXCHANGE-OMP.cpp
+++ b/src/apps/HALOEXCHANGE-OMP.cpp
@@ -33,12 +33,10 @@ void HALOEXCHANGE::runOpenMPVariant(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        // packing
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Real_ptr buffer = buffers[l];
           Int_ptr list = pack_index_lists[l];
           Index_type  len  = pack_index_list_lengths[l];
-          // pack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             #pragma omp parallel for
@@ -47,16 +45,12 @@ void HALOEXCHANGE::runOpenMPVariant(VariantID vid)
             }
             buffer += len;
           }
-          // send single message
         }
 
-        // unpacking
         for (Index_type l = 0; l < num_neighbors; ++l) {
-          // recv single message
           Real_ptr buffer = buffers[l];
           Int_ptr list = unpack_index_lists[l];
           Index_type  len  = unpack_index_list_lengths[l];
-          // unpack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             #pragma omp parallel for
@@ -78,12 +72,10 @@ void HALOEXCHANGE::runOpenMPVariant(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        // packing
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Real_ptr buffer = buffers[l];
           Int_ptr list = pack_index_lists[l];
           Index_type  len  = pack_index_list_lengths[l];
-          // pack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             auto haloexchange_pack_base_lam = [=](Index_type i) {
@@ -95,16 +87,12 @@ void HALOEXCHANGE::runOpenMPVariant(VariantID vid)
             }
             buffer += len;
           }
-          // send single message
         }
 
-        // unpacking
         for (Index_type l = 0; l < num_neighbors; ++l) {
-          // recv single message
           Real_ptr buffer = buffers[l];
           Int_ptr list = unpack_index_lists[l];
           Index_type  len  = unpack_index_list_lengths[l];
-          // unpack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             auto haloexchange_unpack_base_lam = [=](Index_type i) {
@@ -131,12 +119,10 @@ void HALOEXCHANGE::runOpenMPVariant(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        // packing
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Real_ptr buffer = buffers[l];
           Int_ptr list = pack_index_lists[l];
           Index_type  len  = pack_index_list_lengths[l];
-          // pack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             auto haloexchange_pack_base_lam = [=](Index_type i) {
@@ -147,16 +133,12 @@ void HALOEXCHANGE::runOpenMPVariant(VariantID vid)
                 haloexchange_pack_base_lam );
             buffer += len;
           }
-          // send single message
         }
 
-        // unpacking
         for (Index_type l = 0; l < num_neighbors; ++l) {
-          // recv single message
           Real_ptr buffer = buffers[l];
           Int_ptr list = unpack_index_lists[l];
           Index_type  len  = unpack_index_list_lengths[l];
-          // unpack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             auto haloexchange_unpack_base_lam = [=](Index_type i) {

--- a/src/apps/HALOEXCHANGE-OMP.cpp
+++ b/src/apps/HALOEXCHANGE-OMP.cpp
@@ -1,0 +1,188 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "HALOEXCHANGE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace apps
+{
+
+
+void HALOEXCHANGE::runOpenMPVariant(VariantID vid)
+{
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+
+  const Index_type run_reps = getRunReps();
+
+  HALOEXCHANGE_DATA_SETUP;
+
+  switch ( vid ) {
+
+    case Base_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        // packing
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = pack_index_lists[l];
+          Index_type  len  = pack_index_list_lengths[l];
+          // pack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            #pragma omp parallel for
+            for (Index_type i = 0; i < len; i++) {
+              HALOEXCHANGE_PACK_BODY;
+            }
+            buffer += len;
+          }
+          // send single message
+        }
+
+        // unpacking
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          // recv single message
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = unpack_index_lists[l];
+          Index_type  len  = unpack_index_list_lengths[l];
+          // unpack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            #pragma omp parallel for
+            for (Index_type i = 0; i < len; i++) {
+              HALOEXCHANGE_UNPACK_BODY;
+            }
+            buffer += len;
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case Lambda_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        // packing
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = pack_index_lists[l];
+          Index_type  len  = pack_index_list_lengths[l];
+          // pack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            auto haloexchange_pack_base_lam = [=](Index_type i) {
+                  HALOEXCHANGE_PACK_BODY;
+                };
+            #pragma omp parallel for
+            for (Index_type i = 0; i < len; i++) {
+              haloexchange_pack_base_lam(i);
+            }
+            buffer += len;
+          }
+          // send single message
+        }
+
+        // unpacking
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          // recv single message
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = unpack_index_lists[l];
+          Index_type  len  = unpack_index_list_lengths[l];
+          // unpack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            auto haloexchange_unpack_base_lam = [=](Index_type i) {
+                  HALOEXCHANGE_UNPACK_BODY;
+                };
+            #pragma omp parallel for
+            for (Index_type i = 0; i < len; i++) {
+              haloexchange_unpack_base_lam(i);
+            }
+            buffer += len;
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_OpenMP : {
+
+      using EXEC_POL = RAJA::omp_parallel_for_exec;
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        // packing
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = pack_index_lists[l];
+          Index_type  len  = pack_index_list_lengths[l];
+          // pack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            auto haloexchange_pack_base_lam = [=](Index_type i) {
+                  HALOEXCHANGE_PACK_BODY;
+                };
+            RAJA::forall<EXEC_POL>(
+                RAJA::TypedRangeSegment<Index_type>(0, len),
+                haloexchange_pack_base_lam );
+            buffer += len;
+          }
+          // send single message
+        }
+
+        // unpacking
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          // recv single message
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = unpack_index_lists[l];
+          Index_type  len  = unpack_index_list_lengths[l];
+          // unpack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            auto haloexchange_unpack_base_lam = [=](Index_type i) {
+                  HALOEXCHANGE_UNPACK_BODY;
+                };
+            RAJA::forall<EXEC_POL>(
+                RAJA::TypedRangeSegment<Index_type>(0, len),
+                haloexchange_unpack_base_lam );
+            buffer += len;
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    default : {
+      std::cout << "\n HALOEXCHANGE : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+#endif
+}
+
+} // end namespace apps
+} // end namespace rajaperf

--- a/src/apps/HALOEXCHANGE-OMPTarget.cpp
+++ b/src/apps/HALOEXCHANGE-OMPTarget.cpp
@@ -1,0 +1,163 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "HALOEXCHANGE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace apps
+{
+
+#define HALOEXCHANGE_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  for (Index_type v = 0; v < m_num_vars; ++v) { \
+    allocAndInitOpenMPDeviceData(vars[v], m_vars[v], m_var_size, did, hid); \
+  } \
+  for (Index_type l = 0; l < num_neighbors; ++l) { \
+    allocAndInitOpenMPDeviceData(buffers[l], m_buffers[l], m_num_vars*m_pack_index_list_lengths[l], did, hid); \
+    allocAndInitOpenMPDeviceData(pack_index_lists[l], m_pack_index_lists[l], m_pack_index_list_lengths[l], did, hid); \
+    allocAndInitOpenMPDeviceData(unpack_index_lists[l], m_unpack_index_lists[l], m_unpack_index_list_lengths[l], did, hid); \
+  }
+
+#define HALOEXCHANGE_DATA_TEARDOWN_OMP_TARGET \
+  for (Index_type l = 0; l < num_neighbors; ++l) { \
+    deallocOpenMPDeviceData(unpack_index_lists[l], did); \
+    deallocOpenMPDeviceData(pack_index_lists[l], did); \
+    deallocOpenMPDeviceData(buffers[l], did); \
+  } \
+  for (Index_type v = 0; v < m_num_vars; ++v) { \
+    getOpenMPDeviceData(m_vars[v], vars[v], m_var_size, hid, did); \
+    deallocOpenMPDeviceData(vars[v], did); \
+  }
+
+
+void HALOEXCHANGE::runOpenMPTargetVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  HALOEXCHANGE_DATA_SETUP;
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    HALOEXCHANGE_DATA_SETUP_OMP_TARGET;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      // packing
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = pack_index_lists[l];
+        Index_type  len  = pack_index_list_lengths[l];
+        // pack
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          #pragma omp target is_device_ptr(buffer, list, var) device( did )
+          #pragma omp teams distribute parallel for schedule(static, 1)
+          for (Index_type i = 0; i < len; i++) {
+            HALOEXCHANGE_PACK_BODY;
+          }
+          buffer += len;
+        }
+        // send single message
+      }
+
+      // unpacking
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        // recv single message
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = unpack_index_lists[l];
+        Index_type  len  = unpack_index_list_lengths[l];
+        // unpack
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          #pragma omp target is_device_ptr(buffer, list, var) device( did )
+          #pragma omp teams distribute parallel for schedule(static, 1)
+          for (Index_type i = 0; i < len; i++) {
+            HALOEXCHANGE_UNPACK_BODY;
+          }
+          buffer += len;
+        }
+      }
+
+    }
+    stopTimer();
+
+    HALOEXCHANGE_DATA_TEARDOWN_OMP_TARGET;
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    HALOEXCHANGE_DATA_SETUP_OMP_TARGET;
+
+    using EXEC_POL = RAJA::omp_target_parallel_exec;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      // packing
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = pack_index_lists[l];
+        Index_type  len  = pack_index_list_lengths[l];
+        // pack
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          auto haloexchange_pack_base_lam = [=](Index_type i) {
+                HALOEXCHANGE_PACK_BODY;
+              };
+          RAJA::forall<EXEC_POL>(
+              RAJA::TypedRangeSegment<Index_type>(0, len),
+              haloexchange_pack_base_lam );
+          buffer += len;
+        }
+        // send single message
+      }
+
+      // unpacking
+      for (Index_type l = 0; l < num_neighbors; ++l) {
+        // recv single message
+        Real_ptr buffer = buffers[l];
+        Int_ptr list = unpack_index_lists[l];
+        Index_type  len  = unpack_index_list_lengths[l];
+        // unpack
+        for (Index_type v = 0; v < num_vars; ++v) {
+          Real_ptr var = vars[v];
+          auto haloexchange_unpack_base_lam = [=](Index_type i) {
+                HALOEXCHANGE_UNPACK_BODY;
+              };
+          RAJA::forall<EXEC_POL>(
+              RAJA::TypedRangeSegment<Index_type>(0, len),
+              haloexchange_unpack_base_lam );
+          buffer += len;
+        }
+      }
+
+    }
+    stopTimer();
+
+    HALOEXCHANGE_DATA_TEARDOWN_OMP_TARGET;
+
+  } else {
+     std::cout << "\n HALOEXCHANGE : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/apps/HALOEXCHANGE-OMPTarget.cpp
+++ b/src/apps/HALOEXCHANGE-OMPTarget.cpp
@@ -59,12 +59,10 @@ void HALOEXCHANGE::runOpenMPTargetVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      // packing
       for (Index_type l = 0; l < num_neighbors; ++l) {
         Real_ptr buffer = buffers[l];
         Int_ptr list = pack_index_lists[l];
         Index_type  len  = pack_index_list_lengths[l];
-        // pack
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           #pragma omp target is_device_ptr(buffer, list, var) device( did )
@@ -74,16 +72,12 @@ void HALOEXCHANGE::runOpenMPTargetVariant(VariantID vid)
           }
           buffer += len;
         }
-        // send single message
       }
 
-      // unpacking
       for (Index_type l = 0; l < num_neighbors; ++l) {
-        // recv single message
         Real_ptr buffer = buffers[l];
         Int_ptr list = unpack_index_lists[l];
         Index_type  len  = unpack_index_list_lengths[l];
-        // unpack
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           #pragma omp target is_device_ptr(buffer, list, var) device( did )
@@ -109,12 +103,10 @@ void HALOEXCHANGE::runOpenMPTargetVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      // packing
       for (Index_type l = 0; l < num_neighbors; ++l) {
         Real_ptr buffer = buffers[l];
         Int_ptr list = pack_index_lists[l];
         Index_type  len  = pack_index_list_lengths[l];
-        // pack
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           auto haloexchange_pack_base_lam = [=](Index_type i) {
@@ -125,16 +117,12 @@ void HALOEXCHANGE::runOpenMPTargetVariant(VariantID vid)
               haloexchange_pack_base_lam );
           buffer += len;
         }
-        // send single message
       }
 
-      // unpacking
       for (Index_type l = 0; l < num_neighbors; ++l) {
-        // recv single message
         Real_ptr buffer = buffers[l];
         Int_ptr list = unpack_index_lists[l];
         Index_type  len  = unpack_index_list_lengths[l];
-        // unpack
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           auto haloexchange_unpack_base_lam = [=](Index_type i) {

--- a/src/apps/HALOEXCHANGE-Seq.cpp
+++ b/src/apps/HALOEXCHANGE-Seq.cpp
@@ -1,0 +1,183 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "HALOEXCHANGE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace apps
+{
+
+
+void HALOEXCHANGE::runSeqVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  HALOEXCHANGE_DATA_SETUP;
+
+  switch ( vid ) {
+
+    case Base_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        // packing
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = pack_index_lists[l];
+          Index_type  len  = pack_index_list_lengths[l];
+          // pack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            for (Index_type i = 0; i < len; i++) {
+              HALOEXCHANGE_PACK_BODY;
+            }
+            buffer += len;
+          }
+          // send single message
+        }
+
+        // unpacking
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          // recv single message
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = unpack_index_lists[l];
+          Index_type  len  = unpack_index_list_lengths[l];
+          // unpack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            for (Index_type i = 0; i < len; i++) {
+              HALOEXCHANGE_UNPACK_BODY;
+            }
+            buffer += len;
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+#if defined(RUN_RAJA_SEQ)
+    case Lambda_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        // packing
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = pack_index_lists[l];
+          Index_type  len  = pack_index_list_lengths[l];
+          // pack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            auto haloexchange_pack_base_lam = [=](Index_type i) {
+                  HALOEXCHANGE_PACK_BODY;
+                };
+            for (Index_type i = 0; i < len; i++) {
+              haloexchange_pack_base_lam(i);
+            }
+            buffer += len;
+          }
+          // send single message
+        }
+
+        // unpacking
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          // recv single message
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = unpack_index_lists[l];
+          Index_type  len  = unpack_index_list_lengths[l];
+          // unpack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            auto haloexchange_unpack_base_lam = [=](Index_type i) {
+                  HALOEXCHANGE_UNPACK_BODY;
+                };
+            for (Index_type i = 0; i < len; i++) {
+              haloexchange_unpack_base_lam(i);
+            }
+            buffer += len;
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_Seq : {
+
+      using EXEC_POL = RAJA::loop_exec;
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        // packing
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = pack_index_lists[l];
+          Index_type  len  = pack_index_list_lengths[l];
+          // pack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            auto haloexchange_pack_base_lam = [=](Index_type i) {
+                  HALOEXCHANGE_PACK_BODY;
+                };
+            RAJA::forall<EXEC_POL>(
+                RAJA::TypedRangeSegment<Index_type>(0, len),
+                haloexchange_pack_base_lam );
+            buffer += len;
+          }
+          // send single message
+        }
+
+        // unpacking
+        for (Index_type l = 0; l < num_neighbors; ++l) {
+          // recv single message
+          Real_ptr buffer = buffers[l];
+          Int_ptr list = unpack_index_lists[l];
+          Index_type  len  = unpack_index_list_lengths[l];
+          // unpack
+          for (Index_type v = 0; v < num_vars; ++v) {
+            Real_ptr var = vars[v];
+            auto haloexchange_unpack_base_lam = [=](Index_type i) {
+                  HALOEXCHANGE_UNPACK_BODY;
+                };
+            RAJA::forall<EXEC_POL>(
+                RAJA::TypedRangeSegment<Index_type>(0, len),
+                haloexchange_unpack_base_lam );
+            buffer += len;
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+#endif // RUN_RAJA_SEQ
+
+    default : {
+      std::cout << "\n HALOEXCHANGE : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+}
+
+} // end namespace apps
+} // end namespace rajaperf

--- a/src/apps/HALOEXCHANGE-Seq.cpp
+++ b/src/apps/HALOEXCHANGE-Seq.cpp
@@ -31,12 +31,10 @@ void HALOEXCHANGE::runSeqVariant(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        // packing
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Real_ptr buffer = buffers[l];
           Int_ptr list = pack_index_lists[l];
           Index_type  len  = pack_index_list_lengths[l];
-          // pack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             for (Index_type i = 0; i < len; i++) {
@@ -44,16 +42,12 @@ void HALOEXCHANGE::runSeqVariant(VariantID vid)
             }
             buffer += len;
           }
-          // send single message
         }
 
-        // unpacking
         for (Index_type l = 0; l < num_neighbors; ++l) {
-          // recv single message
           Real_ptr buffer = buffers[l];
           Int_ptr list = unpack_index_lists[l];
           Index_type  len  = unpack_index_list_lengths[l];
-          // unpack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             for (Index_type i = 0; i < len; i++) {
@@ -75,12 +69,10 @@ void HALOEXCHANGE::runSeqVariant(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        // packing
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Real_ptr buffer = buffers[l];
           Int_ptr list = pack_index_lists[l];
           Index_type  len  = pack_index_list_lengths[l];
-          // pack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             auto haloexchange_pack_base_lam = [=](Index_type i) {
@@ -91,16 +83,12 @@ void HALOEXCHANGE::runSeqVariant(VariantID vid)
             }
             buffer += len;
           }
-          // send single message
         }
 
-        // unpacking
         for (Index_type l = 0; l < num_neighbors; ++l) {
-          // recv single message
           Real_ptr buffer = buffers[l];
           Int_ptr list = unpack_index_lists[l];
           Index_type  len  = unpack_index_list_lengths[l];
-          // unpack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             auto haloexchange_unpack_base_lam = [=](Index_type i) {
@@ -126,12 +114,10 @@ void HALOEXCHANGE::runSeqVariant(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        // packing
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Real_ptr buffer = buffers[l];
           Int_ptr list = pack_index_lists[l];
           Index_type  len  = pack_index_list_lengths[l];
-          // pack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             auto haloexchange_pack_base_lam = [=](Index_type i) {
@@ -142,16 +128,12 @@ void HALOEXCHANGE::runSeqVariant(VariantID vid)
                 haloexchange_pack_base_lam );
             buffer += len;
           }
-          // send single message
         }
 
-        // unpacking
         for (Index_type l = 0; l < num_neighbors; ++l) {
-          // recv single message
           Real_ptr buffer = buffers[l];
           Int_ptr list = unpack_index_lists[l];
           Index_type  len  = unpack_index_list_lengths[l];
-          // unpack
           for (Index_type v = 0; v < num_vars; ++v) {
             Real_ptr var = vars[v];
             auto haloexchange_unpack_base_lam = [=](Index_type i) {

--- a/src/apps/HALOEXCHANGE.cpp
+++ b/src/apps/HALOEXCHANGE.cpp
@@ -1,0 +1,453 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "HALOEXCHANGE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
+#include <cmath>
+
+namespace rajaperf
+{
+namespace apps
+{
+
+namespace {
+
+void create_pack_lists(std::vector<Int_ptr>& pack_index_lists,
+                       std::vector<Index_type >& pack_index_list_lengths,
+                       const Index_type halo_width, const Index_type* grid_dims,
+                       const Index_type num_neighbors,
+                       VariantID vid);
+void create_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
+                         std::vector<Index_type >& unpack_index_list_lengths,
+                         const Index_type halo_width, const Index_type* grid_dims,
+                         const Index_type num_neighbors,
+                         VariantID vid);
+void destroy_pack_lists(std::vector<Int_ptr>& pack_index_lists,
+                        const Index_type num_neighbors,
+                        VariantID vid);
+void destroy_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
+                          const Index_type num_neighbors,
+                          VariantID vid);
+
+}
+
+
+HALOEXCHANGE::HALOEXCHANGE(const RunParams& params)
+  : KernelBase(rajaperf::Apps_HALOEXCHANGE, params)
+{
+  m_grid_dims_default[0] = 100;
+  m_grid_dims_default[1] = 100;
+  m_grid_dims_default[2] = 100;
+  m_halo_width_default   = 1;
+  m_num_vars_default     = 3;
+
+  setDefaultSize((m_grid_dims_default[0] + 2*m_halo_width_default) *
+                 (m_grid_dims_default[1] + 2*m_halo_width_default) *
+                 (m_grid_dims_default[2] + 2*m_halo_width_default) *
+                 m_num_vars_default);
+  setDefaultReps(50);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
+}
+
+HALOEXCHANGE::~HALOEXCHANGE()
+{
+}
+
+void HALOEXCHANGE::setUp(VariantID vid)
+{
+  double cbrt_size_fact = std::cbrt(run_params.getSizeFactor());
+
+  m_grid_dims[0] = cbrt_size_fact * m_grid_dims_default[0];
+  m_grid_dims[1] = cbrt_size_fact * m_grid_dims_default[1];
+  m_grid_dims[2] = cbrt_size_fact * m_grid_dims_default[2];
+  m_halo_width = m_halo_width_default;
+  m_num_vars   = m_num_vars_default;
+
+  m_grid_plus_halo_dims[0] = m_grid_dims[0] + 2*m_halo_width;
+  m_grid_plus_halo_dims[1] = m_grid_dims[1] + 2*m_halo_width;
+  m_grid_plus_halo_dims[2] = m_grid_dims[2] + 2*m_halo_width;
+  m_var_size = m_grid_plus_halo_dims[0] *
+               m_grid_plus_halo_dims[1] *
+               m_grid_plus_halo_dims[2] ;
+
+  m_vars.resize(m_num_vars, nullptr);
+  for (Index_type v = 0; v < m_num_vars; ++v) {
+    allocAndInitData(m_vars[v], m_var_size, vid);
+
+    Real_ptr var = m_vars[v];
+
+    for (Index_type i = 0; i < m_var_size; i++) {
+      var[i] = i + v;
+    }
+  }
+
+  m_pack_index_lists.resize(s_num_neighbors, nullptr);
+  m_pack_index_list_lengths.resize(s_num_neighbors, 0);
+  create_pack_lists(m_pack_index_lists, m_pack_index_list_lengths, m_halo_width, m_grid_dims, s_num_neighbors, vid);
+
+  m_unpack_index_lists.resize(s_num_neighbors, nullptr);
+  m_unpack_index_list_lengths.resize(s_num_neighbors, 0);
+  create_unpack_lists(m_unpack_index_lists, m_unpack_index_list_lengths, m_halo_width, m_grid_dims, s_num_neighbors, vid);
+
+  m_buffers.resize(s_num_neighbors, nullptr);
+  for (Index_type l = 0; l < s_num_neighbors; ++l) {
+    Index_type buffer_len = m_num_vars * m_pack_index_list_lengths[l];
+    allocAndInitData(m_buffers[l], buffer_len, vid);
+  }
+}
+
+void HALOEXCHANGE::updateChecksum(VariantID vid)
+{
+  for (Real_ptr var : m_vars) {
+    checksum[vid] += calcChecksum(var, m_var_size);
+  }
+}
+
+void HALOEXCHANGE::tearDown(VariantID vid)
+{
+  for (int l = 0; l < s_num_neighbors; ++l) {
+    deallocData(m_buffers[l]);
+  }
+  m_buffers.clear();
+
+  destroy_unpack_lists(m_unpack_index_lists, s_num_neighbors, vid);
+  m_unpack_index_list_lengths.clear();
+  m_unpack_index_lists.clear();
+
+  destroy_pack_lists(m_pack_index_lists, s_num_neighbors, vid);
+  m_pack_index_list_lengths.clear();
+  m_pack_index_lists.clear();
+
+  for (int v = 0; v < m_num_vars; ++v) {
+    deallocData(m_vars[v]);
+  }
+  m_vars.clear();
+}
+
+namespace {
+
+struct Extent
+{
+  Index_type i_min;
+  Index_type i_max;
+  Index_type j_min;
+  Index_type j_max;
+  Index_type k_min;
+  Index_type k_max;
+};
+
+//
+// Function to generate index lists for packing.
+//
+void create_pack_lists(std::vector<Int_ptr>& pack_index_lists,
+                       std::vector<Index_type >& pack_index_list_lengths,
+                       const Index_type halo_width, const Index_type* grid_dims,
+                       const Index_type num_neighbors,
+                       VariantID vid)
+{
+  std::vector<Extent> pack_index_list_extents(num_neighbors);
+
+  // faces
+  pack_index_list_extents[0]  = Extent{halo_width  , halo_width   + halo_width,
+                                       halo_width  , grid_dims[1] + halo_width,
+                                       halo_width  , grid_dims[2] + halo_width};
+  pack_index_list_extents[1]  = Extent{grid_dims[0], grid_dims[0] + halo_width,
+                                       halo_width  , grid_dims[1] + halo_width,
+                                       halo_width  , grid_dims[2] + halo_width};
+  pack_index_list_extents[2]  = Extent{halo_width  , grid_dims[0] + halo_width,
+                                       halo_width  , halo_width   + halo_width,
+                                       halo_width  , grid_dims[2] + halo_width};
+  pack_index_list_extents[3]  = Extent{halo_width  , grid_dims[0] + halo_width,
+                                       grid_dims[1], grid_dims[1] + halo_width,
+                                       halo_width  , grid_dims[2] + halo_width};
+  pack_index_list_extents[4]  = Extent{halo_width  , grid_dims[0] + halo_width,
+                                       halo_width  , grid_dims[1] + halo_width,
+                                       halo_width  , halo_width   + halo_width};
+  pack_index_list_extents[5]  = Extent{halo_width  , grid_dims[0] + halo_width,
+                                       halo_width  , grid_dims[1] + halo_width,
+                                       grid_dims[2], grid_dims[2] + halo_width};
+
+  // edges
+  pack_index_list_extents[6]  = Extent{halo_width  , halo_width   + halo_width,
+                                       halo_width  , halo_width   + halo_width,
+                                       halo_width  , grid_dims[2] + halo_width};
+  pack_index_list_extents[7]  = Extent{halo_width  , halo_width   + halo_width,
+                                       grid_dims[1], grid_dims[1] + halo_width,
+                                       halo_width  , grid_dims[2] + halo_width};
+  pack_index_list_extents[8]  = Extent{grid_dims[0], grid_dims[0] + halo_width,
+                                       halo_width  , halo_width   + halo_width,
+                                       halo_width  , grid_dims[2] + halo_width};
+  pack_index_list_extents[9]  = Extent{grid_dims[0], grid_dims[0] + halo_width,
+                                       grid_dims[1], grid_dims[1] + halo_width,
+                                       halo_width  , grid_dims[2] + halo_width};
+  pack_index_list_extents[10] = Extent{halo_width  , halo_width   + halo_width,
+                                       halo_width  , grid_dims[1] + halo_width,
+                                       halo_width  , halo_width   + halo_width};
+  pack_index_list_extents[11] = Extent{halo_width  , halo_width   + halo_width,
+                                       halo_width  , grid_dims[1] + halo_width,
+                                       grid_dims[2], grid_dims[2] + halo_width};
+  pack_index_list_extents[12] = Extent{grid_dims[0], grid_dims[0] + halo_width,
+                                       halo_width  , grid_dims[1] + halo_width,
+                                       halo_width  , halo_width   + halo_width};
+  pack_index_list_extents[13] = Extent{grid_dims[0], grid_dims[0] + halo_width,
+                                       halo_width  , grid_dims[1] + halo_width,
+                                       grid_dims[2], grid_dims[2] + halo_width};
+  pack_index_list_extents[14] = Extent{halo_width  , grid_dims[0] + halo_width,
+                                       halo_width  , halo_width   + halo_width,
+                                       halo_width  , halo_width   + halo_width};
+  pack_index_list_extents[15] = Extent{halo_width  , grid_dims[0] + halo_width,
+                                       halo_width  , halo_width   + halo_width,
+                                       grid_dims[2], grid_dims[2] + halo_width};
+  pack_index_list_extents[16] = Extent{halo_width  , grid_dims[0] + halo_width,
+                                       grid_dims[1], grid_dims[1] + halo_width,
+                                       halo_width  , halo_width   + halo_width};
+  pack_index_list_extents[17] = Extent{halo_width  , grid_dims[0] + halo_width,
+                                       grid_dims[1], grid_dims[1] + halo_width,
+                                       grid_dims[2], grid_dims[2] + halo_width};
+
+  // corners
+  pack_index_list_extents[18] = Extent{halo_width  , halo_width   + halo_width,
+                                       halo_width  , halo_width   + halo_width,
+                                       halo_width  , halo_width   + halo_width};
+  pack_index_list_extents[19] = Extent{halo_width  , halo_width   + halo_width,
+                                       halo_width  , halo_width   + halo_width,
+                                       grid_dims[2], grid_dims[2] + halo_width};
+  pack_index_list_extents[20] = Extent{halo_width  , halo_width   + halo_width,
+                                       grid_dims[1], grid_dims[1] + halo_width,
+                                       halo_width  , halo_width   + halo_width};
+  pack_index_list_extents[21] = Extent{halo_width  , halo_width   + halo_width,
+                                       grid_dims[1], grid_dims[1] + halo_width,
+                                       grid_dims[2], grid_dims[2] + halo_width};
+  pack_index_list_extents[22] = Extent{grid_dims[0], grid_dims[0] + halo_width,
+                                       halo_width  , halo_width   + halo_width,
+                                       halo_width  , halo_width   + halo_width};
+  pack_index_list_extents[23] = Extent{grid_dims[0], grid_dims[0] + halo_width,
+                                       halo_width  , halo_width   + halo_width,
+                                       grid_dims[2], grid_dims[2] + halo_width};
+  pack_index_list_extents[24] = Extent{grid_dims[0], grid_dims[0] + halo_width,
+                                       grid_dims[1], grid_dims[1] + halo_width,
+                                       halo_width  , halo_width   + halo_width};
+  pack_index_list_extents[25] = Extent{grid_dims[0], grid_dims[0] + halo_width,
+                                       grid_dims[1], grid_dims[1] + halo_width,
+                                       grid_dims[2], grid_dims[2] + halo_width};
+
+  const Index_type grid_i_stride = 1;
+  const Index_type grid_j_stride = grid_dims[0] + 2*halo_width;
+  const Index_type grid_k_stride = grid_j_stride * (grid_dims[1] + 2*halo_width);
+
+  for (Index_type l = 0; l < num_neighbors; ++l) {
+
+    Extent extent = pack_index_list_extents[l];
+
+    pack_index_list_lengths[l] = (extent.i_max - extent.i_min) *
+                                 (extent.j_max - extent.j_min) *
+                                 (extent.k_max - extent.k_min) ;
+
+    allocAndInitData(pack_index_lists[l], pack_index_list_lengths[l], vid);
+
+    Int_ptr pack_list = pack_index_lists[l];
+
+    Index_type list_idx = 0;
+    for (Index_type kk = extent.k_min; kk < extent.k_max; ++kk) {
+      for (Index_type jj = extent.j_min; jj < extent.j_max; ++jj) {
+        for (Index_type ii = extent.i_min; ii < extent.i_max; ++ii) {
+
+          Index_type pack_idx = ii * grid_i_stride +
+                         jj * grid_j_stride +
+                         kk * grid_k_stride ;
+
+          pack_list[list_idx] = pack_idx;
+
+          list_idx += 1;
+        }
+      }
+    }
+  }
+}
+
+//
+// Function to destroy packing index lists.
+//
+void destroy_pack_lists(std::vector<Int_ptr>& pack_index_lists,
+                       const Index_type num_neighbors,
+                       VariantID vid)
+{
+  (void) vid;
+
+  for (Index_type l = 0; l < num_neighbors; ++l) {
+    deallocData(pack_index_lists[l]);
+  }
+}
+
+//
+// Function to generate index lists for unpacking.
+//
+void create_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
+                         std::vector<Index_type >& unpack_index_list_lengths,
+                         const Index_type halo_width, const Index_type* grid_dims,
+                         const Index_type num_neighbors,
+                         VariantID vid)
+{
+  std::vector<Extent> unpack_index_list_extents(num_neighbors);
+
+  // faces
+  unpack_index_list_extents[0]  = Extent{0                        ,                  halo_width,
+                                         halo_width               , grid_dims[1] +   halo_width,
+                                         halo_width               , grid_dims[2] +   halo_width};
+  unpack_index_list_extents[1]  = Extent{grid_dims[0] + halo_width, grid_dims[0] + 2*halo_width,
+                                         halo_width               , grid_dims[1] +   halo_width,
+                                         halo_width               , grid_dims[2] +   halo_width};
+  unpack_index_list_extents[2]  = Extent{halo_width               , grid_dims[0] +   halo_width,
+                                         0                        ,                  halo_width,
+                                         halo_width               , grid_dims[2] +   halo_width};
+  unpack_index_list_extents[3]  = Extent{halo_width               , grid_dims[0] +   halo_width,
+                                         grid_dims[1] + halo_width, grid_dims[1] + 2*halo_width,
+                                         halo_width               , grid_dims[2] +   halo_width};
+  unpack_index_list_extents[4]  = Extent{halo_width               , grid_dims[0] +   halo_width,
+                                         halo_width               , grid_dims[1] +   halo_width,
+                                         0                        ,                  halo_width};
+  unpack_index_list_extents[5]  = Extent{halo_width               , grid_dims[0] +   halo_width,
+                                         halo_width               , grid_dims[1] +   halo_width,
+                                         grid_dims[2] + halo_width, grid_dims[2] + 2*halo_width};
+
+  // edges
+  unpack_index_list_extents[6]  = Extent{0                        ,                  halo_width,
+                                         0                        ,                  halo_width,
+                                         halo_width               , grid_dims[2] +   halo_width};
+  unpack_index_list_extents[7]  = Extent{0                        ,                  halo_width,
+                                         grid_dims[1] + halo_width, grid_dims[1] + 2*halo_width,
+                                         halo_width               , grid_dims[2] +   halo_width};
+  unpack_index_list_extents[8]  = Extent{grid_dims[0] + halo_width, grid_dims[0] + 2*halo_width,
+                                         0                        ,                  halo_width,
+                                         halo_width               , grid_dims[2] +   halo_width};
+  unpack_index_list_extents[9]  = Extent{grid_dims[0] + halo_width, grid_dims[0] + 2*halo_width,
+                                         grid_dims[1] + halo_width, grid_dims[1] + 2*halo_width,
+                                         halo_width               , grid_dims[2] +   halo_width};
+  unpack_index_list_extents[10] = Extent{0                        ,                  halo_width,
+                                         halo_width               , grid_dims[1] +   halo_width,
+                                         0                        ,                  halo_width};
+  unpack_index_list_extents[11] = Extent{0                        ,                  halo_width,
+                                         halo_width               , grid_dims[1] +   halo_width,
+                                         grid_dims[2] + halo_width, grid_dims[2] + 2*halo_width};
+  unpack_index_list_extents[12] = Extent{grid_dims[0] + halo_width, grid_dims[0] + 2*halo_width,
+                                         halo_width               , grid_dims[1] +   halo_width,
+                                         0                        ,                  halo_width};
+  unpack_index_list_extents[13] = Extent{grid_dims[0] + halo_width, grid_dims[0] + 2*halo_width,
+                                         halo_width               , grid_dims[1] +   halo_width,
+                                         grid_dims[2] + halo_width, grid_dims[2] + 2*halo_width};
+  unpack_index_list_extents[14] = Extent{halo_width               , grid_dims[0] +   halo_width,
+                                         0                        ,                  halo_width,
+                                         0                        ,                  halo_width};
+  unpack_index_list_extents[15] = Extent{halo_width               , grid_dims[0] +   halo_width,
+                                         0                        ,                  halo_width,
+                                         grid_dims[2] + halo_width, grid_dims[2] + 2*halo_width};
+  unpack_index_list_extents[16] = Extent{halo_width               , grid_dims[0] +   halo_width,
+                                         grid_dims[1] + halo_width, grid_dims[1] + 2*halo_width,
+                                         0                        ,                  halo_width};
+  unpack_index_list_extents[17] = Extent{halo_width               , grid_dims[0] +   halo_width,
+                                         grid_dims[1] + halo_width, grid_dims[1] + 2*halo_width,
+                                         grid_dims[2] + halo_width, grid_dims[2] + 2*halo_width};
+
+  // corners
+  unpack_index_list_extents[18] = Extent{0                        ,                  halo_width,
+                                         0                        ,                  halo_width,
+                                         0                        ,                  halo_width};
+  unpack_index_list_extents[19] = Extent{0                        ,                  halo_width,
+                                         0                        ,                  halo_width,
+                                         grid_dims[2] + halo_width, grid_dims[2] + 2*halo_width};
+  unpack_index_list_extents[20] = Extent{0                        ,                  halo_width,
+                                         grid_dims[1] + halo_width, grid_dims[1] + 2*halo_width,
+                                         0                        ,                  halo_width};
+  unpack_index_list_extents[21] = Extent{0                        ,                  halo_width,
+                                         grid_dims[1] + halo_width, grid_dims[1] + 2*halo_width,
+                                         grid_dims[2] + halo_width, grid_dims[2] + 2*halo_width};
+  unpack_index_list_extents[22] = Extent{grid_dims[0] + halo_width, grid_dims[0] + 2*halo_width,
+                                         0                        ,                  halo_width,
+                                         0                        ,                  halo_width};
+  unpack_index_list_extents[23] = Extent{grid_dims[0] + halo_width, grid_dims[0] + 2*halo_width,
+                                         0                        ,                  halo_width,
+                                         grid_dims[2] + halo_width, grid_dims[2] + 2*halo_width};
+  unpack_index_list_extents[24] = Extent{grid_dims[0] + halo_width, grid_dims[0] + 2*halo_width,
+                                         grid_dims[1] + halo_width, grid_dims[1] + 2*halo_width,
+                                         0                        ,                  halo_width};
+  unpack_index_list_extents[25] = Extent{grid_dims[0] + halo_width, grid_dims[0] + 2*halo_width,
+                                         grid_dims[1] + halo_width, grid_dims[1] + 2*halo_width,
+                                         grid_dims[2] + halo_width, grid_dims[2] + 2*halo_width};
+
+  const Index_type grid_i_stride = 1;
+  const Index_type grid_j_stride = grid_dims[0] + 2*halo_width;
+  const Index_type grid_k_stride = grid_j_stride * (grid_dims[1] + 2*halo_width);
+
+  for (Index_type l = 0; l < num_neighbors; ++l) {
+
+    Extent extent = unpack_index_list_extents[l];
+
+    unpack_index_list_lengths[l] = (extent.i_max - extent.i_min) *
+                                   (extent.j_max - extent.j_min) *
+                                   (extent.k_max - extent.k_min) ;
+
+    allocAndInitData(unpack_index_lists[l], unpack_index_list_lengths[l], vid);
+
+    Int_ptr unpack_list = unpack_index_lists[l];
+
+    Index_type list_idx = 0;
+    for (Index_type kk = extent.k_min; kk < extent.k_max; ++kk) {
+      for (Index_type jj = extent.j_min; jj < extent.j_max; ++jj) {
+        for (Index_type ii = extent.i_min; ii < extent.i_max; ++ii) {
+
+          Index_type unpack_idx = ii * grid_i_stride +
+                           jj * grid_j_stride +
+                           kk * grid_k_stride ;
+
+          unpack_list[list_idx] = unpack_idx;
+
+          list_idx += 1;
+        }
+      }
+    }
+  }
+}
+
+//
+// Function to destroy unpacking index lists.
+//
+void destroy_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
+                          const Index_type num_neighbors,
+                          VariantID vid)
+{
+  (void) vid;
+
+  for (Index_type l = 0; l < num_neighbors; ++l) {
+    deallocData(unpack_index_lists[l]);
+  }
+}
+
+} // end namespace
+
+} // end namespace apps
+} // end namespace rajaperf

--- a/src/apps/HALOEXCHANGE.hpp
+++ b/src/apps/HALOEXCHANGE.hpp
@@ -9,22 +9,37 @@
 ///
 /// HALOEXCHANGE kernel reference implementation:
 ///
-/// for (Index_type z = 0; z < num_z; ++z ) {
-///   for (Index_type g = 0; g < num_g; ++g ) {
-///     for (Index_type m = 0; z < num_m; ++m ) {
-///       for (Index_type d = 0; d < num_d; ++d ) {
-///
-///         phi[m+ (g * num_m) + (z * num_m * num_g)] +=
-///           ell[d+ (m * num_d)] * psi[d+ (g * num_d) + (z * num_d * num_g];
-///
-///       }
+/// // pack message for each neighbor
+/// for (Index_type l = 0; l < num_neighbors; ++l) {
+///   Real_ptr buffer = buffers[l];
+///   Int_ptr list = pack_index_lists[l];
+///   Index_type  len  = pack_index_list_lengths[l];
+///   // pack part of each variable
+///   for (Index_type v = 0; v < num_vars; ++v) {
+///     Real_ptr var = vars[v];
+///     for (Index_type i = 0; i < len; i++) {
+///       HALOEXCHANGE_PACK_BODY;
 ///     }
+///     buffer += len;
 ///   }
+///   // send message to neighbor
 /// }
 ///
-/// The RAJA variants of this kernel use RAJA multi-dimensional data layouts
-/// and views to do the same thing without explicit index calculations (see
-/// the loop body definitions below).
+/// // unpack messages for each neighbor
+/// for (Index_type l = 0; l < num_neighbors; ++l) {
+///   // receive message from neighbor
+///   Real_ptr buffer = buffers[l];
+///   Int_ptr list = unpack_index_lists[l];
+///   Index_type  len  = unpack_index_list_lengths[l];
+///   // unpack part of each variable
+///   for (Index_type v = 0; v < num_vars; ++v) {
+///     Real_ptr var = vars[v];
+///     for (Index_type i = 0; i < len; i++) {
+///       HALOEXCHANGE_UNPACK_BODY;
+///     }
+///     buffer += len;
+///   }
+/// }
 ///
 
 #ifndef RAJAPerf_Apps_HALOEXCHANGE_HPP

--- a/src/apps/HALOEXCHANGE.hpp
+++ b/src/apps/HALOEXCHANGE.hpp
@@ -1,0 +1,108 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// HALOEXCHANGE kernel reference implementation:
+///
+/// for (Index_type z = 0; z < num_z; ++z ) {
+///   for (Index_type g = 0; g < num_g; ++g ) {
+///     for (Index_type m = 0; z < num_m; ++m ) {
+///       for (Index_type d = 0; d < num_d; ++d ) {
+///
+///         phi[m+ (g * num_m) + (z * num_m * num_g)] +=
+///           ell[d+ (m * num_d)] * psi[d+ (g * num_d) + (z * num_d * num_g];
+///
+///       }
+///     }
+///   }
+/// }
+///
+/// The RAJA variants of this kernel use RAJA multi-dimensional data layouts
+/// and views to do the same thing without explicit index calculations (see
+/// the loop body definitions below).
+///
+
+#ifndef RAJAPerf_Apps_HALOEXCHANGE_HPP
+#define RAJAPerf_Apps_HALOEXCHANGE_HPP
+
+#define HALOEXCHANGE_DATA_SETUP \
+  std::vector<Real_ptr> vars = m_vars; \
+  std::vector<Real_ptr> buffers = m_buffers; \
+\
+  Index_type num_neighbors = s_num_neighbors; \
+  Index_type num_vars = m_num_vars; \
+  std::vector<Int_ptr> pack_index_lists = m_pack_index_lists; \
+  std::vector<Index_type> pack_index_list_lengths = m_pack_index_list_lengths; \
+  std::vector<Int_ptr> unpack_index_lists = m_unpack_index_lists; \
+  std::vector<Index_type> unpack_index_list_lengths = m_unpack_index_list_lengths;
+
+#define HALOEXCHANGE_PACK_BODY \
+  buffer[i] = var[list[i]];
+
+#define HALOEXCHANGE_UNPACK_BODY \
+  var[list[i]] = buffer[i];
+
+
+#include "common/KernelBase.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <vector>
+
+namespace rajaperf
+{
+class RunParams;
+
+namespace apps
+{
+
+class HALOEXCHANGE : public KernelBase
+{
+public:
+
+  HALOEXCHANGE(const RunParams& params);
+
+  ~HALOEXCHANGE();
+
+  void setUp(VariantID vid);
+  void updateChecksum(VariantID vid);
+  void tearDown(VariantID vid);
+
+  void runSeqVariant(VariantID vid);
+  void runOpenMPVariant(VariantID vid);
+  void runCudaVariant(VariantID vid);
+  void runHipVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
+
+private:
+  static const int s_num_neighbors = 26;
+
+  Index_type m_grid_dims[3];
+  Index_type m_halo_width;
+  Index_type m_num_vars;
+
+  Index_type m_grid_dims_default[3];
+  Index_type m_halo_width_default;
+  Index_type m_num_vars_default;
+
+  Index_type m_grid_plus_halo_dims[3];
+  Index_type m_var_size;
+
+  std::vector<Real_ptr> m_vars;
+  std::vector<Real_ptr> m_buffers;
+
+  std::vector<Int_ptr> m_pack_index_lists;
+  std::vector<Index_type > m_pack_index_list_lengths;
+  std::vector<Int_ptr> m_unpack_index_lists;
+  std::vector<Index_type > m_unpack_index_list_lengths;
+};
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -64,8 +64,8 @@ public:
 
   void execute(VariantID vid);
 
-  void startTimer() 
-  { 
+  void synchronize()
+  {
 #if defined(RAJA_ENABLE_CUDA)
     if ( running_variant == Base_CUDA || running_variant == RAJA_CUDA ) {
       cudaDeviceSynchronize();
@@ -76,22 +76,18 @@ public:
       hipDeviceSynchronize();
     }
 #endif
-    timer.start(); 
   }
 
-  void stopTimer()  
-  { 
-#if defined(RAJA_ENABLE_CUDA)
-    if ( running_variant == Base_CUDA || running_variant == RAJA_CUDA ) {
-      cudaDeviceSynchronize();
-    }
-#endif
-#if defined(RAJA_ENABLE_HIP)
-    if ( running_variant == Base_HIP || running_variant == RAJA_HIP ) {
-      hipDeviceSynchronize();
-    }
-#endif
-    timer.stop(); recordExecTime(); 
+  void startTimer()
+  {
+    synchronize();
+    timer.start();
+  }
+
+  void stopTimer()
+  {
+    synchronize();
+    timer.stop(); recordExecTime();
   }
 
   void resetTimer() { timer.reset(); }

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -72,6 +72,7 @@
 #include "apps/DEL_DOT_VEC_2D.hpp"
 #include "apps/ENERGY.hpp"
 #include "apps/FIR.hpp"
+#include "apps/HALOEXCHANGE.hpp"
 #include "apps/LTIMES.hpp"
 #include "apps/LTIMES_NOVIEW.hpp"
 #include "apps/PRESSURE.hpp"
@@ -185,6 +186,7 @@ static const std::string KernelNames [] =
   std::string("Apps_DEL_DOT_VEC_2D"),
   std::string("Apps_ENERGY"),
   std::string("Apps_FIR"),
+  std::string("Apps_HALOEXCHANGE"),
   std::string("Apps_LTIMES"),
   std::string("Apps_LTIMES_NOVIEW"),
   std::string("Apps_PRESSURE"),
@@ -542,6 +544,10 @@ KernelBase* getKernelObject(KernelID kid,
     }
     case Apps_FIR : {
        kernel = new apps::FIR(run_params);
+       break;
+    }
+    case Apps_HALOEXCHANGE : {
+       kernel = new apps::HALOEXCHANGE(run_params);
        break;
     }
     case Apps_LTIMES : {

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -157,6 +157,7 @@ enum KernelID {
   Apps_DEL_DOT_VEC_2D,
   Apps_ENERGY,
   Apps_FIR,
+  Apps_HALOEXCHANGE,
   Apps_LTIMES,
   Apps_LTIMES_NOVIEW,
   Apps_PRESSURE,


### PR DESCRIPTION
Add a loop to the perf suite that is the set of loops performed by a single mpi rank during a halo exchange. A single instance of the loop does both packing and unpacking. Synchronization is performed after both packing and unpacking. This is derived from the halo exchange example in RAJA.

This is currently a work in progress. Kernel Fusion variants will be added soon.