### PR TITLE
Lambda GPU variants

### DIFF
--- a/scripts/lc-builds/toss3_hipcc3.10.0.sh
+++ b/scripts/lc-builds/toss3_hipcc3.10.0.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+BUILD_SUFFIX=lc_toss3-hipcc-3.10.0
+RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss3/hip.cmake
+
+rm -rf build_${BUILD_SUFFIX} >/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+
+module load cmake/3.14.5
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DRAJA_HIPCC_FLAGS="--amdgpu-target=gfx906" \
+  -DHIP_ROOT_DIR=/opt/rocm-3.10.0/hip \
+  -DHIP_CLANG_PATH=/opt/rocm-3.10.0/llvm/bin \
+  -C ${RAJA_HOSTCONFIG} \
+  -DENABLE_HIP=ON \
+  -DENABLE_OPENMP=OFF \
+  -DENABLE_CUDA=OFF \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  ..

--- a/scripts/lc-builds/toss3_hipcc3.7.0.sh
+++ b/scripts/lc-builds/toss3_hipcc3.7.0.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+BUILD_SUFFIX=lc_toss3-hipcc-3.7.0
+RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss3/hip.cmake
+
+rm -rf build_${BUILD_SUFFIX} >/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+
+module load cmake/3.14.5
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DRAJA_HIPCC_FLAGS="--amdgpu-target=gfx906" \
+  -DHIP_ROOT_DIR=/opt/rocm-3.7.0/hip \
+  -DHIP_CLANG_PATH=/opt/rocm-3.7.0/llvm/bin \
+  -C ${RAJA_HOSTCONFIG} \
+  -DENABLE_HIP=ON \
+  -DENABLE_OPENMP=OFF \
+  -DENABLE_CUDA=OFF \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  ..

--- a/scripts/lc-builds/toss3_hipcc4.0.1.sh
+++ b/scripts/lc-builds/toss3_hipcc4.0.1.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+BUILD_SUFFIX=lc_toss3-hipcc-4.0.1
+RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss3/hip.cmake
+
+rm -rf build_${BUILD_SUFFIX} >/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+
+module load cmake/3.14.5
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DRAJA_HIPCC_FLAGS="--amdgpu-target=gfx906" \
+  -DHIP_ROOT_DIR=/opt/rocm-4.0.1/hip \
+  -DHIP_CLANG_PATH=/opt/rocm-4.0.1/llvm/bin \
+  -C ${RAJA_HOSTCONFIG} \
+  -DENABLE_HIP=ON \
+  -DENABLE_OPENMP=OFF \
+  -DENABLE_CUDA=OFF \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  ..

--- a/src/apps/DEL_DOT_VEC_2D-Hip.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-Hip.cpp
@@ -104,6 +104,35 @@ void DEL_DOT_VEC_2D::runHipVariant(VariantID vid)
 
     DEL_DOT_VEC_2D_DATA_TEARDOWN_HIP;
 
+  } else if ( vid == Lambda_HIP ) {
+
+    DEL_DOT_VEC_2D_DATA_SETUP_HIP;
+
+    NDSET2D(m_domain->jp, x,x1,x2,x3,x4) ;
+    NDSET2D(m_domain->jp, y,y1,y2,y3,y4) ;
+    NDSET2D(m_domain->jp, xdot,fx1,fx2,fx3,fx4) ;
+    NDSET2D(m_domain->jp, ydot,fy1,fy2,fy3,fy4) ;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto deldotvec2d_lambda = [=] __device__ (Index_type ii) {
+
+        DEL_DOT_VEC_2D_BODY_INDEX;
+        DEL_DOT_VEC_2D_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+
+      hipLaunchKernelGGL(lambda_hip_forall<decltype(deldotvec2d_lambda)>,
+        grid_size, block_size, 0, 0,
+        0, iend, deldotvec2d_lambda);
+
+    }
+    stopTimer();
+
+    DEL_DOT_VEC_2D_DATA_TEARDOWN_HIP;
+
   } else if ( vid == RAJA_HIP ) {
 
     DEL_DOT_VEC_2D_DATA_SETUP_HIP;

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -13,7 +13,7 @@
 #include "AppsData.hpp"
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace apps
 {
@@ -41,19 +41,21 @@ DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
   setVariantDefined( RAJA_OpenMPTarget );
 
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
 
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-DEL_DOT_VEC_2D::~DEL_DOT_VEC_2D() 
+DEL_DOT_VEC_2D::~DEL_DOT_VEC_2D()
 {
   delete m_domain;
 }
 
-Index_type DEL_DOT_VEC_2D::getItsPerRep() const 
-{ 
+Index_type DEL_DOT_VEC_2D::getItsPerRep() const
+{
   return m_domain->n_real_zones;
 }
 

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace apps
 {
@@ -63,7 +63,32 @@ void LTIMES::runCudaVariant(VariantID vid)
       dim3 nblocks(1, 1, num_z);
 
       ltimes<<<nblocks, nthreads_per_block>>>(phidat, elldat, psidat,
-                                              num_d, num_g, num_m);  
+                                              num_d, num_g, num_m);
+
+    }
+    stopTimer();
+
+    LTIMES_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    LTIMES_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      dim3 nthreads_per_block(num_m, num_g, 1);
+      dim3 nblocks(1, 1, num_z);
+
+      lambda_cuda_kernel<RAJA::cuda_block_z_direct, RAJA::cuda_thread_y_direct, RAJA::cuda_thread_x_direct>
+                        <<<nblocks, nthreads_per_block>>>(
+        0, num_z, 0, num_g, 0, num_m,
+        [=] __device__ (Index_type z, Index_type g, Index_type m) {
+
+        for (Index_type d = 0; d < num_d; ++d ) {
+          LTIMES_BODY;
+        }
+      });
 
     }
     stopTimer();
@@ -76,12 +101,12 @@ void LTIMES::runCudaVariant(VariantID vid)
 
     LTIMES_VIEWS_RANGES_RAJA;
 
-    using EXEC_POL = 
+    using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<1, RAJA::cuda_block_z_loop,      //z 
-            RAJA::statement::For<2, RAJA::cuda_thread_y_loop,    //g
-              RAJA::statement::For<3, RAJA::cuda_thread_x_loop, //m
+          RAJA::statement::For<1, RAJA::cuda_block_z_direct,      //z
+            RAJA::statement::For<2, RAJA::cuda_thread_y_direct,    //g
+              RAJA::statement::For<3, RAJA::cuda_thread_x_direct, //m
                 RAJA::statement::For<0, RAJA::seq_exec,       //d
                   RAJA::statement::Lambda<0>
                 >
@@ -89,8 +114,8 @@ void LTIMES::runCudaVariant(VariantID vid)
             >
           >
         >
-      >; 
-    
+      >;
+
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace apps
 {
@@ -26,7 +26,7 @@ LTIMES::LTIMES(const RunParams& params)
   m_num_g_default = 32;
   m_num_m_default = 25;
 
-  setDefaultSize(m_num_d_default * m_num_m_default * 
+  setDefaultSize(m_num_d_default * m_num_m_default *
                  m_num_g_default * m_num_z_default);
   setDefaultReps(50);
 
@@ -42,22 +42,24 @@ LTIMES::LTIMES(const RunParams& params)
   setVariantDefined( RAJA_OpenMPTarget );
 
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
 
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-LTIMES::~LTIMES() 
+LTIMES::~LTIMES()
 {
 }
 
 void LTIMES::setUp(VariantID vid)
 {
   m_num_z = run_params.getSizeFactor() * m_num_z_default;
-  m_num_g = m_num_g_default;  
-  m_num_m = m_num_m_default;  
-  m_num_d = m_num_d_default;  
+  m_num_g = m_num_g_default;
+  m_num_m = m_num_m_default;
+  m_num_d = m_num_d_default;
 
   m_philen = m_num_m * m_num_g * m_num_z;
   m_elllen = m_num_d * m_num_m;
@@ -76,7 +78,7 @@ void LTIMES::updateChecksum(VariantID vid)
 void LTIMES::tearDown(VariantID vid)
 {
   (void) vid;
- 
+
   deallocData(m_phidat);
   deallocData(m_elldat);
   deallocData(m_psidat);

--- a/src/apps/LTIMES_NOVIEW-Hip.cpp
+++ b/src/apps/LTIMES_NOVIEW-Hip.cpp
@@ -70,6 +70,33 @@ void LTIMES_NOVIEW::runHipVariant(VariantID vid)
 
     LTIMES_NOVIEW_DATA_TEARDOWN_HIP;
 
+  } else if ( vid == Lambda_HIP ) {
+
+    LTIMES_NOVIEW_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      dim3 nthreads_per_block(num_m, num_g, 1);
+      dim3 nblocks(1, 1, num_z);
+
+      auto ltimes_noview_lambda = [=] __device__ (Index_type z, Index_type g, Index_type m) {
+
+        for (Index_type d = 0; d < num_d; ++d ) {
+          LTIMES_NOVIEW_BODY;
+        }
+      };
+
+      auto kernel = lambda_hip_kernel<RAJA::hip_block_z_direct, RAJA::hip_thread_y_direct, RAJA::hip_thread_x_direct, decltype(ltimes_noview_lambda)>;
+      hipLaunchKernelGGL(kernel,
+        nblocks, nthreads_per_block, 0, 0,
+        0, num_z, 0, num_g, 0, num_m, ltimes_noview_lambda);
+
+    }
+    stopTimer();
+
+    LTIMES_NOVIEW_DATA_TEARDOWN_HIP;
+
   } else if ( vid == RAJA_HIP ) {
 
     LTIMES_NOVIEW_DATA_SETUP_HIP;
@@ -77,9 +104,9 @@ void LTIMES_NOVIEW::runHipVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<1, RAJA::hip_block_z_loop,      //z
-            RAJA::statement::For<2, RAJA::hip_thread_y_loop,    //g
-              RAJA::statement::For<3, RAJA::hip_thread_x_loop, //m
+          RAJA::statement::For<1, RAJA::hip_block_z_direct,      //z
+            RAJA::statement::For<2, RAJA::hip_thread_y_direct,    //g
+              RAJA::statement::For<3, RAJA::hip_thread_x_direct, //m
                 RAJA::statement::For<0, RAJA::seq_exec,       //d
                   RAJA::statement::Lambda<0>
                 >

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace apps
 {
@@ -26,7 +26,7 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   m_num_g_default = 32;
   m_num_m_default = 25;
 
-  setDefaultSize(m_num_d_default * m_num_m_default * 
+  setDefaultSize(m_num_d_default * m_num_m_default *
                  m_num_g_default * m_num_z_default);
   setDefaultReps(50);
 
@@ -42,22 +42,24 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   setVariantDefined( RAJA_OpenMPTarget );
 
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
 
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-LTIMES_NOVIEW::~LTIMES_NOVIEW() 
+LTIMES_NOVIEW::~LTIMES_NOVIEW()
 {
 }
 
 void LTIMES_NOVIEW::setUp(VariantID vid)
 {
   m_num_z = run_params.getSizeFactor() * m_num_z_default;
-  m_num_g = m_num_g_default;  
-  m_num_m = m_num_m_default;  
-  m_num_d = m_num_d_default;  
+  m_num_g = m_num_g_default;
+  m_num_m = m_num_m_default;
+  m_num_d = m_num_d_default;
 
   m_philen = m_num_m * m_num_g * m_num_z;
   m_elllen = m_num_d * m_num_m;
@@ -76,7 +78,7 @@ void LTIMES_NOVIEW::updateChecksum(VariantID vid)
 void LTIMES_NOVIEW::tearDown(VariantID vid)
 {
   (void) vid;
- 
+
   deallocData(m_phidat);
   deallocData(m_elldat);
   deallocData(m_psidat);

--- a/src/basic/ATOMIC_PI.cpp
+++ b/src/basic/ATOMIC_PI.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -36,13 +36,15 @@ ATOMIC_PI::ATOMIC_PI(const RunParams& params)
   setVariantDefined( RAJA_OpenMPTarget );
 
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
 
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-ATOMIC_PI::~ATOMIC_PI() 
+ATOMIC_PI::~ATOMIC_PI()
 {
 }
 

--- a/src/basic/DAXPY-Cuda.cpp
+++ b/src/basic/DAXPY-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -36,16 +36,15 @@ namespace basic
   deallocCudaDeviceData(x); \
   deallocCudaDeviceData(y);
 
-__global__ void daxpy(Real_ptr y, Real_ptr x, 
-                      Real_type a, 
-                      Index_type iend) 
+__global__ void daxpy(Real_ptr y, Real_ptr x,
+                      Real_type a,
+                      Index_type iend)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i < iend) {
-     DAXPY_BODY; 
+     DAXPY_BODY;
    }
 }
-
 
 void DAXPY::runCudaVariant(VariantID vid)
 {
@@ -64,7 +63,25 @@ void DAXPY::runCudaVariant(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       daxpy<<<grid_size, block_size>>>( y, x, a,
-                                        iend ); 
+                                        iend );
+
+    }
+    stopTimer();
+
+    DAXPY_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    DAXPY_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      lambda_cuda_forall<<<grid_size, block_size>>>(
+        ibegin, iend, [=] __device__ (Index_type i) {
+        DAXPY_BODY;
+      });
 
     }
     stopTimer();

--- a/src/basic/DAXPY.cpp
+++ b/src/basic/DAXPY.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -36,13 +36,15 @@ DAXPY::DAXPY(const RunParams& params)
   setVariantDefined( RAJA_OpenMPTarget );
 
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
 
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-DAXPY::~DAXPY() 
+DAXPY::~DAXPY()
 {
 }
 

--- a/src/basic/IF_QUAD-Cuda.cpp
+++ b/src/basic/IF_QUAD-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -47,10 +47,10 @@ __global__ void ifquad(Real_ptr x1, Real_ptr x2,
                        Real_ptr a, Real_ptr b, Real_ptr c,
                        Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     IF_QUAD_BODY;
-   }
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < iend) {
+    IF_QUAD_BODY;
+  }
 }
 
 
@@ -69,9 +69,26 @@ void IF_QUAD::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       ifquad<<<grid_size, block_size>>>( x1, x2, a, b, c,
-                                          iend );
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      ifquad<<<grid_size, block_size>>>( x1, x2, a, b, c, iend );
+
+    }
+    stopTimer();
+
+    IF_QUAD_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    IF_QUAD_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      lambda_cuda_forall<<<grid_size, block_size>>>(
+        ibegin, iend, [=] __device__ (Index_type i) {
+        IF_QUAD_BODY;
+      });
 
     }
     stopTimer();
@@ -85,10 +102,10 @@ void IF_QUAD::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-         IF_QUAD_BODY;
-       });
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        IF_QUAD_BODY;
+      });
 
     }
     stopTimer();

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -36,13 +36,15 @@ IF_QUAD::IF_QUAD(const RunParams& params)
   setVariantDefined( RAJA_OpenMPTarget );
 
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
 
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-IF_QUAD::~IF_QUAD() 
+IF_QUAD::~IF_QUAD()
 {
 }
 

--- a/src/basic/INIT3-Cuda.cpp
+++ b/src/basic/INIT3-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -44,14 +44,14 @@ namespace basic
   deallocCudaDeviceData(in1); \
   deallocCudaDeviceData(in2);
 
-__global__ void init3(Real_ptr out1, Real_ptr out2, Real_ptr out3, 
-                      Real_ptr in1, Real_ptr in2, 
-                      Index_type iend) 
+__global__ void init3(Real_ptr out1, Real_ptr out2, Real_ptr out3,
+                      Real_ptr in1, Real_ptr in2,
+                      Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     INIT3_BODY; 
-   }
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < iend) {
+    INIT3_BODY;
+  }
 }
 
 
@@ -71,8 +71,26 @@ void INIT3::runCudaVariant(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      init3<<<grid_size, block_size>>>( out1, out2, out3, in1, in2, 
-                                        iend ); 
+      init3<<<grid_size, block_size>>>( out1, out2, out3, in1, in2,
+                                        iend );
+
+    }
+    stopTimer();
+
+    INIT3_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    INIT3_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      lambda_cuda_forall<<<grid_size, block_size>>>(
+        ibegin, iend, [=] __device__ (Index_type i) {
+        INIT3_BODY;
+      });
 
     }
     stopTimer();

--- a/src/basic/INIT3.cpp
+++ b/src/basic/INIT3.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -36,13 +36,15 @@ INIT3::INIT3(const RunParams& params)
   setVariantDefined( RAJA_OpenMPTarget );
 
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
 
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-INIT3::~INIT3() 
+INIT3::~INIT3()
 {
 }
 

--- a/src/basic/INIT_VIEW1D-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D-Cuda.cpp
@@ -34,14 +34,14 @@ namespace basic
   getCudaDeviceData(m_a, a, getRunSize()); \
   deallocCudaDeviceData(a);
 
-__global__ void initview1d(Real_ptr a, 
+__global__ void initview1d(Real_ptr a,
                            Real_type v,
-                           const Index_type iend) 
+                           const Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     INIT_VIEW1D_BODY; 
-   }
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < iend) {
+    INIT_VIEW1D_BODY;
+  }
 }
 
 
@@ -60,10 +60,26 @@ void INIT_VIEW1D::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       initview1d<<<grid_size, block_size>>>( a,
-                                              v, 
-                                              iend ); 
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      initview1d<<<grid_size, block_size>>>( a, v, iend );
+
+    }
+    stopTimer();
+
+    INIT_VIEW1D_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    INIT_VIEW1D_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      lambda_cuda_forall<<<grid_size, block_size>>>(
+        ibegin, iend, [=] __device__ (Index_type i) {
+        INIT_VIEW1D_BODY;
+      });
 
     }
     stopTimer();

--- a/src/basic/INIT_VIEW1D-Hip.cpp
+++ b/src/basic/INIT_VIEW1D-Hip.cpp
@@ -38,10 +38,10 @@ __global__ void initview1d(Real_ptr a,
                            Real_type v,
                            const Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     INIT_VIEW1D_BODY;
-   }
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < iend) {
+    INIT_VIEW1D_BODY;
+  }
 }
 
 
@@ -60,10 +60,29 @@ void INIT_VIEW1D::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       hipLaunchKernelGGL((initview1d), dim3(grid_size), dim3(block_size), 0, 0,  a,
-                                              v,
-                                              iend );
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      hipLaunchKernelGGL((initview1d), dim3(grid_size), dim3(block_size), 0, 0,
+          a, v, iend );
+
+    }
+    stopTimer();
+
+    INIT_VIEW1D_DATA_TEARDOWN_HIP;
+
+  } else if ( vid == Lambda_HIP ) {
+
+    INIT_VIEW1D_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto initview1d_lambda = [=] __device__ (Index_type i) {
+        INIT_VIEW1D_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      hipLaunchKernelGGL(lambda_hip_forall<decltype(initview1d_lambda)>,
+        grid_size, block_size, 0, 0, ibegin, iend, initview1d_lambda);
 
     }
     stopTimer();

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -36,13 +36,15 @@ INIT_VIEW1D::INIT_VIEW1D(const RunParams& params)
   setVariantDefined( RAJA_OpenMPTarget );
 
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
 
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-INIT_VIEW1D::~INIT_VIEW1D() 
+INIT_VIEW1D::~INIT_VIEW1D()
 {
 }
 

--- a/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -34,15 +34,15 @@ namespace basic
   getCudaDeviceData(m_a, a, getRunSize()); \
   deallocCudaDeviceData(a);
 
-__global__ void initview1d_offset(Real_ptr a, 
+__global__ void initview1d_offset(Real_ptr a,
                                   Real_type v,
                                   const Index_type ibegin,
-                                  const Index_type iend) 
+                                  const Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i >= ibegin && i < iend) {
-     INIT_VIEW1D_OFFSET_BODY; 
-   }
+  Index_type i = ibegin + blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < iend) {
+    INIT_VIEW1D_OFFSET_BODY;
+  }
 }
 
 
@@ -61,10 +61,28 @@ void INIT_VIEW1D_OFFSET::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend-ibegin, block_size);
       initview1d_offset<<<grid_size, block_size>>>( a, v,
                                                     ibegin,
-                                                    iend ); 
+                                                    iend );
+
+    }
+    stopTimer();
+
+    INIT_VIEW1D_OFFSET_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    INIT_VIEW1D_OFFSET_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend-ibegin, block_size);
+      lambda_cuda_forall<<<grid_size, block_size>>>(
+        ibegin, iend, [=] __device__ (Index_type i) {
+        INIT_VIEW1D_OFFSET_BODY;
+      });
 
     }
     stopTimer();

--- a/src/basic/INIT_VIEW1D_OFFSET-Hip.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Hip.cpp
@@ -39,10 +39,10 @@ __global__ void initview1d_offset(Real_ptr a,
                                   const Index_type ibegin,
                                   const Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i >= ibegin && i < iend) {
-     INIT_VIEW1D_OFFSET_BODY;
-   }
+  Index_type i = ibegin + blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < iend) {
+    INIT_VIEW1D_OFFSET_BODY;
+  }
 }
 
 
@@ -61,10 +61,29 @@ void INIT_VIEW1D_OFFSET::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      hipLaunchKernelGGL((initview1d_offset), dim3(grid_size), dim3(block_size), 0, 0,  a, v,
-                                                    ibegin,
-                                                    iend );
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend-ibegin, block_size);
+      hipLaunchKernelGGL((initview1d_offset), dim3(grid_size), dim3(block_size), 0, 0,
+          a, v, ibegin, iend );
+
+    }
+    stopTimer();
+
+    INIT_VIEW1D_OFFSET_DATA_TEARDOWN_HIP;
+
+  } else if ( vid == Lambda_HIP ) {
+
+    INIT_VIEW1D_OFFSET_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto initview1d_offset_lambda = [=] __device__ (Index_type i) {
+        INIT_VIEW1D_OFFSET_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend-ibegin, block_size);
+      hipLaunchKernelGGL(lambda_hip_forall<decltype(initview1d_offset_lambda)>,
+        grid_size, block_size, 0, 0, ibegin, iend, initview1d_offset_lambda);
 
     }
     stopTimer();

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -36,20 +36,22 @@ INIT_VIEW1D_OFFSET::INIT_VIEW1D_OFFSET(const RunParams& params)
   setVariantDefined( RAJA_OpenMPTarget );
 
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
 
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-INIT_VIEW1D_OFFSET::~INIT_VIEW1D_OFFSET() 
+INIT_VIEW1D_OFFSET::~INIT_VIEW1D_OFFSET()
 {
 }
 
 void INIT_VIEW1D_OFFSET::setUp(VariantID vid)
 {
   allocAndInitDataConst(m_a, getRunSize(), 0.0, vid);
-  m_val = 0.00000123;  
+  m_val = 0.00000123;
 }
 
 void INIT_VIEW1D_OFFSET::updateChecksum(VariantID vid)

--- a/src/basic/MULADDSUB.cpp
+++ b/src/basic/MULADDSUB.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -36,13 +36,15 @@ MULADDSUB::MULADDSUB(const RunParams& params)
   setVariantDefined( RAJA_OpenMPTarget );
 
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
 
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-MULADDSUB::~MULADDSUB() 
+MULADDSUB::~MULADDSUB()
 {
 }
 

--- a/src/basic/NESTED_INIT-Hip.cpp
+++ b/src/basic/NESTED_INIT-Hip.cpp
@@ -31,11 +31,11 @@ namespace basic
 __global__ void nested_init(Real_ptr array,
                             Index_type ni, Index_type nj)
 {
-   Index_type i = threadIdx.x;
-   Index_type j = blockIdx.y;
-   Index_type k = blockIdx.z;
+  Index_type i = threadIdx.x;
+  Index_type j = blockIdx.y;
+  Index_type k = blockIdx.z;
 
-   NESTED_INIT_BODY;
+  NESTED_INIT_BODY;
 }
 
 
@@ -63,6 +63,30 @@ void NESTED_INIT::runHipVariant(VariantID vid)
 
     NESTED_INIT_DATA_TEARDOWN_HIP;
 
+  } else if ( vid == Lambda_HIP ) {
+
+    NESTED_INIT_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto nested_init_lambda = [=] __device__ (Index_type i, Index_type j, Index_type k) {
+        NESTED_INIT_BODY;
+      };
+
+      dim3 nthreads_per_block(ni, 1, 1);
+      dim3 nblocks(1, nj, nk);
+
+      auto kernel = lambda_hip_kernel<RAJA::hip_thread_x_direct, RAJA::hip_block_y_direct, RAJA::hip_block_z_direct, decltype(nested_init_lambda)>;
+      hipLaunchKernelGGL(kernel,
+        nblocks, nthreads_per_block, 0, 0,
+        0, ni, 0, nj, 0, nk, nested_init_lambda);
+
+    }
+    stopTimer();
+
+    NESTED_INIT_DATA_TEARDOWN_HIP;
+
   } else if ( vid == RAJA_HIP ) {
 
     NESTED_INIT_DATA_SETUP_HIP;
@@ -70,9 +94,9 @@ void NESTED_INIT::runHipVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<2, RAJA::hip_block_z_loop,      // k
-            RAJA::statement::For<1, RAJA::hip_block_y_loop,    // j
-              RAJA::statement::For<0, RAJA::hip_thread_x_loop, // i
+          RAJA::statement::For<2, RAJA::hip_block_z_direct,      // k
+            RAJA::statement::For<1, RAJA::hip_block_y_direct,    // j
+              RAJA::statement::For<0, RAJA::hip_thread_x_direct, // i
                 RAJA::statement::Lambda<0>
               >
             >

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -43,13 +43,15 @@ NESTED_INIT::NESTED_INIT(const RunParams& params)
   setVariantDefined( RAJA_OpenMPTarget );
 
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
 
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-NESTED_INIT::~NESTED_INIT() 
+NESTED_INIT::~NESTED_INIT()
 {
 }
 
@@ -70,7 +72,7 @@ void NESTED_INIT::tearDown(VariantID vid)
 {
   (void) vid;
   RAJA::free_aligned(m_array);
-  m_array = 0; 
+  m_array = 0;
 }
 
 } // end namespace basic

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -41,31 +41,31 @@ __global__ void lambda_cuda_forall(Index_type ibegin, Index_type iend, Lambda bo
  * \brief Getters for cuda kernel indices.
  */
 template < typename Index >
-__device__ Index_type lambda_cuda_get_index();
+__device__ inline Index_type lambda_cuda_get_index();
 
 template < >
-__device__ Index_type lambda_cuda_get_index<RAJA::cuda_thread_x_direct>() {
+__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_thread_x_direct>() {
   return threadIdx.x;
 }
 template < >
-__device__ Index_type lambda_cuda_get_index<RAJA::cuda_thread_y_direct>() {
+__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_thread_y_direct>() {
   return threadIdx.y;
 }
 template < >
-__device__ Index_type lambda_cuda_get_index<RAJA::cuda_thread_z_direct>() {
+__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_thread_z_direct>() {
   return threadIdx.z;
 }
 
 template < >
-__device__ Index_type lambda_cuda_get_index<RAJA::cuda_block_x_direct>() {
+__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_block_x_direct>() {
   return blockIdx.x;
 }
 template < >
-__device__ Index_type lambda_cuda_get_index<RAJA::cuda_block_y_direct>() {
+__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_block_y_direct>() {
   return blockIdx.y;
 }
 template < >
-__device__ Index_type lambda_cuda_get_index<RAJA::cuda_block_z_direct>() {
+__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_block_z_direct>() {
   return blockIdx.z;
 }
 

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -72,6 +72,20 @@ __device__ Index_type lambda_cuda_get_index<RAJA::cuda_block_z_direct>() {
 /*!
  * \brief Simple kernel cuda kernel that runs a lambda.
  */
+template < typename I_Index, typename J_Index, typename Lambda >
+__global__ void lambda_cuda_kernel(Index_type ibegin, Index_type iend,
+                                   Index_type jbegin, Index_type jend,
+                                   Lambda body)
+{
+  Index_type i = ibegin + lambda_cuda_get_index<I_Index>();
+  Index_type j = jbegin + lambda_cuda_get_index<J_Index>();
+  if (i < iend) {
+    if (j < jend) {
+      body(i, j);
+    }
+  }
+}
+///
 template < typename I_Index, typename J_Index, typename K_Index, typename Lambda >
 __global__ void lambda_cuda_kernel(Index_type ibegin, Index_type iend,
                                    Index_type jbegin, Index_type jend,

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -26,6 +26,71 @@ namespace rajaperf
 {
 
 /*!
+ * \brief Simple forall cuda kernel that runs a lambda.
+ */
+template < typename Lambda >
+__global__ void lambda_cuda_forall(Index_type ibegin, Index_type iend, Lambda body)
+{
+  Index_type i = ibegin + blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < iend) {
+    body(i);
+  }
+}
+
+/*!
+ * \brief Getters for cuda kernel indices.
+ */
+template < typename Index >
+__device__ Index_type lambda_cuda_get_index();
+
+template < >
+__device__ Index_type lambda_cuda_get_index<RAJA::cuda_thread_x_direct>() {
+  return threadIdx.x;
+}
+template < >
+__device__ Index_type lambda_cuda_get_index<RAJA::cuda_thread_y_direct>() {
+  return threadIdx.y;
+}
+template < >
+__device__ Index_type lambda_cuda_get_index<RAJA::cuda_thread_z_direct>() {
+  return threadIdx.z;
+}
+
+template < >
+__device__ Index_type lambda_cuda_get_index<RAJA::cuda_block_x_direct>() {
+  return blockIdx.x;
+}
+template < >
+__device__ Index_type lambda_cuda_get_index<RAJA::cuda_block_y_direct>() {
+  return blockIdx.y;
+}
+template < >
+__device__ Index_type lambda_cuda_get_index<RAJA::cuda_block_z_direct>() {
+  return blockIdx.z;
+}
+
+/*!
+ * \brief Simple kernel cuda kernel that runs a lambda.
+ */
+template < typename I_Index, typename J_Index, typename K_Index, typename Lambda >
+__global__ void lambda_cuda_kernel(Index_type ibegin, Index_type iend,
+                                   Index_type jbegin, Index_type jend,
+                                   Index_type kbegin, Index_type kend,
+                                   Lambda body)
+{
+  Index_type i = ibegin + lambda_cuda_get_index<I_Index>();
+  Index_type j = jbegin + lambda_cuda_get_index<J_Index>();
+  Index_type k = kbegin + lambda_cuda_get_index<K_Index>();
+  if (i < iend) {
+    if (j < jend) {
+      if (k < kend) {
+        body(i, j, k);
+      }
+    }
+  }
+}
+
+/*!
  * \brief Copy given hptr (host) data to CUDA device (dptr).
  *
  * Method assumes both host and device data arrays are allocated
@@ -34,7 +99,7 @@ namespace rajaperf
 template <typename T>
 void initCudaDeviceData(T& dptr, const T hptr, int len)
 {
-  cudaErrchk( cudaMemcpy( dptr, hptr, 
+  cudaErrchk( cudaMemcpy( dptr, hptr,
                           len * sizeof(typename std::remove_pointer<T>::type),
                           cudaMemcpyHostToDevice ) );
 
@@ -42,7 +107,7 @@ void initCudaDeviceData(T& dptr, const T hptr, int len)
 }
 
 /*!
- * \brief Allocate CUDA device data array (dptr) and copy given hptr (host) 
+ * \brief Allocate CUDA device data array (dptr) and copy given hptr (host)
  * data to device array.
  */
 template <typename T>
@@ -63,7 +128,7 @@ void allocAndInitCudaDeviceData(T& dptr, const T hptr, int len)
 template <typename T>
 void getCudaDeviceData(T& hptr, const T dptr, int len)
 {
-  cudaErrchk( cudaMemcpy( hptr, dptr, 
+  cudaErrchk( cudaMemcpy( hptr, dptr,
               len * sizeof(typename std::remove_pointer<T>::type),
               cudaMemcpyDeviceToHost ) );
 }
@@ -77,7 +142,6 @@ void deallocCudaDeviceData(T& dptr)
   cudaErrchk( cudaFree( dptr ) );
   dptr = 0;
 }
-
 
 }  // closing brace for rajaperf namespace
 

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -72,11 +72,25 @@ __device__ Index_type lambda_hip_get_index<RAJA::hip_block_z_direct>() {
 /*!
  * \brief Simple multi-dimensional hip kernel that runs a lambda.
  */
+template < typename I_Index, typename J_Index, typename Lambda >
+__global__ void lambda_hip_kernel(Index_type ibegin, Index_type iend,
+                                  Index_type jbegin, Index_type jend,
+                                  Lambda body)
+{
+  Index_type i = ibegin + lambda_hip_get_index<I_Index>();
+  Index_type j = jbegin + lambda_hip_get_index<J_Index>();
+  if (i < iend) {
+    if (j < jend) {
+      body(i, j);
+    }
+  }
+}
+///
 template < typename I_Index, typename J_Index, typename K_Index, typename Lambda >
 __global__ void lambda_hip_kernel(Index_type ibegin, Index_type iend,
-                                   Index_type jbegin, Index_type jend,
-                                   Index_type kbegin, Index_type kend,
-                                   Lambda body)
+                                  Index_type jbegin, Index_type jend,
+                                  Index_type kbegin, Index_type kend,
+                                  Lambda body)
 {
   Index_type i = ibegin + lambda_hip_get_index<I_Index>();
   Index_type j = jbegin + lambda_hip_get_index<J_Index>();

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -41,31 +41,31 @@ __global__ void lambda_hip_forall(Index_type ibegin, Index_type iend, Lambda bod
  * \brief Getters for hip kernel indices.
  */
 template < typename Index >
-__device__ Index_type lambda_hip_get_index();
+__device__ inline Index_type lambda_hip_get_index();
 
 template < >
-__device__ Index_type lambda_hip_get_index<RAJA::hip_thread_x_direct>() {
+__device__ inline Index_type lambda_hip_get_index<RAJA::hip_thread_x_direct>() {
   return threadIdx.x;
 }
 template < >
-__device__ Index_type lambda_hip_get_index<RAJA::hip_thread_y_direct>() {
+__device__ inline Index_type lambda_hip_get_index<RAJA::hip_thread_y_direct>() {
   return threadIdx.y;
 }
 template < >
-__device__ Index_type lambda_hip_get_index<RAJA::hip_thread_z_direct>() {
+__device__ inline Index_type lambda_hip_get_index<RAJA::hip_thread_z_direct>() {
   return threadIdx.z;
 }
 
 template < >
-__device__ Index_type lambda_hip_get_index<RAJA::hip_block_x_direct>() {
+__device__ inline Index_type lambda_hip_get_index<RAJA::hip_block_x_direct>() {
   return blockIdx.x;
 }
 template < >
-__device__ Index_type lambda_hip_get_index<RAJA::hip_block_y_direct>() {
+__device__ inline Index_type lambda_hip_get_index<RAJA::hip_block_y_direct>() {
   return blockIdx.y;
 }
 template < >
-__device__ Index_type lambda_hip_get_index<RAJA::hip_block_z_direct>() {
+__device__ inline Index_type lambda_hip_get_index<RAJA::hip_block_z_direct>() {
   return blockIdx.z;
 }
 

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -26,6 +26,71 @@ namespace rajaperf
 {
 
 /*!
+ * \brief Simple forall hip kernel that runs a lambda.
+ */
+template < typename Lambda >
+__global__ void lambda_hip_forall(Index_type ibegin, Index_type iend, Lambda body)
+{
+   Index_type i = ibegin + blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     body(i);
+   }
+}
+
+/*!
+ * \brief Getters for hip kernel indices.
+ */
+template < typename Index >
+__device__ Index_type lambda_hip_get_index();
+
+template < >
+__device__ Index_type lambda_hip_get_index<RAJA::hip_thread_x_direct>() {
+  return threadIdx.x;
+}
+template < >
+__device__ Index_type lambda_hip_get_index<RAJA::hip_thread_y_direct>() {
+  return threadIdx.y;
+}
+template < >
+__device__ Index_type lambda_hip_get_index<RAJA::hip_thread_z_direct>() {
+  return threadIdx.z;
+}
+
+template < >
+__device__ Index_type lambda_hip_get_index<RAJA::hip_block_x_direct>() {
+  return blockIdx.x;
+}
+template < >
+__device__ Index_type lambda_hip_get_index<RAJA::hip_block_y_direct>() {
+  return blockIdx.y;
+}
+template < >
+__device__ Index_type lambda_hip_get_index<RAJA::hip_block_z_direct>() {
+  return blockIdx.z;
+}
+
+/*!
+ * \brief Simple multi-dimensional hip kernel that runs a lambda.
+ */
+template < typename I_Index, typename J_Index, typename K_Index, typename Lambda >
+__global__ void lambda_hip_kernel(Index_type ibegin, Index_type iend,
+                                   Index_type jbegin, Index_type jend,
+                                   Index_type kbegin, Index_type kend,
+                                   Lambda body)
+{
+  Index_type i = ibegin + lambda_hip_get_index<I_Index>();
+  Index_type j = jbegin + lambda_hip_get_index<J_Index>();
+  Index_type k = kbegin + lambda_hip_get_index<K_Index>();
+  if (i < iend) {
+    if (j < jend) {
+      if (k < kend) {
+        body(i, j, k);
+      }
+    }
+  }
+}
+
+/*!
  * \brief Copy given hptr (host) data to HIP device (dptr).
  *
  * Method assumes both host and device data arrays are allocated

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -129,6 +129,7 @@ void KernelBase::runKernel(VariantID vid)
     }
 
     case Base_CUDA :
+    case Lambda_CUDA :
     case RAJA_CUDA :
     case RAJA_WORKGROUP_CUDA :
     {
@@ -139,6 +140,7 @@ void KernelBase::runKernel(VariantID vid)
     }
 
     case Base_HIP :
+    case Lambda_HIP :
     case RAJA_HIP :
     case RAJA_WORKGROUP_HIP :
     {

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -73,13 +73,17 @@ public:
   void synchronize()
   {
 #if defined(RAJA_ENABLE_CUDA)
-    if ( running_variant == Base_CUDA || running_variant == RAJA_CUDA ||
+    if ( running_variant == Base_CUDA ||
+         running_variant == Lambda_CUDA ||
+         running_variant == RAJA_CUDA ||
          running_variant == RAJA_WORKGROUP_CUDA ) {
       cudaErrchk( cudaDeviceSynchronize() );
     }
 #endif
 #if defined(RAJA_ENABLE_HIP)
-    if ( running_variant == Base_HIP || running_variant == RAJA_HIP ||
+    if ( running_variant == Base_HIP ||
+         running_variant == Lambda_HIP ||
+         running_variant == RAJA_HIP ||
          running_variant == RAJA_WORKGROUP_HIP ) {
       hipErrchk( hipDeviceSynchronize() );
     }

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -237,10 +237,12 @@ static const std::string VariantNames [] =
   std::string("RAJA_OMPTarget"),
 
   std::string("Base_CUDA"),
+  std::string("Lambda_CUDA"),
   std::string("RAJA_CUDA"),
   std::string("RAJA_WORKGROUP_CUDA"),
 
   std::string("Base_HIP"),
+  std::string("Lambda_HIP"),
   std::string("RAJA_HIP"),
   std::string("RAJA_WORKGROUP_HIP"),
 
@@ -341,6 +343,7 @@ bool isVariantAvailable(VariantID vid)
 
 #if defined(RAJA_ENABLE_CUDA)
   if ( vid == Base_CUDA ||
+       vid == Lambda_CUDA ||
        vid == RAJA_CUDA ||
        vid == RAJA_WORKGROUP_CUDA ) {
     ret_val = true;
@@ -349,6 +352,7 @@ bool isVariantAvailable(VariantID vid)
 
 #if defined(RAJA_ENABLE_HIP)
   if ( vid == Base_HIP ||
+       vid == Lambda_HIP ||
        vid == RAJA_HIP ||
        vid == RAJA_WORKGROUP_HIP ) {
     ret_val = true;

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -201,10 +201,12 @@ enum VariantID {
   RAJA_OpenMPTarget,
 
   Base_CUDA,
+  Lambda_CUDA,
   RAJA_CUDA,
   RAJA_WORKGROUP_CUDA,
 
   Base_HIP,
+  Lambda_HIP,
   RAJA_HIP,
   RAJA_WORKGROUP_HIP,
 

--- a/src/lcals/HYDRO_2D-Cuda.cpp
+++ b/src/lcals/HYDRO_2D-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -50,20 +50,20 @@ namespace lcals
   deallocCudaDeviceData(zroutdat); \
   deallocCudaDeviceData(zzoutdat);
 
-__global__ void hydro_2d1(Real_ptr zadat, Real_ptr zbdat, 
-                          Real_ptr zpdat, Real_ptr zqdat, 
+__global__ void hydro_2d1(Real_ptr zadat, Real_ptr zbdat,
+                          Real_ptr zpdat, Real_ptr zqdat,
                           Real_ptr zrdat, Real_ptr zmdat,
-                          Index_type jn, Index_type kn) 
+                          Index_type jn, Index_type kn)
 {
    Index_type k = blockIdx.y;
    Index_type j = threadIdx.x;
    if (k > 0 && k < kn-1 && j > 0 && j < jn-1) {
-     HYDRO_2D_BODY1; 
+     HYDRO_2D_BODY1;
    }
 }
 
 __global__ void hydro_2d2(Real_ptr zudat, Real_ptr zvdat,
-                          Real_ptr zadat, Real_ptr zbdat, 
+                          Real_ptr zadat, Real_ptr zbdat,
                           Real_ptr zzdat, Real_ptr zrdat,
                           Real_type s,
                           Index_type jn, Index_type kn)
@@ -76,7 +76,7 @@ __global__ void hydro_2d2(Real_ptr zudat, Real_ptr zvdat,
 }
 
 __global__ void hydro_2d3(Real_ptr zroutdat, Real_ptr zzoutdat,
-                          Real_ptr zrdat, Real_ptr zudat, 
+                          Real_ptr zrdat, Real_ptr zudat,
                           Real_ptr zzdat, Real_ptr zvdat,
                           Real_type t,
                           Index_type jn, Index_type kn)
@@ -137,8 +137,8 @@ void HYDRO_2D::runCudaVariant(VariantID vid)
       using EXECPOL =
         RAJA::KernelPolicy<
           RAJA::statement::CudaKernelAsync<
-            RAJA::statement::For<0, RAJA::cuda_block_y_loop,  // k
-              RAJA::statement::For<1, RAJA::cuda_thread_x_loop,  // j
+            RAJA::statement::For<0, RAJA::cuda_block_y_direct,  // k
+              RAJA::statement::For<1, RAJA::cuda_thread_x_direct,  // j
                 RAJA::statement::Lambda<0>
               >
             >
@@ -174,7 +174,7 @@ void HYDRO_2D::runCudaVariant(VariantID vid)
 
     HYDRO_2D_DATA_TEARDOWN_CUDA;
 
-  } else { 
+  } else {
      std::cout << "\n  HYDRO_2D : Unknown Cuda variant id = " << vid << std::endl;
   }
 }

--- a/src/lcals/HYDRO_2D-Hip.cpp
+++ b/src/lcals/HYDRO_2D-Hip.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -57,7 +57,7 @@ __global__ void hydro_2d1(Real_ptr zadat, Real_ptr zbdat,
    Index_type k = blockIdx.y;
    Index_type j = threadIdx.x;
    if (k > 0 && k < kn-1 && j > 0 && j < jn-1) {
-     HYDRO_2D_BODY1; 
+     HYDRO_2D_BODY1;
    }
 }
 
@@ -139,8 +139,8 @@ void HYDRO_2D::runHipVariant(VariantID vid)
       using EXECPOL =
         RAJA::KernelPolicy<
           RAJA::statement::HipKernelAsync<
-            RAJA::statement::For<0, RAJA::hip_block_y_loop,  // k
-              RAJA::statement::For<1, RAJA::hip_thread_x_loop,  // j
+            RAJA::statement::For<0, RAJA::hip_block_y_direct,  // k
+              RAJA::statement::For<1, RAJA::hip_thread_x_direct,  // j
                 RAJA::statement::Lambda<0>
               >
             >
@@ -176,7 +176,7 @@ void HYDRO_2D::runHipVariant(VariantID vid)
 
     HYDRO_2D_DATA_TEARDOWN_HIP;
 
-  } else { 
+  } else {
      std::cout << "\n  HYDRO_2D : Unknown Hip variant id = " << vid << std::endl;
   }
 }

--- a/src/polybench/POLYBENCH_2MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_2MM-Cuda.cpp
@@ -144,8 +144,8 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<0, RAJA::cuda_block_y_loop,
-            RAJA::statement::For<1, RAJA::cuda_thread_x_loop,
+          RAJA::statement::For<0, RAJA::cuda_block_y_direct,
+            RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Params<0>>,
               RAJA::statement::For<2, RAJA::seq_exec,
                 RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>

--- a/src/polybench/POLYBENCH_2MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_2MM-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -26,7 +26,7 @@ namespace polybench
   allocAndInitCudaDeviceData(A, m_A, m_ni * m_nk); \
   allocAndInitCudaDeviceData(B, m_B, m_nk * m_nj); \
   allocAndInitCudaDeviceData(C, m_C, m_nj * m_nl); \
-  allocAndInitCudaDeviceData(D, m_D, m_ni * m_nl); 
+  allocAndInitCudaDeviceData(D, m_D, m_ni * m_nl);
 
 
 #define POLYBENCH_2MM_TEARDOWN_CUDA \
@@ -47,7 +47,7 @@ __global__ void poly_2mm_1(Real_ptr tmp, Real_ptr A, Real_ptr B,
 
    POLYBENCH_2MM_BODY1;
    for (Index_type k=0; k < nk; ++k) {
-     POLYBENCH_2MM_BODY2;              
+     POLYBENCH_2MM_BODY2;
    }
    POLYBENCH_2MM_BODY3;
 }
@@ -95,6 +95,46 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
 
     POLYBENCH_2MM_TEARDOWN_CUDA;
 
+  } else if (vid == Lambda_CUDA) {
+
+    POLYBENCH_2MM_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      dim3 nblocks1(1, ni, 1);
+      dim3 nthreads_per_block1(nj, 1, 1);
+      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
+                        <<<nblocks1, nthreads_per_block1>>>(
+        0, ni, 0, nj,
+        [=] __device__ (Index_type i, Index_type j) {
+
+        POLYBENCH_2MM_BODY1;
+        for (Index_type k=0; k < nk; ++k) {
+          POLYBENCH_2MM_BODY2;
+        }
+        POLYBENCH_2MM_BODY3;
+      });
+
+      dim3 nblocks2(1, ni, 1);
+      dim3 nthreads_per_block2(nl, 1, 1);
+      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
+                        <<<nblocks2, nthreads_per_block2>>>(
+        0, ni, 0, nl,
+        [=] __device__ (Index_type i, Index_type l) {
+
+        POLYBENCH_2MM_BODY4;
+        for (Index_type j=0; j < nj; ++j) {
+          POLYBENCH_2MM_BODY5;
+        }
+        POLYBENCH_2MM_BODY6;
+      });
+
+    }
+    stopTimer();
+
+    POLYBENCH_2MM_TEARDOWN_CUDA;
+
   } else if (vid == RAJA_CUDA) {
 
     POLYBENCH_2MM_DATA_SETUP_CUDA;
@@ -128,7 +168,7 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
         [=] __device__ (Real_type &dot) {
           POLYBENCH_2MM_BODY1_RAJA;
         },
-        [=] __device__ (Index_type i, Index_type j, Index_type k, 
+        [=] __device__ (Index_type i, Index_type j, Index_type k,
                         Real_type &dot) {
           POLYBENCH_2MM_BODY2_RAJA;
         },
@@ -138,7 +178,7 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
         }
       );
 
-      RAJA::kernel_param<EXEC_POL>( 
+      RAJA::kernel_param<EXEC_POL>(
         RAJA::make_tuple(RAJA::RangeSegment{0, ni},
                          RAJA::RangeSegment{0, nl},
                          RAJA::RangeSegment{0, nj}),
@@ -147,7 +187,7 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
         [=] __device__ (Real_type &dot) {
           POLYBENCH_2MM_BODY4_RAJA;
         },
-        [=] __device__ (Index_type i, Index_type l, Index_type j, 
+        [=] __device__ (Index_type i, Index_type l, Index_type j,
                         Real_type &dot) {
           POLYBENCH_2MM_BODY5_RAJA;
         },
@@ -172,4 +212,4 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_CUDA
-  
+

--- a/src/polybench/POLYBENCH_2MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_2MM-Hip.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_2MM.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -26,7 +26,7 @@ namespace polybench
   allocAndInitHipDeviceData(A, m_A, m_ni * m_nk); \
   allocAndInitHipDeviceData(B, m_B, m_nk * m_nj); \
   allocAndInitHipDeviceData(C, m_C, m_nj * m_nl); \
-  allocAndInitHipDeviceData(D, m_D, m_ni * m_nl); 
+  allocAndInitHipDeviceData(D, m_D, m_ni * m_nl);
 
 
 #define POLYBENCH_2MM_TEARDOWN_HIP \
@@ -47,7 +47,7 @@ __global__ void poly_2mm_1(Real_ptr tmp, Real_ptr A, Real_ptr B,
 
    POLYBENCH_2MM_BODY1;
    for (Index_type k=0; k < nk; ++k) {
-     POLYBENCH_2MM_BODY2;              
+     POLYBENCH_2MM_BODY2;
    }
    POLYBENCH_2MM_BODY3;
 }
@@ -82,15 +82,59 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
 
       dim3 nblocks1(1, ni, 1);
       dim3 nthreads_per_block1(nj, 1, 1);
-      hipLaunchKernelGGL((poly_2mm_1), dim3(nblocks1), dim3(nthreads_per_block1), 0, 0, 
+      hipLaunchKernelGGL((poly_2mm_1), dim3(nblocks1), dim3(nthreads_per_block1), 0, 0,
                                                     tmp, A, B, alpha,
                                                     nj, nk);
 
       dim3 nblocks2(1, ni, 1);
       dim3 nthreads_per_block2(nl, 1, 1);
-      hipLaunchKernelGGL((poly_2mm_2), dim3(nblocks2), dim3(nthreads_per_block2), 0, 0, 
+      hipLaunchKernelGGL((poly_2mm_2), dim3(nblocks2), dim3(nthreads_per_block2), 0, 0,
                                                     tmp, C, D, beta,
                                                     nl, nj);
+
+    }
+    stopTimer();
+
+    POLYBENCH_2MM_TEARDOWN_HIP;
+
+  } else if (vid == Lambda_HIP) {
+
+    POLYBENCH_2MM_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto poly_2mm_1_lambda = [=] __device__ (Index_type i, Index_type j) {
+
+        POLYBENCH_2MM_BODY1;
+        for (Index_type k=0; k < nk; ++k) {
+          POLYBENCH_2MM_BODY2;
+        }
+        POLYBENCH_2MM_BODY3;
+      };
+
+      dim3 nblocks1(1, ni, 1);
+      dim3 nthreads_per_block1(nj, 1, 1);
+      auto kernel1 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_2mm_1_lambda)>;
+      hipLaunchKernelGGL(kernel1,
+        nblocks1, nthreads_per_block1, 0, 0,
+        0, ni, 0, nj, poly_2mm_1_lambda);
+
+      auto poly_2mm_2_lambda = [=] __device__ (Index_type i, Index_type l) {
+
+        POLYBENCH_2MM_BODY4;
+        for (Index_type j=0; j < nj; ++j) {
+          POLYBENCH_2MM_BODY5;
+        }
+        POLYBENCH_2MM_BODY6;
+      };
+
+      dim3 nblocks2(1, ni, 1);
+      dim3 nthreads_per_block2(nl, 1, 1);
+      auto kernel2 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_2mm_2_lambda)>;
+      hipLaunchKernelGGL(kernel2,
+        nblocks2, nthreads_per_block2, 0, 0,
+        0, ni, 0, nl, poly_2mm_2_lambda);
 
     }
     stopTimer();
@@ -106,8 +150,8 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_y_loop,
-            RAJA::statement::For<1, RAJA::hip_thread_x_loop,
+          RAJA::statement::For<0, RAJA::hip_block_y_direct,
+            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Params<0>>,
               RAJA::statement::For<2, RAJA::seq_exec,
                 RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
@@ -140,7 +184,7 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
         }
       );
 
-      RAJA::kernel_param<EXEC_POL>( 
+      RAJA::kernel_param<EXEC_POL>(
         RAJA::make_tuple(RAJA::RangeSegment{0, ni},
                          RAJA::RangeSegment{0, nl},
                          RAJA::RangeSegment{0, nj}),
@@ -174,4 +218,4 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_HIP
-  
+

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -12,7 +12,7 @@
 #include "common/DataUtils.hpp"
 
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -21,7 +21,7 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_2MM, params)
 {
   SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0; 
+  int run_reps = 0;
   switch(lsizespec) {
     case Mini:
       m_ni=16; m_nj=18; m_nk=22; m_nl=24;
@@ -58,22 +58,24 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-POLYBENCH_2MM::~POLYBENCH_2MM() 
+POLYBENCH_2MM::~POLYBENCH_2MM()
 {
 
 }

--- a/src/polybench/POLYBENCH_3MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_3MM-Cuda.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//  
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_3MM.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -28,7 +28,7 @@ namespace polybench
   allocAndInitCudaDeviceData(D, m_D, m_nm * m_nl); \
   allocAndInitCudaDeviceData(E, m_E, m_ni * m_nj); \
   allocAndInitCudaDeviceData(F, m_F, m_nj * m_nl); \
-  allocAndInitCudaDeviceData(G, m_G, m_ni * m_nl); 
+  allocAndInitCudaDeviceData(G, m_G, m_ni * m_nl);
 
 
 #define POLYBENCH_3MM_TEARDOWN_CUDA \
@@ -44,40 +44,40 @@ namespace polybench
 __global__ void poly_3mm_1(Real_ptr E, Real_ptr A, Real_ptr B,
                            Index_type nj, Index_type nk)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y;
+  Index_type j = threadIdx.x;
 
-   POLYBENCH_3MM_BODY1;
-   for (Index_type k=0; k < nk; ++k) {
-     POLYBENCH_3MM_BODY2;
-   }
-   POLYBENCH_3MM_BODY3;
+  POLYBENCH_3MM_BODY1;
+  for (Index_type k=0; k < nk; ++k) {
+    POLYBENCH_3MM_BODY2;
+  }
+  POLYBENCH_3MM_BODY3;
 }
 
 __global__ void poly_3mm_2(Real_ptr F, Real_ptr C, Real_ptr D,
                            Index_type nl, Index_type nm)
 {
-   Index_type j = blockIdx.y;
-   Index_type l = threadIdx.x;
+  Index_type j = blockIdx.y;
+  Index_type l = threadIdx.x;
 
-   POLYBENCH_3MM_BODY4;
-   for (Index_type m=0; m < nm; ++m) {
-     POLYBENCH_3MM_BODY5;
-   }
-   POLYBENCH_3MM_BODY6;
+  POLYBENCH_3MM_BODY4;
+  for (Index_type m=0; m < nm; ++m) {
+    POLYBENCH_3MM_BODY5;
+  }
+  POLYBENCH_3MM_BODY6;
 }
 
 __global__ void poly_3mm_3(Real_ptr G, Real_ptr E, Real_ptr F,
                            Index_type nl, Index_type nj)
 {
-   Index_type i = blockIdx.y;
-   Index_type l = threadIdx.x;
+  Index_type i = blockIdx.y;
+  Index_type l = threadIdx.x;
 
-   POLYBENCH_3MM_BODY7;
-   for (Index_type j=0; j < nj; ++j) {
-     POLYBENCH_3MM_BODY8;
-   }
-   POLYBENCH_3MM_BODY9;
+  POLYBENCH_3MM_BODY7;
+  for (Index_type j=0; j < nj; ++j) {
+    POLYBENCH_3MM_BODY8;
+  }
+  POLYBENCH_3MM_BODY9;
 }
 
 
@@ -86,7 +86,7 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
 
   POLYBENCH_3MM_DATA_SETUP;
-  
+
   if ( vid == Base_CUDA ) {
 
     POLYBENCH_3MM_DATA_SETUP_CUDA;
@@ -111,7 +111,61 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
 
     }
     stopTimer();
-    
+
+    POLYBENCH_3MM_TEARDOWN_CUDA;
+
+  } else if (vid == Lambda_CUDA) {
+
+    POLYBENCH_3MM_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      dim3 nblocks1(1, ni, 1);
+      dim3 nthreads_per_block1(nj, 1, 1);
+      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
+                <<<nblocks1, nthreads_per_block1>>>(
+        0, ni, 0, nj,
+        [=] __device__ (Index_type i, Index_type j) {
+
+        POLYBENCH_3MM_BODY1;
+        for (Index_type k=0; k < nk; ++k) {
+          POLYBENCH_3MM_BODY2;
+        }
+        POLYBENCH_3MM_BODY3;
+      });
+
+      dim3 nblocks2(1, nj, 1);
+      dim3 nthreads_per_block2(nl, 1, 1);
+      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
+                <<<nblocks2, nthreads_per_block2>>>(
+        0, nj, 0, nl,
+        [=] __device__ (Index_type j, Index_type l) {
+
+        POLYBENCH_3MM_BODY4;
+        for (Index_type m=0; m < nm; ++m) {
+          POLYBENCH_3MM_BODY5;
+        }
+        POLYBENCH_3MM_BODY6;
+      });
+
+      dim3 nblocks3(1, ni, 1);
+      dim3 nthreads_per_block3(nl, 1, 1);
+      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
+                <<<nblocks3, nthreads_per_block3>>>(
+        0, ni, 0, nl,
+        [=] __device__ (Index_type i, Index_type l) {
+
+        POLYBENCH_3MM_BODY7;
+        for (Index_type j=0; j < nj; ++j) {
+          POLYBENCH_3MM_BODY8;
+        }
+        POLYBENCH_3MM_BODY9;
+      });
+
+    }
+    stopTimer();
+
     POLYBENCH_3MM_TEARDOWN_CUDA;
 
   } else if (vid == RAJA_CUDA) {
@@ -147,7 +201,7 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
         [=] __device__ (Real_type &dot) {
           POLYBENCH_3MM_BODY1_RAJA;
         },
-        [=] __device__ (Index_type i, Index_type j, Index_type k, 
+        [=] __device__ (Index_type i, Index_type j, Index_type k,
                         Real_type &dot) {
           POLYBENCH_3MM_BODY2_RAJA;
         },
@@ -167,7 +221,7 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
         [=] __device__ (Real_type &dot) {
           POLYBENCH_3MM_BODY4_RAJA;
         },
-        [=] __device__ (Index_type j, Index_type l, Index_type m, 
+        [=] __device__ (Index_type j, Index_type l, Index_type m,
                         Real_type &dot) {
           POLYBENCH_3MM_BODY5_RAJA;
         },
@@ -187,7 +241,7 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
         [=] __device__ (Real_type &dot) {
           POLYBENCH_3MM_BODY7_RAJA;
         },
-        [=] __device__ (Index_type i, Index_type l, Index_type j, 
+        [=] __device__ (Index_type i, Index_type l, Index_type j,
                         Real_type &dot) {
           POLYBENCH_3MM_BODY8_RAJA;
         },
@@ -213,4 +267,4 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_CUDA
-  
+

--- a/src/polybench/POLYBENCH_3MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_3MM-Cuda.cpp
@@ -177,8 +177,8 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<0, RAJA::cuda_block_x_loop,
-            RAJA::statement::For<1, RAJA::cuda_thread_y_loop,
+          RAJA::statement::For<0, RAJA::cuda_block_x_direct,
+            RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
               RAJA::statement::Lambda<0, RAJA::Params<0>>,
               RAJA::statement::For<2, RAJA::seq_exec,
                 RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>

--- a/src/polybench/POLYBENCH_3MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_3MM-Hip.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_3MM.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -28,7 +28,7 @@ namespace polybench
   allocAndInitHipDeviceData(D, m_D, m_nm * m_nl); \
   allocAndInitHipDeviceData(E, m_E, m_ni * m_nj); \
   allocAndInitHipDeviceData(F, m_F, m_nj * m_nl); \
-  allocAndInitHipDeviceData(G, m_G, m_ni * m_nl); 
+  allocAndInitHipDeviceData(G, m_G, m_ni * m_nl);
 
 
 #define POLYBENCH_3MM_TEARDOWN_HIP \
@@ -86,7 +86,7 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
   const Index_type run_reps = getRunReps();
 
   POLYBENCH_3MM_DATA_SETUP;
-  
+
   if ( vid == Base_HIP ) {
 
     POLYBENCH_3MM_DATA_SETUP_HIP;
@@ -96,7 +96,7 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
 
       dim3 nblocks1(1, ni, 1);
       dim3 nthreads_per_block1(nj, 1, 1);
-      hipLaunchKernelGGL((poly_3mm_1), dim3(nblocks1) , dim3(nthreads_per_block1), 0, 0, 
+      hipLaunchKernelGGL((poly_3mm_1), dim3(nblocks1) , dim3(nthreads_per_block1), 0, 0,
                                                     E, A, B,
                                                     nj, nk);
 
@@ -108,13 +108,73 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
 
       dim3 nblocks3(1, ni, 1);
       dim3 nthreads_per_block3(nl, 1, 1);
-      hipLaunchKernelGGL((poly_3mm_3), dim3(nblocks3), dim3(nthreads_per_block3), 0, 0, 
+      hipLaunchKernelGGL((poly_3mm_3), dim3(nblocks3), dim3(nthreads_per_block3), 0, 0,
                                                     G, E, F,
                                                     nl, nj);
 
     }
     stopTimer();
-    
+
+    POLYBENCH_3MM_TEARDOWN_HIP;
+
+  } else if (vid == Lambda_HIP) {
+
+    POLYBENCH_3MM_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto poly_3mm_1_lambda = [=] __device__ (Index_type i, Index_type j) {
+
+        POLYBENCH_3MM_BODY1;
+        for (Index_type k=0; k < nk; ++k) {
+          POLYBENCH_3MM_BODY2;
+        }
+        POLYBENCH_3MM_BODY3;
+      };
+
+      dim3 nblocks1(1, ni, 1);
+      dim3 nthreads_per_block1(nj, 1, 1);
+      auto kernel1 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_3mm_1_lambda)>;
+      hipLaunchKernelGGL(kernel1,
+        nblocks1, nthreads_per_block1, 0, 0,
+        0, ni, 0, nj, poly_3mm_1_lambda);
+
+      auto poly_3mm_2_lambda = [=] __device__ (Index_type j, Index_type l) {
+
+        POLYBENCH_3MM_BODY4;
+        for (Index_type m=0; m < nm; ++m) {
+          POLYBENCH_3MM_BODY5;
+        }
+        POLYBENCH_3MM_BODY6;
+      };
+
+      dim3 nblocks2(1, nj, 1);
+      dim3 nthreads_per_block2(nl, 1, 1);
+      auto kernel2 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_3mm_2_lambda)>;
+      hipLaunchKernelGGL(kernel2,
+        nblocks2, nthreads_per_block2, 0, 0,
+        0, nj, 0, nl, poly_3mm_2_lambda);
+
+      auto poly_3mm_3_lambda = [=] __device__ (Index_type i, Index_type l) {
+
+        POLYBENCH_3MM_BODY7;
+        for (Index_type j=0; j < nj; ++j) {
+          POLYBENCH_3MM_BODY8;
+        }
+        POLYBENCH_3MM_BODY9;
+      };
+
+      dim3 nblocks3(1, ni, 1);
+      dim3 nthreads_per_block3(nl, 1, 1);
+      auto kernel3 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_3mm_3_lambda)>;
+      hipLaunchKernelGGL(kernel3,
+        nblocks3, nthreads_per_block3, 0, 0,
+        0, ni, 0, nl, poly_3mm_3_lambda);
+
+    }
+    stopTimer();
+
     POLYBENCH_3MM_TEARDOWN_HIP;
 
   } else if (vid == RAJA_HIP) {
@@ -216,4 +276,4 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_HIP
-  
+

--- a/src/polybench/POLYBENCH_3MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_3MM-Hip.cpp
@@ -186,8 +186,8 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_x_loop,
-            RAJA::statement::For<1, RAJA::hip_thread_y_loop,
+          RAJA::statement::For<0, RAJA::hip_block_x_direct,
+            RAJA::statement::For<1, RAJA::hip_thread_y_direct,
               RAJA::statement::Lambda<0, RAJA::Params<0>>,
               RAJA::statement::For<2, RAJA::seq_exec,
                 RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -12,12 +12,12 @@
 #include "common/DataUtils.hpp"
 
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
 
-  
+
 POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_3MM, params)
 {
@@ -55,22 +55,24 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-POLYBENCH_3MM::~POLYBENCH_3MM() 
+POLYBENCH_3MM::~POLYBENCH_3MM()
 {
 }
 

--- a/src/polybench/POLYBENCH_ADI-Hip.cpp
+++ b/src/polybench/POLYBENCH_ADI-Hip.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_ADI.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -30,7 +30,7 @@ const size_t block_size = 256;
   allocAndInitHipDeviceData(U, m_U, m_n * m_n); \
   allocAndInitHipDeviceData(V, m_V, m_n * m_n); \
   allocAndInitHipDeviceData(P, m_P, m_n * m_n); \
-  allocAndInitHipDeviceData(Q, m_Q, m_n * m_n); 
+  allocAndInitHipDeviceData(Q, m_Q, m_n * m_n);
 
 
 #define POLYBENCH_ADI_TEARDOWN_HIP \
@@ -38,16 +38,16 @@ const size_t block_size = 256;
   deallocHipDeviceData(U); \
   deallocHipDeviceData(V); \
   deallocHipDeviceData(P); \
-  deallocHipDeviceData(Q); 
+  deallocHipDeviceData(Q);
 
 
 __global__ void adi1(const Index_type n,
-                     const Real_type a, const Real_type b, const Real_type c, 
+                     const Real_type a, const Real_type b, const Real_type c,
                      const Real_type d, const Real_type f,
                      Real_ptr P, Real_ptr Q, Real_ptr U, Real_ptr V)
 {
-  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i > 0 && i < n-1) {
+  Index_type i = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n-1) {
     POLYBENCH_ADI_BODY2;
     for (Index_type j = 1; j < n-1; ++j) {
        POLYBENCH_ADI_BODY3;
@@ -60,12 +60,12 @@ __global__ void adi1(const Index_type n,
 }
 
 __global__ void adi2(const Index_type n,
-                     const Real_type a, const Real_type c, const Real_type d, 
+                     const Real_type a, const Real_type c, const Real_type d,
                      const Real_type e, const Real_type f,
                      Real_ptr P, Real_ptr Q, Real_ptr U, Real_ptr V)
 {
-  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i > 0 && i < n-1) {
+  Index_type i = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n-1) {
     POLYBENCH_ADI_BODY6;
     for (Index_type j = 1; j < n-1; ++j) {
       POLYBENCH_ADI_BODY7;
@@ -81,7 +81,7 @@ __global__ void adi2(const Index_type n,
 void POLYBENCH_ADI::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  
+
   POLYBENCH_ADI_DATA_SETUP;
 
   if ( vid == Base_HIP ) {
@@ -93,14 +93,14 @@ void POLYBENCH_ADI::runHipVariant(VariantID vid)
 
       for (Index_type t = 1; t <= tsteps; ++t) {
 
-        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(n-1, block_size);
+        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(n-2, block_size);
 
-        hipLaunchKernelGGL((adi1), dim3(grid_size), dim3(block_size), 0, 0, 
+        hipLaunchKernelGGL((adi1), dim3(grid_size), dim3(block_size), 0, 0,
                                         n,
                                         a, b, c, d, f,
                                         P, Q, U, V);
 
-        hipLaunchKernelGGL((adi2), dim3(grid_size), dim3(block_size), 0, 0, 
+        hipLaunchKernelGGL((adi2), dim3(grid_size), dim3(block_size), 0, 0,
                                         n,
                                         a, c, d, e, f,
                                         P, Q, U, V);
@@ -112,7 +112,57 @@ void POLYBENCH_ADI::runHipVariant(VariantID vid)
 
     POLYBENCH_ADI_TEARDOWN_HIP;
 
-  } else if (vid == RAJA_HIP) {   
+  } else if ( vid == Lambda_HIP ) {
+
+    POLYBENCH_ADI_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      for (Index_type t = 1; t <= tsteps; ++t) {
+
+        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(n-2, block_size);
+
+        auto adi1_lamda = [=] __device__ (Index_type i) {
+
+          POLYBENCH_ADI_BODY2;
+          for (Index_type j = 1; j < n-1; ++j) {
+             POLYBENCH_ADI_BODY3;
+          }
+          POLYBENCH_ADI_BODY4;
+          for (Index_type k = n-2; k >= 1; --k) {
+             POLYBENCH_ADI_BODY5;
+          }
+        };
+
+        hipLaunchKernelGGL(lambda_hip_forall<decltype(adi1_lamda)>,
+          grid_size, block_size, 0, 0,
+          1, n-1, adi1_lamda);
+
+        auto adi2_lamda = [=] __device__ (Index_type i) {
+
+          POLYBENCH_ADI_BODY6;
+          for (Index_type j = 1; j < n-1; ++j) {
+            POLYBENCH_ADI_BODY7;
+          }
+          POLYBENCH_ADI_BODY8;
+          for (Index_type k = n-2; k >= 1; --k) {
+            POLYBENCH_ADI_BODY9;
+          }
+        };
+
+        hipLaunchKernelGGL(lambda_hip_forall<decltype(adi2_lamda)>,
+          grid_size, block_size, 0, 0,
+          1, n-1, adi2_lamda);
+
+      }  // tstep loop
+
+    }
+    stopTimer();
+
+    POLYBENCH_ADI_TEARDOWN_HIP;
+
+  } else if (vid == RAJA_HIP) {
 
     POLYBENCH_ADI_DATA_SETUP_HIP;
 
@@ -120,9 +170,9 @@ void POLYBENCH_ADI::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>, 
-                                   RAJA::hip_block_x_loop,
+        RAJA::statement::HipKernelFixedAsync<block_size,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
+                                   RAJA::hip_block_x_direct,
             RAJA::statement::For<0, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Segs<0>>,
               RAJA::statement::For<1, RAJA::seq_exec,
@@ -191,9 +241,9 @@ void POLYBENCH_ADI::runHipVariant(VariantID vid)
       std::cout << "\n  POLYBENCH_ADI : Unknown Hip variant id = " << vid << std::endl;
   }
 }
-  
+
 } // end namespace polybench
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_HIP
-  
+

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -11,7 +11,7 @@
 #include "RAJA/RAJA.hpp"
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -24,27 +24,27 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
   int run_reps;
   switch(lsizespec) {
     case Mini:
-      m_n=20; m_tsteps=1; 
+      m_n=20; m_tsteps=1;
       run_reps = 10000;
       break;
     case Small:
-      m_n=60; m_tsteps=40; 
+      m_n=60; m_tsteps=40;
       run_reps = 500;
       break;
     case Medium:
-      m_n=200; m_tsteps=100; 
+      m_n=200; m_tsteps=100;
       run_reps = 20;
       break;
     case Large:
-      m_n=1000; m_tsteps=500; 
+      m_n=1000; m_tsteps=500;
       run_reps = 1;
       break;
     case Extralarge:
-      m_n=2000; m_tsteps=1000; 
+      m_n=2000; m_tsteps=1000;
       run_reps = 1;
       break;
     default:
-      m_n=200; m_tsteps=100; 
+      m_n=200; m_tsteps=100;
       run_reps = 20;
       break;
   }
@@ -55,22 +55,24 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-POLYBENCH_ADI::~POLYBENCH_ADI() 
+POLYBENCH_ADI::~POLYBENCH_ADI()
 {
 }
 

--- a/src/polybench/POLYBENCH_ATAX-Hip.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Hip.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_ATAX.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -96,6 +96,46 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
 
     POLYBENCH_ATAX_TEARDOWN_HIP;
 
+  } else if ( vid == Lambda_HIP ) {
+
+    POLYBENCH_ATAX_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
+
+      auto poly_atax_1_lambda = [=] __device__ (Index_type i) {
+
+        POLYBENCH_ATAX_BODY1;
+        for (Index_type j = 0; j < N; ++j ) {
+          POLYBENCH_ATAX_BODY2;
+        }
+        POLYBENCH_ATAX_BODY3;
+      };
+
+      hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_atax_1_lambda)>,
+        grid_size, block_size, 0, 0,
+        0, N, poly_atax_1_lambda);
+
+      auto poly_atax_2_lambda = [=] __device__ (Index_type j) {
+
+        POLYBENCH_ATAX_BODY4;
+        for (Index_type i = 0; i < N; ++i ) {
+          POLYBENCH_ATAX_BODY5;
+        }
+        POLYBENCH_ATAX_BODY6;
+      };
+
+      hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_atax_2_lambda)>,
+        grid_size, block_size, 0, 0,
+        0, N, poly_atax_2_lambda);
+
+    }
+    stopTimer();
+
+    POLYBENCH_ATAX_TEARDOWN_HIP;
+
   } else if (vid == RAJA_HIP) {
 
     POLYBENCH_ATAX_DATA_SETUP_HIP;
@@ -105,8 +145,8 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
     using EXEC_POL1 =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>, 
-                                   RAJA::hip_block_x_loop,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
+                                   RAJA::hip_block_x_direct,
             RAJA::statement::For<0, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
               RAJA::statement::For<1, RAJA::seq_exec,
@@ -121,8 +161,8 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
     using EXEC_POL2 =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::Tile<1, RAJA::tile_fixed<block_size>, 
-                                   RAJA::hip_block_x_loop,
+          RAJA::statement::Tile<1, RAJA::tile_fixed<block_size>,
+                                   RAJA::hip_block_x_direct,
             RAJA::statement::For<1, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Segs<1>, RAJA::Params<0>>,
               RAJA::statement::For<0, RAJA::seq_exec,
@@ -137,7 +177,7 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_param<EXEC_POL1>( 
+      RAJA::kernel_param<EXEC_POL1>(
         RAJA::make_tuple(RAJA::RangeSegment{0, N},
                          RAJA::RangeSegment{0, N}),
         RAJA::tuple<Real_type>{0.0},
@@ -154,7 +194,7 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
 
       );
 
-      RAJA::kernel_param<EXEC_POL2>( 
+      RAJA::kernel_param<EXEC_POL2>(
         RAJA::make_tuple(RAJA::RangeSegment{0, N},
                          RAJA::RangeSegment{0, N}),
         RAJA::tuple<Real_type>{0.0},
@@ -186,4 +226,4 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_HIP
-  
+

--- a/src/polybench/POLYBENCH_ATAX.cpp
+++ b/src/polybench/POLYBENCH_ATAX.cpp
@@ -56,18 +56,20 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 

--- a/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_FDTD_2D.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -43,42 +43,42 @@ namespace polybench
 __global__ void poly_fdtd2d_1(Real_ptr ey, Real_ptr fict,
                               Index_type ny, Index_type t)
 {
-   Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-   if (j < ny) {
-     POLYBENCH_FDTD_2D_BODY1;
-   }
+  if (j < ny) {
+    POLYBENCH_FDTD_2D_BODY1;
+  }
 }
 
 __global__ void poly_fdtd2d_2(Real_ptr ey, Real_ptr hz, Index_type ny)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y;
+  Index_type j = threadIdx.x;
 
-   if (i > 0) {
-     POLYBENCH_FDTD_2D_BODY2;
-   }
+  if (i > 0) {
+    POLYBENCH_FDTD_2D_BODY2;
+  }
 }
 
 __global__ void poly_fdtd2d_3(Real_ptr ex, Real_ptr hz, Index_type ny)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y;
+  Index_type j = threadIdx.x;
 
-   if (j > 0) {
-     POLYBENCH_FDTD_2D_BODY3;
-   }
+  if (j > 0) {
+    POLYBENCH_FDTD_2D_BODY3;
+  }
 }
 
 __global__ void poly_fdtd2d_4(Real_ptr hz, Real_ptr ex, Real_ptr ey,
                               Index_type nx, Index_type ny)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y;
+  Index_type j = threadIdx.x;
 
-   if (i < nx-1 && j < ny-1) {
-     POLYBENCH_FDTD_2D_BODY4;
-   }
+  if (i < nx-1 && j < ny-1) {
+    POLYBENCH_FDTD_2D_BODY4;
+  }
 }
 
 
@@ -87,7 +87,7 @@ void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
-  POLYBENCH_FDTD_2D_DATA_SETUP; 
+  POLYBENCH_FDTD_2D_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
 
@@ -116,6 +116,52 @@ void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
 
     POLYBENCH_FDTD_2D_TEARDOWN_CUDA;
 
+  } else if ( vid == Lambda_CUDA ) {
+
+    POLYBENCH_FDTD_2D_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      for (t = 0; t < tsteps; ++t) {
+
+        const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
+        lambda_cuda_forall<<<grid_size1, block_size>>>(
+          0, ny,
+          [=] __device__ (Index_type j) {
+            POLYBENCH_FDTD_2D_BODY1;
+        });
+
+        dim3 nblocks234(1, nx, 1);
+        dim3 nthreads_per_block234(ny, 1, 1);
+        lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
+                          <<<nblocks234, nthreads_per_block234>>>(
+          1, nx, 0, ny,
+          [=] __device__ (Index_type i, Index_type j) {
+            POLYBENCH_FDTD_2D_BODY2;
+        });
+
+        lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
+                          <<<nblocks234, nthreads_per_block234>>>(
+          0, nx, 1, ny,
+          [=] __device__ (Index_type i, Index_type j) {
+            POLYBENCH_FDTD_2D_BODY3;
+        });
+
+        lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
+                          <<<nblocks234, nthreads_per_block234>>>(
+          0, nx-1, 0, ny-1,
+          [=] __device__ (Index_type i, Index_type j) {
+            POLYBENCH_FDTD_2D_BODY4;
+        });
+
+      } // tstep loop
+
+    } // run_reps
+    stopTimer();
+
+    POLYBENCH_FDTD_2D_TEARDOWN_CUDA;
+
   } else if (vid == RAJA_CUDA) {
 
     POLYBENCH_FDTD_2D_DATA_SETUP_CUDA;
@@ -127,8 +173,8 @@ void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
     using EXEC_POL234 =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<0, RAJA::cuda_block_y_loop,
-            RAJA::statement::For<1, RAJA::cuda_thread_x_loop,
+          RAJA::statement::For<0, RAJA::cuda_block_y_direct,
+            RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
               RAJA::statement::Lambda<0>
             >
           >
@@ -141,8 +187,8 @@ void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
       for (t = 0; t < tsteps; ++t) {
 
         RAJA::forall<EXEC_POL1>( RAJA::RangeSegment(0, ny),
-         [=] __device__ (Index_type j) {
-           POLYBENCH_FDTD_2D_BODY1_RAJA;
+        [=] __device__ (Index_type j) {
+          POLYBENCH_FDTD_2D_BODY1_RAJA;
         });
 
         RAJA::kernel<EXEC_POL234>(
@@ -186,4 +232,4 @@ void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_CUDA
-  
+

--- a/src/polybench/POLYBENCH_FDTD_2D.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.cpp
@@ -14,7 +14,7 @@
 #include <iostream>
 #include <cstring>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -27,27 +27,27 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
   int run_reps;
   switch(lsizespec) {
     case Mini:
-      m_nx=20; m_ny=30; m_tsteps=20; 
+      m_nx=20; m_ny=30; m_tsteps=20;
       run_reps = 10000;
       break;
     case Small:
-      m_nx=60; m_ny=80; m_tsteps=40; 
+      m_nx=60; m_ny=80; m_tsteps=40;
       run_reps = 500;
       break;
     case Medium:
-      m_nx=200; m_ny=240; m_tsteps=100; 
+      m_nx=200; m_ny=240; m_tsteps=100;
       run_reps = 200;
       break;
     case Large:
-      m_nx=800; m_ny=1000; m_tsteps=500; 
+      m_nx=800; m_ny=1000; m_tsteps=500;
       run_reps = 1;
       break;
     case Extralarge:
-      m_nx=2000; m_ny=2600; m_tsteps=1000; 
+      m_nx=2000; m_ny=2600; m_tsteps=1000;
       run_reps = 1;
       break;
     default:
-      m_nx=800; m_ny=1000; m_tsteps=60; 
+      m_nx=800; m_ny=1000; m_tsteps=60;
       run_reps = 10;
       break;
   }
@@ -58,22 +58,24 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-POLYBENCH_FDTD_2D::~POLYBENCH_FDTD_2D() 
+POLYBENCH_FDTD_2D::~POLYBENCH_FDTD_2D()
 {
 
 }

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
@@ -14,7 +14,7 @@
 
 #include "common/HipDataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -37,7 +37,7 @@ __global__ void poly_floyd_warshall(Real_ptr pout, Real_ptr pin,
    Index_type i = blockIdx.y;
    Index_type j = threadIdx.x;
 
-   POLYBENCH_FLOYD_WARSHALL_BODY;              
+   POLYBENCH_FLOYD_WARSHALL_BODY;
 }
 
 
@@ -68,6 +68,34 @@ void POLYBENCH_FLOYD_WARSHALL::runHipVariant(VariantID vid)
 
     POLYBENCH_FLOYD_WARSHALL_TEARDOWN_HIP;
 
+  } else if ( vid == Lambda_HIP ) {
+
+    POLYBENCH_FLOYD_WARSHALL_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      for (Index_type k = 0; k < N; ++k) {
+
+        auto poly_floyd_warshall_lambda = [=] __device__ (Index_type i, Index_type j) {
+
+          POLYBENCH_FLOYD_WARSHALL_BODY;
+        };
+
+        dim3 nblocks1(1, N, 1);
+        dim3 nthreads_per_block1(N, 1, 1);
+        auto kernel = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_floyd_warshall_lambda)>;
+        hipLaunchKernelGGL(kernel,
+          nblocks1, nthreads_per_block1,0,0,
+          0, N, 0, N, poly_floyd_warshall_lambda);
+
+      }
+
+    }
+    stopTimer();
+
+    POLYBENCH_FLOYD_WARSHALL_TEARDOWN_HIP;
+
   } else if (vid == RAJA_HIP) {
 
     POLYBENCH_FLOYD_WARSHALL_DATA_SETUP_HIP;
@@ -78,8 +106,8 @@ void POLYBENCH_FLOYD_WARSHALL::runHipVariant(VariantID vid)
       RAJA::KernelPolicy<
         RAJA::statement::For<0, RAJA::seq_exec,
           RAJA::statement::HipKernelAsync<
-            RAJA::statement::For<1, RAJA::hip_block_y_loop,
-              RAJA::statement::For<2, RAJA::hip_thread_x_loop,
+            RAJA::statement::For<1, RAJA::hip_block_y_direct,
+              RAJA::statement::For<2, RAJA::hip_thread_x_direct,
                 RAJA::statement::Lambda<0>
               >
             >
@@ -113,4 +141,4 @@ void POLYBENCH_FLOYD_WARSHALL::runHipVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_HIP
-  
+

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
@@ -12,17 +12,17 @@
 #include "common/DataUtils.hpp"
 
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
 
- 
+
 POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
   : KernelBase(rajaperf::Polybench_FLOYD_WARSHALL, params)
 {
   SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0; 
+  int run_reps = 0;
   switch(lsizespec) {
     case Mini:
       m_N=60;
@@ -56,22 +56,24 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-POLYBENCH_FLOYD_WARSHALL::~POLYBENCH_FLOYD_WARSHALL() 
+POLYBENCH_FLOYD_WARSHALL::~POLYBENCH_FLOYD_WARSHALL()
 {
 
 }

--- a/src/polybench/POLYBENCH_GEMM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Cuda.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_GEMM.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -36,7 +36,7 @@ namespace polybench
 
 __global__ void poly_gemm(Real_ptr C, Real_ptr A, Real_ptr B,
                           Real_type alpha, Real_type beta,
-                          Index_type nj, Index_type nk) 
+                          Index_type nj, Index_type nk)
 {
    Index_type i = blockIdx.y;
    Index_type j = threadIdx.x;
@@ -66,9 +66,37 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
       dim3 nblocks(1, ni, 1);
       dim3 nthreads_per_block(nj, 1, 1);
 
-      poly_gemm<<<nblocks, nthreads_per_block>>>(C, A, B, 
+      poly_gemm<<<nblocks, nthreads_per_block>>>(C, A, B,
                                                  alpha, beta,
                                                  nj, nk);
+
+    }
+    stopTimer();
+
+    POLYBENCH_GEMM_TEARDOWN_CUDA;
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    POLYBENCH_GEMM_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      dim3 nblocks(1, ni, 1);
+      dim3 nthreads_per_block(nj, 1, 1);
+
+      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
+                        <<<nblocks, nthreads_per_block>>>(
+        0, ni, 0, nj,
+        [=] __device__ (Index_type i, Index_type j) {
+
+        POLYBENCH_GEMM_BODY1;
+        POLYBENCH_GEMM_BODY2;
+        for (Index_type k = 0; k < nk; ++k ) {
+          POLYBENCH_GEMM_BODY3;
+        }
+        POLYBENCH_GEMM_BODY4;
+      });
 
     }
     stopTimer();
@@ -113,7 +141,7 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_GEMM_BODY2_RAJA;
           },
-          [=] __device__ (Index_type i, Index_type j, Index_type k, 
+          [=] __device__ (Index_type i, Index_type j, Index_type k,
                           Real_type& dot) {
             POLYBENCH_GEMM_BODY3_RAJA;
           },
@@ -138,4 +166,4 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_CUDA
-  
+

--- a/src/polybench/POLYBENCH_GEMM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Cuda.cpp
@@ -112,8 +112,8 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<0, RAJA::cuda_block_y_loop,
-            RAJA::statement::For<1, RAJA::cuda_thread_x_loop,
+          RAJA::statement::For<0, RAJA::cuda_block_y_direct,
+            RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Params<0>>,
               RAJA::statement::Lambda<1, RAJA::Segs<0,1>>,
               RAJA::statement::For<2, RAJA::seq_exec,

--- a/src/polybench/POLYBENCH_GEMM-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Hip.cpp
@@ -114,8 +114,8 @@ void POLYBENCH_GEMM::runHipVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_y_loop,
-            RAJA::statement::For<1, RAJA::hip_thread_x_loop,
+          RAJA::statement::For<0, RAJA::hip_block_y_direct,
+            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Params<0>>,
               RAJA::statement::Lambda<1, RAJA::Segs<0,1>>,
               RAJA::statement::For<2, RAJA::seq_exec,

--- a/src/polybench/POLYBENCH_GEMM-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Hip.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_GEMM.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -36,7 +36,7 @@ namespace polybench
 
 __global__ void poly_gemm(Real_ptr C, Real_ptr A, Real_ptr B,
                           Real_type alpha, Real_type beta,
-                          Index_type nj, Index_type nk) 
+                          Index_type nj, Index_type nk)
 {
    Index_type i = blockIdx.y;
    Index_type j = threadIdx.x;
@@ -66,9 +66,39 @@ void POLYBENCH_GEMM::runHipVariant(VariantID vid)
       dim3 nblocks(1, ni, 1);
       dim3 nthreads_per_block(nj, 1, 1);
 
-      hipLaunchKernelGGL((poly_gemm), dim3(nblocks), dim3(nthreads_per_block), 0,0,C, A, B, 
+      hipLaunchKernelGGL((poly_gemm), dim3(nblocks), dim3(nthreads_per_block), 0,0,C, A, B,
                                                  alpha, beta,
                                                  nj, nk);
+
+    }
+    stopTimer();
+
+    POLYBENCH_GEMM_TEARDOWN_HIP;
+
+  } else if ( vid == Lambda_HIP ) {
+
+    POLYBENCH_GEMM_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto poly_gemm_lambda = [=] __device__ (Index_type i, Index_type j) {
+
+        POLYBENCH_GEMM_BODY1;
+        POLYBENCH_GEMM_BODY2;
+        for (Index_type k = 0; k < nk; ++k ) {
+          POLYBENCH_GEMM_BODY3;
+        }
+        POLYBENCH_GEMM_BODY4;
+      };
+
+      dim3 nblocks(1, ni, 1);
+      dim3 nthreads_per_block(nj, 1, 1);
+
+      auto kernel = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_gemm_lambda)>;
+      hipLaunchKernelGGL(kernel,
+        nblocks, nthreads_per_block, 0, 0,
+        0, ni, 0, nj, poly_gemm_lambda);
 
     }
     stopTimer();
@@ -138,4 +168,4 @@ void POLYBENCH_GEMM::runHipVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_HIP
-  
+

--- a/src/polybench/POLYBENCH_GEMM.cpp
+++ b/src/polybench/POLYBENCH_GEMM.cpp
@@ -12,7 +12,7 @@
 #include "common/DataUtils.hpp"
 
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -22,7 +22,7 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GEMM, params)
 {
   SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0; 
+  int run_reps = 0;
   switch(lsizespec) {
     case Mini:
       m_ni = 20; m_nj = 25; m_nk = 30;
@@ -59,22 +59,24 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-POLYBENCH_GEMM::~POLYBENCH_GEMM() 
+POLYBENCH_GEMM::~POLYBENCH_GEMM()
 {
 }
 

--- a/src/polybench/POLYBENCH_GEMVER-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Hip.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_GEMVER.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -35,7 +35,7 @@ const size_t block_size = 256;
   allocAndInitHipDeviceData(w, m_w, m_n); \
   allocAndInitHipDeviceData(x, m_x, m_n); \
   allocAndInitHipDeviceData(y, m_y, m_n); \
-  allocAndInitHipDeviceData(z, m_z, m_n); 
+  allocAndInitHipDeviceData(z, m_z, m_n);
 
 
 #define POLYBENCH_GEMVER_TEARDOWN_HIP \
@@ -48,26 +48,26 @@ const size_t block_size = 256;
   deallocHipDeviceData(w); \
   deallocHipDeviceData(x); \
   deallocHipDeviceData(y); \
-  deallocHipDeviceData(z); 
+  deallocHipDeviceData(z);
 
-__global__ void poly_gemmver_1(Real_ptr A, 
-                               Real_ptr u1, Real_ptr v1, 
+__global__ void poly_gemmver_1(Real_ptr A,
+                               Real_ptr u1, Real_ptr v1,
                                Real_ptr u2, Real_ptr v2,
                                Index_type n)
 {
   Index_type i = blockIdx.y;
-  Index_type j = threadIdx.x; 
+  Index_type j = threadIdx.x;
 
   POLYBENCH_GEMVER_BODY1;
 }
 
-__global__ void poly_gemmver_2(Real_ptr A, 
+__global__ void poly_gemmver_2(Real_ptr A,
                                Real_ptr x, Real_ptr y,
-                               Real_type beta, 
+                               Real_type beta,
                                Index_type n)
 {
   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i < n) { 
+  if (i < n) {
     POLYBENCH_GEMVER_BODY2;
     for (Index_type j = 0; j < n; ++j) {
       POLYBENCH_GEMVER_BODY3;
@@ -91,7 +91,7 @@ __global__ void poly_gemmver_4(Real_ptr A,
                                Index_type n)
 {
   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i < n) { 
+  if (i < n) {
     POLYBENCH_GEMVER_BODY6;
     for (Index_type j = 0; j < n; ++j) {
       POLYBENCH_GEMVER_BODY7;
@@ -104,7 +104,7 @@ __global__ void poly_gemmver_4(Real_ptr A,
 void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  
+
   POLYBENCH_GEMVER_DATA_SETUP;
 
   if ( vid == Base_HIP ) {
@@ -116,10 +116,10 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
 
       dim3 nblocks(1, n, 1);
       dim3 nthreads_per_block(n, 1, 1);
-      hipLaunchKernelGGL((poly_gemmver_1) , dim3(nblocks), dim3(nthreads_per_block), 0, 0, 
+      hipLaunchKernelGGL((poly_gemmver_1) , dim3(nblocks), dim3(nthreads_per_block), 0, 0,
                                 A, u1, v1, u2, v2, n);
 
-      size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size); 
+      size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
 
       hipLaunchKernelGGL((poly_gemmver_2), dim3(grid_size), dim3(block_size), 0, 0,
                                                 A, x, y,
@@ -128,12 +128,69 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
 
       hipLaunchKernelGGL((poly_gemmver_3), dim3(grid_size), dim3(block_size), 0, 0,
                                                 x, z,
-                                                n); 
+                                                n);
 
       hipLaunchKernelGGL((poly_gemmver_4), dim3(grid_size), dim3(block_size), 0, 0,
                                                 A, x, w,
                                                 alpha,
                                                 n);
+    }
+    stopTimer();
+
+    POLYBENCH_GEMVER_TEARDOWN_HIP;
+
+  } else if ( vid == Lambda_HIP ) {
+
+    POLYBENCH_GEMVER_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto poly_gemmver_1_lambda = [=] __device__ (Index_type i, Index_type j) {
+          POLYBENCH_GEMVER_BODY1;
+      };
+
+      dim3 nblocks(1, n, 1);
+      dim3 nthreads_per_block(n, 1, 1);
+      auto kernel1 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_gemmver_1_lambda)>;
+      hipLaunchKernelGGL(kernel1,
+        nblocks, nthreads_per_block, 0, 0,
+        0, n, 0, n, poly_gemmver_1_lambda);
+
+      size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
+
+      auto poly_gemmver_2_lambda = [=] __device__ (Index_type i) {
+          POLYBENCH_GEMVER_BODY2;
+          for (Index_type j = 0; j < n; ++j) {
+            POLYBENCH_GEMVER_BODY3;
+          }
+          POLYBENCH_GEMVER_BODY4;
+      };
+
+      hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_gemmver_2_lambda)>,
+        grid_size, block_size, 0, 0,
+        0, n, poly_gemmver_2_lambda);
+
+      auto poly_gemmver_3_lambda = [=] __device__ (Index_type i) {
+          POLYBENCH_GEMVER_BODY5;
+      };
+
+      hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_gemmver_3_lambda)>,
+        grid_size, block_size, 0, 0,
+        0, n, poly_gemmver_3_lambda);
+
+      auto poly_gemmver_4_lambda = [=] __device__ (Index_type i) {
+          POLYBENCH_GEMVER_BODY6;
+          for (Index_type j = 0; j < n; ++j) {
+            POLYBENCH_GEMVER_BODY7;
+          }
+          POLYBENCH_GEMVER_BODY8;
+      };
+
+      hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_gemmver_4_lambda)>,
+        grid_size, block_size, 0, 0,
+        0, n, poly_gemmver_4_lambda);
+
     }
     stopTimer();
 
@@ -148,19 +205,19 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
     using EXEC_POL1 =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_y_loop,
-            RAJA::statement::For<1, RAJA::hip_thread_x_loop,
+          RAJA::statement::For<0, RAJA::hip_block_y_direct,
+            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<0>
             >
           >
         >
       >;
 
-    using EXEC_POL2 = 
+    using EXEC_POL2 =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>, 
-                                   RAJA::hip_block_x_loop,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
+                                   RAJA::hip_block_x_direct,
             RAJA::statement::For<0, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Params<0>>,
               RAJA::statement::For<1, RAJA::seq_exec,
@@ -171,14 +228,14 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
           >
         >
       >;
- 
+
     using EXEC_POL3 = RAJA::hip_exec<block_size, true /*async*/>;
 
     using EXEC_POL4 =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
           RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::hip_block_x_loop,
+                                   RAJA::hip_block_x_direct,
             RAJA::statement::For<0, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
               RAJA::statement::For<1, RAJA::seq_exec,
@@ -237,7 +294,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
           POLYBENCH_GEMVER_BODY8_RAJA;
         }
       );
-      
+
     }
     stopTimer();
 
@@ -253,4 +310,4 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_HIP
-  
+

--- a/src/polybench/POLYBENCH_GEMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMVER.cpp
@@ -12,7 +12,7 @@
 #include "common/DataUtils.hpp"
 
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -29,7 +29,7 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
       run_reps = 200;
       break;
     case Small:
-      m_n=120; 
+      m_n=120;
       run_reps = 200;
       break;
     case Medium:
@@ -41,7 +41,7 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
       run_reps = 20;
       break;
     case Extralarge:
-      m_n=4000; 
+      m_n=4000;
       run_reps = 5;
       break;
     default:
@@ -59,22 +59,24 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-POLYBENCH_GEMVER::~POLYBENCH_GEMVER() 
+POLYBENCH_GEMVER::~POLYBENCH_GEMVER()
 {
 }
 

--- a/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_GESUMMV.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -44,7 +44,7 @@ namespace polybench
 __global__ void poly_gesummv(Real_ptr x, Real_ptr y,
                              Real_ptr A, Real_ptr B,
                              Real_type alpha, Real_type beta,
-                             Index_type N) 
+                             Index_type N)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -73,8 +73,8 @@ void POLYBENCH_GESUMMV::runCudaVariant(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
 
-      poly_gesummv<<<grid_size, block_size>>>(x, y, 
-                                              A, B, 
+      poly_gesummv<<<grid_size, block_size>>>(x, y,
+                                              A, B,
                                               alpha, beta,
                                               N);
 
@@ -92,8 +92,8 @@ void POLYBENCH_GESUMMV::runCudaVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelAsync<
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>, 
-                                   RAJA::cuda_block_x_loop,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
+                                   RAJA::cuda_block_x_direct,
             RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Params<0,1>>,
               RAJA::statement::For<1, RAJA::seq_exec,
@@ -111,8 +111,8 @@ void POLYBENCH_GESUMMV::runCudaVariant(VariantID vid)
         RAJA::kernel_param<EXEC_POL>(
           RAJA::make_tuple( RAJA::RangeSegment{0, N},
                             RAJA::RangeSegment{0, N} ),
-          RAJA::make_tuple(static_cast<Real_type>(0.0), 
-                           static_cast<Real_type>(0.0)), 
+          RAJA::make_tuple(static_cast<Real_type>(0.0),
+                           static_cast<Real_type>(0.0)),
 
           [=] __device__ (Real_type& tmpdot,
                           Real_type& ydot) {
@@ -143,4 +143,4 @@ void POLYBENCH_GESUMMV::runCudaVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_CUDA
-  
+

--- a/src/polybench/POLYBENCH_GESUMMV-Hip.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Hip.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_GESUMMV.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -44,7 +44,7 @@ namespace polybench
 __global__ void poly_gesummv(Real_ptr x, Real_ptr y,
                              Real_ptr A, Real_ptr B,
                              Real_type alpha, Real_type beta,
-                             Index_type N) 
+                             Index_type N)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -73,8 +73,8 @@ void POLYBENCH_GESUMMV::runHipVariant(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
 
-      hipLaunchKernelGGL((poly_gesummv), dim3(grid_size), dim3(block_size),0,0,x, y, 
-                                              A, B, 
+      hipLaunchKernelGGL((poly_gesummv), dim3(grid_size), dim3(block_size),0,0,x, y,
+                                              A, B,
                                               alpha, beta,
                                               N);
 
@@ -93,7 +93,7 @@ void POLYBENCH_GESUMMV::runHipVariant(VariantID vid)
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
           RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::hip_block_x_loop,
+                                   RAJA::hip_block_x_direct,
             RAJA::statement::For<0, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Params<0,1>>,
               RAJA::statement::For<1, RAJA::seq_exec,
@@ -143,4 +143,4 @@ void POLYBENCH_GESUMMV::runHipVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_HIP
-  
+

--- a/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_HEAT_3D.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -35,22 +35,22 @@ namespace polybench
 
 __global__ void poly_heat_3D_1(Real_ptr A, Real_ptr B, Index_type N)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = blockIdx.z;
-   Index_type k = threadIdx.x;
+   Index_type i = 1 + blockIdx.y;
+   Index_type j = 1 + blockIdx.z;
+   Index_type k = 1 + threadIdx.x;
 
-   if (i > 0 && j > 0 && k > 0 && i < N-1 && j < N-1 && k < N-1) {
+   if (i < N-1 && j < N-1 && k < N-1) {
      POLYBENCH_HEAT_3D_BODY1;
    }
 }
 
 __global__ void poly_heat_3D_2(Real_ptr A, Real_ptr B, Index_type N)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = blockIdx.z;
-   Index_type k = threadIdx.x;
+   Index_type i = 1 + blockIdx.y;
+   Index_type j = 1 + blockIdx.z;
+   Index_type k = 1 + threadIdx.x;
 
-   if (i > 0 && j > 0 && k > 0 && i < N-1 && j < N-1 && k < N-1) {
+   if (i < N-1 && j < N-1 && k < N-1) {
      POLYBENCH_HEAT_3D_BODY2;
    }
 }
@@ -71,12 +71,51 @@ void POLYBENCH_HEAT_3D::runHipVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        dim3 nblocks(1, N, N);
-        dim3 nthreads_per_block(N, 1, 1);
+        dim3 nblocks(1, N-2, N-2);
+        dim3 nthreads_per_block(N-2, 1, 1);
 
         hipLaunchKernelGGL((poly_heat_3D_1),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
 
         hipLaunchKernelGGL((poly_heat_3D_2),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
+
+      }
+
+    }
+    stopTimer();
+
+    POLYBENCH_HEAT_3D_TEARDOWN_HIP;
+
+  } else if ( vid == Lambda_HIP ) {
+
+    POLYBENCH_HEAT_3D_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      for (Index_type t = 0; t < tsteps; ++t) {
+
+        dim3 nblocks(1, N-2, N-2);
+        dim3 nthreads_per_block(N-2, 1, 1);
+
+        auto poly_heat_3D_1_lambda = [=] __device__ (Index_type i, Index_type j, Index_type k) {
+
+          POLYBENCH_HEAT_3D_BODY1;
+        };
+
+        auto kernel1 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_block_z_direct, RAJA::hip_thread_x_direct, decltype(poly_heat_3D_1_lambda)>;
+        hipLaunchKernelGGL(kernel1,
+          nblocks, nthreads_per_block, 0, 0,
+          1, N-1, 1, N-1, 1, N-1, poly_heat_3D_1_lambda);
+
+        auto poly_heat_3D_2_lambda = [=] __device__ (Index_type i, Index_type j, Index_type k) {
+
+          POLYBENCH_HEAT_3D_BODY2;
+        };
+
+        auto kernel2 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_block_z_direct, RAJA::hip_thread_x_direct, decltype(poly_heat_3D_2_lambda)>;
+        hipLaunchKernelGGL(kernel2,
+          nblocks, nthreads_per_block, 0, 0,
+          1, N-1, 1, N-1, 1, N-1, poly_heat_3D_2_lambda);
 
       }
 
@@ -94,18 +133,18 @@ void POLYBENCH_HEAT_3D::runHipVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_z_loop,
-            RAJA::statement::For<1, RAJA::hip_block_y_loop,
-              RAJA::statement::For<2, RAJA::hip_thread_x_loop,
+          RAJA::statement::For<0, RAJA::hip_block_z_direct,
+            RAJA::statement::For<1, RAJA::hip_block_y_direct,
+              RAJA::statement::For<2, RAJA::hip_thread_x_direct,
                 RAJA::statement::Lambda<0>
               >
             >
           >
         >,
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_z_loop,
-            RAJA::statement::For<1, RAJA::hip_block_y_loop,
-              RAJA::statement::For<2, RAJA::hip_thread_x_loop,
+          RAJA::statement::For<0, RAJA::hip_block_z_direct,
+            RAJA::statement::For<1, RAJA::hip_block_y_direct,
+              RAJA::statement::For<2, RAJA::hip_thread_x_direct,
                 RAJA::statement::Lambda<1>
               >
             >

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -12,17 +12,17 @@
 #include "common/DataUtils.hpp"
 
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
 
- 
+
 POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_HEAT_3D, params)
 {
   SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0; 
+  int run_reps = 0;
 //
 // Note: 'factor' was added to keep the checksums (which can get very large
 //       for this kernel) within a reasonable range for comparison across
@@ -73,22 +73,24 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-POLYBENCH_HEAT_3D::~POLYBENCH_HEAT_3D() 
+POLYBENCH_HEAT_3D::~POLYBENCH_HEAT_3D()
 {
 }
 

--- a/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//  
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_JACOBI_2D.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -35,20 +35,20 @@ namespace polybench
 
 __global__ void poly_jacobi_2D_1(Real_ptr A, Real_ptr B, Index_type N)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+   Index_type i = 1 + blockIdx.y;
+   Index_type j = 1 + threadIdx.x;
 
-   if ( i > 0 && j > 0 && i < N-1 && j < N-1 ) {
+   if ( i < N-1 && j < N-1 ) {
      POLYBENCH_JACOBI_2D_BODY1;
    }
 }
 
 __global__ void poly_jacobi_2D_2(Real_ptr A, Real_ptr B, Index_type N)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+   Index_type i = 1 + blockIdx.y;
+   Index_type j = 1 + threadIdx.x;
 
-   if ( i > 0 && j > 0 && i < N-1 && j < N-1 ) {
+   if ( i < N-1 && j < N-1 ) {
      POLYBENCH_JACOBI_2D_BODY2;
    }
 }
@@ -69,12 +69,51 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        dim3 nblocks(1, N, 1);
-        dim3 nthreads_per_block(N, 1, 1);
+        dim3 nblocks(1, N-2, 1);
+        dim3 nthreads_per_block(N-2, 1, 1);
 
         hipLaunchKernelGGL((poly_jacobi_2D_1),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
 
         hipLaunchKernelGGL((poly_jacobi_2D_2),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
+
+      }
+
+    }
+    stopTimer();
+
+    POLYBENCH_JACOBI_2D_TEARDOWN_HIP;
+
+  } else if ( vid == Lambda_HIP ) {
+
+    POLYBENCH_JACOBI_2D_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      for (Index_type t = 0; t < tsteps; ++t) {
+
+        dim3 nblocks(1, N-2, 1);
+        dim3 nthreads_per_block(N-2, 1, 1);
+
+        auto poly_jacobi_2D_1_kernel = [=] __device__ (Index_type i, Index_type j) {
+
+          POLYBENCH_JACOBI_2D_BODY1;
+        };
+
+        auto kernel1 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_jacobi_2D_1_kernel)>;
+        hipLaunchKernelGGL(kernel1,
+          nblocks, nthreads_per_block, 0, 0,
+          1, N-1, 1, N-1, poly_jacobi_2D_1_kernel);
+
+        auto poly_jacobi_2D_2_kernel = [=] __device__ (Index_type i, Index_type j) {
+
+          POLYBENCH_JACOBI_2D_BODY2;
+        };
+
+        auto kernel2 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_jacobi_2D_2_kernel)>;
+        hipLaunchKernelGGL(kernel2,
+          nblocks, nthreads_per_block, 0, 0,
+          1, N-1, 1, N-1, poly_jacobi_2D_2_kernel);
 
       }
 
@@ -92,15 +131,15 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_y_loop,
-            RAJA::statement::For<1, RAJA::hip_thread_x_loop,
+          RAJA::statement::For<0, RAJA::hip_block_y_direct,
+            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<0>
             >
           >
         >,
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_y_loop,
-            RAJA::statement::For<1, RAJA::hip_thread_x_loop,
+          RAJA::statement::For<0, RAJA::hip_block_y_direct,
+            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<1>
             >
           >
@@ -139,4 +178,4 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_HIP
-  
+

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -12,7 +12,7 @@
 #include "common/DataUtils.hpp"
 
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -22,7 +22,7 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_JACOBI_2D, params)
 {
   SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0; 
+  int run_reps = 0;
   switch(lsizespec) {
     case Mini:
       m_N=30;
@@ -62,22 +62,24 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-POLYBENCH_JACOBI_2D::~POLYBENCH_JACOBI_2D() 
+POLYBENCH_JACOBI_2D::~POLYBENCH_JACOBI_2D()
 {
 }
 

--- a/src/polybench/POLYBENCH_MVT-Cuda.cpp
+++ b/src/polybench/POLYBENCH_MVT-Cuda.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_MVT.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -45,7 +45,7 @@ namespace polybench
 
 
 __global__ void poly_mvt_1(Real_ptr A, Real_ptr x1, Real_ptr y1,
-                           Index_type N) 
+                           Index_type N)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -59,7 +59,7 @@ __global__ void poly_mvt_1(Real_ptr A, Real_ptr x1, Real_ptr y1,
 }
 
 __global__ void poly_mvt_2(Real_ptr A, Real_ptr x2, Real_ptr y2,
-                           Index_type N) 
+                           Index_type N)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -106,8 +106,8 @@ void POLYBENCH_MVT::runCudaVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelAsync<
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>, 
-                                   RAJA::cuda_block_x_loop,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
+                                   RAJA::cuda_block_x_direct,
             RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Params<0>>,
               RAJA::statement::For<1, RAJA::seq_exec,
@@ -181,4 +181,4 @@ void POLYBENCH_MVT::runCudaVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_CUDA
-  
+

--- a/src/polybench/POLYBENCH_MVT-Hip.cpp
+++ b/src/polybench/POLYBENCH_MVT-Hip.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_MVT.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -45,7 +45,7 @@ namespace polybench
 
 
 __global__ void poly_mvt_1(Real_ptr A, Real_ptr x1, Real_ptr y1,
-                           Index_type N) 
+                           Index_type N)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -59,7 +59,7 @@ __global__ void poly_mvt_1(Real_ptr A, Real_ptr x1, Real_ptr y1,
 }
 
 __global__ void poly_mvt_2(Real_ptr A, Real_ptr x2, Real_ptr y2,
-                           Index_type N) 
+                           Index_type N)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
 
@@ -106,8 +106,8 @@ void POLYBENCH_MVT::runHipVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelAsync<
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>, 
-                                   RAJA::hip_block_x_loop,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
+                                   RAJA::hip_block_x_direct,
             RAJA::statement::For<0, RAJA::hip_thread_x_direct,
               RAJA::statement::Lambda<0, RAJA::Params<0>>,
               RAJA::statement::For<1, RAJA::seq_exec,
@@ -175,4 +175,4 @@ void POLYBENCH_MVT::runHipVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_HIP
-  
+

--- a/src/stream/ADD-Cuda.cpp
+++ b/src/stream/ADD-Cuda.cpp
@@ -41,10 +41,10 @@ namespace stream
 __global__ void add(Real_ptr c, Real_ptr a, Real_ptr b,
                      Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     ADD_BODY;
-   }
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < iend) {
+    ADD_BODY;
+  }
 }
 
 
@@ -66,6 +66,24 @@ void ADD::runCudaVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       add<<<grid_size, block_size>>>( c, a, b,
                                       iend );
+
+    }
+    stopTimer();
+
+    ADD_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    ADD_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      lambda_cuda_forall<<<grid_size, block_size>>>(
+        ibegin, iend, [=] __device__ (Index_type i) {
+        ADD_BODY;
+      });
 
     }
     stopTimer();

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -12,12 +12,12 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace stream
 {
 
- 
+
 ADD::ADD(const RunParams& params)
   : KernelBase(rajaperf::Stream_ADD, params)
 {
@@ -27,22 +27,24 @@ ADD::ADD(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-ADD::~ADD() 
+ADD::~ADD()
 {
 }
 

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace stream
 {
@@ -27,22 +27,24 @@ COPY::COPY(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-COPY::~COPY() 
+COPY::~COPY()
 {
 }
 

--- a/src/stream/MUL-Cuda.cpp
+++ b/src/stream/MUL-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace stream
 {
@@ -37,12 +37,12 @@ namespace stream
   deallocCudaDeviceData(c)
 
 __global__ void mul(Real_ptr b, Real_ptr c, Real_type alpha,
-                    Index_type iend) 
+                    Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     MUL_BODY; 
-   }
+  ndex_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  f (i < iend) {
+   MUL_BODY;
+
 }
 
 void MUL::runCudaVariant(VariantID vid)
@@ -60,9 +60,27 @@ void MUL::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       mul<<<grid_size, block_size>>>( b, c, alpha,
-                                       iend ); 
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      mul<<<grid_size, block_size>>>( b, c, alpha,
+                                      iend );
+
+    }
+    stopTimer();
+
+    MUL_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    MUL_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      lambda_cuda_forall<<<grid_size, block_size>>>(
+        ibegin, iend, [=] __device__ (Index_type i) {
+        MUL_BODY;
+      });
 
     }
     stopTimer();
@@ -76,10 +94,10 @@ void MUL::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-         MUL_BODY;
-       });
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        MUL_BODY;
+      });
 
     }
     stopTimer();

--- a/src/stream/MUL-Cuda.cpp
+++ b/src/stream/MUL-Cuda.cpp
@@ -39,10 +39,10 @@ namespace stream
 __global__ void mul(Real_ptr b, Real_ptr c, Real_type alpha,
                     Index_type iend)
 {
-  ndex_type i = blockIdx.x * blockDim.x + threadIdx.x;
-  f (i < iend) {
-   MUL_BODY;
-
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < iend) {
+    MUL_BODY;
+  }
 }
 
 void MUL::runCudaVariant(VariantID vid)

--- a/src/stream/MUL-Hip.cpp
+++ b/src/stream/MUL-Hip.cpp
@@ -39,10 +39,10 @@ namespace stream
 __global__ void mul(Real_ptr b, Real_ptr c, Real_type alpha,
                     Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     MUL_BODY;
-   }
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < iend) {
+    MUL_BODY;
+  }
 }
 
 void MUL::runHipVariant(VariantID vid)
@@ -60,9 +60,29 @@ void MUL::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       hipLaunchKernelGGL((mul), dim3(grid_size), dim3(block_size), 0, 0,  b, c, alpha,
-                                       iend );
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      hipLaunchKernelGGL((mul), dim3(grid_size), dim3(block_size), 0, 0,  b, c, alpha,
+                                      iend );
+
+    }
+    stopTimer();
+
+    MUL_DATA_TEARDOWN_HIP;
+
+  } else if ( vid == Lambda_HIP ) {
+
+    MUL_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto mul_lambda = [=] __device__ (Index_type i) {
+        MUL_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      hipLaunchKernelGGL(lambda_hip_forall<decltype(mul_lambda)>,
+        grid_size, block_size, 0, 0, ibegin, iend, mul_lambda);
 
     }
     stopTimer();
@@ -76,10 +96,10 @@ void MUL::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
-         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-         MUL_BODY;
-       });
+      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        MUL_BODY;
+      });
 
     }
     stopTimer();

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace stream
 {
@@ -27,22 +27,24 @@ MUL::MUL(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-MUL::~MUL() 
+MUL::~MUL()
 {
 
 }

--- a/src/stream/TRIAD-Hip.cpp
+++ b/src/stream/TRIAD-Hip.cpp
@@ -41,10 +41,10 @@ namespace stream
 __global__ void triad(Real_ptr a, Real_ptr b, Real_ptr c, Real_type alpha,
                       Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     TRIAD_BODY;
-   }
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < iend) {
+    TRIAD_BODY;
+  }
 }
 
 
@@ -63,9 +63,29 @@ void TRIAD::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       hipLaunchKernelGGL((triad), dim3(grid_size), dim3(block_size), 0, 0,  a, b, c, alpha,
-                                         iend );
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      hipLaunchKernelGGL((triad), dim3(grid_size), dim3(block_size), 0, 0,  a, b, c, alpha,
+                                        iend );
+
+    }
+    stopTimer();
+
+    TRIAD_DATA_TEARDOWN_HIP;
+
+  } else if ( vid == Lambda_HIP ) {
+
+    TRIAD_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto triad_lambda = [=] __device__ (Index_type i) {
+        TRIAD_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      hipLaunchKernelGGL(lambda_hip_forall<decltype(triad_lambda)>,
+        grid_size, block_size, 0, 0, ibegin, iend, triad_lambda);
 
     }
     stopTimer();
@@ -79,10 +99,10 @@ void TRIAD::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
-         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-         TRIAD_BODY;
-       });
+      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        TRIAD_BODY;
+      });
 
     }
     stopTimer();

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -12,7 +12,7 @@
 
 #include "common/DataUtils.hpp"
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace stream
 {
@@ -27,22 +27,24 @@ TRIAD::TRIAD(const RunParams& params)
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
   setVariantDefined( RAJA_Seq );
-                     
+
   setVariantDefined( Base_OpenMP );
   setVariantDefined( Lambda_OpenMP );
   setVariantDefined( RAJA_OpenMP );
-  
+
   setVariantDefined( Base_OpenMPTarget );
   setVariantDefined( RAJA_OpenMPTarget );
-      
+
   setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
   setVariantDefined( RAJA_CUDA );
-        
+
   setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 }
 
-TRIAD::~TRIAD() 
+TRIAD::~TRIAD()
 {
 }
 


### PR DESCRIPTION
Add lambda GPU variants for some of the kernels.
I also changed some of the RAJA GPU variants to use direct thread and block mapping instead of loop. This improved the performance of most of these variants to be similar to the base variant.
It may be best to pull the changes to use direct mapping into a separate PR, and/or drop the Lambda GPU variants entirely.