### PR TITLE
Add GPU error checking

### DIFF
--- a/scripts/lc-builds/toss3_hipcc4.1.0.sh
+++ b/scripts/lc-builds/toss3_hipcc4.1.0.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2016-20, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJA/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+BUILD_SUFFIX=lc_toss3-hipcc-4.1.0
+RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss3/hip.cmake
+
+rm -rf build_${BUILD_SUFFIX} >/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+
+module load cmake/3.14.5
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DRAJA_HIPCC_FLAGS="--amdgpu-target=gfx906" \
+  -DHIP_ROOT_DIR=/opt/rocm-4.1.0/hip \
+  -DHIP_CLANG_PATH=/opt/rocm-4.1.0/llvm/bin \
+  -C ${RAJA_HOSTCONFIG} \
+  -DENABLE_HIP=ON \
+  -DENABLE_OPENMP=OFF \
+  -DENABLE_CUDA=OFF \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  ..

--- a/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
@@ -98,6 +98,7 @@ void DEL_DOT_VEC_2D::runCudaVariant(VariantID vid)
                                              real_zones,
                                              half, ptiny,
                                              iend);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
@@ -126,6 +126,7 @@ void DEL_DOT_VEC_2D::runCudaVariant(VariantID vid)
         DEL_DOT_VEC_2D_BODY_INDEX;
         DEL_DOT_VEC_2D_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/DEL_DOT_VEC_2D-Hip.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-Hip.cpp
@@ -98,6 +98,7 @@ void DEL_DOT_VEC_2D::runHipVariant(VariantID vid)
                                              real_zones,
                                              half, ptiny,
                                              iend);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -127,6 +128,7 @@ void DEL_DOT_VEC_2D::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(lambda_hip_forall<decltype(deldotvec2d_lambda)>,
         grid_size, block_size, 0, 0,
         0, iend, deldotvec2d_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/ENERGY-Cuda.cpp
+++ b/src/apps/ENERGY-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace apps
 {
@@ -87,7 +87,7 @@ __global__ void energycalc2(Real_ptr delvc, Real_ptr q_new,
 }
 
 __global__ void energycalc3(Real_ptr e_new, Real_ptr delvc,
-                            Real_ptr p_old, Real_ptr q_old, 
+                            Real_ptr p_old, Real_ptr q_old,
                             Real_ptr pHalfStep, Real_ptr q_new,
                             Index_type iend)
 {
@@ -146,7 +146,7 @@ void ENERGY::runCudaVariant(VariantID vid)
   ENERGY_DATA_SETUP;
 
   if ( vid == Base_CUDA ) {
-    
+
     ENERGY_DATA_SETUP_CUDA;
 
     startTimer();
@@ -157,6 +157,7 @@ void ENERGY::runCudaVariant(VariantID vid)
        energycalc1<<<grid_size, block_size>>>( e_new, e_old, delvc,
                                                p_old, q_old, work,
                                                iend );
+       cudaErrchk( cudaGetLastError() );
 
        energycalc2<<<grid_size, block_size>>>( delvc, q_new,
                                                compHalfStep, pHalfStep,
@@ -164,15 +165,18 @@ void ENERGY::runCudaVariant(VariantID vid)
                                                ql_old, qq_old,
                                                rho0,
                                                iend );
+       cudaErrchk( cudaGetLastError() );
 
        energycalc3<<<grid_size, block_size>>>( e_new, delvc,
                                                p_old, q_old,
                                                pHalfStep, q_new,
                                                iend );
+       cudaErrchk( cudaGetLastError() );
 
        energycalc4<<<grid_size, block_size>>>( e_new, work,
                                                e_cut, emin,
                                                iend );
+       cudaErrchk( cudaGetLastError() );
 
        energycalc5<<<grid_size, block_size>>>( delvc,
                                                pbvc, e_new, vnewc,
@@ -182,6 +186,7 @@ void ENERGY::runCudaVariant(VariantID vid)
                                                pHalfStep, q_new,
                                                rho0, e_cut, emin,
                                                iend );
+       cudaErrchk( cudaGetLastError() );
 
        energycalc6<<<grid_size, block_size>>>( delvc,
                                                pbvc, e_new, vnewc,
@@ -190,6 +195,7 @@ void ENERGY::runCudaVariant(VariantID vid)
                                                ql_old, qq_old,
                                                rho0, q_cut,
                                                iend );
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();
@@ -220,22 +226,22 @@ void ENERGY::runCudaVariant(VariantID vid)
           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
           ENERGY_BODY2;
         });
- 
+
         RAJA::forall< RAJA::cuda_exec<block_size, async> >(
           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
           ENERGY_BODY3;
         });
- 
+
         RAJA::forall< RAJA::cuda_exec<block_size, async> >(
           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
           ENERGY_BODY4;
         });
- 
+
         RAJA::forall< RAJA::cuda_exec<block_size, async> >(
           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
           ENERGY_BODY5;
         });
- 
+
         RAJA::forall< RAJA::cuda_exec<block_size, async> >(
           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
           ENERGY_BODY6;

--- a/src/apps/ENERGY-Hip.cpp
+++ b/src/apps/ENERGY-Hip.cpp
@@ -157,6 +157,7 @@ void ENERGY::runHipVariant(VariantID vid)
        hipLaunchKernelGGL((energycalc1), dim3(grid_size), dim3(block_size), 0, 0,  e_new, e_old, delvc,
                                                p_old, q_old, work,
                                                iend );
+       hipErrchk( hipGetLastError() );
 
        hipLaunchKernelGGL((energycalc2), dim3(grid_size), dim3(block_size), 0, 0,  delvc, q_new,
                                                compHalfStep, pHalfStep,
@@ -164,15 +165,18 @@ void ENERGY::runHipVariant(VariantID vid)
                                                ql_old, qq_old,
                                                rho0,
                                                iend );
+       hipErrchk( hipGetLastError() );
 
        hipLaunchKernelGGL((energycalc3), dim3(grid_size), dim3(block_size), 0, 0,  e_new, delvc,
                                                p_old, q_old,
                                                pHalfStep, q_new,
                                                iend );
+       hipErrchk( hipGetLastError() );
 
        hipLaunchKernelGGL((energycalc4), dim3(grid_size), dim3(block_size), 0, 0,  e_new, work,
                                                e_cut, emin,
                                                iend );
+       hipErrchk( hipGetLastError() );
 
        hipLaunchKernelGGL((energycalc5), dim3(grid_size), dim3(block_size), 0, 0,  delvc,
                                                pbvc, e_new, vnewc,
@@ -182,6 +186,7 @@ void ENERGY::runHipVariant(VariantID vid)
                                                pHalfStep, q_new,
                                                rho0, e_cut, emin,
                                                iend );
+       hipErrchk( hipGetLastError() );
 
        hipLaunchKernelGGL((energycalc6), dim3(grid_size), dim3(block_size), 0, 0,  delvc,
                                                pbvc, e_new, vnewc,
@@ -190,6 +195,7 @@ void ENERGY::runHipVariant(VariantID vid)
                                                ql_old, qq_old,
                                                rho0, q_cut,
                                                iend );
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -237,7 +243,7 @@ void ENERGY::runHipVariant(VariantID vid)
           ENERGY_BODY6;
         });
 
-      });  // end sequential region (for single-source code) 
+      });  // end sequential region (for single-source code)
 
     }
     stopTimer();

--- a/src/apps/FIR-Cuda.cpp
+++ b/src/apps/FIR-Cuda.cpp
@@ -17,7 +17,7 @@
 #include <algorithm>
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace apps
 {
@@ -56,7 +56,7 @@ __global__ void fir(Real_ptr out, Real_ptr in,
    }
 }
 
-#else  // use global memry for coefficients 
+#else  // use global memry for coefficients
 
 #define FIR_DATA_SETUP_CUDA \
   Real_ptr coeff; \
@@ -84,7 +84,7 @@ __global__ void fir(Real_ptr out, Real_ptr in,
    }
 }
 
-#endif 
+#endif
 
 
 void FIR::runCudaVariant(VariantID vid)
@@ -110,11 +110,13 @@ void FIR::runCudaVariant(VariantID vid)
        fir<<<grid_size, block_size>>>( out, in,
                                        coefflen,
                                        iend );
+       cudaErrchk( cudaGetLastError() );
 #else
        fir<<<grid_size, block_size>>>( out, in,
                                        coeff,
                                        coefflen,
                                        iend );
+       cudaErrchk( cudaGetLastError() );
 #endif
 
     }

--- a/src/apps/FIR-Hip.cpp
+++ b/src/apps/FIR-Hip.cpp
@@ -110,11 +110,13 @@ void FIR::runHipVariant(VariantID vid)
        hipLaunchKernelGGL((fir), dim3(grid_size), dim3(block_size), 0, 0,  out, in,
                                        coefflen,
                                        iend );
+       hipErrchk( hipGetLastError() );
 #else
        hipLaunchKernelGGL((fir), dim3(grid_size), dim3(block_size), 0, 0,  out, in,
                                        coeff,
                                        coefflen,
                                        iend );
+       hipErrchk( hipGetLastError() );
 #endif
 
     }

--- a/src/apps/HALOEXCHANGE-Cuda.cpp
+++ b/src/apps/HALOEXCHANGE-Cuda.cpp
@@ -92,6 +92,7 @@ void HALOEXCHANGE::runCudaVariant(VariantID vid)
           dim3 nthreads_per_block(block_size);
           dim3 nblocks((len + block_size-1) / block_size);
           haloexchange_pack<<<nblocks, nthreads_per_block>>>(buffer, list, var, len);
+          cudaErrchk( cudaGetLastError() );
           buffer += len;
         }
       }
@@ -106,6 +107,7 @@ void HALOEXCHANGE::runCudaVariant(VariantID vid)
           dim3 nthreads_per_block(block_size);
           dim3 nblocks((len + block_size-1) / block_size);
           haloexchange_unpack<<<nblocks, nthreads_per_block>>>(buffer, list, var, len);
+          cudaErrchk( cudaGetLastError() );
           buffer += len;
         }
       }

--- a/src/apps/HALOEXCHANGE-Hip.cpp
+++ b/src/apps/HALOEXCHANGE-Hip.cpp
@@ -92,6 +92,7 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
           dim3 nblocks((len + block_size-1) / block_size);
           hipLaunchKernelGGL((haloexchange_pack), nblocks, nthreads_per_block, 0, 0,
               buffer, list, var, len);
+          hipErrchk( hipGetLastError() );
           buffer += len;
         }
       }
@@ -107,6 +108,7 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
           dim3 nblocks((len + block_size-1) / block_size);
           hipLaunchKernelGGL((haloexchange_unpack), nblocks, nthreads_per_block, 0, 0,
               buffer, list, var, len);
+          hipErrchk( hipGetLastError() );
           buffer += len;
         }
       }

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -64,6 +64,7 @@ void LTIMES::runCudaVariant(VariantID vid)
 
       ltimes<<<nblocks, nthreads_per_block>>>(phidat, elldat, psidat,
                                               num_d, num_g, num_m);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -90,6 +90,7 @@ void LTIMES::runCudaVariant(VariantID vid)
           LTIMES_BODY;
         }
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/LTIMES-Hip.cpp
+++ b/src/apps/LTIMES-Hip.cpp
@@ -64,6 +64,7 @@ void LTIMES::runHipVariant(VariantID vid)
 
       hipLaunchKernelGGL((ltimes), dim3(nblocks), dim3(nthreads_per_block), 0, 0, phidat, elldat, psidat,
                                               num_d, num_g, num_m);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -91,6 +92,7 @@ void LTIMES::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(kernel,
         nblocks, nthreads_per_block, 0, 0,
         0, num_z, 0, num_g, 0, num_m, ltimes_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -64,6 +64,7 @@ void LTIMES_NOVIEW::runCudaVariant(VariantID vid)
 
       ltimes_noview<<<nblocks, nthreads_per_block>>>(phidat, elldat, psidat,
                                                      num_d, num_g, num_m);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -90,6 +90,7 @@ void LTIMES_NOVIEW::runCudaVariant(VariantID vid)
           LTIMES_NOVIEW_BODY;
         }
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/LTIMES_NOVIEW-Hip.cpp
+++ b/src/apps/LTIMES_NOVIEW-Hip.cpp
@@ -64,6 +64,7 @@ void LTIMES_NOVIEW::runHipVariant(VariantID vid)
 
       hipLaunchKernelGGL((ltimes_noview), dim3(nblocks), dim3(nthreads_per_block), 0, 0, phidat, elldat, psidat,
                                                      num_d, num_g, num_m);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -91,6 +92,7 @@ void LTIMES_NOVIEW::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(kernel,
         nblocks, nthreads_per_block, 0, 0,
         0, num_z, 0, num_g, 0, num_m, ltimes_noview_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/PRESSURE-Cuda.cpp
+++ b/src/apps/PRESSURE-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace apps
 {
@@ -85,11 +85,13 @@ void PRESSURE::runCudaVariant(VariantID vid)
        pressurecalc1<<<grid_size, block_size>>>( bvc, compression,
                                                  cls,
                                                  iend );
+       cudaErrchk( cudaGetLastError() );
 
        pressurecalc2<<<grid_size, block_size>>>( p_new, bvc, e_old,
                                                  vnewc,
                                                  p_cut, eosvmax, pmin,
                                                  iend );
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/PRESSURE-Hip.cpp
+++ b/src/apps/PRESSURE-Hip.cpp
@@ -85,11 +85,13 @@ void PRESSURE::runHipVariant(VariantID vid)
        hipLaunchKernelGGL((pressurecalc1), dim3(grid_size), dim3(block_size), 0, 0,  bvc, compression,
                                                  cls,
                                                  iend );
+       hipErrchk( hipGetLastError() );
 
        hipLaunchKernelGGL((pressurecalc2), dim3(grid_size), dim3(block_size), 0, 0,  p_new, bvc, e_old,
                                                  vnewc,
                                                  p_cut, eosvmax, pmin,
                                                  iend );
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/VOL3D-Cuda.cpp
+++ b/src/apps/VOL3D-Cuda.cpp
@@ -18,7 +18,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace apps
 {
@@ -59,7 +59,7 @@ __global__ void vol3d(Real_ptr vol,
                       Index_type ibegin, Index_type iend)
 {
    Index_type ii = blockIdx.x * blockDim.x + threadIdx.x;
-   Index_type i = ii + ibegin; 
+   Index_type i = ii + ibegin;
    if (i < iend) {
      VOL3D_BODY;
    }
@@ -84,7 +84,7 @@ void VOL3D::runCudaVariant(VariantID vid)
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
- 
+
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
 
       vol3d<<<grid_size, block_size>>>(vol,
@@ -93,10 +93,11 @@ void VOL3D::runCudaVariant(VariantID vid)
                                        z0, z1, z2, z3, z4, z5, z6, z7,
                                        vnormq,
                                        ibegin, iend);
- 
+      cudaErrchk( cudaGetLastError() );
+
     }
     stopTimer();
- 
+
     VOL3D_DATA_TEARDOWN_CUDA;
 
   } else if ( vid == RAJA_CUDA ) {
@@ -109,15 +110,15 @@ void VOL3D::runCudaVariant(VariantID vid)
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
- 
+
       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
         VOL3D_BODY;
       });
- 
+
     }
     stopTimer();
- 
+
     VOL3D_DATA_TEARDOWN_CUDA;
 
   } else {

--- a/src/apps/VOL3D-Hip.cpp
+++ b/src/apps/VOL3D-Hip.cpp
@@ -93,6 +93,7 @@ void VOL3D::runHipVariant(VariantID vid)
                                        z0, z1, z2, z3, z4, z5, z6, z7,
                                        vnormq,
                                        ibegin, iend);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/ATOMIC_PI-Cuda.cpp
+++ b/src/basic/ATOMIC_PI-Cuda.cpp
@@ -64,6 +64,7 @@ void ATOMIC_PI::runCudaVariant(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       atomic_pi<<<grid_size, block_size>>>( pi, dx, iend );
+      cudaErrchk( cudaGetLastError() );
 
       getCudaDeviceData(m_pi, pi, 1);
       *m_pi *= 4.0;

--- a/src/basic/ATOMIC_PI-Cuda.cpp
+++ b/src/basic/ATOMIC_PI-Cuda.cpp
@@ -89,6 +89,7 @@ void ATOMIC_PI::runCudaVariant(VariantID vid)
           double x = (double(i) + 0.5) * dx;
           RAJA::atomicAdd<RAJA::cuda_atomic>(pi, dx / (1.0 + x * x));
       });
+      cudaErrchk( cudaGetLastError() );
 
       getCudaDeviceData(m_pi, pi, 1);
       *m_pi *= 4.0;

--- a/src/basic/ATOMIC_PI-Hip.cpp
+++ b/src/basic/ATOMIC_PI-Hip.cpp
@@ -64,6 +64,7 @@ void ATOMIC_PI::runHipVariant(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL(atomic_pi,grid_size, block_size, 0, 0, pi, dx, iend );
+      hipErrchk( hipGetLastError() );
 
       getHipDeviceData(m_pi, pi, 1);
       *m_pi *= 4.0;
@@ -90,6 +91,7 @@ void ATOMIC_PI::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(atomic_pi_lambda)>,
           grid_size, block_size, 0, 0, ibegin, iend, atomic_pi_lambda);
+      hipErrchk( hipGetLastError() );
 
       getHipDeviceData(m_pi, pi, 1);
       *m_pi *= 4.0;

--- a/src/basic/DAXPY-Cuda.cpp
+++ b/src/basic/DAXPY-Cuda.cpp
@@ -83,6 +83,7 @@ void DAXPY::runCudaVariant(VariantID vid)
         ibegin, iend, [=] __device__ (Index_type i) {
         DAXPY_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/DAXPY-Cuda.cpp
+++ b/src/basic/DAXPY-Cuda.cpp
@@ -64,6 +64,7 @@ void DAXPY::runCudaVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       daxpy<<<grid_size, block_size>>>( y, x, a,
                                         iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/DAXPY-Hip.cpp
+++ b/src/basic/DAXPY-Hip.cpp
@@ -65,6 +65,7 @@ void DAXPY::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL((daxpy),dim3(grid_size), dim3(block_size), 0, 0, y, x, a,
                                         iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -85,6 +86,7 @@ void DAXPY::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(daxpy_lambda)>,
         grid_size, block_size, 0, 0, ibegin, iend, daxpy_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/IF_QUAD-Cuda.cpp
+++ b/src/basic/IF_QUAD-Cuda.cpp
@@ -90,6 +90,7 @@ void IF_QUAD::runCudaVariant(VariantID vid)
         ibegin, iend, [=] __device__ (Index_type i) {
         IF_QUAD_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/IF_QUAD-Cuda.cpp
+++ b/src/basic/IF_QUAD-Cuda.cpp
@@ -71,6 +71,7 @@ void IF_QUAD::runCudaVariant(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       ifquad<<<grid_size, block_size>>>( x1, x2, a, b, c, iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/IF_QUAD-Hip.cpp
+++ b/src/basic/IF_QUAD-Hip.cpp
@@ -72,6 +72,7 @@ void IF_QUAD::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL((ifquad), dim3(grid_size), dim3(block_size), 0, 0,  x1, x2, a, b, c,
                                           iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -92,6 +93,7 @@ void IF_QUAD::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(ifquad_lambda)>,
         grid_size, block_size, 0, 0, ibegin, iend, ifquad_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/INIT3-Cuda.cpp
+++ b/src/basic/INIT3-Cuda.cpp
@@ -73,6 +73,7 @@ void INIT3::runCudaVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       init3<<<grid_size, block_size>>>( out1, out2, out3, in1, in2,
                                         iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/INIT3-Cuda.cpp
+++ b/src/basic/INIT3-Cuda.cpp
@@ -92,6 +92,7 @@ void INIT3::runCudaVariant(VariantID vid)
         ibegin, iend, [=] __device__ (Index_type i) {
         INIT3_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/INIT3-Hip.cpp
+++ b/src/basic/INIT3-Hip.cpp
@@ -73,6 +73,7 @@ void INIT3::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL((init3), dim3(grid_size), dim3(block_size), 0, 0,  out1, out2, out3, in1, in2,
                                         iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -93,6 +94,7 @@ void INIT3::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(init3_lambda)>,
         grid_size, block_size, 0, 0, ibegin, iend, init3_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/INIT_VIEW1D-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D-Cuda.cpp
@@ -62,6 +62,7 @@ void INIT_VIEW1D::runCudaVariant(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       initview1d<<<grid_size, block_size>>>( a, v, iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/INIT_VIEW1D-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D-Cuda.cpp
@@ -81,6 +81,7 @@ void INIT_VIEW1D::runCudaVariant(VariantID vid)
         ibegin, iend, [=] __device__ (Index_type i) {
         INIT_VIEW1D_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/INIT_VIEW1D-Hip.cpp
+++ b/src/basic/INIT_VIEW1D-Hip.cpp
@@ -63,6 +63,7 @@ void INIT_VIEW1D::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL((initview1d), dim3(grid_size), dim3(block_size), 0, 0,
           a, v, iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -83,6 +84,7 @@ void INIT_VIEW1D::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(initview1d_lambda)>,
         grid_size, block_size, 0, 0, ibegin, iend, initview1d_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
@@ -65,6 +65,7 @@ void INIT_VIEW1D_OFFSET::runCudaVariant(VariantID vid)
       initview1d_offset<<<grid_size, block_size>>>( a, v,
                                                     ibegin,
                                                     iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
@@ -84,6 +84,7 @@ void INIT_VIEW1D_OFFSET::runCudaVariant(VariantID vid)
         ibegin, iend, [=] __device__ (Index_type i) {
         INIT_VIEW1D_OFFSET_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/INIT_VIEW1D_OFFSET-Hip.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Hip.cpp
@@ -64,6 +64,7 @@ void INIT_VIEW1D_OFFSET::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend-ibegin, block_size);
       hipLaunchKernelGGL((initview1d_offset), dim3(grid_size), dim3(block_size), 0, 0,
           a, v, ibegin, iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -84,6 +85,7 @@ void INIT_VIEW1D_OFFSET::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend-ibegin, block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(initview1d_offset_lambda)>,
         grid_size, block_size, 0, 0, ibegin, iend, initview1d_offset_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/MULADDSUB-Cuda.cpp
+++ b/src/basic/MULADDSUB-Cuda.cpp
@@ -73,6 +73,7 @@ void MULADDSUB::runCudaVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       muladdsub<<<grid_size, block_size>>>( out1, out2, out3, in1, in2,
                                             iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/MULADDSUB-Cuda.cpp
+++ b/src/basic/MULADDSUB-Cuda.cpp
@@ -92,6 +92,7 @@ void MULADDSUB::runCudaVariant(VariantID vid)
         ibegin, iend, [=] __device__ (Index_type i) {
         MULADDSUB_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/MULADDSUB-Hip.cpp
+++ b/src/basic/MULADDSUB-Hip.cpp
@@ -73,6 +73,7 @@ void MULADDSUB::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL((muladdsub), dim3(grid_size), dim3(block_size), 0, 0,
           out1, out2, out3, in1, in2, iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -93,6 +94,7 @@ void MULADDSUB::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(muladdsub_lambda)>,
         grid_size, block_size, 0, 0, ibegin, iend, muladdsub_lambda );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -57,6 +57,7 @@ void NESTED_INIT::runCudaVariant(VariantID vid)
 
       nested_init<<<nblocks, nthreads_per_block>>>(array,
                                                    ni, nj);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -79,6 +79,7 @@ void NESTED_INIT::runCudaVariant(VariantID vid)
         [=] __device__ (Index_type i, Index_type j, Index_type k) {
         NESTED_INIT_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/NESTED_INIT-Hip.cpp
+++ b/src/basic/NESTED_INIT-Hip.cpp
@@ -57,6 +57,7 @@ void NESTED_INIT::runHipVariant(VariantID vid)
 
       hipLaunchKernelGGL((nested_init), dim3(nblocks), dim3(nthreads_per_block), 0, 0, array,
                                                    ni, nj);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -81,6 +82,7 @@ void NESTED_INIT::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(kernel,
         nblocks, nthreads_per_block, 0, 0,
         0, ni, 0, nj, 0, nk, nested_init_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/basic/REDUCE3_INT-Cuda.cpp
+++ b/src/basic/REDUCE3_INT-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -38,7 +38,7 @@ __global__ void reduce3int(Int_ptr vec,
                            Int_ptr vsum, Int_type vsum_init,
                            Int_ptr vmin, Int_type vmin_init,
                            Int_ptr vmax, Int_type vmax_init,
-                           Index_type iend) 
+                           Index_type iend)
 {
   extern __shared__ Int_type psum[ ];
   Int_type* pmin = (Int_type*)&psum[ 1 * blockDim.x ];
@@ -57,8 +57,8 @@ __global__ void reduce3int(Int_ptr vec,
   }
   __syncthreads();
 
-  for ( i = blockDim.x / 2; i > 0; i /= 2 ) { 
-    if ( threadIdx.x < i ) { 
+  for ( i = blockDim.x / 2; i > 0; i /= 2 ) {
+    if ( threadIdx.x < i ) {
       psum[ threadIdx.x ] += psum[ threadIdx.x + i ];
       pmin[ threadIdx.x ] = RAJA_MIN( pmin[ threadIdx.x ], pmin[ threadIdx.x + i ] );
       pmax[ threadIdx.x ] = RAJA_MAX( pmax[ threadIdx.x ], pmax[ threadIdx.x + i ] );
@@ -109,12 +109,13 @@ void REDUCE3_INT::runCudaVariant(VariantID vid)
       initCudaDeviceData(vmax, &m_vmax_init, 1);
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      reduce3int<<<grid_size, block_size, 
-                   3*sizeof(Int_type)*block_size>>>(vec, 
+      reduce3int<<<grid_size, block_size,
+                   3*sizeof(Int_type)*block_size>>>(vec,
                                                     vsum, m_vsum_init,
                                                     vmin, m_vmin_init,
                                                     vmax, m_vmax_init,
-                                                    iend ); 
+                                                    iend );
+      cudaErrchk( cudaGetLastError() );
 
       Int_type lsum;
       Int_ptr plsum = &lsum;

--- a/src/basic/REDUCE3_INT-Hip.cpp
+++ b/src/basic/REDUCE3_INT-Hip.cpp
@@ -114,6 +114,7 @@ void REDUCE3_INT::runHipVariant(VariantID vid)
                                                     vmin, m_vmin_init,
                                                     vmax, m_vmax_init,
                                                     iend );
+      hipErrchk( hipGetLastError() );
 
       Int_type lsum;
       Int_ptr plsum = &lsum;

--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace basic
 {
@@ -49,8 +49,8 @@ Real_type trap_int_func(Real_type x,
 
 
 __global__ void trapint(Real_type x0, Real_type xp,
-                        Real_type y, Real_type yp, 
-                        Real_type h, 
+                        Real_type y, Real_type yp,
+                        Real_type h,
                         Real_ptr sumx,
                         Index_type iend)
 {
@@ -104,15 +104,16 @@ void TRAP_INT::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      initCudaDeviceData(sumx, &m_sumx_init, 1); 
+      initCudaDeviceData(sumx, &m_sumx_init, 1);
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      trapint<<<grid_size, block_size, 
+      trapint<<<grid_size, block_size,
                 sizeof(Real_type)*block_size>>>(x0, xp,
                                                 y, yp,
                                                 h,
                                                 sumx,
                                                 iend);
+      cudaErrchk( cudaGetLastError() );
 
       Real_type lsumx;
       Real_ptr plsumx = &lsumx;

--- a/src/basic/TRAP_INT-Hip.cpp
+++ b/src/basic/TRAP_INT-Hip.cpp
@@ -112,6 +112,7 @@ void TRAP_INT::runHipVariant(VariantID vid)
                                                 h,
                                                 sumx,
                                                 iend);
+      hipErrchk( hipGetLastError() );
 
       Real_type lsumx;
       Real_ptr plsumx = &lsumx;

--- a/src/lcals/DIFF_PREDICT-Cuda.cpp
+++ b/src/lcals/DIFF_PREDICT-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -37,12 +37,12 @@ namespace lcals
   deallocCudaDeviceData(cx);
 
 __global__ void diff_predict(Real_ptr px, Real_ptr cx,
-                             const Index_type offset, 
-                             Index_type iend) 
+                             const Index_type offset,
+                             Index_type iend)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i < iend) {
-     DIFF_PREDICT_BODY; 
+     DIFF_PREDICT_BODY;
    }
 }
 
@@ -65,7 +65,8 @@ void DIFF_PREDICT::runCudaVariant(VariantID vid)
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        diff_predict<<<grid_size, block_size>>>( px, cx,
                                                 offset,
-                                                iend ); 
+                                                iend );
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/DIFF_PREDICT-Hip.cpp
+++ b/src/lcals/DIFF_PREDICT-Hip.cpp
@@ -66,6 +66,7 @@ void DIFF_PREDICT::runHipVariant(VariantID vid)
        hipLaunchKernelGGL((diff_predict), dim3(grid_size), dim3(block_size), 0, 0,  px, cx,
                                                 offset,
                                                 iend );
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/EOS-Cuda.cpp
+++ b/src/lcals/EOS-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -42,11 +42,11 @@ namespace lcals
 
 __global__ void eos(Real_ptr x, Real_ptr y, Real_ptr z, Real_ptr u,
                     Real_type q, Real_type r, Real_type t,
-                    Index_type iend) 
+                    Index_type iend)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i < iend) {
-     EOS_BODY; 
+     EOS_BODY;
    }
 }
 
@@ -67,9 +67,10 @@ void EOS::runCudaVariant(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       eos<<<grid_size, block_size>>>( x, y, z, u, 
+       eos<<<grid_size, block_size>>>( x, y, z, u,
                                        q, r, t,
-                                       iend ); 
+                                       iend );
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/EOS-Hip.cpp
+++ b/src/lcals/EOS-Hip.cpp
@@ -70,6 +70,7 @@ void EOS::runHipVariant(VariantID vid)
        hipLaunchKernelGGL((eos), dim3(grid_size), dim3(block_size), 0, 0,  x, y, z, u,
                                        q, r, t,
                                        iend );
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/FIRST_DIFF-Cuda.cpp
+++ b/src/lcals/FIRST_DIFF-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -37,11 +37,11 @@ namespace lcals
   deallocCudaDeviceData(y);
 
 __global__ void first_diff(Real_ptr x, Real_ptr y,
-                           Index_type iend) 
+                           Index_type iend)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i < iend) {
-     FIRST_DIFF_BODY; 
+     FIRST_DIFF_BODY;
    }
 }
 
@@ -63,7 +63,8 @@ void FIRST_DIFF::runCudaVariant(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        first_diff<<<grid_size, block_size>>>( x, y,
-                                              iend ); 
+                                              iend );
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/FIRST_DIFF-Hip.cpp
+++ b/src/lcals/FIRST_DIFF-Hip.cpp
@@ -64,6 +64,7 @@ void FIRST_DIFF::runHipVariant(VariantID vid)
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        hipLaunchKernelGGL((first_diff), dim3(grid_size), dim3(block_size), 0, 0,  x, y,
                                               iend );
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/FIRST_MIN-Cuda.cpp
+++ b/src/lcals/FIRST_MIN-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -35,7 +35,7 @@ namespace lcals
 
 __global__ void first_min(Real_ptr x,
                           MyMinLoc* dminloc,
-                          Index_type iend) 
+                          Index_type iend)
 {
   extern __shared__ MyMinLoc minloc[ ];
 
@@ -52,17 +52,17 @@ __global__ void first_min(Real_ptr x,
   for ( i = blockDim.x / 2; i > 0; i /= 2 ) {
     if ( threadIdx.x < i ) {
       if ( minloc[ threadIdx.x + i].val < minloc[ threadIdx.x ].val ) {
-        minloc[ threadIdx.x ] = minloc[ threadIdx.x + i]; 
+        minloc[ threadIdx.x ] = minloc[ threadIdx.x + i];
       }
     }
      __syncthreads();
   }
- 
+
   if ( threadIdx.x == 0 ) {
     if ( minloc[ 0 ].val < (*dminloc).val ) {
       *dminloc = minloc[ 0 ];
     }
-  } 
+  }
 }
 
 
@@ -82,17 +82,18 @@ void FIRST_MIN::runCudaVariant(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
        FIRST_MIN_MINLOC_INIT;
-    
+
        MyMinLoc* dminloc;
        cudaErrchk( cudaMalloc( (void**)&dminloc, sizeof(MyMinLoc) ) );
        cudaErrchk( cudaMemcpy( dminloc, &mymin, sizeof(MyMinLoc),
                                cudaMemcpyHostToDevice ) );
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       first_min<<<grid_size, block_size, 
-                   sizeof(MyMinLoc)*block_size>>>( x, 
+       first_min<<<grid_size, block_size,
+                   sizeof(MyMinLoc)*block_size>>>( x,
                                                    dminloc,
-                                                   iend ); 
+                                                   iend );
+       cudaErrchk( cudaGetLastError() );
 
        cudaErrchk( cudaMemcpy( &mymin, dminloc, sizeof(MyMinLoc),
                                cudaMemcpyDeviceToHost ) );

--- a/src/lcals/FIRST_MIN-Hip.cpp
+++ b/src/lcals/FIRST_MIN-Hip.cpp
@@ -93,6 +93,7 @@ void FIRST_MIN::runHipVariant(VariantID vid)
                    sizeof(MyMinLoc)*block_size, 0, x,
                                                    dminloc,
                                                    iend );
+       hipErrchk( hipGetLastError() );
 
        hipErrchk( hipMemcpy( &mymin, dminloc, sizeof(MyMinLoc),
                                hipMemcpyDeviceToHost ) );

--- a/src/lcals/FIRST_SUM-Cuda.cpp
+++ b/src/lcals/FIRST_SUM-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -37,11 +37,11 @@ namespace lcals
   deallocCudaDeviceData(y);
 
 __global__ void first_sum(Real_ptr x, Real_ptr y,
-                          Index_type iend) 
+                          Index_type iend)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i > 0 && i < iend) {
-     FIRST_SUM_BODY; 
+     FIRST_SUM_BODY;
    }
 }
 
@@ -63,7 +63,8 @@ void FIRST_SUM::runCudaVariant(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        first_sum<<<grid_size, block_size>>>( x, y,
-                                              iend ); 
+                                              iend );
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/FIRST_SUM-Hip.cpp
+++ b/src/lcals/FIRST_SUM-Hip.cpp
@@ -64,6 +64,7 @@ void FIRST_SUM::runHipVariant(VariantID vid)
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        hipLaunchKernelGGL(first_sum,grid_size, block_size, 0, 0, x, y,
                                               iend );
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/GEN_LIN_RECUR-Cuda.cpp
+++ b/src/lcals/GEN_LIN_RECUR-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -40,18 +40,18 @@ namespace lcals
   deallocCudaDeviceData(sa); \
   deallocCudaDeviceData(sb);
 
-__global__ void genlinrecur1(Real_ptr b5, Real_ptr stb5, 
+__global__ void genlinrecur1(Real_ptr b5, Real_ptr stb5,
                              Real_ptr sa, Real_ptr sb,
                              Index_type kb5i,
-                             Index_type N) 
+                             Index_type N)
 {
    Index_type k = blockIdx.x * blockDim.x + threadIdx.x;
    if (k < N) {
-     GEN_LIN_RECUR_BODY1; 
+     GEN_LIN_RECUR_BODY1;
    }
 }
 
-__global__ void genlinrecur2(Real_ptr b5, Real_ptr stb5, 
+__global__ void genlinrecur2(Real_ptr b5, Real_ptr stb5,
                              Real_ptr sa, Real_ptr sb,
                              Index_type kb5i,
                              Index_type N)
@@ -77,14 +77,16 @@ void GEN_LIN_RECUR::runCudaVariant(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
        const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(N, block_size);
-       genlinrecur1<<<grid_size1, block_size>>>( b5, stb5, sa, sb, 
+       genlinrecur1<<<grid_size1, block_size>>>( b5, stb5, sa, sb,
                                                  kb5i,
-                                                 N ); 
+                                                 N );
+       cudaErrchk( cudaGetLastError() );
 
        const size_t grid_size2 = RAJA_DIVIDE_CEILING_INT(N+1, block_size);
-       genlinrecur1<<<grid_size2, block_size>>>( b5, stb5, sa, sb, 
+       genlinrecur1<<<grid_size2, block_size>>>( b5, stb5, sa, sb,
                                                  kb5i,
-                                                 N ); 
+                                                 N );
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/GEN_LIN_RECUR-Hip.cpp
+++ b/src/lcals/GEN_LIN_RECUR-Hip.cpp
@@ -81,12 +81,14 @@ void GEN_LIN_RECUR::runHipVariant(VariantID vid)
                                                  b5, stb5, sa, sb,
                                                  kb5i,
                                                  N );
+       hipErrchk( hipGetLastError() );
 
        const size_t grid_size2 = RAJA_DIVIDE_CEILING_INT(N+1, block_size);
        hipLaunchKernelGGL(genlinrecur1, grid_size2, block_size, 0, 0,
                                                  b5, stb5, sa, sb,
                                                  kb5i,
                                                  N );
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/HYDRO_1D-Cuda.cpp
+++ b/src/lcals/HYDRO_1D-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -40,11 +40,11 @@ namespace lcals
 
 __global__ void hydro_1d(Real_ptr x, Real_ptr y, Real_ptr z,
                          Real_type q, Real_type r, Real_type t,
-                         Index_type iend) 
+                         Index_type iend)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i < iend) {
-     HYDRO_1D_BODY; 
+     HYDRO_1D_BODY;
    }
 }
 
@@ -67,7 +67,8 @@ void HYDRO_1D::runCudaVariant(VariantID vid)
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        hydro_1d<<<grid_size, block_size>>>( x, y, z,
                                             q, r, t,
-                                            iend ); 
+                                            iend );
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();
@@ -91,7 +92,7 @@ void HYDRO_1D::runCudaVariant(VariantID vid)
 
     HYDRO_1D_DATA_TEARDOWN_CUDA;
 
-  } else { 
+  } else {
      std::cout << "\n  HYDRO_1D : Unknown Cuda variant id = " << vid << std::endl;
   }
 }

--- a/src/lcals/HYDRO_1D-Hip.cpp
+++ b/src/lcals/HYDRO_1D-Hip.cpp
@@ -68,6 +68,7 @@ void HYDRO_1D::runHipVariant(VariantID vid)
        hipLaunchKernelGGL((hydro_1d), dim3(grid_size), dim3(block_size), 0, 0,  x, y, z,
                                             q, r, t,
                                             iend );
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/HYDRO_2D-Cuda.cpp
+++ b/src/lcals/HYDRO_2D-Cuda.cpp
@@ -112,16 +112,19 @@ void HYDRO_2D::runCudaVariant(VariantID vid)
        hydro_2d1<<<nblocks, nthreads_per_block>>>(zadat, zbdat,
                                                   zpdat, zqdat, zrdat, zmdat,
                                                   jn, kn);
+       cudaErrchk( cudaGetLastError() );
 
        hydro_2d2<<<nblocks, nthreads_per_block>>>(zudat, zvdat,
                                                   zadat, zbdat, zzdat, zrdat,
                                                   s,
                                                   jn, kn);
+       cudaErrchk( cudaGetLastError() );
 
        hydro_2d3<<<nblocks, nthreads_per_block>>>(zroutdat, zzoutdat,
                                                   zrdat, zudat, zzdat, zvdat,
                                                   t,
                                                   jn, kn);
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/HYDRO_2D-Hip.cpp
+++ b/src/lcals/HYDRO_2D-Hip.cpp
@@ -112,18 +112,21 @@ void HYDRO_2D::runHipVariant(VariantID vid)
                                                   zadat, zbdat,
                                                   zpdat, zqdat, zrdat, zmdat,
                                                   jn, kn);
+       hipErrchk( hipGetLastError() );
 
        hipLaunchKernelGGL((hydro_2d2), dim3(nblocks), dim3(nthreads_per_block), 0, 0,
                                                   zudat, zvdat,
                                                   zadat, zbdat, zzdat, zrdat,
                                                   s,
                                                   jn, kn);
+       hipErrchk( hipGetLastError() );
 
        hipLaunchKernelGGL((hydro_2d3), dim3(nblocks), dim3(nthreads_per_block), 0, 0,
                                                   zroutdat, zzoutdat,
                                                   zrdat, zudat, zzdat, zvdat,
                                                   t,
                                                   jn, kn);
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/INT_PREDICT-Cuda.cpp
+++ b/src/lcals/INT_PREDICT-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -38,12 +38,12 @@ __global__ void int_predict(Real_ptr px,
                             Real_type dm22, Real_type dm23, Real_type dm24,
                             Real_type dm25, Real_type dm26, Real_type dm27,
                             Real_type dm28, Real_type c0,
-                            const Index_type offset, 
-                            Index_type iend) 
+                            const Index_type offset,
+                            Index_type iend)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i < iend) {
-     INT_PREDICT_BODY; 
+     INT_PREDICT_BODY;
    }
 }
 
@@ -64,11 +64,12 @@ void INT_PREDICT::runCudaVariant(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       int_predict<<<grid_size, block_size>>>( px, 
+       int_predict<<<grid_size, block_size>>>( px,
                                                dm22, dm23, dm24, dm25,
                                                dm26, dm27, dm28, c0,
                                                offset,
-                                               iend ); 
+                                               iend );
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/INT_PREDICT-Hip.cpp
+++ b/src/lcals/INT_PREDICT-Hip.cpp
@@ -69,6 +69,7 @@ void INT_PREDICT::runHipVariant(VariantID vid)
                                                dm26, dm27, dm28, c0,
                                                offset,
                                                iend );
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/PLANCKIAN-Cuda.cpp
+++ b/src/lcals/PLANCKIAN-Cuda.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <cmath>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -44,12 +44,12 @@ namespace lcals
   deallocCudaDeviceData(w);
 
 __global__ void planckian(Real_ptr x, Real_ptr y,
-                          Real_ptr u, Real_ptr v, Real_ptr w, 
-                          Index_type iend) 
+                          Real_ptr u, Real_ptr v, Real_ptr w,
+                          Index_type iend)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i < iend) {
-     PLANCKIAN_BODY; 
+     PLANCKIAN_BODY;
    }
 }
 
@@ -70,9 +70,10 @@ void PLANCKIAN::runCudaVariant(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       planckian<<<grid_size, block_size>>>( x, y, 
+       planckian<<<grid_size, block_size>>>( x, y,
                                              u, v, w,
                                              iend );
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/PLANCKIAN-Hip.cpp
+++ b/src/lcals/PLANCKIAN-Hip.cpp
@@ -73,6 +73,7 @@ void PLANCKIAN::runHipVariant(VariantID vid)
        hipLaunchKernelGGL((planckian), dim3(grid_size), dim3(block_size), 0, 0,  x, y,
                                              u, v, w,
                                              iend );
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/TRIDIAG_ELIM-Cuda.cpp
+++ b/src/lcals/TRIDIAG_ELIM-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace lcals
 {
@@ -41,11 +41,11 @@ namespace lcals
   deallocCudaDeviceData(z);
 
 __global__ void eos(Real_ptr xout, Real_ptr xin, Real_ptr y, Real_ptr z,
-                    Index_type N) 
+                    Index_type N)
 {
    Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
    if (i > 0 && i < N) {
-     TRIDIAG_ELIM_BODY; 
+     TRIDIAG_ELIM_BODY;
    }
 }
 
@@ -67,7 +67,8 @@ void TRIDIAG_ELIM::runCudaVariant(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        eos<<<grid_size, block_size>>>( xout, xin, y, z,
-                                       iend ); 
+                                       iend );
+       cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/TRIDIAG_ELIM-Hip.cpp
+++ b/src/lcals/TRIDIAG_ELIM-Hip.cpp
@@ -68,6 +68,7 @@ void TRIDIAG_ELIM::runHipVariant(VariantID vid)
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        hipLaunchKernelGGL(eos, grid_size, block_size, 0, 0, xout, xin, y, z,
                                        iend );
+       hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_2MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_2MM-Cuda.cpp
@@ -84,11 +84,13 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
       dim3 nthreads_per_block1(nj, 1, 1);
       poly_2mm_1<<<nblocks1, nthreads_per_block1>>>(tmp, A, B, alpha,
                                                     nj, nk);
+      cudaErrchk( cudaGetLastError() );
 
       dim3 nblocks2(1, ni, 1);
       dim3 nthreads_per_block2(nl, 1, 1);
       poly_2mm_2<<<nblocks2, nthreads_per_block2>>>(tmp, C, D, beta,
                                                     nl, nj);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_2MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_2MM-Cuda.cpp
@@ -117,6 +117,7 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
         }
         POLYBENCH_2MM_BODY3;
       });
+      cudaErrchk( cudaGetLastError() );
 
       dim3 nblocks2(1, ni, 1);
       dim3 nthreads_per_block2(nl, 1, 1);
@@ -131,6 +132,7 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
         }
         POLYBENCH_2MM_BODY6;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_2MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_2MM-Hip.cpp
@@ -85,12 +85,14 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
       hipLaunchKernelGGL((poly_2mm_1), dim3(nblocks1), dim3(nthreads_per_block1), 0, 0,
                                                     tmp, A, B, alpha,
                                                     nj, nk);
+      hipErrchk( hipGetLastError() );
 
       dim3 nblocks2(1, ni, 1);
       dim3 nthreads_per_block2(nl, 1, 1);
       hipLaunchKernelGGL((poly_2mm_2), dim3(nblocks2), dim3(nthreads_per_block2), 0, 0,
                                                     tmp, C, D, beta,
                                                     nl, nj);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -119,6 +121,7 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(kernel1,
         nblocks1, nthreads_per_block1, 0, 0,
         0, ni, 0, nj, poly_2mm_1_lambda);
+      hipErrchk( hipGetLastError() );
 
       auto poly_2mm_2_lambda = [=] __device__ (Index_type i, Index_type l) {
 
@@ -135,6 +138,7 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(kernel2,
         nblocks2, nthreads_per_block2, 0, 0,
         0, ni, 0, nl, poly_2mm_2_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_3MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_3MM-Cuda.cpp
@@ -98,16 +98,19 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
       dim3 nthreads_per_block1(nj, 1, 1);
       poly_3mm_1<<<nblocks1, nthreads_per_block1>>>(E, A, B,
                                                     nj, nk);
+      cudaErrchk( cudaGetLastError() );
 
       dim3 nblocks2(1, nj, 1);
       dim3 nthreads_per_block2(nl, 1, 1);
       poly_3mm_2<<<nblocks2, nthreads_per_block2>>>(F, C, D,
                                                     nl, nm);
+      cudaErrchk( cudaGetLastError() );
 
       dim3 nblocks3(1, ni, 1);
       dim3 nthreads_per_block3(nl, 1, 1);
       poly_3mm_3<<<nblocks3, nthreads_per_block3>>>(G, E, F,
                                                     nl, nj);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_3MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_3MM-Cuda.cpp
@@ -137,6 +137,7 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
         }
         POLYBENCH_3MM_BODY3;
       });
+      cudaErrchk( cudaGetLastError() );
 
       dim3 nblocks2(1, nj, 1);
       dim3 nthreads_per_block2(nl, 1, 1);
@@ -151,6 +152,7 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
         }
         POLYBENCH_3MM_BODY6;
       });
+      cudaErrchk( cudaGetLastError() );
 
       dim3 nblocks3(1, ni, 1);
       dim3 nthreads_per_block3(nl, 1, 1);
@@ -165,6 +167,7 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
         }
         POLYBENCH_3MM_BODY9;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_3MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_3MM-Hip.cpp
@@ -99,18 +99,21 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
       hipLaunchKernelGGL((poly_3mm_1), dim3(nblocks1) , dim3(nthreads_per_block1), 0, 0,
                                                     E, A, B,
                                                     nj, nk);
+      hipErrchk( hipGetLastError() );
 
       dim3 nblocks2(1, nj, 1);
       dim3 nthreads_per_block2(nl, 1, 1);
       hipLaunchKernelGGL((poly_3mm_2), dim3(nblocks2), dim3(nthreads_per_block2), 0, 0,
                                                     F, C, D,
                                                     nl, nm);
+      hipErrchk( hipGetLastError() );
 
       dim3 nblocks3(1, ni, 1);
       dim3 nthreads_per_block3(nl, 1, 1);
       hipLaunchKernelGGL((poly_3mm_3), dim3(nblocks3), dim3(nthreads_per_block3), 0, 0,
                                                     G, E, F,
                                                     nl, nj);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -139,6 +142,7 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(kernel1,
         nblocks1, nthreads_per_block1, 0, 0,
         0, ni, 0, nj, poly_3mm_1_lambda);
+      hipErrchk( hipGetLastError() );
 
       auto poly_3mm_2_lambda = [=] __device__ (Index_type j, Index_type l) {
 
@@ -155,6 +159,7 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(kernel2,
         nblocks2, nthreads_per_block2, 0, 0,
         0, nj, 0, nl, poly_3mm_2_lambda);
+      hipErrchk( hipGetLastError() );
 
       auto poly_3mm_3_lambda = [=] __device__ (Index_type i, Index_type l) {
 
@@ -171,6 +176,7 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(kernel3,
         nblocks3, nthreads_per_block3, 0, 0,
         0, ni, 0, nl, poly_3mm_3_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_ADI-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ADI-Cuda.cpp
@@ -97,10 +97,12 @@ void POLYBENCH_ADI::runCudaVariant(VariantID vid)
         adi1<<<grid_size, block_size>>>(n,
                                         a, b, c, d, f,
                                         P, Q, U, V);
+        cudaErrchk( cudaGetLastError() );
 
         adi2<<<grid_size, block_size>>>(n,
                                         a, c, d, e, f,
                                         P, Q, U, V);
+        cudaErrchk( cudaGetLastError() );
 
       }  // tstep loop
 

--- a/src/polybench/POLYBENCH_ADI-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ADI-Cuda.cpp
@@ -135,6 +135,7 @@ void POLYBENCH_ADI::runCudaVariant(VariantID vid)
              POLYBENCH_ADI_BODY5;
           }
         });
+        cudaErrchk( cudaGetLastError() );
 
         lambda_cuda_forall<<<grid_size, block_size>>>(
           1, n-1,
@@ -149,6 +150,7 @@ void POLYBENCH_ADI::runCudaVariant(VariantID vid)
             POLYBENCH_ADI_BODY9;
           }
         });
+        cudaErrchk( cudaGetLastError() );
       }  // tstep loop
 
     }

--- a/src/polybench/POLYBENCH_ADI-Hip.cpp
+++ b/src/polybench/POLYBENCH_ADI-Hip.cpp
@@ -99,11 +99,13 @@ void POLYBENCH_ADI::runHipVariant(VariantID vid)
                                         n,
                                         a, b, c, d, f,
                                         P, Q, U, V);
+        hipErrchk( hipGetLastError() );
 
         hipLaunchKernelGGL((adi2), dim3(grid_size), dim3(block_size), 0, 0,
                                         n,
                                         a, c, d, e, f,
                                         P, Q, U, V);
+        hipErrchk( hipGetLastError() );
 
       }  // tstep loop
 
@@ -138,6 +140,7 @@ void POLYBENCH_ADI::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(lambda_hip_forall<decltype(adi1_lamda)>,
           grid_size, block_size, 0, 0,
           1, n-1, adi1_lamda);
+        hipErrchk( hipGetLastError() );
 
         auto adi2_lamda = [=] __device__ (Index_type i) {
 
@@ -154,6 +157,7 @@ void POLYBENCH_ADI::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(lambda_hip_forall<decltype(adi2_lamda)>,
           grid_size, block_size, 0, 0,
           1, n-1, adi2_lamda);
+        hipErrchk( hipGetLastError() );
 
       }  // tstep loop
 

--- a/src/polybench/POLYBENCH_ATAX-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Cuda.cpp
@@ -115,6 +115,7 @@ void POLYBENCH_ATAX::runCudaVariant(VariantID vid)
         }
         POLYBENCH_ATAX_BODY3;
       });
+      cudaErrchk( cudaGetLastError() );
 
       lambda_cuda_forall<<<grid_size, block_size>>>(
         0, N,
@@ -126,6 +127,7 @@ void POLYBENCH_ATAX::runCudaVariant(VariantID vid)
         }
         POLYBENCH_ATAX_BODY6;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_ATAX-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Cuda.cpp
@@ -86,8 +86,10 @@ void POLYBENCH_ATAX::runCudaVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
 
       poly_atax_1<<<grid_size, block_size>>>(A, x, y, tmp, N);
+      cudaErrchk( cudaGetLastError() );
 
       poly_atax_2<<<grid_size, block_size>>>(A, tmp, y, N);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_ATAX-Hip.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Hip.cpp
@@ -87,9 +87,11 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
 
       hipLaunchKernelGGL((poly_atax_1), dim3(grid_size), dim3(block_size), 0, 0,
                                       A, x, y, tmp, N);
+      hipErrchk( hipGetLastError() );
 
       hipLaunchKernelGGL((poly_atax_2), dim3(grid_size), dim3(block_size), 0, 0,
                                       A, tmp, y, N);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -117,6 +119,7 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_atax_1_lambda)>,
         grid_size, block_size, 0, 0,
         0, N, poly_atax_1_lambda);
+      hipErrchk( hipGetLastError() );
 
       auto poly_atax_2_lambda = [=] __device__ (Index_type j) {
 
@@ -130,6 +133,7 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_atax_2_lambda)>,
         grid_size, block_size, 0, 0,
         0, N, poly_atax_2_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
@@ -100,14 +100,20 @@ void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
 
         const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
         poly_fdtd2d_1<<<grid_size1, block_size>>>(ey, fict, ny, t);
+        cudaErrchk( cudaGetLastError() );
 
         dim3 nblocks234(1, nx, 1);
         dim3 nthreads_per_block234(ny, 1, 1);
         poly_fdtd2d_2<<<nblocks234, nthreads_per_block234>>>(ey, hz, ny);
+        cudaErrchk( cudaGetLastError() );
 
         poly_fdtd2d_3<<<nblocks234, nthreads_per_block234>>>(ex, hz, ny);
 
+        cudaErrchk( cudaGetLastError() );
+
         poly_fdtd2d_4<<<nblocks234, nthreads_per_block234>>>(hz, ex, ey, nx, ny);
+
+        cudaErrchk( cudaGetLastError() );
 
       } // tstep loop
 

--- a/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
@@ -100,17 +100,21 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
 
         const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
         hipLaunchKernelGGL((poly_fdtd2d_1), dim3(grid_size1), dim3(block_size), 0, 0, ey, fict, ny, t);
+        hipErrchk( hipGetLastError() );
 
         dim3 nblocks234(1, nx, 1);
         dim3 nthreads_per_block234(ny, 1, 1);
         hipLaunchKernelGGL((poly_fdtd2d_2), dim3(nblocks234), dim3(nthreads_per_block234),
                                     0, 0, ey, hz, ny);
+        hipErrchk( hipGetLastError() );
 
         hipLaunchKernelGGL((poly_fdtd2d_3), dim3(nblocks234), dim3(nthreads_per_block234),
                                     0, 0, ex, hz, ny);
+        hipErrchk( hipGetLastError() );
 
         hipLaunchKernelGGL((poly_fdtd2d_4), dim3(nblocks234), dim3(nthreads_per_block234),
                                     0, 0, hz, ex, ey, nx, ny);
+        hipErrchk( hipGetLastError() );
 
       } // tstep loop
 
@@ -136,6 +140,7 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_fdtd2d_1_lambda)>,
           grid_size1, block_size, 0, 0,
           0, ny, poly_fdtd2d_1_lambda);
+        hipErrchk( hipGetLastError() );
 
         auto poly_fdtd2d_2_lambda = [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_FDTD_2D_BODY2;
@@ -147,6 +152,7 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(kernel2,
           nblocks234, nthreads_per_block234, 0, 0,
           1, nx, 0, ny, poly_fdtd2d_2_lambda);
+        hipErrchk( hipGetLastError() );
 
         auto poly_fdtd2d_3_lambda = [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_FDTD_2D_BODY3;
@@ -156,6 +162,7 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(kernel3,
           nblocks234, nthreads_per_block234, 0, 0,
           0, nx, 1, ny, poly_fdtd2d_3_lambda);
+        hipErrchk( hipGetLastError() );
 
         auto poly_fdtd2d_4_lambda = [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_FDTD_2D_BODY4;
@@ -165,6 +172,7 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(kernel4,
           nblocks234, nthreads_per_block234, 0, 0,
           0, nx-1, 0, ny-1, poly_fdtd2d_4_lambda);
+        hipErrchk( hipGetLastError() );
 
       } // tstep loop
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
@@ -60,6 +60,7 @@ void POLYBENCH_FLOYD_WARSHALL::runCudaVariant(VariantID vid)
         dim3 nthreads_per_block1(N, 1, 1);
         poly_floyd_warshall<<<nblocks1, nthreads_per_block1>>>(pout, pin,
                                                                k, N);
+        cudaErrchk( cudaGetLastError() );
 
       }
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
@@ -60,6 +60,7 @@ void POLYBENCH_FLOYD_WARSHALL::runHipVariant(VariantID vid)
         dim3 nthreads_per_block1(N, 1, 1);
         hipLaunchKernelGGL((poly_floyd_warshall),dim3(nblocks1), dim3(nthreads_per_block1),0,0,pout, pin,
                                                                k, N);
+        hipErrchk( hipGetLastError() );
 
       }
 
@@ -88,6 +89,7 @@ void POLYBENCH_FLOYD_WARSHALL::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(kernel,
           nblocks1, nthreads_per_block1,0,0,
           0, N, 0, N, poly_floyd_warshall_lambda);
+        hipErrchk( hipGetLastError() );
 
       }
 

--- a/src/polybench/POLYBENCH_GEMM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Cuda.cpp
@@ -69,6 +69,7 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
       poly_gemm<<<nblocks, nthreads_per_block>>>(C, A, B,
                                                  alpha, beta,
                                                  nj, nk);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_GEMM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Cuda.cpp
@@ -98,6 +98,7 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
         }
         POLYBENCH_GEMM_BODY4;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_GEMM-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Hip.cpp
@@ -69,6 +69,7 @@ void POLYBENCH_GEMM::runHipVariant(VariantID vid)
       hipLaunchKernelGGL((poly_gemm), dim3(nblocks), dim3(nthreads_per_block), 0,0,C, A, B,
                                                  alpha, beta,
                                                  nj, nk);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -99,6 +100,7 @@ void POLYBENCH_GEMM::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(kernel,
         nblocks, nthreads_per_block, 0, 0,
         0, ni, 0, nj, poly_gemm_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
@@ -118,19 +118,23 @@ void POLYBENCH_GEMVER::runCudaVariant(VariantID vid)
       dim3 nthreads_per_block(n, 1, 1);
       poly_gemmver_1<<<nblocks, nthreads_per_block>>>(A, u1, v1, u2, v2,
                                                       n);
+      cudaErrchk( cudaGetLastError() );
 
       size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
 
       poly_gemmver_2<<<grid_size, block_size>>>(A, x, y,
                                                 beta,
                                                 n);
+      cudaErrchk( cudaGetLastError() );
 
       poly_gemmver_3<<<grid_size, block_size>>>(x, z,
                                                 n);
+      cudaErrchk( cudaGetLastError() );
 
       poly_gemmver_4<<<grid_size, block_size>>>(A, x, w,
                                                 alpha,
                                                 n);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
@@ -156,6 +156,7 @@ void POLYBENCH_GEMVER::runCudaVariant(VariantID vid)
         [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_GEMVER_BODY1;
       });
+      cudaErrchk( cudaGetLastError() );
 
       size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
 
@@ -168,12 +169,14 @@ void POLYBENCH_GEMVER::runCudaVariant(VariantID vid)
           }
           POLYBENCH_GEMVER_BODY4;
       });
+      cudaErrchk( cudaGetLastError() );
 
       lambda_cuda_forall<<<grid_size, block_size>>>(
         0, n,
         [=] __device__ (Index_type i) {
           POLYBENCH_GEMVER_BODY5;
       });
+      cudaErrchk( cudaGetLastError() );
 
       lambda_cuda_forall<<<grid_size, block_size>>>(
         0, n,
@@ -184,6 +187,7 @@ void POLYBENCH_GEMVER::runCudaVariant(VariantID vid)
           }
           POLYBENCH_GEMVER_BODY8;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_GEMVER-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Hip.cpp
@@ -118,6 +118,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
       dim3 nthreads_per_block(n, 1, 1);
       hipLaunchKernelGGL((poly_gemmver_1) , dim3(nblocks), dim3(nthreads_per_block), 0, 0,
                                 A, u1, v1, u2, v2, n);
+      hipErrchk( hipGetLastError() );
 
       size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
 
@@ -125,15 +126,18 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
                                                 A, x, y,
                                                 beta,
                                                 n);
+      hipErrchk( hipGetLastError() );
 
       hipLaunchKernelGGL((poly_gemmver_3), dim3(grid_size), dim3(block_size), 0, 0,
                                                 x, z,
                                                 n);
+      hipErrchk( hipGetLastError() );
 
       hipLaunchKernelGGL((poly_gemmver_4), dim3(grid_size), dim3(block_size), 0, 0,
                                                 A, x, w,
                                                 alpha,
                                                 n);
+      hipErrchk( hipGetLastError() );
     }
     stopTimer();
 
@@ -156,6 +160,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(kernel1,
         nblocks, nthreads_per_block, 0, 0,
         0, n, 0, n, poly_gemmver_1_lambda);
+      hipErrchk( hipGetLastError() );
 
       size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
 
@@ -170,6 +175,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_gemmver_2_lambda)>,
         grid_size, block_size, 0, 0,
         0, n, poly_gemmver_2_lambda);
+      hipErrchk( hipGetLastError() );
 
       auto poly_gemmver_3_lambda = [=] __device__ (Index_type i) {
           POLYBENCH_GEMVER_BODY5;
@@ -178,6 +184,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_gemmver_3_lambda)>,
         grid_size, block_size, 0, 0,
         0, n, poly_gemmver_3_lambda);
+      hipErrchk( hipGetLastError() );
 
       auto poly_gemmver_4_lambda = [=] __device__ (Index_type i) {
           POLYBENCH_GEMVER_BODY6;
@@ -190,6 +197,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
       hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_gemmver_4_lambda)>,
         grid_size, block_size, 0, 0,
         0, n, poly_gemmver_4_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
@@ -77,6 +77,7 @@ void POLYBENCH_GESUMMV::runCudaVariant(VariantID vid)
                                               A, B,
                                               alpha, beta,
                                               N);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_GESUMMV-Hip.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Hip.cpp
@@ -77,6 +77,7 @@ void POLYBENCH_GESUMMV::runHipVariant(VariantID vid)
                                               A, B,
                                               alpha, beta,
                                               N);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
@@ -76,7 +76,11 @@ void POLYBENCH_HEAT_3D::runCudaVariant(VariantID vid)
 
         poly_heat_3D_1<<<nblocks, nthreads_per_block>>>(A, B, N);
 
+        cudaErrchk( cudaGetLastError() );
+
         poly_heat_3D_2<<<nblocks, nthreads_per_block>>>(A, B, N);
+
+        cudaErrchk( cudaGetLastError() );
 
       }
 

--- a/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
@@ -75,8 +75,10 @@ void POLYBENCH_HEAT_3D::runHipVariant(VariantID vid)
         dim3 nthreads_per_block(N-2, 1, 1);
 
         hipLaunchKernelGGL((poly_heat_3D_1),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
+        hipErrchk( hipGetLastError() );
 
         hipLaunchKernelGGL((poly_heat_3D_2),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
+        hipErrchk( hipGetLastError() );
 
       }
 
@@ -106,6 +108,7 @@ void POLYBENCH_HEAT_3D::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(kernel1,
           nblocks, nthreads_per_block, 0, 0,
           1, N-1, 1, N-1, 1, N-1, poly_heat_3D_1_lambda);
+        hipErrchk( hipGetLastError() );
 
         auto poly_heat_3D_2_lambda = [=] __device__ (Index_type i, Index_type j, Index_type k) {
 
@@ -116,6 +119,7 @@ void POLYBENCH_HEAT_3D::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(kernel2,
           nblocks, nthreads_per_block, 0, 0,
           1, N-1, 1, N-1, 1, N-1, poly_heat_3D_2_lambda);
+        hipErrchk( hipGetLastError() );
 
       }
 

--- a/src/polybench/POLYBENCH_JACOBI_1D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-Cuda.cpp
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -75,8 +75,10 @@ void POLYBENCH_JACOBI_1D::runCudaVariant(VariantID vid)
         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
 
         poly_jacobi_1D_1<<<grid_size, block_size>>>(A, B, N);
+        cudaErrchk( cudaGetLastError() );
 
         poly_jacobi_1D_2<<<grid_size, block_size>>>(A, B, N);
+        cudaErrchk( cudaGetLastError() );
 
       }
 
@@ -96,12 +98,12 @@ void POLYBENCH_JACOBI_1D::runCudaVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        RAJA::forall<EXEC_POL> ( RAJA::RangeSegment{1, N-1}, 
+        RAJA::forall<EXEC_POL> ( RAJA::RangeSegment{1, N-1},
           [=] __device__ (Index_type i) {
             POLYBENCH_JACOBI_1D_BODY1;
         });
 
-        RAJA::forall<EXEC_POL> ( RAJA::RangeSegment{1, N-1}, 
+        RAJA::forall<EXEC_POL> ( RAJA::RangeSegment{1, N-1},
           [=] __device__ (Index_type i) {
             POLYBENCH_JACOBI_1D_BODY2;
         });
@@ -123,4 +125,4 @@ void POLYBENCH_JACOBI_1D::runCudaVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_CUDA
-  
+

--- a/src/polybench/POLYBENCH_JACOBI_1D-Hip.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-Hip.cpp
@@ -4,7 +4,7 @@
 // See the RAJAPerf/COPYRIGHT file for details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~// 
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_JACOBI_1D.hpp"
 
@@ -16,7 +16,7 @@
 
 #include <iostream>
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace polybench
 {
@@ -76,9 +76,11 @@ void POLYBENCH_JACOBI_1D::runHipVariant(VariantID vid)
 
         hipLaunchKernelGGL((poly_jacobi_1D_1), dim3(grid_size), dim3(block_size), 0, 0,
                                             A, B, N);
+        hipErrchk( hipGetLastError() );
 
         hipLaunchKernelGGL((poly_jacobi_1D_2), dim3(grid_size), dim3(block_size), 0, 0,
                                             A, B, N);
+        hipErrchk( hipGetLastError() );
 
       }
 
@@ -98,12 +100,12 @@ void POLYBENCH_JACOBI_1D::runHipVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        RAJA::forall<EXEC_POL> ( RAJA::RangeSegment{1, N-1}, 
+        RAJA::forall<EXEC_POL> ( RAJA::RangeSegment{1, N-1},
           [=] __device__ (Index_type i) {
             POLYBENCH_JACOBI_1D_BODY1;
         });
 
-        RAJA::forall<EXEC_POL> ( RAJA::RangeSegment{1, N-1}, 
+        RAJA::forall<EXEC_POL> ( RAJA::RangeSegment{1, N-1},
           [=] __device__ (Index_type i) {
             POLYBENCH_JACOBI_1D_BODY2;
         });
@@ -125,4 +127,4 @@ void POLYBENCH_JACOBI_1D::runHipVariant(VariantID vid)
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_HIP
-  
+

--- a/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
@@ -73,8 +73,10 @@ void POLYBENCH_JACOBI_2D::runCudaVariant(VariantID vid)
         dim3 nthreads_per_block(N-2, 1, 1);
 
         poly_jacobi_2D_1<<<nblocks, nthreads_per_block>>>(A, B, N);
+        cudaErrchk( cudaGetLastError() );
 
         poly_jacobi_2D_2<<<nblocks, nthreads_per_block>>>(A, B, N);
+        cudaErrchk( cudaGetLastError() );
 
       }
 

--- a/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
@@ -104,6 +104,7 @@ void POLYBENCH_JACOBI_2D::runCudaVariant(VariantID vid)
 
           POLYBENCH_JACOBI_2D_BODY1;
         });
+        cudaErrchk( cudaGetLastError() );
 
         lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
                           <<<nblocks, nthreads_per_block>>>(
@@ -112,6 +113,7 @@ void POLYBENCH_JACOBI_2D::runCudaVariant(VariantID vid)
 
           POLYBENCH_JACOBI_2D_BODY2;
         });
+        cudaErrchk( cudaGetLastError() );
 
       }
 

--- a/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
@@ -73,8 +73,10 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
         dim3 nthreads_per_block(N-2, 1, 1);
 
         hipLaunchKernelGGL((poly_jacobi_2D_1),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
+        hipErrchk( hipGetLastError() );
 
         hipLaunchKernelGGL((poly_jacobi_2D_2),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
+        hipErrchk( hipGetLastError() );
 
       }
 
@@ -104,6 +106,7 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(kernel1,
           nblocks, nthreads_per_block, 0, 0,
           1, N-1, 1, N-1, poly_jacobi_2D_1_kernel);
+        hipErrchk( hipGetLastError() );
 
         auto poly_jacobi_2D_2_kernel = [=] __device__ (Index_type i, Index_type j) {
 
@@ -114,6 +117,7 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(kernel2,
           nblocks, nthreads_per_block, 0, 0,
           1, N-1, 1, N-1, poly_jacobi_2D_2_kernel);
+        hipErrchk( hipGetLastError() );
 
       }
 

--- a/src/polybench/POLYBENCH_MVT-Cuda.cpp
+++ b/src/polybench/POLYBENCH_MVT-Cuda.cpp
@@ -89,8 +89,10 @@ void POLYBENCH_MVT::runCudaVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
 
       poly_mvt_1<<<grid_size, block_size>>>(A, x1, y1, N);
+      cudaErrchk( cudaGetLastError() );
 
       poly_mvt_2<<<grid_size, block_size>>>(A, x2, y2, N);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/polybench/POLYBENCH_MVT-Hip.cpp
+++ b/src/polybench/POLYBENCH_MVT-Hip.cpp
@@ -89,8 +89,10 @@ void POLYBENCH_MVT::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
 
       hipLaunchKernelGGL((poly_mvt_1),dim3(grid_size), dim3(block_size),0,0,A, x1, y1, N);
+      hipErrchk( hipGetLastError() );
 
       hipLaunchKernelGGL((poly_mvt_2),dim3(grid_size), dim3(block_size),0,0,A, x2, y2, N);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/ADD-Cuda.cpp
+++ b/src/stream/ADD-Cuda.cpp
@@ -85,6 +85,7 @@ void ADD::runCudaVariant(VariantID vid)
         ibegin, iend, [=] __device__ (Index_type i) {
         ADD_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/ADD-Cuda.cpp
+++ b/src/stream/ADD-Cuda.cpp
@@ -66,6 +66,7 @@ void ADD::runCudaVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       add<<<grid_size, block_size>>>( c, a, b,
                                       iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/ADD-Hip.cpp
+++ b/src/stream/ADD-Hip.cpp
@@ -66,6 +66,7 @@ void ADD::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL((add), dim3(grid_size), dim3(block_size), 0, 0,  c, a, b,
                                       iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -86,6 +87,7 @@ void ADD::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(add_lambda)>,
         grid_size, block_size, 0, 0, ibegin, iend, add_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/COPY-Cuda.cpp
+++ b/src/stream/COPY-Cuda.cpp
@@ -64,6 +64,7 @@ void COPY::runCudaVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       copy<<<grid_size, block_size>>>( c, a,
                                        iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/COPY-Cuda.cpp
+++ b/src/stream/COPY-Cuda.cpp
@@ -83,6 +83,7 @@ void COPY::runCudaVariant(VariantID vid)
         ibegin, iend, [=] __device__ (Index_type i) {
         COPY_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/COPY-Hip.cpp
+++ b/src/stream/COPY-Hip.cpp
@@ -64,6 +64,7 @@ void COPY::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL((copy), dim3(grid_size), dim3(block_size), 0, 0,
           c, a, iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -84,6 +85,7 @@ void COPY::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(copy_lambda)>,
         grid_size, block_size, 0, 0, ibegin, iend, copy_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/DOT-Cuda.cpp
+++ b/src/stream/DOT-Cuda.cpp
@@ -17,7 +17,7 @@
 #include <iostream>
 
 
-namespace rajaperf 
+namespace rajaperf
 {
 namespace stream
 {
@@ -38,13 +38,13 @@ namespace stream
 
 __global__ void dot(Real_ptr a, Real_ptr b,
                     Real_ptr dprod, Real_type dprod_init,
-                    Index_type iend) 
+                    Index_type iend)
 {
   extern __shared__ Real_type pdot[ ];
 
   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
 
-  pdot[ threadIdx.x ] = dprod_init; 
+  pdot[ threadIdx.x ] = dprod_init;
   for ( ; i < iend ; i += gridDim.x * blockDim.x ) {
     pdot[ threadIdx.x ] += a[ i ] * b[i];
   }
@@ -91,15 +91,16 @@ void DOT::runCudaVariant(VariantID vid)
       initCudaDeviceData(dprod, &m_dot_init, 1);
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      dot<<<grid_size, block_size, 
-            sizeof(Real_type)*block_size>>>( a, b, 
+      dot<<<grid_size, block_size,
+            sizeof(Real_type)*block_size>>>( a, b,
                                              dprod, m_dot_init,
-                                             iend ); 
+                                             iend );
+      cudaErrchk( cudaGetLastError() );
 
       Real_type lprod;
       Real_ptr plprod = &lprod;
       getCudaDeviceData(plprod, dprod, 1);
-      m_dot += lprod;  
+      m_dot += lprod;
 
     }
     stopTimer();

--- a/src/stream/DOT-Hip.cpp
+++ b/src/stream/DOT-Hip.cpp
@@ -95,6 +95,7 @@ void DOT::runHipVariant(VariantID vid)
       hipLaunchKernelGGL((dot), dim3(grid_size), dim3(block_size), sizeof(Real_type)*block_size, 0,  a, b,
                                              dprod, m_dot_init,
                                              iend );
+      hipErrchk( hipGetLastError() );
 
       Real_type lprod;
       Real_ptr plprod = &lprod;

--- a/src/stream/MUL-Cuda.cpp
+++ b/src/stream/MUL-Cuda.cpp
@@ -63,6 +63,7 @@ void MUL::runCudaVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       mul<<<grid_size, block_size>>>( b, c, alpha,
                                       iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/MUL-Cuda.cpp
+++ b/src/stream/MUL-Cuda.cpp
@@ -82,6 +82,7 @@ void MUL::runCudaVariant(VariantID vid)
         ibegin, iend, [=] __device__ (Index_type i) {
         MUL_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/MUL-Hip.cpp
+++ b/src/stream/MUL-Hip.cpp
@@ -63,6 +63,7 @@ void MUL::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL((mul), dim3(grid_size), dim3(block_size), 0, 0,  b, c, alpha,
                                       iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -83,6 +84,7 @@ void MUL::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(mul_lambda)>,
         grid_size, block_size, 0, 0, ibegin, iend, mul_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/TRIAD-Cuda.cpp
+++ b/src/stream/TRIAD-Cuda.cpp
@@ -66,6 +66,7 @@ void TRIAD::runCudaVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       triad<<<grid_size, block_size>>>( a, b, c, alpha,
                                         iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/TRIAD-Cuda.cpp
+++ b/src/stream/TRIAD-Cuda.cpp
@@ -85,6 +85,7 @@ void TRIAD::runCudaVariant(VariantID vid)
         ibegin, iend, [=] __device__ (Index_type i) {
         TRIAD_BODY;
       });
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/stream/TRIAD-Hip.cpp
+++ b/src/stream/TRIAD-Hip.cpp
@@ -66,6 +66,7 @@ void TRIAD::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL((triad), dim3(grid_size), dim3(block_size), 0, 0,  a, b, c, alpha,
                                         iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();
@@ -86,6 +87,7 @@ void TRIAD::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(triad_lambda)>,
         grid_size, block_size, 0, 0, ibegin, iend, triad_lambda);
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();


### PR DESCRIPTION
Add error checking to Base_CUDA, Lambda_CUDA, Base-HIP, and Lambda_HIP variants.

This reveals kernel launch failures in some polybench kernels for larger problem sizes.