### PR TITLE
Always allow Base_Seq variants to run

### DIFF
--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -95,6 +95,11 @@ void KernelBase::runKernel(VariantID vid)
   switch ( vid ) {
 
     case Base_Seq :
+    {
+      runSeqVariant(vid);
+      break;
+    }
+
     case Lambda_Seq :
     case RAJA_Seq :
     {


### PR DESCRIPTION
Always allow Base_Seq variants to run. Unlike the parallel variants which are enabled or disabled based on Raja support for the backed base sequential variants are always enabled and will now always be allowed to run.

Fixes #106.