### PR TITLE
mat-mat mult. with shared memory 

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Lastly, the program will generate a summary of provided input if it is given
 input that the code does not know how to parse. Hopefully, this will make it 
 easy for users to correct erroneous usage, such as mis-spellled option names.
 
-# Important note
+## Important note
 
  * The OpenMP target offload variants of the kernels in the Suite are a 
    work-in-progress since the RAJA OpenMP target offload back-end is also
@@ -195,10 +195,10 @@ Currently, there are five files generated:
 3. Speedup -- runtime speedup of each loop kernel and variant with respect to a reference variant. The reference variant can be set with a command line option. If not specified, the first variant run will be used as the reference. The reference variant used will be noted in the file.
 4. Figure of Merit (FOM) -- basic statistics about speedup of RAJA variant vs. baseline for each programming model run. Also, when a RAJA variant timing differs from the corresponding baseline variant timing by more than some tolerance, this will be noted in the file with `OVER_TOL`. By default the tolerance is 10%. This can be changed via a command line option.
 5. Kernel -- Basic information about each kernel that is run, which is the same
-for each variant of the kernel that is run.
+for each variant of the kernel that is run. See descriptions below.
 
 All output files are text files. Other than the checksum file, all are in 
-'csv' format for easy processing by comoon tools and generating plots.
+'csv' format for easy processing by common tools and generating plots.
 
 ## Kernel information definitions
 
@@ -207,12 +207,79 @@ located in the ''RAJAPerf-kernels.csv'' file includes the following:
 
 1. Kernel name -- Format is group name followed by kernel name, separated by an underscore. 
 2. Feature -- RAJA feature(s) exercised in RAJA variants of kernel, available via a command line option.
-3. Problem size -- The largest parallel iteration space over all 'loop structures' (e.g., single loop, nested loops, etc.) run in an instance of the kernel. note: some kernels run multiple loops, possibly of different sizes in each kernel instance.
-4. Reps -- Number of time a kernel is run in a single pass through the Suite.
-5. Iterations/rep -- Sum of sizes of all parallel iteration spaces for all loops run in a kernel instance (see 'problem size' above).
-6. Kernels/rep -- total number of loop structures run in each kernel instance.
+3. Problem size -- Size of the problem represented by a kernel. Please see notes below for more information..
+4. Reps -- Number of times a kernel runs in a single pass through the Suite.
+5. Iterations/rep -- Sum of sizes of all parallel iteration spaces for all loops run in a single kernel execution (see 'problem size' above).
+6. Kernels/rep -- total number of loop structures run in each kernel repetition.
 7. Bytes/rep -- Total number of bytes read from and written to memory for each repetition of kernel.
 8. FLOPs/rep -- Total number of floating point operations executed for each repetition of kernel. Currently, we count arithmetic operations (+, -, *, /) and functions, such as exp, sin, code, etc. as on FLOP. We do not currently count operations like abs and comparisons (<, >, etc.) in the FLOP count.
+
+### Notes about 'problem size'
+
+ * The Suite uses three notions of problem size for each kernel: 'default', 
+   'target', and 'actual'. Default is the 'default' problem size defined for a 
+   kernel and the size that will attempt to be run if no runtime options are 
+   provided to run a different size. Target is the desired problem size to run
+   based on default settings and alterations to that if input is provided to
+   change the default. Actual is the problem size that is run based on how 
+   each kernel calculates this.
+ * The concept of problem size is subjective and can be interpreted differently
+   depending on the kernel structure and what one is trying to measure. For 
+   example, problem size could refer to the amount of data needed to be stored 
+   in memory to run the problem, or it could refer to the amount of parallel 
+   work that is possible, etc. 
+ * We employ the following, admittedly somewhat loose definition, which 
+   depends on the particular kernel structure. Of all the 
+   'loop structures' (e.g., single loop, nested loops, etc.) that are run for 
+   a kernel (note that some kernels run multiple loops, possibly of different 
+   sizes or loop structures), problem size refers to the size of the 
+   data set required to generate the kernel result. The interpretation of 
+   this and the definition of problem size for each kernel in the suite is
+   determined by the kernel developer and team discussion.
+
+Here are a few examples to give a better sense of how we determine problem 
+size for various kernels in the Suite.
+
+Vector addition.
+```cpp
+for (int i = 0; i < 0; i < N; ++i) {
+  c[i] = a[i] + b[i]; 
+}
+```
+The problem size for this kernel is 'N', the loop length. Note that this 
+happens to match the size of the vectors a, b, c and the total amount of 
+parallel work in the kernel. This is common for simple, single loop kernels.
+
+Matrix-vector multiplication.
+```cpp
+for (int r = 0; r < N_r; ++r) {
+  b[r] = 0;
+  for (int c = 0; c < N_c; ++c) {
+    b[r] += A[r][c] + x[c];
+  }
+}
+```
+The problem size if N_r * N_c, the size of the matrix. Note that this matches
+the total size of the problem iteration space, but the total amount of parallel
+work is N_r, the number of rows in the matrix and the length of the vector b.
+
+Matrix-matrix multiplication.
+```cpp
+for (int i = 0; i < N_i; ++i) {  
+  for (int j = 0; j < N_j; ++j) {
+    A[i][j] = 0;
+    for (int k = 0; k < N_k; ++k) {
+      A[i][j] += B[i][k] + C[k][j];
+    }
+  }
+}
+```
+Here, we are multiplying matrix B (N_i x N_k) and matrix C (N_k x N_j) and
+storing the result in matrix A (N_i X N_j). Problem size could be chosen to
+be the maximum number of entries in matrix B or C. We choose the size of 
+matrix C (N_i * N_j), which is more closely aligned with the number of 
+independent operations (i.e., the amount of parallel work) in the kernels. 
+
 
 * * *
 
@@ -397,7 +464,7 @@ key steps and conventions that must be followed to ensure that all kernels
 interact with the performance Suite machinery in the same way:
 
 1. Initialize the `KernelBase` class object with `KernelID` and `RunParams` object passed to the FOO class constructor.
-2. Set the default size, and default run repetition count in the FOO class constructor. Then, set kernel run information, problem size, iterations per rep, kernels per rep, bytes per rep, FLOPs per rep, the RAJA features used by the kernel, and kernel variants defined (i.e., implemented) by calling the corresponding members in the `KernelBase`` class, also in the constructor. See the *.cpp file for any existing kernel in the suite for examples of how to do this..
+2. In the class constructor, define kernel information. This includes: default problem size, default run repetition count, iterations per rep, kernels per rep, bytes per rep, FLOPs per rep, the RAJA features used by the kernel, and kernel variants defined (i.e., implemented) by calling the appropriate members in the `KernelBase`` class, also in the constructor. See the *.cpp file for any existing kernel in the suite for examples of how to do this..
 3. Implement data allocation and initialization operations for each kernel variant in the `setUp` method.
 4. Compute the checksum for each variant in the `updateChecksum` method.
 5. Deallocate and reset any data that will be allocated and/or initialized in subsequent kernel executions in the `tearDown` method.
@@ -412,26 +479,34 @@ variant.
 
 The constructor must pass the kernel ID and RunParams object to the base
 class `KernelBase` constructor. The body of the constructor must also call
-base class methods to set kernel information as described above. The code
-snippet below illustrates how this typically looks. Note that the arguments
-passed to each method may be specific to each kernel.
+base class methods to set kernel information as described above. Note that 
+the arguments passed to each method are specific to each kernel, in general. 
+This code snippets shows a typical way this looks for a simple single for-loop
+data parallel kernel.
 
 ```cpp
 FOO::FOO(const RunParams& params)
   : KernelBase(rajaperf::Basic_Foo, params),
-    // default initialization of class members
 {
-  setDefaultSize(1000000);
-  setDefaultReps(1000);
+  setDefaultProblemSize(1000000);  // length of the for-loop
+  setDefaultReps(1000);            // number of times the kernel will execute
+                                   // to generate an execution run time value
+
+  setActualProblemSize( getTargetProblemSize() );  // actual problem size may
+                                                   // be different than the 
+                                                   // default size based on
+                                                   // user-provided run time
+                                                   // options
  
-  setProblemSize( getRunSize() );
-
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( ... );
-  setFLOPsPerRep( ... );
+  setBytesPerRep( ... );  // value set based on data read and written when
+                          // kernel executes
+  setFLOPsPerRep( ... );  // value set based on floating-point operations
+                          // performed when kernel executes
 
-  setUsesFeature(Forall);
+  setUsesFeature(Forall); // the kernel uses the RAJA::forall construct and
+                          // no other RAJA features.
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/scripts/lc-builds/blueos_clang.sh
+++ b/scripts/lc-builds/blueos_clang.sh
@@ -23,7 +23,9 @@ BUILD_SUFFIX=lc_blueos-clang-${COMP_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/clang_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -42,5 +44,5 @@ cmake \
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"

--- a/scripts/lc-builds/blueos_clang_omptarget.sh
+++ b/scripts/lc-builds/blueos_clang_omptarget.sh
@@ -23,7 +23,9 @@ BUILD_SUFFIX=lc_blueos-clang-${COMP_VER}_omptarget
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/clang_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -41,10 +43,10 @@ cmake \
   -DOpenMP_CXX_FLAGS="-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda" \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
-  .. 
+  ..
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"
 

--- a/scripts/lc-builds/blueos_gcc.sh
+++ b/scripts/lc-builds/blueos_gcc.sh
@@ -21,7 +21,9 @@ BUILD_SUFFIX=lc_blueos-gcc-${COMP_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/gcc_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -36,9 +38,9 @@ cmake \
   -DENABLE_OPENMP=On \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
-  .. 
+  ..
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"

--- a/scripts/lc-builds/blueos_nvcc_clang.sh
+++ b/scripts/lc-builds/blueos_nvcc_clang.sh
@@ -10,10 +10,10 @@
 if [[ $# -ne 3 ]]; then
   echo
   echo "You must pass 3 arguments to the script (in this order): "
-  echo "   1) compiler version number for nvcc"  
+  echo "   1) compiler version number for nvcc"
   echo "   2) CUDA compute architecture"
   echo "   3) compiler version number for clang. "
-  echo 
+  echo
   echo "For example: "
   echo "    blueos_nvcc_clang.sh 10.2.89 sm_70 10.0.1"
   exit
@@ -28,7 +28,9 @@ BUILD_SUFFIX=lc_blueos-nvcc${COMP_NVCC_VER}-${COMP_ARCH}-clang${COMP_CLANG_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/nvcc_clang_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} >/dev/null
@@ -53,11 +55,11 @@ cmake \
 echo
 echo "***********************************************************************"
 echo
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo
-echo "  Please note that you have to disable CUDA GPU hooks when you run" 
+echo "  Please note that you have to disable CUDA GPU hooks when you run"
 echo "  the RAJA Perf Suite; for example,"
-echo 
+echo
 echo "    lrun -1 --smpiargs="-disable_gpu_hooks" ./bin/raja-perf.exe"
 echo
 echo "***********************************************************************"

--- a/scripts/lc-builds/blueos_nvcc_gcc.sh
+++ b/scripts/lc-builds/blueos_nvcc_gcc.sh
@@ -28,7 +28,9 @@ BUILD_SUFFIX=lc_blueos-nvcc${COMP_NVCC_VER}-${COMP_ARCH}-gcc${COMP_GCC_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/nvcc_gcc_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} >/dev/null
@@ -53,11 +55,11 @@ cmake \
 echo
 echo "***********************************************************************"
 echo
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo
 echo "  Please note that you have to disable CUDA GPU hooks when you run"
 echo "  the RAJA Perf Suite; for example,"
-echo 
+echo
 echo "    lrun -1 --smpiargs="-disable_gpu_hooks" ./bin/raja-perf.exe"
 echo
 echo "***********************************************************************"

--- a/scripts/lc-builds/blueos_nvcc_xl.sh
+++ b/scripts/lc-builds/blueos_nvcc_xl.sh
@@ -28,7 +28,9 @@ BUILD_SUFFIX=lc_blueos-nvcc${COMP_NVCC_VER}-${COMP_ARCH}-xl${COMP_XL_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/nvcc_xl_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} >/dev/null
@@ -53,11 +55,11 @@ cmake \
 echo
 echo "***********************************************************************"
 echo
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo
 echo "  Please note that you have to disable CUDA GPU hooks when you run"
 echo "  the RAJA Perf Suite; for example,"
-echo 
+echo
 echo "    lrun -1 --smpiargs="-disable_gpu_hooks" ./bin/raja-perf.exe"
 echo
 echo "***********************************************************************"

--- a/scripts/lc-builds/blueos_pgi.sh
+++ b/scripts/lc-builds/blueos_pgi.sh
@@ -21,7 +21,9 @@ BUILD_SUFFIX=lc_blueos-pgi-${COMP_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/pgi_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -41,5 +43,5 @@ cmake \
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"

--- a/scripts/lc-builds/blueos_xl.sh
+++ b/scripts/lc-builds/blueos_xl.sh
@@ -21,7 +21,9 @@ BUILD_SUFFIX=lc_blueos-xl-${COMP_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/xl_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -41,5 +43,5 @@ cmake \
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"

--- a/scripts/lc-builds/blueos_xl_omptarget.sh
+++ b/scripts/lc-builds/blueos_xl_omptarget.sh
@@ -21,7 +21,9 @@ BUILD_SUFFIX=lc_blueos-xl-${COMP_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/xl_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -43,5 +45,5 @@ cmake \
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"

--- a/scripts/lc-builds/toss3_clang.sh
+++ b/scripts/lc-builds/toss3_clang.sh
@@ -21,7 +21,9 @@ BUILD_SUFFIX=lc_toss3-clang-${COMP_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss3/clang_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -36,9 +38,9 @@ cmake \
   -DENABLE_OPENMP=On \
   -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
   "$@" \
-  .. 
+  ..
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"

--- a/scripts/lc-builds/toss3_gcc.sh
+++ b/scripts/lc-builds/toss3_gcc.sh
@@ -21,7 +21,9 @@ BUILD_SUFFIX=lc_toss3-gcc-${COMP_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss3/gcc_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -40,5 +42,5 @@ cmake \
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"

--- a/scripts/lc-builds/toss3_hipcc.sh
+++ b/scripts/lc-builds/toss3_hipcc.sh
@@ -23,10 +23,12 @@ COMP_ARCH=$2
 shift 2
 
 BUILD_SUFFIX=lc_toss3-hipcc-${COMP_VER}-${COMP_ARCH}
-RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss3/hip_link_${COMP_VER}.cmake
+RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss3/hip_link_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} >/dev/null
@@ -37,6 +39,7 @@ module load cmake/3.14.5
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
+  -DROCM_ROOT_DIR="/opt/rocm-${COMP_VER}" \
   -DHIP_ROOT_DIR="/opt/rocm-${COMP_VER}/hip" \
   -DHIP_CLANG_PATH=/opt/rocm-${COMP_VER}/llvm/bin \
   -DCMAKE_C_COMPILER=/opt/rocm-${COMP_VER}/llvm/bin/clang \
@@ -52,5 +55,5 @@ cmake \
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"

--- a/scripts/lc-builds/toss3_icpc.sh
+++ b/scripts/lc-builds/toss3_icpc.sh
@@ -22,14 +22,16 @@ GCC_HEADER_VER=7
 
 if [ ${COMP_MAJOR_VER} -gt 18 ]
 then
-  GCC_HEADER_VER=8 
+  GCC_HEADER_VER=8
 fi
 
 BUILD_SUFFIX=lc_toss3-icpc-${COMP_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss3/icpc_X_gcc${GCC_HEADER_VER}headers.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -38,7 +40,7 @@ mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 module load cmake/3.14.5
 
 ##
-# CMake option -DENABLE_FORCEINLINE_RECURSIVE=Off used to speed up compile 
+# CMake option -DENABLE_FORCEINLINE_RECURSIVE=Off used to speed up compile
 # times at a potential cost of slower 'forall' execution.
 ##
 
@@ -55,5 +57,5 @@ cmake \
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"

--- a/scripts/lc-builds/toss3_pgi.sh
+++ b/scripts/lc-builds/toss3_pgi.sh
@@ -21,7 +21,9 @@ BUILD_SUFFIX=lc_toss3-pgi-${COMP_VER}
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss3/pgi_X.cmake
 
 echo
-echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -41,5 +43,5 @@ cmake \
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,9 @@ blt_add_executable(
   basic/INIT_VIEW1D_OFFSET.cpp
   basic/INIT_VIEW1D_OFFSET-Seq.cpp
   basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
+  basic/MAT_MAT_SHARED.cpp
+  basic/MAT_MAT_SHARED-Seq.cpp
+  basic/MAT_MAT_SHARED-OMPTarget.cpp
   basic/MULADDSUB.cpp
   basic/MULADDSUB-Seq.cpp
   basic/MULADDSUB-OMPTarget.cpp

--- a/src/algorithm/SORT-Cuda.cpp
+++ b/src/algorithm/SORT-Cuda.cpp
@@ -39,7 +39,7 @@ void SORT::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   SORT_DATA_SETUP;
 

--- a/src/algorithm/SORT-Hip.cpp
+++ b/src/algorithm/SORT-Hip.cpp
@@ -39,7 +39,7 @@ void SORT::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   SORT_DATA_SETUP;
 

--- a/src/algorithm/SORT-OMP.cpp
+++ b/src/algorithm/SORT-OMP.cpp
@@ -24,7 +24,7 @@ void SORT::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   SORT_DATA_SETUP;
 

--- a/src/algorithm/SORT-Seq.cpp
+++ b/src/algorithm/SORT-Seq.cpp
@@ -22,7 +22,7 @@ void SORT::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   SORT_DATA_SETUP;
 

--- a/src/algorithm/SORT.cpp
+++ b/src/algorithm/SORT.cpp
@@ -21,14 +21,14 @@ namespace algorithm
 SORT::SORT(const RunParams& params)
   : KernelBase(rajaperf::Algorithm_SORT, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(20);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getRunSize() ); // touched data size, not actual number of stores and loads
+  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() ); // touched data size, not actual number of stores and loads
   setFLOPsPerRep(0);
 
   setUsesFeature(Sort);
@@ -49,12 +49,12 @@ SORT::~SORT()
 
 void SORT::setUp(VariantID vid)
 {
-  allocAndInitDataRandValue(m_x, getRunSize()*getRunReps(), vid);
+  allocAndInitDataRandValue(m_x, getActualProblemSize()*getRunReps(), vid);
 }
 
 void SORT::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_x, getRunSize()*getRunReps());
+  checksum[vid] += calcChecksum(m_x, getActualProblemSize()*getRunReps());
 }
 
 void SORT::tearDown(VariantID vid)

--- a/src/algorithm/SORTPAIRS-Cuda.cpp
+++ b/src/algorithm/SORTPAIRS-Cuda.cpp
@@ -42,7 +42,7 @@ void SORTPAIRS::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   SORTPAIRS_DATA_SETUP;
 

--- a/src/algorithm/SORTPAIRS-Hip.cpp
+++ b/src/algorithm/SORTPAIRS-Hip.cpp
@@ -42,7 +42,7 @@ void SORTPAIRS::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   SORTPAIRS_DATA_SETUP;
 

--- a/src/algorithm/SORTPAIRS-OMP.cpp
+++ b/src/algorithm/SORTPAIRS-OMP.cpp
@@ -24,7 +24,7 @@ void SORTPAIRS::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   SORTPAIRS_DATA_SETUP;
 

--- a/src/algorithm/SORTPAIRS-Seq.cpp
+++ b/src/algorithm/SORTPAIRS-Seq.cpp
@@ -25,7 +25,7 @@ void SORTPAIRS::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   SORTPAIRS_DATA_SETUP;
 

--- a/src/algorithm/SORTPAIRS.cpp
+++ b/src/algorithm/SORTPAIRS.cpp
@@ -21,14 +21,14 @@ namespace algorithm
 SORTPAIRS::SORTPAIRS(const RunParams& params)
   : KernelBase(rajaperf::Algorithm_SORTPAIRS, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(20);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (2*sizeof(Real_type) + 2*sizeof(Real_type)) * getRunSize() ); // touched data size, not actual number of stores and loads
+  setBytesPerRep( (2*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() ); // touched data size, not actual number of stores and loads
   setFLOPsPerRep(0);
 
   setUsesFeature(Sort);
@@ -49,14 +49,14 @@ SORTPAIRS::~SORTPAIRS()
 
 void SORTPAIRS::setUp(VariantID vid)
 {
-  allocAndInitDataRandValue(m_x, getRunSize()*getRunReps(), vid);
-  allocAndInitDataRandValue(m_i, getRunSize()*getRunReps(), vid);
+  allocAndInitDataRandValue(m_x, getActualProblemSize()*getRunReps(), vid);
+  allocAndInitDataRandValue(m_i, getActualProblemSize()*getRunReps(), vid);
 }
 
 void SORTPAIRS::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_x, getRunSize()*getRunReps());
-  checksum[vid] += calcChecksum(m_i, getRunSize()*getRunReps());
+  checksum[vid] += calcChecksum(m_x, getActualProblemSize()*getRunReps());
+  checksum[vid] += calcChecksum(m_i, getActualProblemSize()*getRunReps());
 }
 
 void SORTPAIRS::tearDown(VariantID vid)

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -25,17 +25,17 @@ namespace apps
 DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
   : KernelBase(rajaperf::Apps_DEL_DOT_VEC_2D, params)
 {
-  setDefaultSize(1000*1000);  // See rzmax in ADomain struct
+  setDefaultProblemSize(1000*1000);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::sqrt(getRunSize())+1;
+  Index_type rzmax = std::sqrt(getTargetProblemSize())+1;
   m_domain = new ADomain(rzmax, /* ndims = */ 2);
 
   m_array_length = m_domain->nnalls;
 
-  setProblemSize( m_domain->n_real_zones );
+  setActualProblemSize(m_domain->n_real_zones);
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   setBytesPerRep( (0*sizeof(Index_type) + 1*sizeof(Index_type)) * getItsPerRep() +
                   (1*sizeof(Real_type)  + 0*sizeof(Real_type) ) * getItsPerRep() +

--- a/src/apps/ENERGY-Cuda.cpp
+++ b/src/apps/ENERGY-Cuda.cpp
@@ -141,7 +141,7 @@ void ENERGY::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   ENERGY_DATA_SETUP;
 

--- a/src/apps/ENERGY-Hip.cpp
+++ b/src/apps/ENERGY-Hip.cpp
@@ -141,7 +141,7 @@ void ENERGY::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   ENERGY_DATA_SETUP;
 

--- a/src/apps/ENERGY-OMP.cpp
+++ b/src/apps/ENERGY-OMP.cpp
@@ -24,7 +24,7 @@ void ENERGY::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   ENERGY_DATA_SETUP;
   

--- a/src/apps/ENERGY-OMPTarget.cpp
+++ b/src/apps/ENERGY-OMPTarget.cpp
@@ -69,7 +69,7 @@ void ENERGY::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   ENERGY_DATA_SETUP;
 

--- a/src/apps/ENERGY-Seq.cpp
+++ b/src/apps/ENERGY-Seq.cpp
@@ -22,7 +22,7 @@ void ENERGY::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   ENERGY_DATA_SETUP;
   

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -21,28 +21,28 @@ namespace apps
 ENERGY::ENERGY(const RunParams& params)
   : KernelBase(rajaperf::Apps_ENERGY, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(130);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( 6 * getProblemSize() );
+  setItsPerRep( 6 * getActualProblemSize() );
   setKernelsPerRep(6);
   // some branches are never taken due to the nature of the initialization of delvc
   // the additional reads and writes that would be done if those branches were taken are noted in the comments
-  setBytesPerRep( (1*sizeof(Real_type) + 5*sizeof(Real_type)) * getRunSize() +
-                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getRunSize() + /* 1 + 8 */
-                  (1*sizeof(Real_type) + 6*sizeof(Real_type)) * getRunSize() +
-                  (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getRunSize() +
-                  (1*sizeof(Real_type) + 7*sizeof(Real_type)) * getRunSize() + /* 1 + 12 */
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getRunSize() ); /* 1 + 8 */
+  setBytesPerRep( (1*sizeof(Real_type) + 5*sizeof(Real_type)) * getActualProblemSize() +
+                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() + /* 1 + 8 */
+                  (1*sizeof(Real_type) + 6*sizeof(Real_type)) * getActualProblemSize() +
+                  (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() +
+                  (1*sizeof(Real_type) + 7*sizeof(Real_type)) * getActualProblemSize() + /* 1 + 12 */
+                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() ); /* 1 + 8 */
   setFLOPsPerRep((6  +
                   11 + // 1 sqrt
                   8  +
                   2  +
                   19 + // 1 sqrt
                   9    // 1 sqrt
-                  ) * getProblemSize());
+                  ) * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -70,21 +70,21 @@ ENERGY::~ENERGY()
 
 void ENERGY::setUp(VariantID vid)
 {
-  allocAndInitDataConst(m_e_new, getRunSize(), 0.0, vid);
-  allocAndInitData(m_e_old, getRunSize(), vid);
-  allocAndInitData(m_delvc, getRunSize(), vid);
-  allocAndInitData(m_p_new, getRunSize(), vid);
-  allocAndInitData(m_p_old, getRunSize(), vid);
-  allocAndInitDataConst(m_q_new, getRunSize(), 0.0, vid);
-  allocAndInitData(m_q_old, getRunSize(), vid);
-  allocAndInitData(m_work, getRunSize(), vid);
-  allocAndInitData(m_compHalfStep, getRunSize(), vid);
-  allocAndInitData(m_pHalfStep, getRunSize(), vid);
-  allocAndInitData(m_bvc, getRunSize(), vid);
-  allocAndInitData(m_pbvc, getRunSize(), vid);
-  allocAndInitData(m_ql_old, getRunSize(), vid);
-  allocAndInitData(m_qq_old, getRunSize(), vid);
-  allocAndInitData(m_vnewc, getRunSize(), vid);
+  allocAndInitDataConst(m_e_new, getActualProblemSize(), 0.0, vid);
+  allocAndInitData(m_e_old, getActualProblemSize(), vid);
+  allocAndInitData(m_delvc, getActualProblemSize(), vid);
+  allocAndInitData(m_p_new, getActualProblemSize(), vid);
+  allocAndInitData(m_p_old, getActualProblemSize(), vid);
+  allocAndInitDataConst(m_q_new, getActualProblemSize(), 0.0, vid);
+  allocAndInitData(m_q_old, getActualProblemSize(), vid);
+  allocAndInitData(m_work, getActualProblemSize(), vid);
+  allocAndInitData(m_compHalfStep, getActualProblemSize(), vid);
+  allocAndInitData(m_pHalfStep, getActualProblemSize(), vid);
+  allocAndInitData(m_bvc, getActualProblemSize(), vid);
+  allocAndInitData(m_pbvc, getActualProblemSize(), vid);
+  allocAndInitData(m_ql_old, getActualProblemSize(), vid);
+  allocAndInitData(m_qq_old, getActualProblemSize(), vid);
+  allocAndInitData(m_vnewc, getActualProblemSize(), vid);
 
   initData(m_rho0);
   initData(m_e_cut);
@@ -94,8 +94,8 @@ void ENERGY::setUp(VariantID vid)
 
 void ENERGY::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_e_new, getRunSize());
-  checksum[vid] += calcChecksum(m_q_new, getRunSize());
+  checksum[vid] += calcChecksum(m_e_new, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_q_new, getActualProblemSize());
 }
 
 void ENERGY::tearDown(VariantID vid)

--- a/src/apps/FIR-Cuda.cpp
+++ b/src/apps/FIR-Cuda.cpp
@@ -36,13 +36,13 @@ namespace apps
 __constant__ Real_type coeff[FIR_COEFFLEN];
 
 #define FIR_DATA_SETUP_CUDA \
-  allocAndInitCudaDeviceData(in, m_in, getRunSize()); \
-  allocAndInitCudaDeviceData(out, m_out, getRunSize()); \
+  allocAndInitCudaDeviceData(in, m_in, getActualProblemSize()); \
+  allocAndInitCudaDeviceData(out, m_out, getActualProblemSize()); \
   cudaMemcpyToSymbol(coeff, coeff_array, FIR_COEFFLEN * sizeof(Real_type));
 
 
 #define FIR_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_out, out, getRunSize()); \
+  getCudaDeviceData(m_out, out, getActualProblemSize()); \
   deallocCudaDeviceData(in); \
   deallocCudaDeviceData(out);
 
@@ -61,14 +61,14 @@ __global__ void fir(Real_ptr out, Real_ptr in,
 #define FIR_DATA_SETUP_CUDA \
   Real_ptr coeff; \
 \
-  allocAndInitCudaDeviceData(in, m_in, getRunSize()); \
-  allocAndInitCudaDeviceData(out, m_out, getRunSize()); \
+  allocAndInitCudaDeviceData(in, m_in, getActualProblemSize()); \
+  allocAndInitCudaDeviceData(out, m_out, getActualProblemSize()); \
   Real_ptr tcoeff = &coeff_array[0]; \
   allocAndInitCudaDeviceData(coeff, tcoeff, FIR_COEFFLEN);
 
 
 #define FIR_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_out, out, getRunSize()); \
+  getCudaDeviceData(m_out, out, getActualProblemSize()); \
   deallocCudaDeviceData(in); \
   deallocCudaDeviceData(out); \
   deallocCudaDeviceData(coeff);
@@ -91,7 +91,7 @@ void FIR::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize() - m_coefflen;
+  const Index_type iend = getActualProblemSize() - m_coefflen;
 
   FIR_DATA_SETUP;
 

--- a/src/apps/FIR-Hip.cpp
+++ b/src/apps/FIR-Hip.cpp
@@ -36,13 +36,13 @@ namespace apps
 __constant__ Real_type coeff[FIR_COEFFLEN];
 
 #define FIR_DATA_SETUP_HIP \
-  allocAndInitHipDeviceData(in, m_in, getRunSize()); \
-  allocAndInitHipDeviceData(out, m_out, getRunSize()); \
+  allocAndInitHipDeviceData(in, m_in, getActualProblemSize()); \
+  allocAndInitHipDeviceData(out, m_out, getActualProblemSize()); \
   hipMemcpyToSymbol(HIP_SYMBOL(coeff), coeff_array, FIR_COEFFLEN * sizeof(Real_type), 0, hipMemcpyHostToDevice);
 
 
 #define FIR_DATA_TEARDOWN_HIP \
-  getHipDeviceData(m_out, out, getRunSize()); \
+  getHipDeviceData(m_out, out, getActualProblemSize()); \
   deallocHipDeviceData(in); \
   deallocHipDeviceData(out);
 
@@ -61,14 +61,14 @@ __global__ void fir(Real_ptr out, Real_ptr in,
 #define FIR_DATA_SETUP_HIP \
   Real_ptr coeff; \
 \
-  allocAndInitHipDeviceData(in, m_in, getRunSize()); \
-  allocAndInitHipDeviceData(out, m_out, getRunSize()); \
+  allocAndInitHipDeviceData(in, m_in, getActualProblemSize()); \
+  allocAndInitHipDeviceData(out, m_out, getActualProblemSize()); \
   Real_ptr tcoeff = &coeff_array[0]; \
   allocAndInitHipDeviceData(coeff, tcoeff, FIR_COEFFLEN);
 
 
 #define FIR_DATA_TEARDOWN_HIP \
-  getHipDeviceData(m_out, out, getRunSize()); \
+  getHipDeviceData(m_out, out, getActualProblemSize()); \
   deallocHipDeviceData(in); \
   deallocHipDeviceData(out); \
   deallocHipDeviceData(coeff);
@@ -91,7 +91,7 @@ void FIR::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize() - m_coefflen;
+  const Index_type iend = getActualProblemSize() - m_coefflen;
 
   FIR_DATA_SETUP;
 

--- a/src/apps/FIR-OMP.cpp
+++ b/src/apps/FIR-OMP.cpp
@@ -25,7 +25,7 @@ void FIR::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize() - m_coefflen;
+  const Index_type iend = getActualProblemSize() - m_coefflen;
 
   FIR_COEFF;
 

--- a/src/apps/FIR-OMPTarget.cpp
+++ b/src/apps/FIR-OMPTarget.cpp
@@ -33,14 +33,14 @@ namespace apps
 \
   Real_ptr coeff; \
 \
-  allocAndInitOpenMPDeviceData(in, m_in, getRunSize(), did, hid); \
-  allocAndInitOpenMPDeviceData(out, m_out, getRunSize(), did, hid); \
+  allocAndInitOpenMPDeviceData(in, m_in, getActualProblemSize(), did, hid); \
+  allocAndInitOpenMPDeviceData(out, m_out, getActualProblemSize(), did, hid); \
   Real_ptr tcoeff = &coeff_array[0]; \
   allocAndInitOpenMPDeviceData(coeff, tcoeff, FIR_COEFFLEN, did, hid);
 
 
 #define FIR_DATA_TEARDOWN_OMP_TARGET \
-  getOpenMPDeviceData(m_out, out, getRunSize(), hid, did); \
+  getOpenMPDeviceData(m_out, out, getActualProblemSize(), hid, did); \
   deallocOpenMPDeviceData(in, did); \
   deallocOpenMPDeviceData(out, did); \
   deallocOpenMPDeviceData(coeff, did);
@@ -50,7 +50,7 @@ void FIR::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize() - m_coefflen;
+  const Index_type iend = getActualProblemSize() - m_coefflen;
 
   FIR_DATA_SETUP;
 

--- a/src/apps/FIR-Seq.cpp
+++ b/src/apps/FIR-Seq.cpp
@@ -23,7 +23,7 @@ void FIR::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize() - m_coefflen;
+  const Index_type iend = getActualProblemSize() - m_coefflen;
 
   FIR_COEFF;
 

--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -21,18 +21,18 @@ namespace apps
 FIR::FIR(const RunParams& params)
   : KernelBase(rajaperf::Apps_FIR, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(160);
 
   m_coefflen = FIR_COEFFLEN;
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() - m_coefflen );
+  setItsPerRep( getActualProblemSize() - m_coefflen );
   setKernelsPerRep(1);
   setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getItsPerRep() +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep((2 * m_coefflen) * (getRunSize() - m_coefflen));
+                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep((2 * m_coefflen) * (getActualProblemSize() - m_coefflen));
 
   setUsesFeature(Forall);
 
@@ -60,13 +60,13 @@ FIR::~FIR()
 
 void FIR::setUp(VariantID vid)
 {
-  allocAndInitData(m_in, getRunSize(), vid);
-  allocAndInitDataConst(m_out, getRunSize(), 0.0, vid);
+  allocAndInitData(m_in, getActualProblemSize(), vid);
+  allocAndInitDataConst(m_out, getActualProblemSize(), 0.0, vid);
 }
 
 void FIR::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_out, getRunSize());
+  checksum[vid] += calcChecksum(m_out, getActualProblemSize());
 }
 
 void FIR::tearDown(VariantID vid)

--- a/src/apps/HALOEXCHANGE.cpp
+++ b/src/apps/HALOEXCHANGE.cpp
@@ -50,12 +50,12 @@ HALOEXCHANGE::HALOEXCHANGE(const RunParams& params)
   m_halo_width_default   = 1;
   m_num_vars_default     = 3;
 
-  setDefaultSize( m_grid_dims_default[0] *
-                  m_grid_dims_default[1] *
-                  m_grid_dims_default[2] );
+  setDefaultProblemSize( m_grid_dims_default[0] *
+                         m_grid_dims_default[1] *
+                         m_grid_dims_default[2] );
   setDefaultReps(50);
 
-  double cbrt_run_size = std::cbrt(getRunSize());
+  double cbrt_run_size = std::cbrt(getTargetProblemSize());
 
   m_grid_dims[0] = cbrt_run_size;
   m_grid_dims[1] = cbrt_run_size;
@@ -70,9 +70,9 @@ HALOEXCHANGE::HALOEXCHANGE(const RunParams& params)
                m_grid_plus_halo_dims[1] *
                m_grid_plus_halo_dims[2] ;
 
-  setProblemSize( m_grid_dims[0] * m_grid_dims[1] * m_grid_dims[2] );
+  setActualProblemSize( m_grid_dims[0] * m_grid_dims[1] * m_grid_dims[1] );
 
-  setItsPerRep( m_num_vars * (m_var_size - getProblemSize()) );
+  setItsPerRep( m_num_vars * (m_var_size - getActualProblemSize()) );
   setKernelsPerRep( 2 * s_num_neighbors * m_num_vars );
   setBytesPerRep( (0*sizeof(Int_type)  + 1*sizeof(Int_type) ) * getItsPerRep() +
                   (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() +

--- a/src/apps/HALOEXCHANGE_FUSED.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED.cpp
@@ -50,12 +50,12 @@ HALOEXCHANGE_FUSED::HALOEXCHANGE_FUSED(const RunParams& params)
   m_halo_width_default   = 1;
   m_num_vars_default     = 3;
 
-  setDefaultSize( m_grid_dims_default[0] *
-                  m_grid_dims_default[1] *
-                  m_grid_dims_default[2] );
+  setDefaultProblemSize( m_grid_dims_default[0] *
+                         m_grid_dims_default[1] *
+                         m_grid_dims_default[2] );
   setDefaultReps(50);
 
-  double cbrt_run_size = std::cbrt(getRunSize());
+  double cbrt_run_size = std::cbrt(getTargetProblemSize());
 
   m_grid_dims[0] = cbrt_run_size;
   m_grid_dims[1] = cbrt_run_size;
@@ -70,9 +70,9 @@ HALOEXCHANGE_FUSED::HALOEXCHANGE_FUSED(const RunParams& params)
                m_grid_plus_halo_dims[1] *
                m_grid_plus_halo_dims[2] ;
 
-  setProblemSize( m_grid_dims[0] * m_grid_dims[1] * m_grid_dims[2] );
+  setActualProblemSize( m_grid_dims[0] * m_grid_dims[1] * m_grid_dims[1] );
 
-  setItsPerRep( m_num_vars * (m_var_size - getProblemSize()) );
+  setItsPerRep( m_num_vars * (m_var_size - getActualProblemSize()) );
   setKernelsPerRep( 2 );
   setBytesPerRep( (0*sizeof(Int_type)  + 1*sizeof(Int_type) ) * getItsPerRep() +
                   (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() +

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -28,10 +28,12 @@ LTIMES::LTIMES(const RunParams& params)
   m_num_g_default = 32;
   m_num_m_default = 25;
 
-  setDefaultSize(m_num_d_default * m_num_g_default * m_num_z_default);
+  setDefaultProblemSize(m_num_d_default * m_num_g_default * m_num_z_default);
   setDefaultReps(50);
 
-  m_num_z = std::max(getRunSize() / (m_num_d_default * m_num_g_default), Index_type(1));
+  m_num_z = std::max( getTargetProblemSize() / 
+                      (m_num_d_default * m_num_g_default),
+                      Index_type(1) );
   m_num_g = m_num_g_default;
   m_num_m = m_num_m_default;
   m_num_d = m_num_d_default;
@@ -40,9 +42,9 @@ LTIMES::LTIMES(const RunParams& params)
   m_elllen = m_num_d * m_num_m;
   m_psilen = m_num_d * m_num_g * m_num_z;
 
-  setProblemSize( m_num_d * m_num_g * m_num_z );
+  setActualProblemSize( m_psilen );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   // using total data size instead of writes and reads
   setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * m_philen +

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -28,10 +28,12 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   m_num_g_default = 32;
   m_num_m_default = 25;
 
-  setDefaultSize(m_num_d_default * m_num_g_default * m_num_z_default);
+  setDefaultProblemSize(m_num_d_default * m_num_g_default * m_num_z_default);
   setDefaultReps(50);
 
-  m_num_z = std::max(getRunSize() / (m_num_d_default * m_num_g_default), Index_type(1));
+  m_num_z = std::max( getTargetProblemSize() / 
+                      (m_num_d_default * m_num_g_default),
+                      Index_type(1) );
   m_num_g = m_num_g_default;
   m_num_m = m_num_m_default;
   m_num_d = m_num_d_default;
@@ -40,9 +42,9 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   m_elllen = m_num_d * m_num_m;
   m_psilen = m_num_d * m_num_g * m_num_z;
 
-  setProblemSize( m_num_d * m_num_g * m_num_z );
+  setActualProblemSize( m_psilen );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   // using total data size instead of writes and reads
   setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * m_philen +

--- a/src/apps/MASS3DPA-OMP.cpp
+++ b/src/apps/MASS3DPA-OMP.cpp
@@ -103,6 +103,20 @@ void MASS3DPA::runOpenMPVariant(VariantID vid) {
 
   case RAJA_OpenMP: {
 
+#if defined(RAJA_ENABLE_CUDA)
+    using device_launch = RAJA::expt::cuda_launch_t<true>;
+    using gpu_block_x_policy = RAJA::cuda_block_x_direct;
+    using gpu_thread_x_policy = RAJA::cuda_thread_x_loop;
+    using gpu_thread_y_policy = RAJA::cuda_thread_y_loop;
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+    using device_launch = RAJA::expt::hip_launch_t<true>;
+    using gpu_block_x_policy = RAJA::hip_block_x_direct;
+    using gpu_thread_x_policy = RAJA::hip_thread_x_loop;
+    using gpu_thread_y_policy = RAJA::hip_thread_y_loop;
+#endif
+
     //Currently Teams requires two policies if compiled with a device
     using launch_policy = RAJA::expt::LaunchPolicy<RAJA::expt::omp_launch_t
 #if defined(RAJA_DEVICE_ACTIVE)

--- a/src/apps/MASS3DPA-Seq.cpp
+++ b/src/apps/MASS3DPA-Seq.cpp
@@ -101,6 +101,20 @@ void MASS3DPA::runSeqVariant(VariantID vid) {
 #if defined(RUN_RAJA_SEQ)
   case RAJA_Seq: {
 
+#if defined(RAJA_ENABLE_CUDA)
+    using device_launch = RAJA::expt::cuda_launch_t<true>;
+    using gpu_block_x_policy = RAJA::cuda_block_x_direct;
+    using gpu_thread_x_policy = RAJA::cuda_thread_x_loop;
+    using gpu_thread_y_policy = RAJA::cuda_thread_y_loop;
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+    using device_launch = RAJA::expt::hip_launch_t<true>;
+    using gpu_block_x_policy = RAJA::hip_block_x_direct;
+    using gpu_thread_x_policy = RAJA::hip_thread_x_loop;
+    using gpu_thread_y_policy = RAJA::hip_thread_y_loop;
+#endif
+
     //Currently Teams requires two policies if compiled with a device
     using launch_policy = RAJA::expt::LaunchPolicy<RAJA::expt::seq_launch_t
 #if defined(RAJA_DEVICE_ACTIVE)

--- a/src/apps/MASS3DPA.cpp
+++ b/src/apps/MASS3DPA.cpp
@@ -25,14 +25,14 @@ MASS3DPA::MASS3DPA(const RunParams& params)
 {
   m_NE_default = 8000;
 
-  setDefaultSize(m_NE_default*Q1D*Q1D*Q1D);
+  setDefaultProblemSize(m_NE_default*Q1D*Q1D*Q1D);
   setDefaultReps(50);
 
-  m_NE = std::max(getRunSize()/(Q1D*Q1D*Q1D), Index_type(1));
+  m_NE = std::max(getTargetProblemSize()/(Q1D*Q1D*Q1D), Index_type(1));
 
-  setProblemSize(m_NE*Q1D*Q1D*Q1D);
+  setActualProblemSize( m_NE*Q1D*Q1D*Q1D );
 
-  setItsPerRep(getProblemSize());
+  setItsPerRep(getActualProblemSize());
   setKernelsPerRep(1);
 
   setBytesPerRep( Q1D*D1D*sizeof(Real_type)  +

--- a/src/apps/MASS3DPA.hpp
+++ b/src/apps/MASS3DPA.hpp
@@ -337,21 +337,6 @@ for (int qz = 0; qz < Q1D; ++qz) { \
               Y_(dx, dy, dz, e) += u[dz]; \
             }
 
-
-#if defined(RAJA_ENABLE_CUDA)
-  using device_launch = RAJA::expt::cuda_launch_t<true>;
-  using gpu_block_x_policy = RAJA::cuda_block_x_direct;
-  using gpu_thread_x_policy = RAJA::cuda_thread_x_loop;
-  using gpu_thread_y_policy = RAJA::cuda_thread_y_loop;
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-  using device_launch = RAJA::expt::hip_launch_t<true>;
-  using gpu_block_x_policy = RAJA::hip_block_x_direct;
-  using gpu_thread_x_policy = RAJA::hip_thread_x_loop;
-  using gpu_thread_y_policy = RAJA::hip_thread_y_loop;
-#endif
-
 namespace rajaperf
 {
 class RunParams;

--- a/src/apps/PRESSURE-Cuda.cpp
+++ b/src/apps/PRESSURE-Cuda.cpp
@@ -69,7 +69,7 @@ void PRESSURE::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PRESSURE_DATA_SETUP;
 

--- a/src/apps/PRESSURE-Hip.cpp
+++ b/src/apps/PRESSURE-Hip.cpp
@@ -69,7 +69,7 @@ void PRESSURE::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PRESSURE_DATA_SETUP;
 

--- a/src/apps/PRESSURE-OMP.cpp
+++ b/src/apps/PRESSURE-OMP.cpp
@@ -24,7 +24,7 @@ void PRESSURE::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PRESSURE_DATA_SETUP;
 

--- a/src/apps/PRESSURE-OMPTarget.cpp
+++ b/src/apps/PRESSURE-OMPTarget.cpp
@@ -49,7 +49,7 @@ void PRESSURE::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
   
   PRESSURE_DATA_SETUP;
   

--- a/src/apps/PRESSURE-Seq.cpp
+++ b/src/apps/PRESSURE-Seq.cpp
@@ -22,7 +22,7 @@ void PRESSURE::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PRESSURE_DATA_SETUP;
 

--- a/src/apps/PRESSURE.cpp
+++ b/src/apps/PRESSURE.cpp
@@ -21,18 +21,18 @@ namespace apps
 PRESSURE::PRESSURE(const RunParams& params)
   : KernelBase(rajaperf::Apps_PRESSURE, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(700);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( 2 * getProblemSize() );
+  setItsPerRep( 2 * getActualProblemSize() );
   setKernelsPerRep(2);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getRunSize() +
-                  (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getRunSize() );
+  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() +
+                  (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() );
   setFLOPsPerRep((2 +
                   1
-                  ) * getProblemSize());
+                  ) * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -60,11 +60,11 @@ PRESSURE::~PRESSURE()
 
 void PRESSURE::setUp(VariantID vid)
 {
-  allocAndInitData(m_compression, getRunSize(), vid);
-  allocAndInitData(m_bvc, getRunSize(), vid);
-  allocAndInitDataConst(m_p_new, getRunSize(), 0.0, vid);
-  allocAndInitData(m_e_old, getRunSize(), vid);
-  allocAndInitData(m_vnewc, getRunSize(), vid);
+  allocAndInitData(m_compression, getActualProblemSize(), vid);
+  allocAndInitData(m_bvc, getActualProblemSize(), vid);
+  allocAndInitDataConst(m_p_new, getActualProblemSize(), 0.0, vid);
+  allocAndInitData(m_e_old, getActualProblemSize(), vid);
+  allocAndInitData(m_vnewc, getActualProblemSize(), vid);
 
   initData(m_cls);
   initData(m_p_cut);
@@ -74,7 +74,7 @@ void PRESSURE::setUp(VariantID vid)
 
 void PRESSURE::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_p_new, getRunSize());
+  checksum[vid] += calcChecksum(m_p_new, getActualProblemSize());
 }
 
 void PRESSURE::tearDown(VariantID vid)

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -25,15 +25,15 @@ namespace apps
 VOL3D::VOL3D(const RunParams& params)
   : KernelBase(rajaperf::Apps_VOL3D, params)
 {
-  setDefaultSize(100*100*100);  // See rzmax in ADomain struct
+  setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::cbrt(getRunSize())+1;
+  Index_type rzmax = std::cbrt(getTargetProblemSize())+1;
   m_domain = new ADomain(rzmax, /* ndims = */ 3);
 
   m_array_length = m_domain->nnalls;
 
-  setProblemSize( m_domain->n_real_zones );
+  setActualProblemSize( m_domain->lpz+1 - m_domain->fpz );
 
   setItsPerRep( m_domain->lpz+1 - m_domain->fpz );
   setKernelsPerRep(1);

--- a/src/apps/WIP-COUPLE.cpp
+++ b/src/apps/WIP-COUPLE.cpp
@@ -24,10 +24,10 @@ namespace apps
 COUPLE::COUPLE(const RunParams& params)
   : KernelBase(rajaperf::Apps_COUPLE, params)
 {
-  setDefaultSize(100*100*100);  // See rzmax in ADomain struct
+  setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(50);
 
-  Index_type rzmax = std::cbrt(getRunSize())+1;
+  Index_type rzmax = std::cbrt(getTargetProblemSize())+1;
   m_domain = new ADomain(rzmax, /* ndims = */ 3);
 
   m_imin = m_domain->imin;
@@ -37,9 +37,9 @@ COUPLE::COUPLE(const RunParams& params)
   m_kmin = m_domain->kmin;
   m_kmax = m_domain->kmax;
 
-  setProblemSize( m_domain->n_real_zones );
+  setActualProblemSize( m_domain->n_real_zones );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   setBytesPerRep( (3*sizeof(Complex_type) + 5*sizeof(Complex_type)) * m_domain->n_real_zones );
   setFLOPsPerRep(0);

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -43,6 +43,7 @@ blt_add_library(
           MAT_MAT_SHARED-Hip.cpp
           MAT_MAT_SHARED-Cuda.cpp
           MAT_MAT_SHARED-OMP.cpp
+          MAT_MAT_SHARED-OMPTarget.cpp
           MULADDSUB.cpp
           MULADDSUB-Seq.cpp
           MULADDSUB-Hip.cpp

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -38,6 +38,11 @@ blt_add_library(
           INIT_VIEW1D_OFFSET-Cuda.cpp
           INIT_VIEW1D_OFFSET-OMP.cpp
           INIT_VIEW1D_OFFSET-OMPTarget.cpp
+          MAT_MAT_SHARED.cpp
+          MAT_MAT_SHARED-Seq.cpp
+          MAT_MAT_SHARED-Hip.cpp
+          MAT_MAT_SHARED-Cuda.cpp
+          MAT_MAT_SHARED-OMP.cpp
           MULADDSUB.cpp
           MULADDSUB-Seq.cpp
           MULADDSUB-Hip.cpp

--- a/src/basic/DAXPY-Cuda.cpp
+++ b/src/basic/DAXPY-Cuda.cpp
@@ -50,7 +50,7 @@ void DAXPY::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DAXPY_DATA_SETUP;
 

--- a/src/basic/DAXPY-Hip.cpp
+++ b/src/basic/DAXPY-Hip.cpp
@@ -51,7 +51,7 @@ void DAXPY::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DAXPY_DATA_SETUP;
 

--- a/src/basic/DAXPY-OMP.cpp
+++ b/src/basic/DAXPY-OMP.cpp
@@ -24,7 +24,7 @@ void DAXPY::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DAXPY_DATA_SETUP;
 

--- a/src/basic/DAXPY-OMPTarget.cpp
+++ b/src/basic/DAXPY-OMPTarget.cpp
@@ -43,7 +43,7 @@ void DAXPY::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DAXPY_DATA_SETUP;
 

--- a/src/basic/DAXPY-Seq.cpp
+++ b/src/basic/DAXPY-Seq.cpp
@@ -22,7 +22,7 @@ void DAXPY::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DAXPY_DATA_SETUP;
 

--- a/src/basic/DAXPY.cpp
+++ b/src/basic/DAXPY.cpp
@@ -21,15 +21,15 @@ namespace basic
 DAXPY::DAXPY(const RunParams& params)
   : KernelBase(rajaperf::Basic_DAXPY, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(500);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(2 * getRunSize());
+  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(2 * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -59,14 +59,14 @@ DAXPY::~DAXPY()
 
 void DAXPY::setUp(VariantID vid)
 {
-  allocAndInitDataConst(m_y, getRunSize(), 0.0, vid);
-  allocAndInitData(m_x, getRunSize(), vid);
+  allocAndInitDataConst(m_y, getActualProblemSize(), 0.0, vid);
+  allocAndInitData(m_x, getActualProblemSize(), vid);
   initData(m_a);
 }
 
 void DAXPY::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_y, getRunSize());
+  checksum[vid] += calcChecksum(m_y, getActualProblemSize());
 }
 
 void DAXPY::tearDown(VariantID vid)

--- a/src/basic/IF_QUAD-Cuda.cpp
+++ b/src/basic/IF_QUAD-Cuda.cpp
@@ -58,7 +58,7 @@ void IF_QUAD::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   IF_QUAD_DATA_SETUP;
 

--- a/src/basic/IF_QUAD-Hip.cpp
+++ b/src/basic/IF_QUAD-Hip.cpp
@@ -58,7 +58,7 @@ void IF_QUAD::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   IF_QUAD_DATA_SETUP;
 

--- a/src/basic/IF_QUAD-OMP.cpp
+++ b/src/basic/IF_QUAD-OMP.cpp
@@ -24,7 +24,7 @@ void IF_QUAD::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   IF_QUAD_DATA_SETUP;
 

--- a/src/basic/IF_QUAD-OMPTarget.cpp
+++ b/src/basic/IF_QUAD-OMPTarget.cpp
@@ -49,7 +49,7 @@ void IF_QUAD::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   IF_QUAD_DATA_SETUP;
 

--- a/src/basic/IF_QUAD-Seq.cpp
+++ b/src/basic/IF_QUAD-Seq.cpp
@@ -22,7 +22,7 @@ void IF_QUAD::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   IF_QUAD_DATA_SETUP;
 

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -21,15 +21,15 @@ namespace basic
 IF_QUAD::IF_QUAD(const RunParams& params)
   : KernelBase(rajaperf::Basic_IF_QUAD, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(180);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() ); 
   setKernelsPerRep(1);
-  setBytesPerRep( (2*sizeof(Real_type) + 3*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(11 * getRunSize()); // 1 sqrt
+  setBytesPerRep( (2*sizeof(Real_type) + 3*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(11 * getActualProblemSize()); // 1 sqrt
 
   setUsesFeature(Forall);
 
@@ -59,17 +59,17 @@ IF_QUAD::~IF_QUAD()
 
 void IF_QUAD::setUp(VariantID vid)
 {
-  allocAndInitDataRandSign(m_a, getRunSize(), vid);
-  allocAndInitData(m_b, getRunSize(), vid);
-  allocAndInitData(m_c, getRunSize(), vid);
-  allocAndInitDataConst(m_x1, getRunSize(), 0.0, vid);
-  allocAndInitDataConst(m_x2, getRunSize(), 0.0, vid);
+  allocAndInitDataRandSign(m_a, getActualProblemSize(), vid);
+  allocAndInitData(m_b, getActualProblemSize(), vid);
+  allocAndInitData(m_c, getActualProblemSize(), vid);
+  allocAndInitDataConst(m_x1, getActualProblemSize(), 0.0, vid);
+  allocAndInitDataConst(m_x2, getActualProblemSize(), 0.0, vid);
 }
 
 void IF_QUAD::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_x1, getRunSize());
-  checksum[vid] += calcChecksum(m_x2, getRunSize());
+  checksum[vid] += calcChecksum(m_x1, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_x2, getActualProblemSize());
 }
 
 void IF_QUAD::tearDown(VariantID vid)

--- a/src/basic/INIT3-Cuda.cpp
+++ b/src/basic/INIT3-Cuda.cpp
@@ -59,7 +59,7 @@ void INIT3::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INIT3_DATA_SETUP;
 

--- a/src/basic/INIT3-Hip.cpp
+++ b/src/basic/INIT3-Hip.cpp
@@ -59,7 +59,7 @@ void INIT3::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INIT3_DATA_SETUP;
 

--- a/src/basic/INIT3-OMP.cpp
+++ b/src/basic/INIT3-OMP.cpp
@@ -24,7 +24,7 @@ void INIT3::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INIT3_DATA_SETUP;
 

--- a/src/basic/INIT3-OMPTarget.cpp
+++ b/src/basic/INIT3-OMPTarget.cpp
@@ -51,7 +51,7 @@ void INIT3::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INIT3_DATA_SETUP;
 

--- a/src/basic/INIT3-Seq.cpp
+++ b/src/basic/INIT3-Seq.cpp
@@ -22,7 +22,7 @@ void INIT3::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
   
   INIT3_DATA_SETUP;
 

--- a/src/basic/INIT3.cpp
+++ b/src/basic/INIT3.cpp
@@ -21,15 +21,15 @@ namespace basic
 INIT3::INIT3(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT3, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(500);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (3*sizeof(Real_type) + 2*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(1 * getRunSize());
+  setBytesPerRep( (3*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -59,18 +59,18 @@ INIT3::~INIT3()
 
 void INIT3::setUp(VariantID vid)
 {
-  allocAndInitDataConst(m_out1, getRunSize(), 0.0, vid);
-  allocAndInitDataConst(m_out2, getRunSize(), 0.0, vid);
-  allocAndInitDataConst(m_out3, getRunSize(), 0.0, vid);
-  allocAndInitData(m_in1, getRunSize(), vid);
-  allocAndInitData(m_in2, getRunSize(), vid);
+  allocAndInitDataConst(m_out1, getActualProblemSize(), 0.0, vid);
+  allocAndInitDataConst(m_out2, getActualProblemSize(), 0.0, vid);
+  allocAndInitDataConst(m_out3, getActualProblemSize(), 0.0, vid);
+  allocAndInitData(m_in1, getActualProblemSize(), vid);
+  allocAndInitData(m_in2, getActualProblemSize(), vid);
 }
 
 void INIT3::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_out1, getRunSize());
-  checksum[vid] += calcChecksum(m_out2, getRunSize());
-  checksum[vid] += calcChecksum(m_out3, getRunSize());
+  checksum[vid] += calcChecksum(m_out1, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_out2, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_out3, getActualProblemSize());
 }
 
 void INIT3::tearDown(VariantID vid)

--- a/src/basic/INIT_VIEW1D-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D-Cuda.cpp
@@ -28,10 +28,10 @@ namespace basic
 
 
 #define INIT_VIEW1D_DATA_SETUP_CUDA \
-  allocAndInitCudaDeviceData(a, m_a, getRunSize());
+  allocAndInitCudaDeviceData(a, m_a, getActualProblemSize());
 
 #define INIT_VIEW1D_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_a, a, getRunSize()); \
+  getCudaDeviceData(m_a, a, getActualProblemSize()); \
   deallocCudaDeviceData(a);
 
 __global__ void initview1d(Real_ptr a,
@@ -49,7 +49,7 @@ void INIT_VIEW1D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INIT_VIEW1D_DATA_SETUP;
 

--- a/src/basic/INIT_VIEW1D-Hip.cpp
+++ b/src/basic/INIT_VIEW1D-Hip.cpp
@@ -49,7 +49,7 @@ void INIT_VIEW1D::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INIT_VIEW1D_DATA_SETUP;
 

--- a/src/basic/INIT_VIEW1D-OMP.cpp
+++ b/src/basic/INIT_VIEW1D-OMP.cpp
@@ -24,7 +24,7 @@ void INIT_VIEW1D::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INIT_VIEW1D_DATA_SETUP;
 

--- a/src/basic/INIT_VIEW1D-OMPTarget.cpp
+++ b/src/basic/INIT_VIEW1D-OMPTarget.cpp
@@ -30,10 +30,10 @@ namespace basic
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  allocAndInitOpenMPDeviceData(a, m_a, getRunSize(), did, hid);
+  allocAndInitOpenMPDeviceData(a, m_a, getActualProblemSize(), did, hid);
 
 #define INIT_VIEW1D_DATA_TEARDOWN_OMP_TARGET \
-  getOpenMPDeviceData(m_a, a, getRunSize(), hid, did); \
+  getOpenMPDeviceData(m_a, a, getActualProblemSize(), hid, did); \
   deallocOpenMPDeviceData(a, did);
 
 
@@ -41,7 +41,7 @@ void INIT_VIEW1D::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INIT_VIEW1D_DATA_SETUP;
 

--- a/src/basic/INIT_VIEW1D-Seq.cpp
+++ b/src/basic/INIT_VIEW1D-Seq.cpp
@@ -22,7 +22,7 @@ void INIT_VIEW1D::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INIT_VIEW1D_DATA_SETUP;
 

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -21,15 +21,15 @@ namespace basic
 INIT_VIEW1D::INIT_VIEW1D(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT_VIEW1D, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(2500);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(1 * getRunSize());
+  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature(Forall);
   setUsesFeature(View);
@@ -60,13 +60,13 @@ INIT_VIEW1D::~INIT_VIEW1D()
 
 void INIT_VIEW1D::setUp(VariantID vid)
 {
-  allocAndInitDataConst(m_a, getRunSize(), 0.0, vid);
+  allocAndInitDataConst(m_a, getActualProblemSize(), 0.0, vid);
   m_val = 0.00000123;
 }
 
 void INIT_VIEW1D::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_a, getRunSize());
+  checksum[vid] += calcChecksum(m_a, getActualProblemSize());
 }
 
 void INIT_VIEW1D::tearDown(VariantID vid)

--- a/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Cuda.cpp
@@ -28,10 +28,10 @@ namespace basic
 
 
 #define INIT_VIEW1D_OFFSET_DATA_SETUP_CUDA \
-  allocAndInitCudaDeviceData(a, m_a, getRunSize());
+  allocAndInitCudaDeviceData(a, m_a, getActualProblemSize());
 
 #define INIT_VIEW1D_OFFSET_DATA_TEARDOWN_CUDA \
-  getCudaDeviceData(m_a, a, getRunSize()); \
+  getCudaDeviceData(m_a, a, getActualProblemSize()); \
   deallocCudaDeviceData(a);
 
 __global__ void initview1d_offset(Real_ptr a,
@@ -50,7 +50,7 @@ void INIT_VIEW1D_OFFSET::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 1;
-  const Index_type iend = getRunSize()+1;
+  const Index_type iend = getActualProblemSize()+1;
 
   INIT_VIEW1D_OFFSET_DATA_SETUP;
 

--- a/src/basic/INIT_VIEW1D_OFFSET-Hip.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Hip.cpp
@@ -28,10 +28,10 @@ namespace basic
 
 
 #define INIT_VIEW1D_OFFSET_DATA_SETUP_HIP \
-  allocAndInitHipDeviceData(a, m_a, getRunSize());
+  allocAndInitHipDeviceData(a, m_a, getActualProblemSize());
 
 #define INIT_VIEW1D_OFFSET_DATA_TEARDOWN_HIP \
-  getHipDeviceData(m_a, a, getRunSize()); \
+  getHipDeviceData(m_a, a, getActualProblemSize()); \
   deallocHipDeviceData(a);
 
 __global__ void initview1d_offset(Real_ptr a,
@@ -50,7 +50,7 @@ void INIT_VIEW1D_OFFSET::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 1;
-  const Index_type iend = getRunSize()+1;
+  const Index_type iend = getActualProblemSize()+1;
 
   INIT_VIEW1D_OFFSET_DATA_SETUP;
 

--- a/src/basic/INIT_VIEW1D_OFFSET-OMP.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-OMP.cpp
@@ -24,7 +24,7 @@ void INIT_VIEW1D_OFFSET::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 1;
-  const Index_type iend = getRunSize()+1;
+  const Index_type iend = getActualProblemSize()+1;
 
   INIT_VIEW1D_OFFSET_DATA_SETUP;
 

--- a/src/basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
@@ -30,10 +30,10 @@ namespace basic
   int hid = omp_get_initial_device(); \
   int did = omp_get_default_device(); \
 \
-  allocAndInitOpenMPDeviceData(a, m_a, getRunSize(), did, hid);
+  allocAndInitOpenMPDeviceData(a, m_a, getActualProblemSize(), did, hid);
 
 #define INIT_VIEW1D_OFFSET_DATA_TEARDOWN_OMP_TARGET \
-  getOpenMPDeviceData(m_a, a, getRunSize(), hid, did); \
+  getOpenMPDeviceData(m_a, a, getActualProblemSize(), hid, did); \
   deallocOpenMPDeviceData(a, did);
 
 
@@ -41,7 +41,7 @@ void INIT_VIEW1D_OFFSET::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 1;
-  const Index_type iend = getRunSize()+1;
+  const Index_type iend = getActualProblemSize()+1;
 
   INIT_VIEW1D_OFFSET_DATA_SETUP;
 

--- a/src/basic/INIT_VIEW1D_OFFSET-Seq.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Seq.cpp
@@ -22,7 +22,7 @@ void INIT_VIEW1D_OFFSET::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 1;
-  const Index_type iend = getRunSize()+1;
+  const Index_type iend = getActualProblemSize()+1;
 
   INIT_VIEW1D_OFFSET_DATA_SETUP;
 

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -21,15 +21,15 @@ namespace basic
 INIT_VIEW1D_OFFSET::INIT_VIEW1D_OFFSET(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT_VIEW1D_OFFSET, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(2500);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(1 * getRunSize());
+  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature(Forall);
   setUsesFeature(View);
@@ -60,13 +60,13 @@ INIT_VIEW1D_OFFSET::~INIT_VIEW1D_OFFSET()
 
 void INIT_VIEW1D_OFFSET::setUp(VariantID vid)
 {
-  allocAndInitDataConst(m_a, getRunSize(), 0.0, vid);
+  allocAndInitDataConst(m_a, getActualProblemSize(), 0.0, vid);
   m_val = 0.00000123;
 }
 
 void INIT_VIEW1D_OFFSET::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_a, getRunSize());
+  checksum[vid] += calcChecksum(m_a, getActualProblemSize());
 }
 
 void INIT_VIEW1D_OFFSET::tearDown(VariantID vid)

--- a/src/basic/MAT_MAT_SHARED-Cuda.cpp
+++ b/src/basic/MAT_MAT_SHARED-Cuda.cpp
@@ -20,7 +20,7 @@ namespace rajaperf {
 namespace basic {
 
 #define MAT_MAT_SHARED_DATA_SETUP_CUDA                                         \
-  const Index_type NN = getRunSize() * getRunSize();                           \
+  const Index_type NN = m_N * m_N;                                             \
   allocAndInitCudaDeviceData(A, m_A, NN);                                      \
   allocAndInitCudaDeviceData(B, m_B, NN);                                      \
   allocAndInitCudaDeviceData(C, m_C, NN);
@@ -62,7 +62,7 @@ __global__ void mat_mat_shared(Index_type N, Real_ptr C, Real_ptr A,
 void MAT_MAT_SHARED::runCudaVariant(VariantID vid) {
 
   const Index_type run_reps = getRunReps();
-  const Index_type N = getRunSize();
+  const Index_type N = m_N;
 
   dim3 block_size(TL_SZ, TL_SZ);
   dim3 grid_size(RAJA_DIVIDE_CEILING_INT(N, block_size.x),

--- a/src/basic/MAT_MAT_SHARED-Cuda.cpp
+++ b/src/basic/MAT_MAT_SHARED-Cuda.cpp
@@ -1,0 +1,279 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT_SHARED.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+#define MAT_MAT_SHARED_DATA_SETUP_CUDA                                         \
+  const Index_type NN = getRunSize() * getRunSize();                           \
+  allocAndInitCudaDeviceData(A, m_A, NN);                                      \
+  allocAndInitCudaDeviceData(B, m_B, NN);                                      \
+  allocAndInitCudaDeviceData(C, m_C, NN);
+
+#define MAT_MAT_SHARED_DATA_TEARDOWN_CUDA                                      \
+  getCudaDeviceData(m_A, A, NN);                                               \
+  getCudaDeviceData(m_B, B, NN);                                               \
+  getCudaDeviceData(m_C, C, NN);                                               \
+  deallocCudaDeviceData(A);                                                    \
+  deallocCudaDeviceData(B);                                                    \
+  deallocCudaDeviceData(C);
+
+__global__ void mat_mat_shared(Index_type N, Real_ptr C, Real_ptr A,
+                               Real_ptr B) {
+
+  Index_type tx = threadIdx.x;
+  Index_type ty = threadIdx.y;
+  Index_type bx = blockIdx.x;
+  Index_type by = blockIdx.y;
+
+  MAT_MAT_SHARED_BODY_0
+
+  MAT_MAT_SHARED_BODY_1
+
+  for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; k++) {
+
+    MAT_MAT_SHARED_BODY_2
+
+    __syncthreads();
+
+    MAT_MAT_SHARED_BODY_3
+
+    __syncthreads();
+  }
+
+  MAT_MAT_SHARED_BODY_4
+}
+
+void MAT_MAT_SHARED::runCudaVariant(VariantID vid) {
+
+  const Index_type run_reps = getRunReps();
+  const Index_type N = getRunSize();
+
+  dim3 block_size(TL_SZ, TL_SZ);
+  dim3 grid_size(RAJA_DIVIDE_CEILING_INT(N, block_size.x),
+               RAJA_DIVIDE_CEILING_INT(N, block_size.y));
+
+  const Index_type Nx = grid_size.x;
+  const Index_type Ny = grid_size.y;
+
+  MAT_MAT_SHARED_DATA_SETUP;
+
+  if (vid == Base_CUDA) {
+
+    MAT_MAT_SHARED_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      mat_mat_shared<<<grid_size, block_size>>>(N, A, B, C);
+
+      cudaErrchk( cudaGetLastError() );
+    }
+    stopTimer();
+
+    MAT_MAT_SHARED_DATA_TEARDOWN_CUDA;
+
+  } else if (vid == Lambda_CUDA) {
+
+    MAT_MAT_SHARED_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      lambda_cuda<<<grid_size, block_size>>>([=] __device__() {
+        auto outer_y = [&](Index_type by) {
+          auto outer_x = [&](Index_type bx) {
+            MAT_MAT_SHARED_BODY_0
+
+            auto inner_y_1 = [&](Index_type ty) {
+              auto inner_x_1 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_1 };
+
+              {
+                Index_type tx = threadIdx.x;
+                if (tx < TL_SZ)
+                  inner_x_1(tx);
+              }
+            };
+
+            {
+              Index_type ty = threadIdx.y;
+              if (ty < TL_SZ)
+                inner_y_1(ty);
+            }
+
+            for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; ++k) {
+
+              auto inner_y_2 = [&](Index_type ty) {
+                auto inner_x_2 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_2 };
+
+                {
+                  Index_type tx = threadIdx.x;
+                  if (tx < TL_SZ)
+                    inner_x_2(tx);
+                }
+              };
+
+              {
+                Index_type ty = threadIdx.y;
+                if (ty < TL_SZ)
+                  inner_y_2(ty);
+              }
+
+              __syncthreads();
+
+              auto inner_y_3 = [&](Index_type ty) {
+                auto inner_x_3 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_3 };
+
+                {
+                  Index_type tx = threadIdx.x;
+                  if (tx < TL_SZ)
+                    inner_x_3(tx);
+                }
+              };
+
+              {
+                Index_type ty = threadIdx.y;
+                if (ty < TL_SZ)
+                  inner_y_3(ty);
+              }
+
+              __syncthreads();
+            }
+
+            auto inner_y_4 = [&](Index_type ty) {
+              auto inner_x_4 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_4 };
+
+              {
+                Index_type tx = threadIdx.x;
+                if (tx < TL_SZ)
+                  inner_x_4(tx);
+              }
+            };
+
+            {
+              Index_type ty = threadIdx.y;
+              if (ty < TL_SZ)
+                inner_y_4(ty);
+            }
+          }; // outer_x
+
+          {
+            Index_type bx = blockIdx.x;
+            if(bx < Nx) outer_x(bx);
+          }
+        };
+
+        {
+          Index_type by = blockIdx.y;
+          if(by < Ny) outer_y(by);
+        }
+      });
+
+      cudaErrchk( cudaGetLastError() );
+    }
+    stopTimer();
+
+    MAT_MAT_SHARED_DATA_TEARDOWN_CUDA;
+
+  } else if (vid == RAJA_CUDA) {
+
+    MAT_MAT_SHARED_DATA_SETUP_CUDA;
+
+    using launch_policy = RAJA::expt::LaunchPolicy<RAJA::expt::seq_launch_t
+                                                   ,RAJA::expt::cuda_launch_t<true>
+                                                   >;
+
+    using teams_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
+                                           ,RAJA::cuda_block_x_direct
+                                           >;
+
+    using teams_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+                                           ,RAJA::cuda_block_y_direct
+                                           >;
+
+    using threads_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
+                                             ,RAJA::cuda_thread_x_direct
+                                             >;
+
+    using threads_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+                                             ,RAJA::cuda_thread_y_direct
+                                             >;
+
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::expt::launch<launch_policy>(
+          RAJA::expt::DEVICE,
+          RAJA::expt::Resources(RAJA::expt::Teams(Nx, Ny),
+                                RAJA::expt::Threads(TL_SZ, TL_SZ)),
+          [=] RAJA_HOST_DEVICE(RAJA::expt::LaunchContext ctx) {
+
+            RAJA::expt::loop<teams_y>(ctx, RAJA::RangeSegment(0, Ny), [&](Index_type by) {
+               RAJA::expt::loop<teams_x>(ctx, RAJA::RangeSegment(0, Nx), [&](Index_type bx) {
+
+                   MAT_MAT_SHARED_BODY_0
+
+                   RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                     RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                         MAT_MAT_SHARED_BODY_1
+                     });
+                   });
+
+                   for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; k++) {
+
+                     RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                       RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                           MAT_MAT_SHARED_BODY_2
+                        });
+                      });
+
+                      ctx.teamSync();
+
+                      RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                        RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                            MAT_MAT_SHARED_BODY_3
+                        });
+                      });
+
+                      ctx.teamSync();
+                    }
+
+                    RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                      RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                          MAT_MAT_SHARED_BODY_4
+                      });
+                    });
+               });
+            });
+          }); // kernel
+    }
+    stopTimer();
+
+    MAT_MAT_SHARED_DATA_TEARDOWN_CUDA;
+
+  } else {
+    std::cout << "\n  MAT_MAT_SHARED : Unknown Cuda variant id = " << vid
+              << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // RAJA_ENABLE_CUDA

--- a/src/basic/MAT_MAT_SHARED-Hip.cpp
+++ b/src/basic/MAT_MAT_SHARED-Hip.cpp
@@ -1,0 +1,283 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT_SHARED.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+#include "common/HipDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+#define MAT_MAT_SHARED_DATA_SETUP_HIP                                          \
+  const Index_type NN = getRunSize() * getRunSize();                           \
+  allocAndInitHipDeviceData(A, m_A, NN);                                       \
+  allocAndInitHipDeviceData(B, m_B, NN);                                       \
+  allocAndInitHipDeviceData(C, m_C, NN);
+
+#define MAT_MAT_SHARED_DATA_TEARDOWN_HIP                                       \
+  getHipDeviceData(m_A, A, NN);                                                \
+  getHipDeviceData(m_B, B, NN);                                                \
+  getHipDeviceData(m_C, C, NN);                                                \
+  deallocHipDeviceData(A);                                                     \
+  deallocHipDeviceData(B);                                                     \
+  deallocHipDeviceData(C);
+
+__global__ void mat_mat_shared(Index_type N, Real_ptr C, Real_ptr A,
+                               Real_ptr B) {
+
+  Index_type tx = threadIdx.x;
+  Index_type ty = threadIdx.y;
+  Index_type bx = blockIdx.x;
+  Index_type by = blockIdx.y;
+
+  MAT_MAT_SHARED_BODY_0
+
+  MAT_MAT_SHARED_BODY_1
+
+  for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; k++) {
+
+    MAT_MAT_SHARED_BODY_2
+
+    __syncthreads();
+
+    MAT_MAT_SHARED_BODY_3
+
+    __syncthreads();
+  }
+
+  MAT_MAT_SHARED_BODY_4
+}
+
+void MAT_MAT_SHARED::runHipVariant(VariantID vid) {
+
+  const Index_type run_reps = getRunReps();
+  const Index_type N = getRunSize();
+
+  dim3 block_size(TL_SZ, TL_SZ);
+  dim3 grid_size(RAJA_DIVIDE_CEILING_INT(N, block_size.x),
+               RAJA_DIVIDE_CEILING_INT(N, block_size.y));
+
+  const Index_type Nx = grid_size.x;
+  const Index_type Ny = grid_size.y;
+
+  MAT_MAT_SHARED_DATA_SETUP;
+
+  if (vid == Base_HIP) {
+
+    MAT_MAT_SHARED_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      hipLaunchKernelGGL((mat_mat_shared), dim3(grid_size), dim3(block_size), 0, 0,
+                         N, A, B, C);
+
+      hipErrchk( hipGetLastError() );
+    }
+    stopTimer();
+
+    MAT_MAT_SHARED_DATA_TEARDOWN_HIP;
+
+  } else if (vid == Lambda_HIP) {
+
+    MAT_MAT_SHARED_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto mat_mat_shared_lam = [=] __device__() {
+
+        auto outer_y = [&](Index_type by) {
+          auto outer_x = [&](Index_type bx) {
+            MAT_MAT_SHARED_BODY_0
+
+            auto inner_y_1 = [&](Index_type ty) {
+              auto inner_x_1 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_1 };
+
+              {
+                Index_type tx = threadIdx.x;
+                if (tx < TL_SZ)
+                  inner_x_1(tx);
+              }
+            };
+
+            {
+              Index_type ty = threadIdx.y;
+              if (ty < TL_SZ)
+                inner_y_1(ty);
+            }
+
+            for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; ++k) {
+
+              auto inner_y_2 = [&](Index_type ty) {
+                auto inner_x_2 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_2 };
+
+                {
+                  Index_type tx = threadIdx.x;
+                  if (tx < TL_SZ)
+                    inner_x_2(tx);
+                }
+              };
+
+              {
+                Index_type ty = threadIdx.y;
+                if (ty < TL_SZ)
+                  inner_y_2(ty);
+              }
+
+              __syncthreads();
+
+              auto inner_y_3 = [&](Index_type ty) {
+                auto inner_x_3 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_3 };
+
+                {
+                  Index_type tx = threadIdx.x;
+                  if (tx < TL_SZ)
+                    inner_x_3(tx);
+                }
+              };
+
+              {
+                Index_type ty = threadIdx.y;
+                if (ty < TL_SZ)
+                  inner_y_3(ty);
+              }
+
+              __syncthreads();
+            }
+
+            auto inner_y_4 = [&](Index_type ty) {
+              auto inner_x_4 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_4 };
+
+              {
+                Index_type tx = threadIdx.x;
+                if (tx < TL_SZ)
+                  inner_x_4(tx);
+              }
+            };
+
+            {
+              Index_type ty = threadIdx.y;
+              if (ty < TL_SZ)
+                inner_y_4(ty);
+            }
+          }; // outer_x
+
+          {
+            Index_type bx = blockIdx.x;
+            if(bx < Nx) outer_x(bx);
+          }
+        };
+
+        {
+          Index_type by = blockIdx.y;
+          if(by < Ny) outer_y(by);
+        }
+      };
+
+      hipLaunchKernelGGL(lambda_hip<decltype(mat_mat_shared_lam)>,
+        grid_size, block_size, 0, 0, mat_mat_shared_lam);
+
+      hipErrchk( hipGetLastError() );
+    }
+    stopTimer();
+
+    MAT_MAT_SHARED_DATA_TEARDOWN_HIP;
+
+  } else if (vid == RAJA_HIP) {
+
+    MAT_MAT_SHARED_DATA_SETUP_HIP;
+
+    using launch_policy = RAJA::expt::LaunchPolicy<RAJA::expt::seq_launch_t
+                                                   ,RAJA::expt::hip_launch_t<true>
+                                                   >;
+
+    using teams_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
+                                           ,RAJA::hip_block_x_direct
+                                           >;
+
+    using teams_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+                                           ,RAJA::hip_block_y_direct
+                                           >;
+
+    using threads_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
+                                             ,RAJA::hip_thread_x_direct
+                                             >;
+
+    using threads_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+                                             ,RAJA::hip_thread_y_direct
+                                             >;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::expt::launch<launch_policy>(
+          RAJA::expt::DEVICE,
+          RAJA::expt::Resources(RAJA::expt::Teams(Nx, Ny),
+                                RAJA::expt::Threads(TL_SZ, TL_SZ)),
+          [=] RAJA_HOST_DEVICE(RAJA::expt::LaunchContext ctx) {
+
+            RAJA::expt::loop<teams_y>(ctx, RAJA::RangeSegment(0, Ny), [&](Index_type by) {
+               RAJA::expt::loop<teams_x>(ctx, RAJA::RangeSegment(0, Nx), [&](Index_type bx) {
+
+                   MAT_MAT_SHARED_BODY_0
+
+                   RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                     RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                         MAT_MAT_SHARED_BODY_1
+                     });
+                   });
+
+                   for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; k++) {
+
+                     RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                       RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                           MAT_MAT_SHARED_BODY_2
+                        });
+                      });
+
+                      ctx.teamSync();
+
+                      RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                        RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                            MAT_MAT_SHARED_BODY_3
+                        });
+                      });
+
+                      ctx.teamSync();
+                    }
+
+                    RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                      RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                          MAT_MAT_SHARED_BODY_4
+                      });
+                    });
+               });
+            });
+          }); // kernel
+    }
+    stopTimer();
+
+    MAT_MAT_SHARED_DATA_TEARDOWN_HIP;
+
+  } else {
+    std::cout << "\n  MAT_MAT_SHARED : Unknown Hip variant id = " << vid
+              << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // RAJA_ENABLE_HIP

--- a/src/basic/MAT_MAT_SHARED-Hip.cpp
+++ b/src/basic/MAT_MAT_SHARED-Hip.cpp
@@ -20,7 +20,7 @@ namespace rajaperf {
 namespace basic {
 
 #define MAT_MAT_SHARED_DATA_SETUP_HIP                                          \
-  const Index_type NN = getRunSize() * getRunSize();                           \
+  const Index_type NN = m_N * m_N;                                             \
   allocAndInitHipDeviceData(A, m_A, NN);                                       \
   allocAndInitHipDeviceData(B, m_B, NN);                                       \
   allocAndInitHipDeviceData(C, m_C, NN);

--- a/src/basic/MAT_MAT_SHARED-OMP.cpp
+++ b/src/basic/MAT_MAT_SHARED-OMP.cpp
@@ -1,0 +1,253 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT_SHARED.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void MAT_MAT_SHARED::runOpenMPVariant(VariantID vid) {
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+
+  const Index_type run_reps = getRunReps();
+  const Index_type N = getRunSize();
+
+  MAT_MAT_SHARED_DATA_SETUP;
+
+  const Index_type Nx = RAJA_DIVIDE_CEILING_INT(N, TL_SZ);
+  const Index_type Ny = RAJA_DIVIDE_CEILING_INT(N, TL_SZ);
+
+  switch (vid) {
+
+  case Base_OpenMP: {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+#pragma omp parallel
+      {
+#pragma omp for
+        for (int by = 0; by < Ny; ++by) {
+          for (int bx = 0; bx < Nx; ++bx) {
+
+            MAT_MAT_SHARED_BODY_0
+
+            for (int ty = 0; ty < TL_SZ; ++ty) {
+              for (int tx = 0; tx < TL_SZ; ++tx) {
+                MAT_MAT_SHARED_BODY_1
+              }
+            }
+
+            for (int k = 0; k < (TL_SZ + N - 1) / TL_SZ; ++k) {
+
+              for (int ty = 0; ty < TL_SZ; ++ty) {
+                for (int tx = 0; tx < TL_SZ; ++tx) {
+
+                  MAT_MAT_SHARED_BODY_2
+                }
+              }
+
+              for (int ty = 0; ty < TL_SZ; ++ty) {
+                for (int tx = 0; tx < TL_SZ; ++tx) {
+
+                  MAT_MAT_SHARED_BODY_3
+                }
+              }
+            }
+
+            for (int ty = 0; ty < TL_SZ; ++ty) {
+              for (int tx = 0; tx < TL_SZ; ++tx) {
+                MAT_MAT_SHARED_BODY_4
+              }
+            }
+          }
+        }
+      }
+    }
+    stopTimer();
+
+    break;
+  }
+
+  case Lambda_OpenMP: {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto outer_y = [&](Index_type by) {
+        auto outer_x = [&](Index_type bx) {
+          MAT_MAT_SHARED_BODY_0
+
+          auto inner_y_1 = [&](Index_type ty) {
+            auto inner_x_1 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_1 };
+
+            for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+              if (tx < TL_SZ)
+                inner_x_1(tx);
+            }
+          };
+
+          for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+            if (ty < TL_SZ)
+              inner_y_1(ty);
+          }
+
+          for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; ++k) {
+
+            auto inner_y_2 = [&](Index_type ty) {
+              auto inner_x_2 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_2 };
+
+              for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+                inner_x_2(tx);
+              }
+            };
+
+            for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+              inner_y_2(ty);
+            }
+
+            auto inner_y_3 = [&](Index_type ty) {
+              auto inner_x_3 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_3 };
+
+              for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+                inner_x_3(tx);
+              }
+            };
+
+            for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+              inner_y_3(ty);
+            }
+          }
+
+          auto inner_y_4 = [&](Index_type ty) {
+            auto inner_x_4 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_4 };
+
+            for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+              inner_x_4(tx);
+            }
+          };
+
+          for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+            inner_y_4(ty);
+          }
+        }; // outer_x
+
+        for (Index_type bx = 0; bx < Nx; ++bx) {
+          outer_x(bx);
+        }
+      };
+
+#pragma omp parallel for
+      for (Index_type by = 0; by < Ny; ++by) {
+        outer_y(by);
+      }
+    }
+    stopTimer();
+
+    break;
+  }
+
+  case RAJA_OpenMP: {
+
+    //Currently Teams requires two policies if compiled with a device
+    using launch_policy = RAJA::expt::LaunchPolicy<RAJA::expt::omp_launch_t
+#if defined(RAJA_DEVICE_ACTIVE)
+                                                   ,device_launch
+#endif
+                                                   >;
+
+    using teams_x = RAJA::expt::LoopPolicy<RAJA::omp_for_exec
+#if defined(RAJA_DEVICE_ACTIVE)
+                                           ,gpu_block_x_policy
+#endif
+                                           >;
+
+    using teams_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+#if defined(RAJA_DEVICE_ACTIVE)
+                                           ,gpu_block_y_policy
+#endif
+                                           >;
+
+    using threads_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
+#if defined(RAJA_DEVICE_ACTIVE)
+                                             ,gpu_thread_x_policy
+#endif
+                                             >;
+
+    using threads_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+#if defined(RAJA_DEVICE_ACTIVE)
+                                             ,gpu_thread_y_policy
+#endif
+                                             >;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      //Resources is empty as the host does not need a compute grid to be specified
+      RAJA::expt::launch<launch_policy>(RAJA::expt::HOST, RAJA::expt::Resources(),
+          [=] RAJA_HOST_DEVICE(RAJA::expt::LaunchContext ctx) {
+
+            RAJA::expt::loop<teams_y>(ctx, RAJA::RangeSegment(0, Ny), [&](Index_type by) {
+               RAJA::expt::loop<teams_x>(ctx, RAJA::RangeSegment(0, Nx), [&](Index_type bx) {
+
+                   MAT_MAT_SHARED_BODY_0
+
+                   RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                     RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                         MAT_MAT_SHARED_BODY_1
+                     });
+                   });
+
+                   for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; k++) {
+
+                     RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                       RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                           MAT_MAT_SHARED_BODY_2
+                        });
+                      });
+
+                      ctx.teamSync();
+
+                      RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                        RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                            MAT_MAT_SHARED_BODY_3
+                        });
+                      });
+
+                      ctx.teamSync();
+                    }
+
+                    RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                      RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                          MAT_MAT_SHARED_BODY_4
+                      });
+                    });
+               });
+            });
+          }); // kernel
+    }
+    stopTimer();
+
+    break;
+  }
+
+  default: {
+    std::cout << "\n  MAT_MAT_SHARED : Unknown variant id = " << vid
+              << std::endl;
+  }
+  }
+
+#endif
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/MAT_MAT_SHARED-OMP.cpp
+++ b/src/basic/MAT_MAT_SHARED-OMP.cpp
@@ -181,25 +181,25 @@ void MAT_MAT_SHARED::runOpenMPVariant(VariantID vid) {
 #endif
                                                    >;
 
-    using teams_x = RAJA::expt::LoopPolicy<RAJA::omp_for_exec
+    using outer_x = RAJA::expt::LoopPolicy<RAJA::omp_for_exec
 #if defined(RAJA_DEVICE_ACTIVE)
                                            ,gpu_block_x_policy
 #endif
                                            >;
 
-    using teams_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+    using outer_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
 #if defined(RAJA_DEVICE_ACTIVE)
                                            ,gpu_block_y_policy
 #endif
                                            >;
 
-    using threads_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
+    using inner_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
 #if defined(RAJA_DEVICE_ACTIVE)
                                              ,gpu_thread_x_policy
 #endif
                                              >;
 
-    using threads_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+    using inner_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
 #if defined(RAJA_DEVICE_ACTIVE)
                                              ,gpu_thread_y_policy
 #endif
@@ -212,29 +212,29 @@ void MAT_MAT_SHARED::runOpenMPVariant(VariantID vid) {
       RAJA::expt::launch<launch_policy>(RAJA::expt::HOST, RAJA::expt::Resources(),
           [=] RAJA_HOST_DEVICE(RAJA::expt::LaunchContext ctx) {
 
-            RAJA::expt::loop<teams_y>(ctx, RAJA::RangeSegment(0, Ny), [&](Index_type by) {
-               RAJA::expt::loop<teams_x>(ctx, RAJA::RangeSegment(0, Nx), [&](Index_type bx) {
+            RAJA::expt::loop<outer_y>(ctx, RAJA::RangeSegment(0, Ny), [&](Index_type by) {
+               RAJA::expt::loop<outer_x>(ctx, RAJA::RangeSegment(0, Nx), [&](Index_type bx) {
 
                    MAT_MAT_SHARED_BODY_0
 
-                   RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
-                     RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                   RAJA::expt::loop<inner_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                     RAJA::expt::loop<inner_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
                          MAT_MAT_SHARED_BODY_1
                      });
                    });
 
                    for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; k++) {
 
-                     RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
-                       RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                     RAJA::expt::loop<inner_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                       RAJA::expt::loop<inner_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
                            MAT_MAT_SHARED_BODY_2
                         });
                       });
 
                       ctx.teamSync();
 
-                      RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
-                        RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                      RAJA::expt::loop<inner_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                        RAJA::expt::loop<inner_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
                             MAT_MAT_SHARED_BODY_3
                         });
                       });
@@ -242,8 +242,8 @@ void MAT_MAT_SHARED::runOpenMPVariant(VariantID vid) {
                       ctx.teamSync();
                     }
 
-                    RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
-                      RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                    RAJA::expt::loop<inner_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                      RAJA::expt::loop<inner_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
                           MAT_MAT_SHARED_BODY_4
                       });
                     });

--- a/src/basic/MAT_MAT_SHARED-OMP.cpp
+++ b/src/basic/MAT_MAT_SHARED-OMP.cpp
@@ -19,7 +19,7 @@ void MAT_MAT_SHARED::runOpenMPVariant(VariantID vid) {
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
 
   const Index_type run_reps = getRunReps();
-  const Index_type N = getRunSize();
+  const Index_type N = m_N;
 
   MAT_MAT_SHARED_DATA_SETUP;
 
@@ -157,6 +157,22 @@ void MAT_MAT_SHARED::runOpenMPVariant(VariantID vid) {
   }
 
   case RAJA_OpenMP: {
+
+#if defined(RAJA_ENABLE_CUDA)
+    using device_launch = RAJA::expt::cuda_launch_t<true>;
+    using gpu_block_x_policy = RAJA::cuda_block_x_direct;
+    using gpu_block_y_policy = RAJA::cuda_block_y_direct;
+    using gpu_thread_x_policy = RAJA::cuda_thread_x_direct;
+    using gpu_thread_y_policy = RAJA::cuda_thread_y_direct;
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+    using device_launch = RAJA::expt::hip_launch_t<true>;
+    using gpu_block_x_policy = RAJA::hip_block_x_direct;
+    using gpu_block_y_policy = RAJA::hip_block_y_direct;
+    using gpu_thread_x_policy = RAJA::hip_thread_x_direct;
+    using gpu_thread_y_policy = RAJA::hip_thread_y_direct;
+#endif
 
     //Currently Teams requires two policies if compiled with a device
     using launch_policy = RAJA::expt::LaunchPolicy<RAJA::expt::omp_launch_t

--- a/src/basic/MAT_MAT_SHARED-OMPTarget.cpp
+++ b/src/basic/MAT_MAT_SHARED-OMPTarget.cpp
@@ -1,0 +1,39 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT_SHARED.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf {
+  namespace basic {
+
+
+    void MAT_MAT_SHARED::runOpenMPTargetVariant(VariantID vid) {
+      const Index_type run_reps = getRunReps();
+
+      switch (vid) {
+
+      default: {
+
+        std::cout << "\n MAT_MAT_SHARED : Unknown OpenMPTarget variant id = " << vid << std::endl;
+        break;
+      }
+      }
+    }
+
+  } // end namespace basic
+} // end namespace rajaperf
+
+#endif // RAJA_ENABLE_TARGET_OPENMP

--- a/src/basic/MAT_MAT_SHARED-Seq.cpp
+++ b/src/basic/MAT_MAT_SHARED-Seq.cpp
@@ -16,7 +16,7 @@ namespace basic {
 void MAT_MAT_SHARED::runSeqVariant(VariantID vid) {
 
   const Index_type run_reps = getRunReps();
-  const Index_type N = getRunSize();
+  const Index_type N = m_N;
 
   MAT_MAT_SHARED_DATA_SETUP;
   const Index_type Nx = RAJA_DIVIDE_CEILING_INT(N, TL_SZ);
@@ -153,6 +153,22 @@ void MAT_MAT_SHARED::runSeqVariant(VariantID vid) {
   }
 
   case RAJA_Seq: {
+
+#if defined(RAJA_ENABLE_CUDA)
+    using device_launch = RAJA::expt::cuda_launch_t<true>;
+    using gpu_block_x_policy = RAJA::cuda_block_x_direct;
+    using gpu_block_y_policy = RAJA::cuda_block_y_direct;
+    using gpu_thread_x_policy = RAJA::cuda_thread_x_direct;
+    using gpu_thread_y_policy = RAJA::cuda_thread_y_direct;
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+    using device_launch = RAJA::expt::hip_launch_t<true>;
+    using gpu_block_x_policy = RAJA::hip_block_x_direct;
+    using gpu_block_y_policy = RAJA::hip_block_y_direct;
+    using gpu_thread_x_policy = RAJA::hip_thread_x_direct;
+    using gpu_thread_y_policy = RAJA::hip_thread_y_direct;
+#endif
 
     //Currently Teams requires two policies if compiled with a device
     using launch_policy = RAJA::expt::LaunchPolicy<RAJA::expt::seq_launch_t

--- a/src/basic/MAT_MAT_SHARED-Seq.cpp
+++ b/src/basic/MAT_MAT_SHARED-Seq.cpp
@@ -177,25 +177,25 @@ void MAT_MAT_SHARED::runSeqVariant(VariantID vid) {
 #endif
                                                    >;
 
-    using teams_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
+    using outer_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
 #if defined(RAJA_DEVICE_ACTIVE)
                                            ,gpu_block_x_policy
 #endif
                                            >;
 
-    using teams_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+    using outer_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
 #if defined(RAJA_DEVICE_ACTIVE)
                                            ,gpu_block_y_policy
 #endif
                                            >;
 
-    using threads_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
+    using inner_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
 #if defined(RAJA_DEVICE_ACTIVE)
                                              ,gpu_thread_x_policy
 #endif
                                              >;
 
-    using threads_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+    using inner_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
 #if defined(RAJA_DEVICE_ACTIVE)
                                              ,gpu_thread_y_policy
 #endif
@@ -208,29 +208,29 @@ void MAT_MAT_SHARED::runSeqVariant(VariantID vid) {
       RAJA::expt::launch<launch_policy>(RAJA::expt::HOST, RAJA::expt::Resources(),
           [=] RAJA_HOST_DEVICE(RAJA::expt::LaunchContext ctx) {
 
-            RAJA::expt::loop<teams_y>(ctx, RAJA::RangeSegment(0, Ny), [&](Index_type by) {
-               RAJA::expt::loop<teams_x>(ctx, RAJA::RangeSegment(0, Nx), [&](Index_type bx) {
+            RAJA::expt::loop<outer_y>(ctx, RAJA::RangeSegment(0, Ny), [&](Index_type by) {
+               RAJA::expt::loop<outer_x>(ctx, RAJA::RangeSegment(0, Nx), [&](Index_type bx) {
 
                    MAT_MAT_SHARED_BODY_0
 
-                   RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
-                     RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                   RAJA::expt::loop<inner_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                     RAJA::expt::loop<inner_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
                          MAT_MAT_SHARED_BODY_1
                      });
                    });
 
                    for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; k++) {
 
-                     RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
-                       RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                     RAJA::expt::loop<inner_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                       RAJA::expt::loop<inner_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
                            MAT_MAT_SHARED_BODY_2
                         });
                       });
 
                       ctx.teamSync();
 
-                      RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
-                        RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                      RAJA::expt::loop<inner_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                        RAJA::expt::loop<inner_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
                             MAT_MAT_SHARED_BODY_3
                         });
                       });
@@ -238,8 +238,8 @@ void MAT_MAT_SHARED::runSeqVariant(VariantID vid) {
                       ctx.teamSync();
                     }
 
-                    RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
-                      RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                    RAJA::expt::loop<inner_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                      RAJA::expt::loop<inner_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
                           MAT_MAT_SHARED_BODY_4
                       });
                     });

--- a/src/basic/MAT_MAT_SHARED-Seq.cpp
+++ b/src/basic/MAT_MAT_SHARED-Seq.cpp
@@ -1,0 +1,248 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT_SHARED.hpp"
+
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void MAT_MAT_SHARED::runSeqVariant(VariantID vid) {
+
+  const Index_type run_reps = getRunReps();
+  const Index_type N = getRunSize();
+
+  MAT_MAT_SHARED_DATA_SETUP;
+  const Index_type Nx = RAJA_DIVIDE_CEILING_INT(N, TL_SZ);
+  const Index_type Ny = RAJA_DIVIDE_CEILING_INT(N, TL_SZ);
+
+  switch (vid) {
+
+  case Base_Seq: {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      for (Index_type by = 0; by < Ny; ++by) {
+        for (Index_type bx = 0; bx < Nx; ++bx) {
+
+          //Work around for when compiling with CLANG and HIP
+          //See notes in MAT_MAT_SHARED.hpp
+          MAT_MAT_SHARED_BODY_0_CLANG_HIP_CPU
+
+          for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+            for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+              MAT_MAT_SHARED_BODY_1
+            }
+          }
+
+          for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; ++k) {
+
+            for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+              for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+                MAT_MAT_SHARED_BODY_2
+              }
+            }
+
+            for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+              for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+                MAT_MAT_SHARED_BODY_3
+              }
+            }
+
+          } // Sequential loop
+
+          for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+            for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+              MAT_MAT_SHARED_BODY_4
+            }
+          }
+        }
+      }
+
+    } // number of iterations
+    stopTimer();
+
+    break;
+  }
+
+#if defined(RUN_RAJA_SEQ)
+  case Lambda_Seq: {
+
+
+    startTimer();
+    for (Index_type irep = 0; irep < run_reps; ++irep) {
+
+      auto outer_y = [&](Index_type by) {
+        auto outer_x = [&](Index_type bx) {
+          MAT_MAT_SHARED_BODY_0
+
+          auto inner_y_1 = [&](Index_type ty) {
+            auto inner_x_1 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_1 };
+
+            for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+              if (tx < TL_SZ)
+                inner_x_1(tx);
+            }
+          };
+
+          for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+            if (ty < TL_SZ)
+              inner_y_1(ty);
+          }
+
+          for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; ++k) {
+
+            auto inner_y_2 = [&](Index_type ty) {
+              auto inner_x_2 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_2 };
+
+              for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+                inner_x_2(tx);
+              }
+            };
+
+            for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+              inner_y_2(ty);
+            }
+
+            auto inner_y_3 = [&](Index_type ty) {
+              auto inner_x_3 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_3 };
+
+              for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+                inner_x_3(tx);
+              }
+            };
+
+            for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+              inner_y_3(ty);
+            }
+          }
+
+          auto inner_y_4 = [&](Index_type ty) {
+            auto inner_x_4 = [&](Index_type tx) { MAT_MAT_SHARED_BODY_4 };
+
+            for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+              inner_x_4(tx);
+            }
+          };
+
+          for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+            inner_y_4(ty);
+          }
+        }; // outer_x
+
+        for (Index_type bx = 0; bx < Nx; ++bx) {
+          outer_x(bx);
+        }
+      };
+
+      for (Index_type by = 0; by < Ny; ++by) {
+        outer_y(by);
+      }
+
+    } // irep
+    stopTimer();
+
+    break;
+  }
+
+  case RAJA_Seq: {
+
+    //Currently Teams requires two policies if compiled with a device
+    using launch_policy = RAJA::expt::LaunchPolicy<RAJA::expt::seq_launch_t
+#if defined(RAJA_DEVICE_ACTIVE)
+                                                   ,device_launch
+#endif
+                                                   >;
+
+    using teams_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
+#if defined(RAJA_DEVICE_ACTIVE)
+                                           ,gpu_block_x_policy
+#endif
+                                           >;
+
+    using teams_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+#if defined(RAJA_DEVICE_ACTIVE)
+                                           ,gpu_block_y_policy
+#endif
+                                           >;
+
+    using threads_x = RAJA::expt::LoopPolicy<RAJA::loop_exec
+#if defined(RAJA_DEVICE_ACTIVE)
+                                             ,gpu_thread_x_policy
+#endif
+                                             >;
+
+    using threads_y = RAJA::expt::LoopPolicy<RAJA::loop_exec
+#if defined(RAJA_DEVICE_ACTIVE)
+                                             ,gpu_thread_y_policy
+#endif
+                                             >;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      //Resources is empty as the host does not need a compute grid to be specified
+      RAJA::expt::launch<launch_policy>(RAJA::expt::HOST, RAJA::expt::Resources(),
+          [=] RAJA_HOST_DEVICE(RAJA::expt::LaunchContext ctx) {
+
+            RAJA::expt::loop<teams_y>(ctx, RAJA::RangeSegment(0, Ny), [&](Index_type by) {
+               RAJA::expt::loop<teams_x>(ctx, RAJA::RangeSegment(0, Nx), [&](Index_type bx) {
+
+                   MAT_MAT_SHARED_BODY_0
+
+                   RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                     RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                         MAT_MAT_SHARED_BODY_1
+                     });
+                   });
+
+                   for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; k++) {
+
+                     RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                       RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                           MAT_MAT_SHARED_BODY_2
+                        });
+                      });
+
+                      ctx.teamSync();
+
+                      RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                        RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                            MAT_MAT_SHARED_BODY_3
+                        });
+                      });
+
+                      ctx.teamSync();
+                    }
+
+                    RAJA::expt::loop<threads_y>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type ty) {
+                      RAJA::expt::loop<threads_x>(ctx, RAJA::RangeSegment(0, TL_SZ), [&](Index_type tx) {
+                          MAT_MAT_SHARED_BODY_4
+                      });
+                    });
+               });
+            });
+          }); // kernel
+    }
+    stopTimer();
+
+    break;
+  }
+#endif // RUN_RAJA_SEQ
+
+  default: {
+    std::cout << "\n  MAT_MAT_SHARED : Unknown variant id = " << vid
+              << std::endl;
+  }
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/MAT_MAT_SHARED.cpp
+++ b/src/basic/MAT_MAT_SHARED.cpp
@@ -1,0 +1,63 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT_SHARED.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
+namespace rajaperf {
+namespace basic {
+
+MAT_MAT_SHARED::MAT_MAT_SHARED(const RunParams &params)
+    : KernelBase(rajaperf::Basic_MAT_MAT_SHARED, params) {
+  setDefaultSize(1000);
+  setDefaultReps(50);
+
+  setUsesFeature(Teams);
+
+  setVariantDefined(Base_Seq);
+  setVariantDefined(Lambda_Seq);
+  setVariantDefined(RAJA_Seq);
+
+  setVariantDefined(Base_OpenMP);
+  setVariantDefined(Lambda_OpenMP);
+  setVariantDefined(RAJA_OpenMP);
+
+  setVariantDefined(Base_CUDA);
+  setVariantDefined(Lambda_CUDA);
+  setVariantDefined(RAJA_CUDA);
+
+  setVariantDefined(Base_HIP);
+  setVariantDefined(Lambda_HIP);
+  setVariantDefined(RAJA_HIP);
+}
+
+MAT_MAT_SHARED::~MAT_MAT_SHARED() {}
+
+void MAT_MAT_SHARED::setUp(VariantID vid) {
+  const Index_type NN = getRunSize() * getRunSize();
+  allocAndInitData(m_A, NN, vid);
+  allocAndInitData(m_B, NN, vid);
+  allocAndInitData(m_C, NN, vid);
+}
+
+void MAT_MAT_SHARED::updateChecksum(VariantID vid) {
+  checksum[vid] += calcChecksum(m_C, getRunSize());
+}
+
+void MAT_MAT_SHARED::tearDown(VariantID vid) {
+  (void)vid;
+  deallocData(m_A);
+  deallocData(m_B);
+  deallocData(m_C);
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/MAT_MAT_SHARED.hpp
+++ b/src/basic/MAT_MAT_SHARED.hpp
@@ -66,23 +66,6 @@
   if (Row < N && Col < N)                                                      \
     C[Col + N * Row] = Cs[ty][tx];
 
-
-#if defined(RAJA_ENABLE_CUDA)
-using device_launch = RAJA::expt::cuda_launch_t<true>;
-using gpu_block_x_policy = RAJA::cuda_block_x_direct;
-using gpu_block_y_policy = RAJA::cuda_block_y_direct;
-using gpu_thread_x_policy = RAJA::cuda_thread_x_direct;
-using gpu_thread_y_policy = RAJA::cuda_thread_y_direct;
-#endif
-
-#if defined(RAJA_ENABLE_HIP)
-using device_launch = RAJA::expt::hip_launch_t<true>;
-using gpu_block_x_policy = RAJA::hip_block_x_direct;
-using gpu_block_y_policy = RAJA::hip_block_y_direct;
-using gpu_thread_x_policy = RAJA::hip_thread_x_direct;
-using gpu_thread_y_policy = RAJA::hip_thread_y_direct;
-#endif
-
 namespace rajaperf {
 class RunParams;
 
@@ -108,6 +91,9 @@ private:
   Real_ptr m_A;
   Real_ptr m_B;
   Real_ptr m_C;
+
+  Index_type m_N;
+  Index_type m_N_default;
 };
 
 } // end namespace basic

--- a/src/basic/MAT_MAT_SHARED.hpp
+++ b/src/basic/MAT_MAT_SHARED.hpp
@@ -1,0 +1,116 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Matrix matrix multiplication with shared memory
+///
+///
+
+#ifndef RAJAPerf_Basic_MAT_MAT_SHARED_HPP
+#define RAJAPerf_Basic_MAT_MAT_SHARED_HPP
+
+#include "RAJA/RAJA.hpp"
+#include "common/KernelBase.hpp"
+
+#define TL_SZ 16
+
+#define MAT_MAT_SHARED_DATA_SETUP                                              \
+  Real_ptr A = m_A;                                                            \
+  Real_ptr B = m_B;                                                            \
+  Real_ptr C = m_C;
+
+/*
+ When doing the device compile pass hipcc/clang will put in the device
+ versions of the macros everywhere, in device functions, host device functions,
+ and host only functions. Then it will make sure that code is valid everywhere,
+ that's fine for device and host device functions, but it is not ok for host only
+ functions. Nvcc doesn't look at host only code when it does the device pass
+ so it doesn't see these kind of problems.
+ */
+#define MAT_MAT_SHARED_BODY_0_CLANG_HIP_CPU                   \
+  double As[TL_SZ][TL_SZ];                                    \
+  double Bs[TL_SZ][TL_SZ];                                    \
+  double Cs[TL_SZ][TL_SZ];
+
+#define MAT_MAT_SHARED_BODY_0                                                  \
+  RAJA_TEAM_SHARED double As[TL_SZ][TL_SZ];                                    \
+  RAJA_TEAM_SHARED double Bs[TL_SZ][TL_SZ];                                    \
+  RAJA_TEAM_SHARED double Cs[TL_SZ][TL_SZ];
+
+#define MAT_MAT_SHARED_BODY_1 Cs[ty][tx] = 0;
+
+#define MAT_MAT_SHARED_BODY_2                                                  \
+  const Index_type Row = by * TL_SZ + ty;                                      \
+  const Index_type Col = bx * TL_SZ + tx;                                      \
+  if (k * TL_SZ + tx < N && Row < N)                                           \
+    As[ty][tx] = A[Row * N + k * TL_SZ + tx];                                  \
+  else                                                                         \
+    As[ty][tx] = 0.0;                                                          \
+  if (k * TL_SZ + ty < N && Col < N)                                           \
+    Bs[ty][tx] = B[(k * TL_SZ + ty) * N + Col];                                \
+  else                                                                         \
+    Bs[ty][tx] = 0.0;
+
+#define MAT_MAT_SHARED_BODY_3                                                  \
+  for (Index_type n = 0; n < TL_SZ; ++n)                                       \
+    Cs[ty][tx] += As[ty][n] * Bs[n][tx];
+
+#define MAT_MAT_SHARED_BODY_4                                                  \
+  const Index_type Row = by * TL_SZ + ty;                                      \
+  const Index_type Col = bx * TL_SZ + tx;                                      \
+  if (Row < N && Col < N)                                                      \
+    C[Col + N * Row] = Cs[ty][tx];
+
+
+#if defined(RAJA_ENABLE_CUDA)
+using device_launch = RAJA::expt::cuda_launch_t<true>;
+using gpu_block_x_policy = RAJA::cuda_block_x_direct;
+using gpu_block_y_policy = RAJA::cuda_block_y_direct;
+using gpu_thread_x_policy = RAJA::cuda_thread_x_direct;
+using gpu_thread_y_policy = RAJA::cuda_thread_y_direct;
+#endif
+
+#if defined(RAJA_ENABLE_HIP)
+using device_launch = RAJA::expt::hip_launch_t<true>;
+using gpu_block_x_policy = RAJA::hip_block_x_direct;
+using gpu_block_y_policy = RAJA::hip_block_y_direct;
+using gpu_thread_x_policy = RAJA::hip_thread_x_direct;
+using gpu_thread_y_policy = RAJA::hip_thread_y_direct;
+#endif
+
+namespace rajaperf {
+class RunParams;
+
+namespace basic {
+
+class MAT_MAT_SHARED : public KernelBase {
+public:
+  MAT_MAT_SHARED(const RunParams &params);
+
+  ~MAT_MAT_SHARED();
+
+  void setUp(VariantID vid);
+  void updateChecksum(VariantID vid);
+  void tearDown(VariantID vid);
+
+  void runSeqVariant(VariantID vid);
+  void runOpenMPVariant(VariantID vid);
+  void runCudaVariant(VariantID vid);
+  void runHipVariant(VariantID vid);
+  void runOpenMPTargetVariant(VariantID vid);
+
+private:
+  Real_ptr m_A;
+  Real_ptr m_B;
+  Real_ptr m_C;
+};
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/basic/MAT_MAT_SHARED.hpp
+++ b/src/basic/MAT_MAT_SHARED.hpp
@@ -8,6 +8,58 @@
 
 ///
 /// Matrix matrix multiplication with shared memory
+/// reference implementation:
+///
+///      for (Index_type by = 0; by < Ny; ++by) {
+///        for (Index_type bx = 0; bx < Nx; ++bx) {
+///
+///          double As[TL_SZ][TL_SZ];
+///          double Bs[TL_SZ][TL_SZ];
+///          double Cs[TL_SZ][TL_SZ];
+///
+///          for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+///            for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+///                Cs[ty][tx] = 0;
+///            }
+///          }
+///
+///          for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; ++k) {
+///
+///            for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+///              for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+///                const Index_type Row = by * TL_SZ + ty;
+///                const Index_type Col = bx * TL_SZ + tx;
+///                if (k * TL_SZ + tx < N && Row < N)
+///                  As[ty][tx] = A[Row * N + k * TL_SZ + tx];
+///                else
+///                  As[ty][tx] = 0.0;
+///                if (k * TL_SZ + ty < N && Col < N)
+///                  Bs[ty][tx] = B[(k * TL_SZ + ty) * N + Col];
+///                else
+///                  Bs[ty][tx] = 0.0;
+///              }
+///            }
+///
+///            for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+///              for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+///                for (Index_type n = 0; n < TL_SZ; ++n)
+///                  Cs[ty][tx] += As[ty][n] * Bs[n][tx];
+///              }
+///            }
+///
+///          }
+///
+///          for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+///            for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+///
+///              const Index_type Row = by * TL_SZ + ty;
+///              const Index_type Col = bx * TL_SZ + tx;
+///              if (Row < N && Col < N)
+///                C[Col + N * Row] = Cs[ty][tx];
+///            }
+///          }
+///        }
+///      }
 ///
 ///
 

--- a/src/basic/MULADDSUB-Cuda.cpp
+++ b/src/basic/MULADDSUB-Cuda.cpp
@@ -59,7 +59,7 @@ void MULADDSUB::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   MULADDSUB_DATA_SETUP;
 

--- a/src/basic/MULADDSUB-Hip.cpp
+++ b/src/basic/MULADDSUB-Hip.cpp
@@ -59,7 +59,7 @@ void MULADDSUB::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   MULADDSUB_DATA_SETUP;
 

--- a/src/basic/MULADDSUB-OMP.cpp
+++ b/src/basic/MULADDSUB-OMP.cpp
@@ -24,7 +24,7 @@ void MULADDSUB::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   MULADDSUB_DATA_SETUP;
 

--- a/src/basic/MULADDSUB-OMPTarget.cpp
+++ b/src/basic/MULADDSUB-OMPTarget.cpp
@@ -51,7 +51,7 @@ void MULADDSUB::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   MULADDSUB_DATA_SETUP;
 

--- a/src/basic/MULADDSUB-Seq.cpp
+++ b/src/basic/MULADDSUB-Seq.cpp
@@ -22,7 +22,7 @@ void MULADDSUB::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   MULADDSUB_DATA_SETUP;
 

--- a/src/basic/MULADDSUB.cpp
+++ b/src/basic/MULADDSUB.cpp
@@ -21,15 +21,15 @@ namespace basic
 MULADDSUB::MULADDSUB(const RunParams& params)
   : KernelBase(rajaperf::Basic_MULADDSUB, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(350);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (3*sizeof(Real_type) + 2*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(3 * getRunSize());
+  setBytesPerRep( (3*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(3 * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -59,18 +59,18 @@ MULADDSUB::~MULADDSUB()
 
 void MULADDSUB::setUp(VariantID vid)
 {
-  allocAndInitDataConst(m_out1, getRunSize(), 0.0, vid);
-  allocAndInitDataConst(m_out2, getRunSize(), 0.0, vid);
-  allocAndInitDataConst(m_out3, getRunSize(), 0.0, vid);
-  allocAndInitData(m_in1, getRunSize(), vid);
-  allocAndInitData(m_in2, getRunSize(), vid);
+  allocAndInitDataConst(m_out1, getActualProblemSize(), 0.0, vid);
+  allocAndInitDataConst(m_out2, getActualProblemSize(), 0.0, vid);
+  allocAndInitDataConst(m_out3, getActualProblemSize(), 0.0, vid);
+  allocAndInitData(m_in1, getActualProblemSize(), vid);
+  allocAndInitData(m_in2, getActualProblemSize(), vid);
 }
 
 void MULADDSUB::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_out1, getRunSize());
-  checksum[vid] += calcChecksum(m_out2, getRunSize());
-  checksum[vid] += calcChecksum(m_out3, getRunSize());
+  checksum[vid] += calcChecksum(m_out1, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_out2, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_out3, getActualProblemSize());
 }
 
 void MULADDSUB::tearDown(VariantID vid)

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -26,21 +26,21 @@ NESTED_INIT::NESTED_INIT(const RunParams& params)
 {
   m_n_init = 100;
 
-  setDefaultSize(m_n_init * m_n_init * m_n_init);
+  setDefaultProblemSize(m_n_init * m_n_init * m_n_init);
   setDefaultReps(1000);
 
-  auto n_final = std::cbrt(getRunSize());
+  auto n_final = std::cbrt( getTargetProblemSize() );
   m_ni = n_final;
   m_nj = n_final;
   m_nk = n_final;
   m_array_length = m_ni * m_nj * m_nk;
 
-  setProblemSize( m_array_length );
+  setActualProblemSize( m_array_length );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * m_array_length );
-  setFLOPsPerRep(3 * m_array_length);
+  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(3 * getActualProblemSize());
 
   setUsesFeature(Kernel);
 

--- a/src/basic/PI_ATOMIC-Cuda.cpp
+++ b/src/basic/PI_ATOMIC-Cuda.cpp
@@ -49,7 +49,7 @@ void PI_ATOMIC::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PI_ATOMIC_DATA_SETUP;
 

--- a/src/basic/PI_ATOMIC-Hip.cpp
+++ b/src/basic/PI_ATOMIC-Hip.cpp
@@ -49,7 +49,7 @@ void PI_ATOMIC::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PI_ATOMIC_DATA_SETUP;
 

--- a/src/basic/PI_ATOMIC-OMP.cpp
+++ b/src/basic/PI_ATOMIC-OMP.cpp
@@ -24,7 +24,7 @@ void PI_ATOMIC::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PI_ATOMIC_DATA_SETUP;
 

--- a/src/basic/PI_ATOMIC-OMPTarget.cpp
+++ b/src/basic/PI_ATOMIC-OMPTarget.cpp
@@ -40,7 +40,7 @@ void PI_ATOMIC::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PI_ATOMIC_DATA_SETUP;
 

--- a/src/basic/PI_ATOMIC-Seq.cpp
+++ b/src/basic/PI_ATOMIC-Seq.cpp
@@ -22,7 +22,7 @@ void PI_ATOMIC::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PI_ATOMIC_DATA_SETUP;
 

--- a/src/basic/PI_ATOMIC.cpp
+++ b/src/basic/PI_ATOMIC.cpp
@@ -21,16 +21,16 @@ namespace basic
 PI_ATOMIC::PI_ATOMIC(const RunParams& params)
   : KernelBase(rajaperf::Basic_PI_ATOMIC, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) +
-                  (0*sizeof(Real_type) + 0*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(6 * getRunSize() + 1);
+                  (0*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(6 * getActualProblemSize() + 1);
 
   setUsesFeature(Forall);
   setUsesFeature(Atomic);
@@ -61,7 +61,7 @@ PI_ATOMIC::~PI_ATOMIC()
 
 void PI_ATOMIC::setUp(VariantID vid)
 {
-  m_dx = 1.0 / double(getRunSize());
+  m_dx = 1.0 / double(getActualProblemSize());
   allocAndInitDataConst(m_pi, 1, 0.0, vid);
   m_pi_init = 0.0;
 }

--- a/src/basic/PI_REDUCE-Cuda.cpp
+++ b/src/basic/PI_REDUCE-Cuda.cpp
@@ -65,7 +65,7 @@ void PI_REDUCE::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PI_REDUCE_DATA_SETUP;
 

--- a/src/basic/PI_REDUCE-Hip.cpp
+++ b/src/basic/PI_REDUCE-Hip.cpp
@@ -65,7 +65,7 @@ void PI_REDUCE::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PI_REDUCE_DATA_SETUP;
 

--- a/src/basic/PI_REDUCE-OMP.cpp
+++ b/src/basic/PI_REDUCE-OMP.cpp
@@ -24,7 +24,7 @@ void PI_REDUCE::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PI_REDUCE_DATA_SETUP;
 

--- a/src/basic/PI_REDUCE-OMPTarget.cpp
+++ b/src/basic/PI_REDUCE-OMPTarget.cpp
@@ -31,7 +31,7 @@ void PI_REDUCE::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PI_REDUCE_DATA_SETUP;
 

--- a/src/basic/PI_REDUCE-Seq.cpp
+++ b/src/basic/PI_REDUCE-Seq.cpp
@@ -22,7 +22,7 @@ void PI_REDUCE::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PI_REDUCE_DATA_SETUP;
 

--- a/src/basic/PI_REDUCE.cpp
+++ b/src/basic/PI_REDUCE.cpp
@@ -21,16 +21,16 @@ namespace basic
 PI_REDUCE::PI_REDUCE(const RunParams& params)
   : KernelBase(rajaperf::Basic_PI_REDUCE, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) +
-                  (0*sizeof(Real_type) + 0*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(6 * getRunSize() + 1);
+                  (0*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(6 * getActualProblemSize() + 1);
 
   setUsesFeature(Forall);
   setUsesFeature(Reduction);
@@ -60,7 +60,7 @@ PI_REDUCE::~PI_REDUCE()
 void PI_REDUCE::setUp(VariantID vid)
 {
   (void) vid;
-  m_dx = 1.0 / double(getRunSize());
+  m_dx = 1.0 / double(getActualProblemSize());
   m_pi_init = 0.0;
   m_pi = 0.0;
 }

--- a/src/basic/REDUCE3_INT-Cuda.cpp
+++ b/src/basic/REDUCE3_INT-Cuda.cpp
@@ -86,7 +86,7 @@ void REDUCE3_INT::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   REDUCE3_INT_DATA_SETUP;
 

--- a/src/basic/REDUCE3_INT-Hip.cpp
+++ b/src/basic/REDUCE3_INT-Hip.cpp
@@ -86,7 +86,7 @@ void REDUCE3_INT::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   REDUCE3_INT_DATA_SETUP;
 

--- a/src/basic/REDUCE3_INT-OMP.cpp
+++ b/src/basic/REDUCE3_INT-OMP.cpp
@@ -25,7 +25,7 @@ void REDUCE3_INT::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   REDUCE3_INT_DATA_SETUP;
 

--- a/src/basic/REDUCE3_INT-OMPTarget.cpp
+++ b/src/basic/REDUCE3_INT-OMPTarget.cpp
@@ -40,7 +40,7 @@ void REDUCE3_INT::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   REDUCE3_INT_DATA_SETUP;
 

--- a/src/basic/REDUCE3_INT-Seq.cpp
+++ b/src/basic/REDUCE3_INT-Seq.cpp
@@ -23,7 +23,7 @@ void REDUCE3_INT::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   REDUCE3_INT_DATA_SETUP;
 

--- a/src/basic/REDUCE3_INT.cpp
+++ b/src/basic/REDUCE3_INT.cpp
@@ -23,19 +23,19 @@ namespace basic
 REDUCE3_INT::REDUCE3_INT(const RunParams& params)
   : KernelBase(rajaperf::Basic_REDUCE3_INT, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
 //setDefaultReps(5000);
 // Set reps to low value until we resolve RAJA omp-target
 // reduction performance issues
   setDefaultReps(50);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   setBytesPerRep( (3*sizeof(Int_type) + 3*sizeof(Int_type)) +
-                  (0*sizeof(Int_type) + 1*sizeof(Int_type)) * getRunSize() );
-  setFLOPsPerRep(1 * getRunSize() + 1);
+                  (0*sizeof(Int_type) + 1*sizeof(Int_type)) * getActualProblemSize() );
+  setFLOPsPerRep(1 * getActualProblemSize() + 1);
 
   setUsesFeature(Forall);
   setUsesFeature(Reduction);
@@ -64,7 +64,7 @@ REDUCE3_INT::~REDUCE3_INT()
 
 void REDUCE3_INT::setUp(VariantID vid)
 {
-  allocAndInitData(m_vec, getRunSize(), vid);
+  allocAndInitData(m_vec, getActualProblemSize(), vid);
 
   m_vsum = 0;
   m_vsum_init = 0;

--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -90,7 +90,7 @@ void TRAP_INT::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   TRAP_INT_DATA_SETUP;
 

--- a/src/basic/TRAP_INT-Hip.cpp
+++ b/src/basic/TRAP_INT-Hip.cpp
@@ -90,7 +90,7 @@ void TRAP_INT::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   TRAP_INT_DATA_SETUP;
 

--- a/src/basic/TRAP_INT-OMP.cpp
+++ b/src/basic/TRAP_INT-OMP.cpp
@@ -38,7 +38,7 @@ void TRAP_INT::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   TRAP_INT_DATA_SETUP;
 

--- a/src/basic/TRAP_INT-OMPTarget.cpp
+++ b/src/basic/TRAP_INT-OMPTarget.cpp
@@ -50,7 +50,7 @@ void TRAP_INT::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   TRAP_INT_DATA_SETUP;
 

--- a/src/basic/TRAP_INT-Seq.cpp
+++ b/src/basic/TRAP_INT-Seq.cpp
@@ -36,7 +36,7 @@ void TRAP_INT::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   TRAP_INT_DATA_SETUP;
 

--- a/src/basic/TRAP_INT.cpp
+++ b/src/basic/TRAP_INT.cpp
@@ -21,16 +21,16 @@ namespace basic
 TRAP_INT::TRAP_INT(const RunParams& params)
   : KernelBase(rajaperf::Basic_TRAP_INT, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) +
-                  (0*sizeof(Real_type) + 0*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(10 * getRunSize()); // 1 sqrt
+                  (0*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(10 * getActualProblemSize()); // 1 sqrt
 
   setUsesFeature(Forall);
   setUsesFeature(Reduction);

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -38,6 +38,15 @@ __global__ void lambda_cuda_forall(Index_type ibegin, Index_type iend, Lambda bo
 }
 
 /*!
+ * \brief Simple cuda kernel that runs a lambda.
+ */
+template < typename Lambda >
+__global__ void lambda_cuda(Lambda body)
+{
+    body();
+}
+
+/*!
  * \brief Getters for cuda kernel indices.
  */
 template < typename Index >
@@ -191,4 +200,3 @@ void deallocCudaPinnedData(T& pptr)
 #endif // RAJA_ENABLE_CUDA
 
 #endif  // closing endif for header file include guard
-

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -436,7 +436,7 @@ void Executor::writeKernelInfoSummary(ostream& str, bool to_file) const
 
   for (size_t ik = 0; ik < kernels.size(); ++ik) {
     kercol_width = max(kercol_width, kernels[ik]->getName().size());
-    psize_width = max(psize_width, kernels[ik]->getProblemSize());
+    psize_width = max(psize_width, kernels[ik]->getActualProblemSize());
     reps_width = max(reps_width, kernels[ik]->getRunReps());
     itsrep_width = max(reps_width, kernels[ik]->getItsPerRep());
     bytesrep_width = max(bytesrep_width, kernels[ik]->getBytesPerRep());
@@ -502,7 +502,7 @@ void Executor::writeKernelInfoSummary(ostream& str, bool to_file) const
   for (size_t ik = 0; ik < kernels.size(); ++ik) {
     KernelBase* kern = kernels[ik];
     str <<left<< setw(kercol_width) <<  kern->getName()
-        << sepchr <<right<< setw(psize_width) << kern->getProblemSize()
+        << sepchr <<right<< setw(psize_width) << kern->getActualProblemSize()
         << sepchr <<right<< setw(reps_width) << kern->getRunReps()
         << sepchr <<right<< setw(itsrep_width) << kern->getItsPerRep()
         << sepchr <<right<< setw(kernsrep_width) << kern->getKernelsPerRep()

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -38,6 +38,11 @@ __global__ void lambda_hip_forall(Index_type ibegin, Index_type iend, Lambda bod
 }
 
 /*!
+* \brief Simple hip kernel that runs a lambda.
+*/
+template <typename Lambda> __global__ void lambda_hip(Lambda body) { body(); }
+
+/*!
  * \brief Getters for hip kernel indices.
  */
 template < typename Index >
@@ -192,4 +197,3 @@ void deallocHipPinnedData(T& pptr)
 #endif // RAJA_ENABLE_HIP
 
 #endif  // closing endif for header file include guard
-

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -20,8 +20,10 @@ KernelBase::KernelBase(KernelID kid, const RunParams& params) :
   kernel_id = kid;
   name = getFullKernelName(kernel_id);
 
-  default_size = -1;
+  default_prob_size = -1;
   default_reps = -1;
+
+  actual_prob_size = -1;
  
   for (size_t fid = 0; fid < NumFeatures; ++fid) {
     uses_feature[fid] = false;
@@ -31,9 +33,9 @@ KernelBase::KernelBase(KernelID kid, const RunParams& params) :
     has_variant_defined[vid] = false;
   }
 
-  problem_size = -1;
   its_per_rep = -1;
   kernels_per_rep = -1;
+  bytes_per_rep = -1;
   FLOPs_per_rep = -1;
 
   running_variant = NumVariants;
@@ -53,15 +55,16 @@ KernelBase::~KernelBase()
 }
 
 
-Index_type KernelBase::getRunSize() const
+Index_type KernelBase::getTargetProblemSize() const
 { 
-  Index_type run_size = static_cast<Index_type>(0);
+  Index_type target_size = static_cast<Index_type>(0);
   if (run_params.getSizeMeaning() == RunParams::SizeMeaning::Factor) {
-    run_size = static_cast<Index_type>(default_size*run_params.getSizeFactor());
+    target_size = 
+      static_cast<Index_type>(default_prob_size*run_params.getSizeFactor());
   } else if (run_params.getSizeMeaning() == RunParams::SizeMeaning::Direct) {
-    run_size = static_cast<Index_type>(run_params.getSize());
+    target_size = static_cast<Index_type>(run_params.getSize());
   }
-  return run_size;
+  return target_size;
 }
 
 Index_type KernelBase::getRunReps() const
@@ -185,27 +188,47 @@ void KernelBase::print(std::ostream& os) const
 {
   os << "\nKernelBase::print..." << std::endl;
   os << "\t\t name(id) = " << name << "(" << kernel_id << ")" << std::endl;
-  os << "\t\t\t default_size = " << default_size << std::endl;
+  os << "\t\t\t default_prob_size = " << default_prob_size << std::endl;
   os << "\t\t\t default_reps = " << default_reps << std::endl;
+  os << "\t\t\t actual_prob_size = " << actual_prob_size << std::endl;
+  os << "\t\t\t uses_feature: " << std::endl;
+  for (unsigned j = 0; j < NumFeatures; ++j) {
+    os << "\t\t\t\t" << getFeatureName(static_cast<FeatureID>(j)) 
+                     << " : " << uses_feature[j] << std::endl; 
+  }
+  os << "\t\t\t has_variant_defined: " << std::endl;
+  for (unsigned j = 0; j < NumVariants; ++j) {
+    os << "\t\t\t\t" << getVariantName(static_cast<VariantID>(j)) 
+                     << " : " << has_variant_defined[j] << std::endl; 
+  }
+  os << "\t\t\t its_per_rep = " << its_per_rep << std::endl;
+  os << "\t\t\t kernels_per_rep = " << kernels_per_rep << std::endl;
+  os << "\t\t\t bytes_per_rep = " << bytes_per_rep << std::endl;
+  os << "\t\t\t FLOPs_per_rep = " << FLOPs_per_rep << std::endl;
   os << "\t\t\t num_exec: " << std::endl;
   for (unsigned j = 0; j < NumVariants; ++j) {
-    os << "\t\t\t\t" << num_exec[j] << std::endl; 
+    os << "\t\t\t\t" << getVariantName(static_cast<VariantID>(j)) 
+                     << " : " << num_exec[j] << std::endl; 
   }
   os << "\t\t\t min_time: " << std::endl;
   for (unsigned j = 0; j < NumVariants; ++j) {
-    os << "\t\t\t\t" << min_time[j] << std::endl; 
+    os << "\t\t\t\t" << getVariantName(static_cast<VariantID>(j)) 
+                     << " : " << min_time[j] << std::endl; 
   }
   os << "\t\t\t max_time: " << std::endl;
   for (unsigned j = 0; j < NumVariants; ++j) {
-    os << "\t\t\t\t" << max_time[j] << std::endl; 
+    os << "\t\t\t\t" << getVariantName(static_cast<VariantID>(j)) 
+                     << " : " << max_time[j] << std::endl; 
   }
   os << "\t\t\t tot_time: " << std::endl;
   for (unsigned j = 0; j < NumVariants; ++j) {
-    os << "\t\t\t\t" << tot_time[j] << std::endl; 
+    os << "\t\t\t\t" << getVariantName(static_cast<VariantID>(j)) 
+                     << " : " << tot_time[j] << std::endl; 
   }
   os << "\t\t\t checksum: " << std::endl;
   for (unsigned j = 0; j < NumVariants; ++j) {
-    os << "\t\t\t\t" << checksum[j] << std::endl; 
+    os << "\t\t\t\t" << getVariantName(static_cast<VariantID>(j)) 
+                     << " : " << checksum[j] << std::endl; 
   }
   os << std::endl;
 }

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -50,9 +50,9 @@ public:
   // properties used to describe kernel and define how it will run
   //
 
-  void setDefaultSize(Index_type size) { default_size = size; }
+  void setDefaultProblemSize(Index_type size) { default_prob_size = size; }
+  void setActualProblemSize(Index_type size) { actual_prob_size = size; }
   void setDefaultReps(Index_type reps) { default_reps = reps; }
-  void setProblemSize(Index_type prob_size) { problem_size = prob_size; }
   void setItsPerRep(Index_type its) { its_per_rep = its; };
   void setKernelsPerRep(Index_type nkerns) { kernels_per_rep = nkerns; };
   void setBytesPerRep(Index_type bytes) { bytes_per_rep = bytes;}
@@ -66,15 +66,15 @@ public:
   // and kernel details report ouput.
   //
 
-  Index_type getDefaultSize() const { return default_size; }
+  Index_type getDefaultProblemSize() const { return default_prob_size; }
+  Index_type getActualProblemSize() const { return actual_prob_size; }
   Index_type getDefaultReps() const { return default_reps; }
-  Index_type getProblemSize() const { return problem_size; }
   Index_type getItsPerRep() const { return its_per_rep; };
   Index_type getKernelsPerRep() const { return kernels_per_rep; };
   Index_type getBytesPerRep() const { return bytes_per_rep; }
   Index_type getFLOPsPerRep() const { return FLOPs_per_rep; }
 
-  Index_type getRunSize() const;
+  Index_type getTargetProblemSize() const;
   Index_type getRunReps() const;
 
   bool usesFeature(FeatureID fid) const { return uses_feature[fid]; };
@@ -174,8 +174,10 @@ private:
   KernelID    kernel_id;
   std::string name;
 
-  Index_type default_size;
+  Index_type default_prob_size;
   Index_type default_reps;
+
+  Index_type actual_prob_size;
 
   bool uses_feature[NumFeatures];
 
@@ -184,7 +186,6 @@ private:
   //
   // Properties of kernel dependent on how kernel is run
   //
-  Index_type problem_size;
   Index_type its_per_rep;
   Index_type kernels_per_rep;
   Index_type bytes_per_rep;

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -18,6 +18,7 @@
 #include "basic/INIT3.hpp"
 #include "basic/INIT_VIEW1D.hpp"
 #include "basic/INIT_VIEW1D_OFFSET.hpp"
+#include "basic/MAT_MAT_SHARED.hpp"
 #include "basic/MULADDSUB.hpp"
 #include "basic/NESTED_INIT.hpp"
 #include "basic/PI_ATOMIC.hpp"
@@ -142,6 +143,7 @@ static const std::string KernelNames [] =
   std::string("Basic_INIT3"),
   std::string("Basic_INIT_VIEW1D"),
   std::string("Basic_INIT_VIEW1D_OFFSET"),
+  std::string("Basic_MAT_MAT_SHARED"),
   std::string("Basic_MULADDSUB"),
   std::string("Basic_NESTED_INIT"),
   std::string("Basic_PI_ATOMIC"),
@@ -444,6 +446,10 @@ KernelBase* getKernelObject(KernelID kid,
     }
     case Basic_INIT_VIEW1D_OFFSET : {
        kernel = new basic::INIT_VIEW1D_OFFSET(run_params);
+       break;
+    }
+    case Basic_MAT_MAT_SHARED : {
+       kernel = new basic::MAT_MAT_SHARED(run_params);
        break;
     }
     case Basic_MULADDSUB : {

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -104,6 +104,7 @@ enum KernelID {
   Basic_INIT3,
   Basic_INIT_VIEW1D,
   Basic_INIT_VIEW1D_OFFSET,
+  Basic_MAT_MAT_SHARED,
   Basic_MULADDSUB,
   Basic_NESTED_INIT,
   Basic_PI_ATOMIC,

--- a/src/lcals/DIFF_PREDICT-Cuda.cpp
+++ b/src/lcals/DIFF_PREDICT-Cuda.cpp
@@ -51,7 +51,7 @@ void DIFF_PREDICT::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DIFF_PREDICT_DATA_SETUP;
 

--- a/src/lcals/DIFF_PREDICT-Hip.cpp
+++ b/src/lcals/DIFF_PREDICT-Hip.cpp
@@ -51,7 +51,7 @@ void DIFF_PREDICT::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DIFF_PREDICT_DATA_SETUP;
 

--- a/src/lcals/DIFF_PREDICT-OMP.cpp
+++ b/src/lcals/DIFF_PREDICT-OMP.cpp
@@ -24,7 +24,7 @@ void DIFF_PREDICT::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DIFF_PREDICT_DATA_SETUP;
 

--- a/src/lcals/DIFF_PREDICT-OMPTarget.cpp
+++ b/src/lcals/DIFF_PREDICT-OMPTarget.cpp
@@ -43,7 +43,7 @@ void DIFF_PREDICT::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DIFF_PREDICT_DATA_SETUP;
 

--- a/src/lcals/DIFF_PREDICT-Seq.cpp
+++ b/src/lcals/DIFF_PREDICT-Seq.cpp
@@ -22,7 +22,7 @@ void DIFF_PREDICT::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DIFF_PREDICT_DATA_SETUP;
 

--- a/src/lcals/DIFF_PREDICT.cpp
+++ b/src/lcals/DIFF_PREDICT.cpp
@@ -11,7 +11,6 @@
 #include "RAJA/RAJA.hpp"
 
 #include "common/DataUtils.hpp"
-
 namespace rajaperf
 {
 namespace lcals
@@ -21,15 +20,16 @@ namespace lcals
 DIFF_PREDICT::DIFF_PREDICT(const RunParams& params)
   : KernelBase(rajaperf::Lcals_DIFF_PREDICT, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(200);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
+
   setKernelsPerRep(1);
-  setBytesPerRep( (10*sizeof(Real_type) + 10*sizeof(Real_type)) * getRunSize());
-  setFLOPsPerRep(9 * getRunSize());
+  setBytesPerRep( (10*sizeof(Real_type) + 10*sizeof(Real_type)) * getActualProblemSize());
+  setFLOPsPerRep(9 * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -57,8 +57,8 @@ DIFF_PREDICT::~DIFF_PREDICT()
 
 void DIFF_PREDICT::setUp(VariantID vid)
 {
-  m_array_length = getRunSize() * 14;
-  m_offset = getRunSize();
+  m_array_length = getActualProblemSize() * 14;
+  m_offset = getActualProblemSize();
 
   allocAndInitDataConst(m_px, m_array_length, 0.0, vid);
   allocAndInitData(m_cx, m_array_length, vid);

--- a/src/lcals/EOS-Cuda.cpp
+++ b/src/lcals/EOS-Cuda.cpp
@@ -55,7 +55,7 @@ void EOS::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   EOS_DATA_SETUP;
 

--- a/src/lcals/EOS-Hip.cpp
+++ b/src/lcals/EOS-Hip.cpp
@@ -55,7 +55,7 @@ void EOS::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   EOS_DATA_SETUP;
 

--- a/src/lcals/EOS-OMP.cpp
+++ b/src/lcals/EOS-OMP.cpp
@@ -24,7 +24,7 @@ void EOS::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   EOS_DATA_SETUP;
 

--- a/src/lcals/EOS-OMPTarget.cpp
+++ b/src/lcals/EOS-OMPTarget.cpp
@@ -47,7 +47,7 @@ void EOS::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   EOS_DATA_SETUP;
 

--- a/src/lcals/EOS-Seq.cpp
+++ b/src/lcals/EOS-Seq.cpp
@@ -22,7 +22,7 @@ void EOS::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   EOS_DATA_SETUP;
 

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -21,18 +21,19 @@ namespace lcals
 EOS::EOS(const RunParams& params)
   : KernelBase(rajaperf::Lcals_EOS, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(500);
 
-  m_array_length = getRunSize() + 7;
+  setActualProblemSize( getTargetProblemSize() );
 
-  setProblemSize( getRunSize() );
+  m_array_length = getActualProblemSize() + 7;
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getRunSize() +
+  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() +
                   (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_array_length );
-  setFLOPsPerRep(16 * getRunSize());
+  setFLOPsPerRep(16 * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -72,7 +73,7 @@ void EOS::setUp(VariantID vid)
 
 void EOS::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_x, getRunSize());
+  checksum[vid] += calcChecksum(m_x, getActualProblemSize());
 }
 
 void EOS::tearDown(VariantID vid)

--- a/src/lcals/FIRST_DIFF-Cuda.cpp
+++ b/src/lcals/FIRST_DIFF-Cuda.cpp
@@ -50,7 +50,7 @@ void FIRST_DIFF::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_DIFF_DATA_SETUP;
 

--- a/src/lcals/FIRST_DIFF-Hip.cpp
+++ b/src/lcals/FIRST_DIFF-Hip.cpp
@@ -50,7 +50,7 @@ void FIRST_DIFF::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_DIFF_DATA_SETUP;
 

--- a/src/lcals/FIRST_DIFF-OMP.cpp
+++ b/src/lcals/FIRST_DIFF-OMP.cpp
@@ -24,7 +24,7 @@ void FIRST_DIFF::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_DIFF_DATA_SETUP;
 

--- a/src/lcals/FIRST_DIFF-OMPTarget.cpp
+++ b/src/lcals/FIRST_DIFF-OMPTarget.cpp
@@ -43,7 +43,7 @@ void FIRST_DIFF::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_DIFF_DATA_SETUP;
  

--- a/src/lcals/FIRST_DIFF-Seq.cpp
+++ b/src/lcals/FIRST_DIFF-Seq.cpp
@@ -22,7 +22,7 @@ void FIRST_DIFF::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_DIFF_DATA_SETUP;
 

--- a/src/lcals/FIRST_DIFF.cpp
+++ b/src/lcals/FIRST_DIFF.cpp
@@ -21,18 +21,19 @@ namespace lcals
 FIRST_DIFF::FIRST_DIFF(const RunParams& params)
   : KernelBase(rajaperf::Lcals_FIRST_DIFF, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(2000);
 
-  m_N = getRunSize()+1;
+  setActualProblemSize( getTargetProblemSize() );
 
-  setProblemSize( getRunSize() );
+  m_N = getActualProblemSize()+1;
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getRunSize() +
+  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() +
                   (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_N );
-  setFLOPsPerRep(1 * getRunSize());
+  setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -66,7 +67,7 @@ void FIRST_DIFF::setUp(VariantID vid)
 
 void FIRST_DIFF::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_x, getRunSize());
+  checksum[vid] += calcChecksum(m_x, getActualProblemSize());
 }
 
 void FIRST_DIFF::tearDown(VariantID vid)

--- a/src/lcals/FIRST_MIN-Cuda.cpp
+++ b/src/lcals/FIRST_MIN-Cuda.cpp
@@ -70,7 +70,7 @@ void FIRST_MIN::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_MIN_DATA_SETUP;
 

--- a/src/lcals/FIRST_MIN-Hip.cpp
+++ b/src/lcals/FIRST_MIN-Hip.cpp
@@ -70,7 +70,7 @@ void FIRST_MIN::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_MIN_DATA_SETUP;
 

--- a/src/lcals/FIRST_MIN-OMP.cpp
+++ b/src/lcals/FIRST_MIN-OMP.cpp
@@ -25,7 +25,7 @@ void FIRST_MIN::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_MIN_DATA_SETUP;
 

--- a/src/lcals/FIRST_MIN-OMPTarget.cpp
+++ b/src/lcals/FIRST_MIN-OMPTarget.cpp
@@ -41,7 +41,7 @@ void FIRST_MIN::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_MIN_DATA_SETUP;
  

--- a/src/lcals/FIRST_MIN-Seq.cpp
+++ b/src/lcals/FIRST_MIN-Seq.cpp
@@ -22,7 +22,7 @@ void FIRST_MIN::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_MIN_DATA_SETUP;
 

--- a/src/lcals/FIRST_MIN.cpp
+++ b/src/lcals/FIRST_MIN.cpp
@@ -21,17 +21,17 @@ namespace lcals
 FIRST_MIN::FIRST_MIN(const RunParams& params)
   : KernelBase(rajaperf::Lcals_FIRST_MIN, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
 //setDefaultReps(1000);
 // Set reps to low value until we resolve RAJA omp-target
 // reduction performance issues
   setDefaultReps(100);
 
-  m_N = getRunSize();
+  setActualProblemSize( getTargetProblemSize() );
 
-  setProblemSize( getRunSize() );
+  m_N = getActualProblemSize();
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   setBytesPerRep( (1*sizeof(Real_type ) + 1*sizeof(Real_type )) +
                   (1*sizeof(Index_type) + 1*sizeof(Index_type)) +

--- a/src/lcals/FIRST_SUM-Cuda.cpp
+++ b/src/lcals/FIRST_SUM-Cuda.cpp
@@ -50,7 +50,7 @@ void FIRST_SUM::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 1;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_SUM_DATA_SETUP;
 

--- a/src/lcals/FIRST_SUM-Hip.cpp
+++ b/src/lcals/FIRST_SUM-Hip.cpp
@@ -50,7 +50,7 @@ void FIRST_SUM::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 1;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_SUM_DATA_SETUP;
 

--- a/src/lcals/FIRST_SUM-OMP.cpp
+++ b/src/lcals/FIRST_SUM-OMP.cpp
@@ -24,7 +24,7 @@ void FIRST_SUM::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 1;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_SUM_DATA_SETUP;
 

--- a/src/lcals/FIRST_SUM-OMPTarget.cpp
+++ b/src/lcals/FIRST_SUM-OMPTarget.cpp
@@ -43,7 +43,7 @@ void FIRST_SUM::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 1;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_SUM_DATA_SETUP;
  

--- a/src/lcals/FIRST_SUM-Seq.cpp
+++ b/src/lcals/FIRST_SUM-Seq.cpp
@@ -22,7 +22,7 @@ void FIRST_SUM::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 1;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   FIRST_SUM_DATA_SETUP;
 

--- a/src/lcals/FIRST_SUM.cpp
+++ b/src/lcals/FIRST_SUM.cpp
@@ -21,18 +21,18 @@ namespace lcals
 FIRST_SUM::FIRST_SUM(const RunParams& params)
   : KernelBase(rajaperf::Lcals_FIRST_SUM, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(2000);
 
-  m_N = getRunSize();
+  setActualProblemSize( getTargetProblemSize() );
 
-  setProblemSize( getRunSize() );
+  m_N = getActualProblemSize();
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   setBytesPerRep( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * (m_N-1) +
                   (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N );
-  setFLOPsPerRep(1 * (getRunSize()-1));
+  setFLOPsPerRep(1 * (getActualProblemSize()-1));
 
   setUsesFeature(Forall);
 
@@ -66,7 +66,7 @@ void FIRST_SUM::setUp(VariantID vid)
 
 void FIRST_SUM::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_x, getRunSize());
+  checksum[vid] += calcChecksum(m_x, getActualProblemSize());
 }
 
 void FIRST_SUM::tearDown(VariantID vid)

--- a/src/lcals/GEN_LIN_RECUR.cpp
+++ b/src/lcals/GEN_LIN_RECUR.cpp
@@ -21,19 +21,19 @@ namespace lcals
 GEN_LIN_RECUR::GEN_LIN_RECUR(const RunParams& params)
   : KernelBase(rajaperf::Lcals_GEN_LIN_RECUR, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(500);
 
-  m_N = getRunSize();
+  setActualProblemSize( getTargetProblemSize() );
 
-  setProblemSize( getRunSize() );
+  m_N = getActualProblemSize();
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(2);
   setBytesPerRep( (2*sizeof(Real_type ) + 3*sizeof(Real_type )) * m_N +
                   (2*sizeof(Real_type ) + 3*sizeof(Real_type )) * m_N );
   setFLOPsPerRep((3 +
-                  3 ) * getRunSize());
+                  3 ) * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -71,7 +71,7 @@ void GEN_LIN_RECUR::setUp(VariantID vid)
 
 void GEN_LIN_RECUR::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_b5, getRunSize());
+  checksum[vid] += calcChecksum(m_b5, getActualProblemSize());
 }
 
 void GEN_LIN_RECUR::tearDown(VariantID vid)

--- a/src/lcals/HYDRO_1D-Cuda.cpp
+++ b/src/lcals/HYDRO_1D-Cuda.cpp
@@ -53,7 +53,7 @@ void HYDRO_1D::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   HYDRO_1D_DATA_SETUP;
 

--- a/src/lcals/HYDRO_1D-Hip.cpp
+++ b/src/lcals/HYDRO_1D-Hip.cpp
@@ -53,7 +53,7 @@ void HYDRO_1D::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   HYDRO_1D_DATA_SETUP;
 

--- a/src/lcals/HYDRO_1D-OMP.cpp
+++ b/src/lcals/HYDRO_1D-OMP.cpp
@@ -24,7 +24,7 @@ void HYDRO_1D::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   HYDRO_1D_DATA_SETUP;
 

--- a/src/lcals/HYDRO_1D-OMPTarget.cpp
+++ b/src/lcals/HYDRO_1D-OMPTarget.cpp
@@ -45,7 +45,7 @@ void HYDRO_1D::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   HYDRO_1D_DATA_SETUP;
 

--- a/src/lcals/HYDRO_1D-Seq.cpp
+++ b/src/lcals/HYDRO_1D-Seq.cpp
@@ -22,7 +22,7 @@ void HYDRO_1D::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   HYDRO_1D_DATA_SETUP;
 

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -21,18 +21,18 @@ namespace lcals
 HYDRO_1D::HYDRO_1D(const RunParams& params)
   : KernelBase(rajaperf::Lcals_HYDRO_1D, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(1000);
 
-  m_array_length = getRunSize() + 12;
+  setActualProblemSize( getTargetProblemSize() );
 
-  setProblemSize( getRunSize() );
+  m_array_length = getActualProblemSize() + 12;
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type ) + 1*sizeof(Real_type )) * getRunSize() +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * (getRunSize()+1) );
-  setFLOPsPerRep(5 * getRunSize());
+  setBytesPerRep( (1*sizeof(Real_type ) + 1*sizeof(Real_type )) * getActualProblemSize() +
+                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * (getActualProblemSize()+1) );
+  setFLOPsPerRep(5 * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -71,7 +71,7 @@ void HYDRO_1D::setUp(VariantID vid)
 
 void HYDRO_1D::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_x, getRunSize());
+  checksum[vid] += calcChecksum(m_x, getActualProblemSize());
 }
 
 void HYDRO_1D::tearDown(VariantID vid)

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -30,15 +30,15 @@ HYDRO_2D::HYDRO_2D(const RunParams& params)
   m_s = 0.0041;
   m_t = 0.0037;
 
-  setDefaultSize(m_kn * m_jn);
+  setDefaultProblemSize(m_kn * m_jn);
   setDefaultReps(100);
 
-  m_jn = m_kn = std::sqrt(getRunSize());
+  m_jn = m_kn = std::sqrt(getTargetProblemSize());
   m_array_length = m_kn * m_jn;
 
-  setProblemSize( m_array_length );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( 3 * getProblemSize() );
+  setItsPerRep( 3 * getActualProblemSize() );
   setKernelsPerRep(3);
   setBytesPerRep( (2*sizeof(Real_type ) + 0*sizeof(Real_type )) * (m_kn-2) * (m_jn-2) +
                   (0*sizeof(Real_type ) + 4*sizeof(Real_type )) * m_array_length +

--- a/src/lcals/INT_PREDICT-Cuda.cpp
+++ b/src/lcals/INT_PREDICT-Cuda.cpp
@@ -52,7 +52,7 @@ void INT_PREDICT::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INT_PREDICT_DATA_SETUP;
 

--- a/src/lcals/INT_PREDICT-Hip.cpp
+++ b/src/lcals/INT_PREDICT-Hip.cpp
@@ -52,7 +52,7 @@ void INT_PREDICT::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INT_PREDICT_DATA_SETUP;
 

--- a/src/lcals/INT_PREDICT-OMP.cpp
+++ b/src/lcals/INT_PREDICT-OMP.cpp
@@ -24,7 +24,7 @@ void INT_PREDICT::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INT_PREDICT_DATA_SETUP;
 

--- a/src/lcals/INT_PREDICT-OMPTarget.cpp
+++ b/src/lcals/INT_PREDICT-OMPTarget.cpp
@@ -41,7 +41,7 @@ void INT_PREDICT::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INT_PREDICT_DATA_SETUP;
 

--- a/src/lcals/INT_PREDICT-Seq.cpp
+++ b/src/lcals/INT_PREDICT-Seq.cpp
@@ -22,7 +22,7 @@ void INT_PREDICT::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   INT_PREDICT_DATA_SETUP;
 

--- a/src/lcals/INT_PREDICT.cpp
+++ b/src/lcals/INT_PREDICT.cpp
@@ -21,15 +21,15 @@ namespace lcals
 INT_PREDICT::INT_PREDICT(const RunParams& params)
   : KernelBase(rajaperf::Lcals_INT_PREDICT, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(400);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type ) + 10*sizeof(Real_type )) * getRunSize() );
-  setFLOPsPerRep(17 * getRunSize());
+  setBytesPerRep( (1*sizeof(Real_type ) + 10*sizeof(Real_type )) * getActualProblemSize() );
+  setFLOPsPerRep(17 * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -57,8 +57,8 @@ INT_PREDICT::~INT_PREDICT()
 
 void INT_PREDICT::setUp(VariantID vid)
 {
-  m_array_length = getRunSize() * 13;
-  m_offset = getRunSize();
+  m_array_length = getActualProblemSize() * 13;
+  m_offset = getActualProblemSize();
 
   m_px_initval = 1.0;
   allocAndInitDataConst(m_px, m_array_length, m_px_initval, vid);
@@ -75,11 +75,11 @@ void INT_PREDICT::setUp(VariantID vid)
 
 void INT_PREDICT::updateChecksum(VariantID vid)
 {
-  for (Index_type i = 0; i < getRunSize(); ++i) {
+  for (Index_type i = 0; i < getActualProblemSize(); ++i) {
     m_px[i] -= m_px_initval;
   }
 
-  checksum[vid] += calcChecksum(m_px, getRunSize());
+  checksum[vid] += calcChecksum(m_px, getActualProblemSize());
 }
 
 void INT_PREDICT::tearDown(VariantID vid)

--- a/src/lcals/PLANCKIAN-Cuda.cpp
+++ b/src/lcals/PLANCKIAN-Cuda.cpp
@@ -58,7 +58,7 @@ void PLANCKIAN::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PLANCKIAN_DATA_SETUP;
 

--- a/src/lcals/PLANCKIAN-Hip.cpp
+++ b/src/lcals/PLANCKIAN-Hip.cpp
@@ -58,7 +58,7 @@ void PLANCKIAN::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PLANCKIAN_DATA_SETUP;
 

--- a/src/lcals/PLANCKIAN-OMP.cpp
+++ b/src/lcals/PLANCKIAN-OMP.cpp
@@ -25,7 +25,7 @@ void PLANCKIAN::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PLANCKIAN_DATA_SETUP;
 

--- a/src/lcals/PLANCKIAN-OMPTarget.cpp
+++ b/src/lcals/PLANCKIAN-OMPTarget.cpp
@@ -50,7 +50,7 @@ void PLANCKIAN::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PLANCKIAN_DATA_SETUP;
 

--- a/src/lcals/PLANCKIAN-Seq.cpp
+++ b/src/lcals/PLANCKIAN-Seq.cpp
@@ -23,7 +23,7 @@ void PLANCKIAN::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   PLANCKIAN_DATA_SETUP;
 

--- a/src/lcals/PLANCKIAN.cpp
+++ b/src/lcals/PLANCKIAN.cpp
@@ -21,15 +21,15 @@ namespace lcals
 PLANCKIAN::PLANCKIAN(const RunParams& params)
   : KernelBase(rajaperf::Lcals_PLANCKIAN, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (2*sizeof(Real_type ) + 3*sizeof(Real_type )) * getRunSize() );
-  setFLOPsPerRep(4 * getRunSize()); // 1 exp
+  setBytesPerRep( (2*sizeof(Real_type ) + 3*sizeof(Real_type )) * getActualProblemSize() );
+  setFLOPsPerRep(4 * getActualProblemSize()); // 1 exp
 
   setUsesFeature(Forall);
 
@@ -57,16 +57,16 @@ PLANCKIAN::~PLANCKIAN()
 
 void PLANCKIAN::setUp(VariantID vid)
 {
-  allocAndInitData(m_x, getRunSize(), vid);
-  allocAndInitData(m_y, getRunSize(), vid);
-  allocAndInitData(m_u, getRunSize(), vid);
-  allocAndInitData(m_v, getRunSize(), vid);
-  allocAndInitDataConst(m_w, getRunSize(), 0.0, vid);
+  allocAndInitData(m_x, getActualProblemSize(), vid);
+  allocAndInitData(m_y, getActualProblemSize(), vid);
+  allocAndInitData(m_u, getActualProblemSize(), vid);
+  allocAndInitData(m_v, getActualProblemSize(), vid);
+  allocAndInitDataConst(m_w, getActualProblemSize(), 0.0, vid);
 }
 
 void PLANCKIAN::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_w, getRunSize());
+  checksum[vid] += calcChecksum(m_w, getActualProblemSize());
 }
 
 void PLANCKIAN::tearDown(VariantID vid)

--- a/src/lcals/TRIDIAG_ELIM.cpp
+++ b/src/lcals/TRIDIAG_ELIM.cpp
@@ -21,17 +21,17 @@ namespace lcals
 TRIDIAG_ELIM::TRIDIAG_ELIM(const RunParams& params)
   : KernelBase(rajaperf::Lcals_TRIDIAG_ELIM, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(1000);
 
-  m_N = getRunSize();
+  setActualProblemSize( getTargetProblemSize() );
 
-  setProblemSize( getRunSize() );
+  m_N = getActualProblemSize();
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   setBytesPerRep( (1*sizeof(Real_type ) + 3*sizeof(Real_type )) * (m_N-1) );
-  setFLOPsPerRep(2 * (getRunSize()-1));
+  setFLOPsPerRep(2 * (getActualProblemSize()-1));
 
   setUsesFeature(Forall);
 
@@ -67,7 +67,7 @@ void TRIDIAG_ELIM::setUp(VariantID vid)
 
 void TRIDIAG_ELIM::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_xout, getRunSize());
+  checksum[vid] += calcChecksum(m_xout, getActualProblemSize());
 }
 
 void TRIDIAG_ELIM::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -51,13 +51,36 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
       break;
   }
 
+#if 0 // we want this...
+
+  Index_type ni_default = 1000;
+  Index_type nj_default = 1000;
+  Index_type nk_default = 1120;
+  Index_type nl_default = 1000;
+
+  setDefaultProblemSize( std::max( ni_default*nj_default, 
+                                   ni_default*nl_default ) );
+  setDefaultReps(4);
+
+  m_ni = std::sqrt( getTargetProblemSize() ) + 1;
+  m_nj = m_ni;
+  m_nk = nk_default;
+  m_nl = m_ni;
+
   m_alpha = 1.5;
   m_beta = 1.2;
 
-  setDefaultSize( std::max( m_ni*m_nj, m_ni*m_nl ) );
+#else  // this is what we have now...
+
+  m_alpha = 1.5;
+  m_beta = 1.2;
+
+  setDefaultProblemSize( std::max( m_ni*m_nj, m_ni*m_nl ) );
   setDefaultReps(run_reps);
 
-  setProblemSize( std::max( m_ni*m_nj, m_ni*m_nl ) );
+#endif
+
+  setActualProblemSize( std::max( m_ni*m_nj, m_ni*m_nl ) );
 
   setItsPerRep( m_ni*m_nj + m_ni*m_nl );
   setKernelsPerRep(2);

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -51,10 +51,36 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
       break;
   }
 
-  setDefaultSize( std::max( std::max( m_ni*m_nj, m_nj*m_nl), m_ni*m_nl ) );
+#if 0 // we want this...
+
+  Index_type ni_default = 1000;
+  Index_type nj_default = 1000;
+  Index_type nk_default = 1010;
+  Index_type nl_default = 1000;
+  Index_type nm_default = 1200;
+
+  setDefaultProblemSize( std::max( std::max( ni_default*nj_default, 
+                                             nj_default*nl_default ), 
+                                  ni_default*nl_default ) );
+  setDefaultProblemSize( ni_default * nj_default );
+  setDefaultReps(4);
+
+  m_ni = std::sqrt( getTargetProblemSize() ) + 1;
+  m_nj = m_ni;
+  m_nk = nk_default;
+  m_nl = m_ni;
+  m_nm = nm_default;
+
+#else  // this is what we have now...
+
+  setDefaultProblemSize( std::max( std::max( m_ni*m_nj, m_nj*m_nl), m_ni*m_nl ) );
+
   setDefaultReps(m_run_reps);
 
-  setProblemSize( std::max( std::max( m_ni*m_nj, m_nj*m_nl), m_ni*m_nl ) );
+#endif
+
+  setActualProblemSize( std::max( std::max( m_ni*m_nj, m_nj*m_nl ), 
+                                  m_ni*m_nl ) );
 
   setItsPerRep( m_ni*m_nj + m_nj*m_nl + m_ni*m_nl );
   setKernelsPerRep(3);

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -49,13 +49,29 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
       break;
   }
 
-  setDefaultSize( (m_n-2)*(m_n-2) );
-  setDefaultReps(run_reps);
+#if 0 // we want this...
 
-  setProblemSize( (m_n-2)*(m_n-2) );
+  Index_type n_default = 1000;
+  
+  setDefaultProblemSize( (n_default-2) * (n_default-2) );
+  setDefaultReps(4);
+
+  m_n = std::sqrt( getTargetProblemSize() ) + 1;
+  m_tsteps = 4;
+
+  setItsPerRep( m_tsteps * ( (m_n-2) + (m_n-2) ) );
+
+#else // this is what we have now...
+
+  setDefaultProblemSize( (m_n-2)*(m_n-2) );
+  setDefaultReps(run_reps);
 
   setItsPerRep( m_tsteps * ( (m_n-2)*(m_n-2 + m_n-2) +
                              (m_n-2)*(m_n-2 + m_n-2) ) );
+#endif
+
+  setActualProblemSize( (m_n-2) * (m_n-2) );
+
   setKernelsPerRep( m_tsteps * 2 );
   setBytesPerRep( m_tsteps * ( (3*sizeof(Real_type ) + 3*sizeof(Real_type )) * m_n * (m_n-2) +
                                (3*sizeof(Real_type ) + 3*sizeof(Real_type )) * m_n * (m_n-2) ) );

--- a/src/polybench/POLYBENCH_ATAX.cpp
+++ b/src/polybench/POLYBENCH_ATAX.cpp
@@ -50,10 +50,22 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
       break;
   }
 
-  setDefaultSize( m_N );
+#if 0 // we want this...
+
+  Index_type N_default = 2100;
+
+  setDefaultProblemSize( N_default * N_default );
+  setDefaultReps(100);
+
+  m_N = std::sqrt( getTargetProblemSize() )+1;
+
+#else  // this is what we have now...
+  setDefaultProblemSize( m_N );
   setDefaultReps(run_reps);
 
-  setProblemSize( m_N );
+#endif
+
+  setActualProblemSize( m_N * m_N ); 
 
   setItsPerRep( m_N + m_N );
   setKernelsPerRep(2);

--- a/src/polybench/POLYBENCH_FDTD_2D.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.cpp
@@ -53,10 +53,27 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
       break;
   }
 
-  setDefaultSize( std::max( (m_nx-1)*m_ny, m_nx*(m_ny-1) ) );
+#if 0 // we want this...
+
+  Index_type nx_default = 1000;
+  Index_type ny_default = 1000;
+
+  setDefaultProblemSize( std::max( (nx_default-1) * ny_default, 
+                                    nx_default * (ny_default-1) ) );
+  setDefaultReps(8);
+
+  m_nx = std::sqrt( getTargetProblemSize() ) + 1;
+  m_ny = m_nx;
+  m_tsteps = 40;
+
+#else // this is what we have now...
+
+  setDefaultProblemSize( std::max( (m_nx-1)*m_ny, m_nx*(m_ny-1) ) );
   setDefaultReps(run_reps);
 
-  setProblemSize( std::max( (m_nx-1)*m_ny, m_nx*(m_ny-1) ) );
+#endif
+
+  setActualProblemSize( std::max( (m_nx-1)*m_ny, m_nx*(m_ny-1) ) ); 
 
   setItsPerRep( m_tsteps * ( m_ny +
                              (m_nx-1)*m_ny +

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
@@ -50,12 +50,25 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
       break;
   }
 
-  setDefaultSize( m_N*m_N );
+#if 0 // we want this...
+
+  Index_type N_default = 1000;
+
+  setDefaultProblemSize( N_default * N_default ); 
+  setDefaultReps(8);
+
+  m_N = std::sqrt( getTargetProblemSize() ) + 1;
+
+#else  // this is what we have now...
+
+  setDefaultProblemSize( m_N*m_N );
   setDefaultReps(run_reps);
 
-  setProblemSize( m_N*m_N );
+#endif
 
-  setItsPerRep( getProblemSize() );
+  setActualProblemSize( m_N * m_N );
+
+  setItsPerRep( m_N*m_N );
   setKernelsPerRep(1);
   setBytesPerRep( (1*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N * m_N );
   setFLOPsPerRep(1 * m_N*m_N*m_N );

--- a/src/polybench/POLYBENCH_GEMM.cpp
+++ b/src/polybench/POLYBENCH_GEMM.cpp
@@ -50,15 +50,35 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
       break;
   }
 
+#if 0 // we want this...
+
+  Index_type ni_default = 1000;
+  Index_type nj_default = 1000;
+  Index_type nk_default = 1200;
+
+  setDefaultProblemSize( ni_default * nj_default ) );
+  setDefaultReps(4);
+
+  m_ni = std::sqrt( getTargetProblemSize() ) + 1;
+  m_nj = m_ni;
+  m_nk = nk_default;
+  
   m_alpha = 0.62;
   m_beta = 1.002;
 
-  setDefaultSize( m_ni * m_nj );
+#else // this is what we have now...
+
+  m_alpha = 0.62;
+  m_beta = 1.002;
+
+  setDefaultProblemSize( m_ni * m_nj );
   setDefaultReps(run_reps);
 
-  setProblemSize( m_ni * m_nj );
+#endif
 
-  setItsPerRep( getProblemSize() );
+  setActualProblemSize( m_ni * m_nj );
+
+  setItsPerRep( m_ni * m_nj );
   setKernelsPerRep(1);
   setBytesPerRep( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * m_ni * m_nj +
                   (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_ni * m_nk +

--- a/src/polybench/POLYBENCH_GEMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMVER.cpp
@@ -50,13 +50,29 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
       break;
   }
 
+#if 0 // we want this...
+
+  Index_type n_default = 1000;
+
+  setDefaultProblemSize( n_default * n_default ) );
+  setDefaultReps(20);
+
+  m_n =  std::sqrt( getTargetProblemSize() ) + 1;
+
   m_alpha = 1.5;
   m_beta = 1.2;
 
-  setDefaultSize( m_n*m_n );
+#else // this is what we have now...
+
+  m_alpha = 1.5;
+  m_beta = 1.2;
+
+  setDefaultProblemSize( m_n*m_n );
   setDefaultReps(run_reps);
 
-  setProblemSize( m_n*m_n );
+#endif
+
+  setActualProblemSize( m_n * m_n );
 
   setItsPerRep( m_n*m_n +
                 m_n*m_n +

--- a/src/polybench/POLYBENCH_GESUMMV.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV.cpp
@@ -50,15 +50,31 @@ POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
       break;
   }
 
+#if 0 // we want this...
+
+  Index_type N_default = 1000;
+
+  setDefaultProblemSize( N_default * N_default );
+  setDefaultReps(120); 
+
+  m_N = std::sqrt( getTargetProblemSize() ) + 1;
+
   m_alpha = 0.62;
   m_beta = 1.002;
 
-  setDefaultSize( m_N );
+#else // this is what we have now...
+
+  m_alpha = 0.62;
+  m_beta = 1.002;
+
+  setDefaultProblemSize( m_N * m_N );
   setDefaultReps(run_reps);
 
-  setProblemSize( m_N );
+#endif
 
-  setItsPerRep( getProblemSize() );
+  setActualProblemSize( m_N * m_N );
+
+  setItsPerRep( m_N );
   setKernelsPerRep(1);
   setBytesPerRep( (2*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N +
                   (0*sizeof(Real_type ) + 2*sizeof(Real_type )) * m_N * m_N );

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -11,6 +11,7 @@
 #include "RAJA/RAJA.hpp"
 #include "common/DataUtils.hpp"
 
+#include <cmath>
 
 namespace rajaperf
 {
@@ -67,20 +68,38 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
       break;
   }
 
-  setDefaultSize( (m_N-2) * (m_N-2) * (m_N-2) );
+#if 0 // we want this...
+
+  Index_type N_default = 100;
+
+  setDefaultProblemSize( (N_default-2)*(N_default-2)*(N_default-2) );
+  setDefaultReps(10);
+
+  m_N = std::cbrt( getTargetProblemSize() ) + 1;
+  m_tsteps = 20;
+  m_factor = 0.0001;
+
+#else // this is what we have now...
+
+  setDefaultProblemSize( (m_N-2) * (m_N-2) * (m_N-2) );
   setDefaultReps(run_reps);
 
-  setProblemSize( (m_N-2) * (m_N-2) * (m_N-2) );
+#endif
 
-  setItsPerRep( m_tsteps * ( 2 * getProblemSize() ) );
+  setActualProblemSize( (m_N-2) * (m_N-2) * (m_N-2) );
+
+  setItsPerRep( m_tsteps * ( 2 * getActualProblemSize() ) );
   setKernelsPerRep( m_tsteps * 2 );
-  setBytesPerRep( m_tsteps * ( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * (m_N-2) * (m_N-2) * (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * (m_N * m_N * m_N - 12*(m_N-2) - 8) +
-
-                               (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * (m_N-2) * (m_N-2) * (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * (m_N * m_N * m_N - 12*(m_N-2) - 8) ) );
-  setFLOPsPerRep( m_tsteps * ( 15 * (m_N-2)*(m_N-2)*(m_N-2) +
-                               15 * (m_N-2)*(m_N-2)*(m_N-2) ) );
+  setBytesPerRep( m_tsteps * ( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) *
+                               (m_N-2) * (m_N-2) * (m_N-2) + 
+                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) *
+                               (m_N * m_N * m_N - 12*(m_N-2) - 8) +
+                               (1*sizeof(Real_type ) + 0*sizeof(Real_type )) *
+                               (m_N-2) * (m_N-2) * (m_N-2) +
+                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) *
+                               (m_N * m_N * m_N - 12*(m_N-2) - 8) ) );
+  setFLOPsPerRep( m_tsteps * ( 15 * (m_N-2) * (m_N-2) * (m_N-2) +
+                               15 * (m_N-2) * (m_N-2) * (m_N-2) ) );
 
   setUsesFeature(Kernel);
 

--- a/src/polybench/POLYBENCH_JACOBI_1D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.cpp
@@ -56,18 +56,35 @@ POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
       break;
   }
 
-  setDefaultSize( m_N-2 );
+#if 0 // we want this...
+
+  Index_type N_default = 1000000;
+
+  setDefaultProblemSize( N_default-2 );
+  setDefaultReps(20);
+ 
+  m_N = getTargetProblemSize(); 
+  m_tsteps = 16;
+
+#else // this is what we have now...
+
+  setDefaultProblemSize( m_N-2 );
   setDefaultReps(run_reps);
 
-  setProblemSize( m_N-2 );
+#endif
 
-  setItsPerRep( m_tsteps * ( 2 * getProblemSize() ) );
+  setActualProblemSize( m_N-2 );
+
+  setItsPerRep( m_tsteps * ( 2 * getActualProblemSize() ) );
   setKernelsPerRep(m_tsteps * 2);
-  setBytesPerRep( m_tsteps * ( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N +
-
-                               (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N ) );
+  setBytesPerRep( m_tsteps * ( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * 
+                               (m_N-2) + 
+                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * 
+                               m_N +
+                               (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * 
+                               (m_N-2) +
+                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * 
+                               m_N ) );
   setFLOPsPerRep( m_tsteps * ( 3 * (m_N-2) +
                                3 * (m_N-2) ) );
 

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -56,18 +56,35 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
       break;
   }
 
-  setDefaultSize( (m_N-2) * (m_N-2) );
+#if 0 // we want this...
+
+  Index_type N_default = 1000;
+
+  setDefaultProblemSize( N_default * N_default );
+  setDefaultReps(10);
+
+  m_N = std::sqrt( getTargetProblemSize() ) + 1;
+  m_tsteps = 40;
+
+#else // this is what we have now...
+
+  setDefaultProblemSize( (m_N-2) * (m_N-2) );
   setDefaultReps(run_reps);
 
-  setProblemSize( (m_N-2) * (m_N-2) );
+#endif
 
-  setItsPerRep( m_tsteps * (2 * getProblemSize()) );
+  setActualProblemSize( (m_N-2) * (m_N-2) );
+
+  setItsPerRep( m_tsteps * (2 * (m_N-2) * (m_N-2)) );
   setKernelsPerRep(2);
-  setBytesPerRep( m_tsteps * ( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * (m_N-2) * (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * (m_N * m_N - 4) +
-
-                               (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * (m_N-2) * (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * (m_N * m_N  - 4) ) );
+  setBytesPerRep( m_tsteps * ( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) *
+                               (m_N-2) * (m_N-2) +
+                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) *
+                               (m_N * m_N - 4) +
+                               (1*sizeof(Real_type ) + 0*sizeof(Real_type )) *
+                               (m_N-2) * (m_N-2) +
+                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) *
+                               (m_N * m_N  - 4) ) );
   setFLOPsPerRep( m_tsteps * ( 5 * (m_N-2)*(m_N-2) +
                                5 * (m_N -2)*(m_N-2) ) );
 

--- a/src/polybench/POLYBENCH_MVT.cpp
+++ b/src/polybench/POLYBENCH_MVT.cpp
@@ -50,16 +50,28 @@ POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
       break;
   }
 
-  setDefaultSize( m_N );
+#if 0 // we want this...
+
+  Index_type N_default = 1000;
+
+  setDefaultProblemSize( N_default * N_default );
+  setDefaultReps(16);
+
+  m_N = std::sqrt( getTargetProblemSize() ) + 1;
+
+#else // this is what we have now...
+
+  setDefaultProblemSize( m_N );
   setDefaultReps(run_reps);
 
-  setProblemSize( m_N );
+#endif
 
-  setItsPerRep( 2 * getProblemSize() );
+  setActualProblemSize( m_N * m_N );
+
+  setItsPerRep( 2 * m_N );
   setKernelsPerRep(2);
   setBytesPerRep( (1*sizeof(Real_type ) + 2*sizeof(Real_type )) * m_N +
                   (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N * m_N +
-
                   (1*sizeof(Real_type ) + 2*sizeof(Real_type )) * m_N +
                   (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N * m_N );
   setFLOPsPerRep(2 * m_N*m_N +

--- a/src/stream/ADD-Cuda.cpp
+++ b/src/stream/ADD-Cuda.cpp
@@ -52,7 +52,7 @@ void ADD::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   ADD_DATA_SETUP;
 

--- a/src/stream/ADD-Hip.cpp
+++ b/src/stream/ADD-Hip.cpp
@@ -52,7 +52,7 @@ void ADD::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   ADD_DATA_SETUP;
 

--- a/src/stream/ADD-OMP.cpp
+++ b/src/stream/ADD-OMP.cpp
@@ -24,7 +24,7 @@ void ADD::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   ADD_DATA_SETUP;
 

--- a/src/stream/ADD-OMPTarget.cpp
+++ b/src/stream/ADD-OMPTarget.cpp
@@ -44,7 +44,7 @@ void ADD::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   ADD_DATA_SETUP;
 

--- a/src/stream/ADD-Seq.cpp
+++ b/src/stream/ADD-Seq.cpp
@@ -22,7 +22,7 @@ void ADD::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   ADD_DATA_SETUP;
 

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -21,15 +21,16 @@ namespace stream
 ADD::ADD(const RunParams& params)
   : KernelBase(rajaperf::Stream_ADD, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(1000);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(1 * getRunSize());
+  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) * 
+                  getActualProblemSize() );
+  setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature(Forall);
 
@@ -59,14 +60,14 @@ ADD::~ADD()
 
 void ADD::setUp(VariantID vid)
 {
-  allocAndInitData(m_a, getRunSize(), vid);
-  allocAndInitData(m_b, getRunSize(), vid);
-  allocAndInitDataConst(m_c, getRunSize(), 0.0, vid);
+  allocAndInitData(m_a, getActualProblemSize(), vid);
+  allocAndInitData(m_b, getActualProblemSize(), vid);
+  allocAndInitDataConst(m_c, getActualProblemSize(), 0.0, vid);
 }
 
 void ADD::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_c, getRunSize());
+  checksum[vid] += calcChecksum(m_c, getActualProblemSize());
 }
 
 void ADD::tearDown(VariantID vid)

--- a/src/stream/COPY-Cuda.cpp
+++ b/src/stream/COPY-Cuda.cpp
@@ -50,7 +50,7 @@ void COPY::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   COPY_DATA_SETUP;
 

--- a/src/stream/COPY-Hip.cpp
+++ b/src/stream/COPY-Hip.cpp
@@ -50,7 +50,7 @@ void COPY::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   COPY_DATA_SETUP;
 

--- a/src/stream/COPY-OMP.cpp
+++ b/src/stream/COPY-OMP.cpp
@@ -24,7 +24,7 @@ void COPY::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   COPY_DATA_SETUP;
 

--- a/src/stream/COPY-OMPTarget.cpp
+++ b/src/stream/COPY-OMPTarget.cpp
@@ -43,7 +43,7 @@ void COPY::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   COPY_DATA_SETUP;
 

--- a/src/stream/COPY-Seq.cpp
+++ b/src/stream/COPY-Seq.cpp
@@ -22,7 +22,7 @@ void COPY::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   COPY_DATA_SETUP;
 

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -21,14 +21,15 @@ namespace stream
 COPY::COPY(const RunParams& params)
   : KernelBase(rajaperf::Stream_COPY, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(1800);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getRunSize() );
+  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * 
+                  getActualProblemSize() );
   setFLOPsPerRep(0);
 
   setUsesFeature( Forall );
@@ -59,13 +60,13 @@ COPY::~COPY()
 
 void COPY::setUp(VariantID vid)
 {
-  allocAndInitData(m_a, getRunSize(), vid);
-  allocAndInitDataConst(m_c, getRunSize(), 0.0, vid);
+  allocAndInitData(m_a, getActualProblemSize(), vid);
+  allocAndInitDataConst(m_c, getActualProblemSize(), 0.0, vid);
 }
 
 void COPY::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_c, getRunSize());
+  checksum[vid] += calcChecksum(m_c, getActualProblemSize());
 }
 
 void COPY::tearDown(VariantID vid)

--- a/src/stream/DOT-Cuda.cpp
+++ b/src/stream/DOT-Cuda.cpp
@@ -74,7 +74,7 @@ void DOT::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DOT_DATA_SETUP;
 

--- a/src/stream/DOT-Hip.cpp
+++ b/src/stream/DOT-Hip.cpp
@@ -75,7 +75,7 @@ void DOT::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DOT_DATA_SETUP;
 

--- a/src/stream/DOT-OMP.cpp
+++ b/src/stream/DOT-OMP.cpp
@@ -24,7 +24,7 @@ void DOT::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DOT_DATA_SETUP;
 

--- a/src/stream/DOT-OMPTarget.cpp
+++ b/src/stream/DOT-OMPTarget.cpp
@@ -41,7 +41,7 @@ void DOT::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DOT_DATA_SETUP;
 

--- a/src/stream/DOT-Seq.cpp
+++ b/src/stream/DOT-Seq.cpp
@@ -22,7 +22,7 @@ void DOT::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   DOT_DATA_SETUP;
 

--- a/src/stream/DOT.cpp
+++ b/src/stream/DOT.cpp
@@ -21,16 +21,17 @@ namespace stream
 DOT::DOT(const RunParams& params)
   : KernelBase(rajaperf::Stream_DOT, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(2000);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) +
-                  (0*sizeof(Real_type) + 2*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(2 * getRunSize());
+                  (0*sizeof(Real_type) + 2*sizeof(Real_type)) * 
+                  getActualProblemSize() );
+  setFLOPsPerRep(2 * getActualProblemSize());
 
   setUsesFeature( Forall );
   setUsesFeature( Reduction );
@@ -59,8 +60,8 @@ DOT::~DOT()
 
 void DOT::setUp(VariantID vid)
 {
-  allocAndInitData(m_a, getRunSize(), vid);
-  allocAndInitData(m_b, getRunSize(), vid);
+  allocAndInitData(m_a, getActualProblemSize(), vid);
+  allocAndInitData(m_b, getActualProblemSize(), vid);
 
   m_dot = 0.0;
   m_dot_init = 0.0;

--- a/src/stream/MUL-Cuda.cpp
+++ b/src/stream/MUL-Cuda.cpp
@@ -49,7 +49,7 @@ void MUL::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   MUL_DATA_SETUP;
 

--- a/src/stream/MUL-Hip.cpp
+++ b/src/stream/MUL-Hip.cpp
@@ -49,7 +49,7 @@ void MUL::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   MUL_DATA_SETUP;
 

--- a/src/stream/MUL-OMP.cpp
+++ b/src/stream/MUL-OMP.cpp
@@ -24,7 +24,7 @@ void MUL::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   MUL_DATA_SETUP;
 

--- a/src/stream/MUL-OMPTarget.cpp
+++ b/src/stream/MUL-OMPTarget.cpp
@@ -42,7 +42,7 @@ void MUL::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   MUL_DATA_SETUP;
 

--- a/src/stream/MUL-Seq.cpp
+++ b/src/stream/MUL-Seq.cpp
@@ -22,7 +22,7 @@ void MUL::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   MUL_DATA_SETUP;
 

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -21,15 +21,16 @@ namespace stream
 MUL::MUL(const RunParams& params)
   : KernelBase(rajaperf::Stream_MUL, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(1800);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(1 * getRunSize());
+  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * 
+                  getActualProblemSize() );
+  setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature( Forall );
 
@@ -59,14 +60,14 @@ MUL::~MUL()
 
 void MUL::setUp(VariantID vid)
 {
-  allocAndInitDataConst(m_b, getRunSize(), 0.0, vid);
-  allocAndInitData(m_c, getRunSize(), vid);
+  allocAndInitDataConst(m_b, getActualProblemSize(), 0.0, vid);
+  allocAndInitData(m_c, getActualProblemSize(), vid);
   initData(m_alpha, vid);
 }
 
 void MUL::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_b, getRunSize());
+  checksum[vid] += calcChecksum(m_b, getActualProblemSize());
 }
 
 void MUL::tearDown(VariantID vid)

--- a/src/stream/TRIAD-Cuda.cpp
+++ b/src/stream/TRIAD-Cuda.cpp
@@ -52,7 +52,7 @@ void TRIAD::runCudaVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   TRIAD_DATA_SETUP;
 

--- a/src/stream/TRIAD-Hip.cpp
+++ b/src/stream/TRIAD-Hip.cpp
@@ -52,7 +52,7 @@ void TRIAD::runHipVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   TRIAD_DATA_SETUP;
 

--- a/src/stream/TRIAD-OMP.cpp
+++ b/src/stream/TRIAD-OMP.cpp
@@ -24,7 +24,7 @@ void TRIAD::runOpenMPVariant(VariantID vid)
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   TRIAD_DATA_SETUP;
 

--- a/src/stream/TRIAD-OMPTarget.cpp
+++ b/src/stream/TRIAD-OMPTarget.cpp
@@ -44,7 +44,7 @@ void TRIAD::runOpenMPTargetVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   TRIAD_DATA_SETUP;
 

--- a/src/stream/TRIAD-Seq.cpp
+++ b/src/stream/TRIAD-Seq.cpp
@@ -22,7 +22,7 @@ void TRIAD::runSeqVariant(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getRunSize();
+  const Index_type iend = getActualProblemSize();
 
   TRIAD_DATA_SETUP;
 

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -21,15 +21,16 @@ namespace stream
 TRIAD::TRIAD(const RunParams& params)
   : KernelBase(rajaperf::Stream_TRIAD, params)
 {
-  setDefaultSize(1000000);
+  setDefaultProblemSize(1000000);
   setDefaultReps(1000);
 
-  setProblemSize( getRunSize() );
+  setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getProblemSize() );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getRunSize() );
-  setFLOPsPerRep(2 * getRunSize());
+  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) * 
+                  getActualProblemSize() );
+  setFLOPsPerRep(2 * getActualProblemSize());
 
   setUsesFeature( Forall );
 
@@ -59,15 +60,15 @@ TRIAD::~TRIAD()
 
 void TRIAD::setUp(VariantID vid)
 {
-  allocAndInitDataConst(m_a, getRunSize(), 0.0, vid);
-  allocAndInitData(m_b, getRunSize(), vid);
-  allocAndInitData(m_c, getRunSize(), vid);
+  allocAndInitDataConst(m_a, getActualProblemSize(), 0.0, vid);
+  allocAndInitData(m_b, getActualProblemSize(), vid);
+  allocAndInitData(m_c, getActualProblemSize(), vid);
   initData(m_alpha, vid);
 }
 
 void TRIAD::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_a, getRunSize());
+  checksum[vid] += calcChecksum(m_a, getActualProblemSize());
 }
 
 void TRIAD::tearDown(VariantID vid)


### PR DESCRIPTION
This PR adds a variation of matrix-matrix multiplication using RAJA Teams and shared memory. 

Running the kernel variants gave me this (nvcc10-gcc7.3.1) 
```
Speedup Report (T_ref/T_var): ref var = Base_Seq  ,  ,  ,  ,  ,  ,  ,  ,  ,  ,                                                                                                                
Kernel                , Base_Seq , Lambda_Seq , RAJA_Seq , Base_OpenMP , Lambda_OpenMP , RAJA_OpenMP , Base_CUDA , Lambda_CUDA , RAJA_CUDA , RAJA_WORKGROUP_CUDA                              
Basic_MAT_MAT_SHARED  ,    1.000 ,      0.955 ,    0.945 ,      21.366 ,        18.798 ,      17.682 ,   327.116 ,     316.699 ,   348.101 ,             Not run    
```