### PR TITLE
Use caliper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.pyc
 *.o
 *.exe
+*.swp
+*.swo
 build*/
 install*/

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,8 @@
 	url = ssh://git@cz-bitbucket.llnl.gov:7999/raja/polybench-raja.git
 [submodule "blt"]
 	path = blt
-	url = https://github.com/LLNL/blt.git
+   url = https://github.com/LLNL/blt.git
+   ignore = dirty
 [submodule "tpl/RAJA"]
 	path = tpl/RAJA
 	url = https://github.com/LLNL/RAJA.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,13 @@ add_subdirectory(tpl/RAJA)
 get_property(RAJA_INCLUDE_DIRS DIRECTORY tpl/RAJA PROPERTY INCLUDE_DIRECTORIES)
 include_directories(${RAJA_INCLUDE_DIRS})
 
+# the following only for diagnostic purposes
+get_cmake_property(_variableNames VARIABLES)
+list (SORT _variableNames)
+foreach (_variableName ${_variableNames})
+    message(STATUS "${_variableName}=${${_variableName}}")
+endforeach()
+
 
 #
 # Setup variables to pass to Perf suite
@@ -96,6 +103,14 @@ if (ENABLE_CALIPER)
    set(RAJAPERF_USE_CALIPER on)
    add_definitions(-DRAJAPERF_USE_CALIPER)
    message(STATUS "Using Caliper")
+   find_package(adiak REQUIRED)
+   list(APPEND RAJA_PERFSUITE_DEPENDS adiak)
+   message(STATUS "Using Adiak")
+   if (ENABLE_CUDA)
+      # Adiak will propagate -pthread from spectrum mpi from a spack install of Caliper with +mpi; and needs to be handled even if RAJAPerf is non MPI program
+      # We should delegate to BLT to handle unguarded -pthread from any dependencies, but currently BLT doesn't
+      set_target_properties(adiak PROPERTIES INTERFACE_COMPILE_OPTIONS "$<$<NOT:$<COMPILE_LANGUAGE:CUDA>>:-pthread>;$<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=-pthread>")
+   endif ()
 endif ()
 
 set(RAJAPERF_BUILD_SYSTYPE $ENV{SYS_TYPE})
@@ -108,7 +123,7 @@ if (ENABLE_CUDA)
   set(RAJAPERF_COMPILER "${CUDA_NVCC_EXECUTABLE}")
   list(APPEND RAJAPERF_COMPILER ${CMAKE_CXX_COMPILER})
   set(RAJAPERF_COMPILER_OPTIONS "${CUDA_NVCC_FLAGS}")
-elseif (ENABLE_HIP)
+  elseif (ENABLE_HIP)
   set(RAJAPERF_COMPILER "${HIP_HIPCC_EXECUTABLE}")
   list(APPEND RAJAPERF_COMPILER ${CMAKE_CXX_COMPILER})
   set(RAJAPERF_COMPILER_OPTIONS "${HIP_HIPCC_FLAGS}")
@@ -119,9 +134,11 @@ else()
   list(APPEND RAJAPERF_COMPILER_OPTIONS ${CMAKE_CXX_FLAGS})
 endif()
 
+#configure_file(${CMAKE_SOURCE_DIR}/src/rajaperf_config.hpp.in
+#  ${CMAKE_CURRENT_BINARY_DIR}/bin/rajaperf_config.hpp)
+message(STATUS "PROJECT_BINARY_DIR ${PROJECT_BINARY_DIR}")
 configure_file(${CMAKE_SOURCE_DIR}/src/rajaperf_config.hpp.in
-  ${CMAKE_CURRENT_BINARY_DIR}/bin/rajaperf_config.hpp)
-
+   ${PROJECT_BINARY_DIR}/include/rajaperf_config.hpp)
 # Make sure RAJA flag propagate
 set (CUDA_NVCC_FLAGS ${RAJA_NVCC_FLAGS})
 set (HIP_HIPCC_FLAGS ${RAJA_HIPCC_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,19 @@ if (ENABLE_HIP)
   list(APPEND RAJA_PERFSUITE_DEPENDS hip)
 endif()
 
+#
+# Are we using Caliper
+#
+set(ENABLE_CALIPER off CACHE BOOL "")
+set(RAJAPERF_USE_CALIPER off)
+if (ENABLE_CALIPER)
+   find_package(caliper REQUIRED)
+   list(APPEND RAJA_PERFSUITE_DEPENDS caliper)
+   set(RAJAPERF_USE_CALIPER on)
+   add_definitions(-DRAJAPERF_USE_CALIPER)
+   message(STATUS "Using Caliper")
+endif ()
+
 set(RAJAPERF_BUILD_SYSTYPE $ENV{SYS_TYPE})
 set(RAJAPERF_BUILD_HOST $ENV{HOSTNAME})
 

--- a/scripts/lc-builds/blueos_nvcc10_caliper25_gcc8.3.1.sh
+++ b/scripts/lc-builds/blueos_nvcc10_caliper25_gcc8.3.1.sh
@@ -19,11 +19,13 @@ module load caliper-2.5.0-gcc-8.3.1-cu3vy3k
 
 CALIPER_PREFIX=/usr/WS2/holger/spack/opt/spack/linux-rhel7-power9le/gcc-8.3.1/caliper-2.5.0-cu3vy3kjwjerpdm6xis2kauhz4s6wto2/
 
+ADIAK_PREFIX=/usr/WS2/holger/spack/opt/spack/linux-rhel7-power9le/gcc-8.3.1/adiak-0.2.1-hsv444o7ofb6s2znkvvnh6hcmr774g73/
+
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/gcc/gcc-8.3.1/bin/g++ \
   -C ${RAJA_HOSTCONFIG} \
-  -DCMAKE_PREFIX_PATH="${CALIPER_PREFIX}/share/cmake/caliper" \
+  -DCMAKE_PREFIX_PATH="${CALIPER_PREFIX}/share/cmake/caliper;${ADIAK_PREFIX}/lib/cmake/adiak" \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \
   -DCMAKE_CUDA_FLAGS="-Xcompiler -mno-float128" \

--- a/scripts/lc-builds/blueos_nvcc10_caliper25_gcc8.3.1.sh
+++ b/scripts/lc-builds/blueos_nvcc10_caliper25_gcc8.3.1.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+# and RAJA Performance Suite project contributors.
+# See the RAJAPerf/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+#################################################################################
+
+BUILD_SUFFIX=lc_blueos-nvcc10-caliper-gcc8.3.1
+RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/nvcc_gcc_X.cmake
+
+rm -rf build_${BUILD_SUFFIX} >/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+module load cmake/3.14.5
+module load caliper-2.5.0-gcc-8.3.1-cu3vy3k
+
+CALIPER_PREFIX=/usr/WS2/holger/spack/opt/spack/linux-rhel7-power9le/gcc-8.3.1/caliper-2.5.0-cu3vy3kjwjerpdm6xis2kauhz4s6wto2/
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/gcc/gcc-8.3.1/bin/g++ \
+  -C ${RAJA_HOSTCONFIG} \
+  -DCMAKE_PREFIX_PATH="${CALIPER_PREFIX}/share/cmake/caliper" \
+  -DENABLE_OPENMP=On \
+  -DENABLE_CUDA=On \
+  -DCMAKE_CUDA_FLAGS="-Xcompiler -mno-float128" \
+  -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-10.2.89 \
+  -DCMAKE_CUDA_COMPILER=/usr/tce/packages/cuda/cuda-10.1.243/bin/nvcc \
+  -DCUDA_ARCH=sm_70 \
+  -DENABLE_CALIPER=On \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
+  -DCMAKE_VERBOSE_MAKEFILE=On \
+  "$@" \
+  ..

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,9 @@ include_directories(.)
 
 if(RAJAPERF_USE_CALIPER)
    message(STATUS "Caliper includes : ${caliper_INCLUDE_DIR}")
+   message(STATUS "Adiak includes : ${adiak_INCLUDE_DIRS}")
    include_directories(${caliper_INCLUDE_DIR})
+   include_directories(${adiak_INCLUDE_DIRS})
 endif ()
 
 add_subdirectory(common)
@@ -189,8 +191,12 @@ else()
 blt_add_executable(
   NAME raja-perf.exe
   SOURCES RAJAPerfSuiteDriver.cpp
+  INCLUDES ${PROJECT_BINARY_DIR}/include
   DEPENDS_ON ${RAJA_PERFSUITE_EXECUTABLE_DEPENDS}
   )
 endif()
 
+
+message(STATUS "RAJA_VERSION_MAJORPP ${RAJA_VERSION_MAJOR}")
+blt_print_target_properties(TARGET raja-perf.exe)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,7 +196,5 @@ blt_add_executable(
   )
 endif()
 
-
-message(STATUS "RAJA_VERSION_MAJORPP ${RAJA_VERSION_MAJOR}")
-blt_print_target_properties(TARGET raja-perf.exe)
+#blt_print_target_properties(TARGET raja-perf.exe)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 include_directories(.)
 
+if(RAJAPERF_USE_CALIPER)
+   message(STATUS "Caliper includes : ${caliper_INCLUDE_DIR}")
+   include_directories(${caliper_INCLUDE_DIR})
+endif ()
+
 add_subdirectory(common)
 add_subdirectory(apps)
 add_subdirectory(basic)
@@ -187,3 +192,5 @@ blt_add_executable(
   DEPENDS_ON ${RAJA_PERFSUITE_EXECUTABLE_DEPENDS}
   )
 endif()
+
+

--- a/src/RAJAPerfSuiteDriver.cpp
+++ b/src/RAJAPerfSuiteDriver.cpp
@@ -10,6 +10,12 @@
 
 #include <iostream>
 
+#ifdef RAJAPERF_USE_CALIPER
+#include <caliper/cali.h>
+#include <caliper/cali-manager.h>
+#include <adiak.hpp>
+#endif
+
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
@@ -30,6 +36,5 @@ int main( int argc, char** argv )
   executor.outputRunData();
 
   std::cout << "\n\nDONE!!!...." << std::endl; 
-
   return 0;
 }

--- a/src/basic/ATOMIC_PI-OMP.cpp
+++ b/src/basic/ATOMIC_PI-OMP.cpp
@@ -31,7 +31,11 @@ void ATOMIC_PI::runOpenMPVariant(VariantID vid)
   switch ( vid ) {
 
     case Base_OpenMP : {
-
+#ifdef RAJAPERF_USE_CALIPER
+      printf("Caliper marking ATOMIC_PI:BASE_OpenMP\n");                  
+      CALI_MARK_BEGIN("ATOMIC_PI:BASE_OpenMP");
+#endif
+      printf("start ATOMIC_PI:BASE_OpenMP\n");
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
@@ -46,7 +50,9 @@ void ATOMIC_PI::runOpenMPVariant(VariantID vid)
 
       }
       stopTimer();
-
+#ifdef RAJAPERF_USE_CALIPER
+      CALI_MARK_END("ATOMIC_PI:BASE_OpenMP");
+#endif
       break;
     }
 

--- a/src/basic/ATOMIC_PI-OMP.cpp
+++ b/src/basic/ATOMIC_PI-OMP.cpp
@@ -31,11 +31,6 @@ void ATOMIC_PI::runOpenMPVariant(VariantID vid)
   switch ( vid ) {
 
     case Base_OpenMP : {
-#ifdef RAJAPERF_USE_CALIPER
-      printf("Caliper marking ATOMIC_PI:BASE_OpenMP\n");                  
-      CALI_MARK_BEGIN("ATOMIC_PI:BASE_OpenMP");
-#endif
-      printf("start ATOMIC_PI:BASE_OpenMP\n");
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
@@ -50,9 +45,6 @@ void ATOMIC_PI::runOpenMPVariant(VariantID vid)
 
       }
       stopTimer();
-#ifdef RAJAPERF_USE_CALIPER
-      CALI_MARK_END("ATOMIC_PI:BASE_OpenMP");
-#endif
       break;
     }
 
@@ -76,7 +68,6 @@ void ATOMIC_PI::runOpenMPVariant(VariantID vid)
 
       }
       stopTimer();
-
       break;
     }
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -14,5 +14,6 @@ blt_add_library(
           OutputUtils.cpp 
           RAJAPerfSuite.cpp 
           RunParams.cpp
+  INCLUDES ${PROJECT_BINARY_DIR}/include/
   DEPENDS_ON ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -52,12 +52,21 @@ Executor::Executor(int argc, char** argv)
    adiak::value("cmake_build_type",cc.cmake_build_type);
    adiak::value("compiler",cc.compiler);
    adiak::value("compiler_flags",cc.compiler_flags);
-   adiak::value("compiler_flags_release",cc.compiler_flags_release);
-   adiak::value("cuda_compiler_version",cc.cuda_compiler_version);
-   adiak::value("cuda_flags",cc.cuda_flags);
-   adiak::value("cuda_flags_release",cc.cuda_flags_release);
-   adiak::value("systype_build",cc.systype_build);
-   adiak::value("machine_build",cc.machine_build);
+   if(!strcmp(cc.cmake_build_type,"Release"))
+      adiak::value("compiler_flags_release",cc.compiler_flags_release);
+   else if(!strcmp(cc.cmake_build_type,"RelWithDebInfo"))
+      adiak::value("compiler_flags_relwithdebinfo",cc.compiler_flags_relwithdebinfo);
+   else if(!strcmp(cc.cmake_build_type,"Debug"))
+      adiak::value("compiler_flags_debug",cc.compiler_flags_debug);
+   if(strlen(cc.cuda_compiler_version) > 0) {
+      adiak::value("cuda_compiler_version",cc.cuda_compiler_version);
+      adiak::value("cuda_flags",cc.cuda_flags);
+      adiak::value("cuda_flags_release",cc.cuda_flags_release);
+   }
+   if(strlen(cc.systype_build) > 0)
+      adiak::value("systype_build",cc.systype_build);
+   if(strlen(cc.machine_build) > 0)
+      adiak::value("machine_build",cc.machine_build);
 #endif
 }
 

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -36,17 +36,23 @@ Executor::Executor(int argc, char** argv)
     reference_vid(NumVariants)
 {
 #ifdef RAJAPERF_USE_CALIPER
+   struct configuration  cc;
    adiak::init(NULL);
    adiak::user();
    adiak::launchdate();
    adiak::libraries();
    adiak::cmdline();
    adiak::clustername();
-   struct configuration  cc;
    adiak::value("perfsuite_version",cc.perfsuite_version);
    adiak::value("raja_version",cc.raja_version);
    adiak::value("cmake_build_type",cc.cmake_build_type);
+
    adiak::value("compiler",cc.compiler);
+   std::string compiler_str(cc.compiler);
+   std::size_t found = compiler_str.find_last_of("/\\");
+   std::string  compiler_suffix = compiler_str.substr(found+1);
+   adiak::value("compiler_suffix",compiler_suffix.c_str());
+
    adiak::value("compiler_flags",cc.compiler_flags);
    if(!strcmp(cc.cmake_build_type,"Release"))
       adiak::value("compiler_flags_release",cc.compiler_flags_release);
@@ -54,11 +60,13 @@ Executor::Executor(int argc, char** argv)
       adiak::value("compiler_flags_relwithdebinfo",cc.compiler_flags_relwithdebinfo);
    else if(!strcmp(cc.cmake_build_type,"Debug"))
       adiak::value("compiler_flags_debug",cc.compiler_flags_debug);
+
    if(strlen(cc.cuda_compiler_version) > 0) {
       adiak::value("cuda_compiler_version",cc.cuda_compiler_version);
       adiak::value("cuda_flags",cc.cuda_flags);
       adiak::value("cuda_flags_release",cc.cuda_flags_release);
    }
+
    if(strlen(cc.systype_build) > 0)
       adiak::value("systype_build",cc.systype_build);
    if(strlen(cc.machine_build) > 0)

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -27,6 +27,9 @@
 
 #include <unistd.h>
 
+#ifdef RAJAPERF_USE_CALIPER
+#include "rajaperf_config.hpp"
+#endif
 
 namespace rajaperf {
 
@@ -36,6 +39,16 @@ Executor::Executor(int argc, char** argv)
   : run_params(argc, argv),
     reference_vid(NumVariants)
 {
+#ifdef RAJAPERF_USE_CALIPER
+   adiak::init(NULL);
+   adiak::user();
+   adiak::launchdate();
+   adiak::libraries();
+   adiak::cmdline();
+   adiak::clustername();
+   struct configuration  cc;
+   adiak::value("perfsuite_version",cc.perfsuite_version);
+#endif
 }
 
 
@@ -44,6 +57,9 @@ Executor::~Executor()
   for (size_t ik = 0; ik < kernels.size(); ++ik) {
     delete kernels[ik];
   }
+  
+  adiak::fini();
+  //adiak::clean();  // do this at program exit
 }
 
 
@@ -375,7 +391,13 @@ void Executor::runSuite()
       cout << getVariantName(vid) << " variant" << endl;
     }
     if ( warmup_kernel->hasVariantToRun(vid) ) {
+#ifdef RAJAPERF_USE_CALIPER
+      warmup_kernel->caliperOff();
+#endif
       warmup_kernel->execute(vid);
+#ifdef RAJAPERF_USE_CALIPER
+      warmup_kernel->caliperOn();
+#endif
     }
   }
 

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -27,10 +27,6 @@
 
 #include <unistd.h>
 
-#ifdef RAJAPERF_USE_CALIPER
-#include "rajaperf_config.hpp"
-#endif
-
 namespace rajaperf {
 
 using namespace std;
@@ -296,6 +292,9 @@ void Executor::setupSuite()
       for (VIDset::iterator vid = run_var.begin();
            vid != run_var.end(); ++vid) {
         variant_ids.push_back( *vid );
+#ifdef RAJAPERF_USE_CALIPER
+        KernelBase::setCaliperMgrVariant(*vid);
+#endif
       }
 
       //
@@ -456,7 +455,10 @@ void Executor::runSuite()
     } // loop over kernels
 
   } // loop over passes through suite
-
+#ifdef RAJAPERF_USE_CALIPER
+  // Flush Caliper data
+  KernelBase::setCaliperMgrFlush();
+#endif
 }
 
 void Executor::outputRunData()

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -48,6 +48,16 @@ Executor::Executor(int argc, char** argv)
    adiak::clustername();
    struct configuration  cc;
    adiak::value("perfsuite_version",cc.perfsuite_version);
+   adiak::value("raja_version",cc.raja_version);
+   adiak::value("cmake_build_type",cc.cmake_build_type);
+   adiak::value("compiler",cc.compiler);
+   adiak::value("compiler_flags",cc.compiler_flags);
+   adiak::value("compiler_flags_release",cc.compiler_flags_release);
+   adiak::value("cuda_compiler_version",cc.cuda_compiler_version);
+   adiak::value("cuda_flags",cc.cuda_flags);
+   adiak::value("cuda_flags_release",cc.cuda_flags_release);
+   adiak::value("systype_build",cc.systype_build);
+   adiak::value("machine_build",cc.machine_build);
 #endif
 }
 

--- a/src/common/Executor.hpp
+++ b/src/common/Executor.hpp
@@ -12,6 +12,10 @@
 #include "common/RAJAPerfSuite.hpp"
 #include "common/RunParams.hpp"
 
+#ifdef RAJAPERF_USE_CALIPER
+#include "rajaperf_config.hpp"
+#endif
+
 #include <iosfwd>
 #include <utility>
 #include <set>
@@ -76,6 +80,7 @@ private:
   std::vector<VariantID>   variant_ids;
 
   VariantID reference_vid;
+
 };
 
 }  // closing brace for rajaperf namespace

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -92,24 +92,9 @@ void KernelBase::runKernel(VariantID vid)
     return;
   }
 
-
 #ifdef RAJAPERF_USE_CALIPER
-  cali::ConfigManager *mgr=NULL; 
   if(doCaliperTiming) {
-      if(!mgr) {
-         mgr=new(cali::ConfigManager); 
-         std::string kernel  = getName();
-         std::string variant = getVariantName(running_variant);
-         std::string kstr = kernel + "." + variant; 
-         std::string profile = "spot(output=" + kstr + ".cali)"; 
-         mgr->add(profile.c_str()); 
-         if (mgr->error()) 
-           std::cerr << "Caliper error: " << mgr->error_msg() << std::endl; 
-         adiak::value("kernel",kernel.c_str());
-         adiak::value("variant",variant.c_str());
-         adiak::value("kernelvariant",kstr.c_str());
-         mgr->start(); 
-      }
+    KernelBase::setCaliperMgrStart(vid);
   }
 #endif
    
@@ -170,14 +155,9 @@ void KernelBase::runKernel(VariantID vid)
     }
 
   }
-
 #ifdef RAJAPERF_USE_CALIPER
   if(doCaliperTiming) {
-     if(mgr) {
-      mgr->flush();
-      delete(mgr);
-      mgr=NULL;
-     }
+    setCaliperMgrStop(vid); 
   }
 #endif
 }
@@ -211,4 +191,8 @@ void KernelBase::print(std::ostream& os) const
   os << std::endl;
 }
 
+// initialize a KernelBase static 
+std::map<rajaperf::VariantID, cali::ConfigManager> KernelBase::mgr;
 }  // closing brace for rajaperf namespace
+
+

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -101,7 +101,7 @@ void KernelBase::runKernel(VariantID vid)
          std::string kernel  = getName();
          std::string variant = getVariantName(running_variant);
          std::string kstr = kernel + "." + variant; 
-         std::string profile = "hatchet-region-profile(output=" + kstr + ".json)"; 
+         std::string profile = "spot(output=" + kstr + ".cali)"; 
          mgr->add(profile.c_str()); 
          if (mgr->error()) 
            std::cerr << "Caliper error: " << mgr->error_msg() << std::endl; 

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -92,6 +92,27 @@ void KernelBase::runKernel(VariantID vid)
     return;
   }
 
+
+#ifdef RAJAPERF_USE_CALIPER
+  cali::ConfigManager *mgr=NULL; 
+  if(doCaliperTiming) {
+      if(!mgr) {
+         mgr=new(cali::ConfigManager); 
+         std::string kernel  = getName();
+         std::string variant = getVariantName(running_variant);
+         std::string kstr = kernel + "." + variant; 
+         std::string profile = "hatchet-region-profile(output=" + kstr + ".json)"; 
+         mgr->add(profile.c_str()); 
+         if (mgr->error()) 
+           std::cerr << "Caliper error: " << mgr->error_msg() << std::endl; 
+         adiak::value("kernel",kernel.c_str());
+         adiak::value("variant",variant.c_str());
+         adiak::value("kernelvariant",kstr.c_str());
+         mgr->start(); 
+      }
+  }
+#endif
+   
   switch ( vid ) {
 
     case Base_Seq :
@@ -149,6 +170,16 @@ void KernelBase::runKernel(VariantID vid)
     }
 
   }
+
+#ifdef RAJAPERF_USE_CALIPER
+  if(doCaliperTiming) {
+     if(mgr) {
+      mgr->flush();
+      delete(mgr);
+      mgr=NULL;
+     }
+  }
+#endif
 }
 
 void KernelBase::print(std::ostream& os) const

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -190,9 +190,10 @@ void KernelBase::print(std::ostream& os) const
   }
   os << std::endl;
 }
-
+#ifdef RAJAPERF_USE_CALIPER
 // initialize a KernelBase static 
 std::map<rajaperf::VariantID, cali::ConfigManager> KernelBase::mgr;
+#endif
 }  // closing brace for rajaperf namespace
 
 

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -20,12 +20,22 @@
 
 #define CALI_START \
     if(doCaliperTiming) { \
-      CALI_MARK_BEGIN("kernel"); \
+      std::string kstr = getName(); \
+      std::string gstr = getGroupName(kstr); \
+      std::string vstr = getVariantName(running_variant); \
+      CALI_MARK_BEGIN(vstr.c_str()); \
+      CALI_MARK_BEGIN(gstr.c_str()); \
+      CALI_MARK_BEGIN(kstr.c_str()); \
     }
 
 #define CALI_STOP \
     if(doCaliperTiming) { \
-      CALI_MARK_END("kernel"); \
+      std::string kstr = getName(); \
+      std::string gstr = getGroupName(kstr); \
+      std::string vstr = getVariantName(running_variant); \
+      CALI_MARK_END(kstr.c_str()); \
+      CALI_MARK_END(gstr.c_str()); \
+      CALI_MARK_END(vstr.c_str()); \
     }
 #else
 #define CALI_START
@@ -104,6 +114,12 @@ public:
       adiak::value("variant",variant.c_str());
       mgr[kv.first].flush(); 
     }
+  }
+
+  std::string getGroupName(const std::string &kname )
+  {
+    std::size_t found = kname.find("_");
+    return kname.substr(0,found);
   }
 
 #endif

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -219,6 +219,7 @@ private:
 #ifdef RAJAPERF_USE_CALIPER
   bool doCaliperTiming = true; // warmup can use this to exclude timing
 // we need a Caliper Manager object per variant
+// we can inline this with c++17
   static std::map<rajaperf::VariantID, cali::ConfigManager> mgr;
 #endif
 };

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -19,6 +19,18 @@
 #ifdef RAJAPERF_USE_CALIPER
 #include <caliper/cali.h>
 #include <caliper/cali-manager.h>
+
+#define CALI_START \
+    std::string kstr = getName() + ":" + getVariantName(running_variant); \
+    CALI_MARK_BEGIN(kstr.c_str());
+
+#define CALI_STOP \
+    std::string kstr = getName() + ":" + getVariantName(running_variant); \
+    CALI_MARK_END(kstr.c_str());
+
+#else
+#define CALI_START
+#define CALI_STOP
 #endif
 
 #include <string>
@@ -81,6 +93,7 @@ public:
       hipDeviceSynchronize();
     }
 #endif
+    CALI_START;
     timer.start(); 
   }
 
@@ -96,7 +109,9 @@ public:
       hipDeviceSynchronize();
     }
 #endif
-    timer.stop(); recordExecTime(); 
+    timer.stop(); 
+    CALI_STOP;
+    recordExecTime(); 
   }
 
   void resetTimer() { timer.reset(); }

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -21,6 +21,7 @@
 #include <caliper/cali-manager.h>
 #include <adiak.hpp>
 
+#if 0
 #define CALI_START \
     if(doCaliperTiming) { \
       std::string kstr = getName() + "." + getVariantName(running_variant); \
@@ -32,7 +33,16 @@
       std::string kstr = getName() + "." + getVariantName(running_variant); \
       CALI_MARK_END(kstr.c_str()); \
     }
+#endif
+#define CALI_START \
+    if(doCaliperTiming) { \
+      CALI_MARK_BEGIN("kernel"); \
+    }
 
+#define CALI_STOP \
+    if(doCaliperTiming) { \
+      CALI_MARK_END("kernel"); \
+    }
 #else
 #define CALI_START
 #define CALI_STOP

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -16,6 +16,11 @@
 
 #include "RAJA/util/Timer.hpp"
 
+#ifdef RAJAPERF_USE_CALIPER
+#include <caliper/cali.h>
+#include <caliper/cali-manager.h>
+#endif
+
 #include <string>
 #include <iostream>
 

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -19,14 +19,19 @@
 #ifdef RAJAPERF_USE_CALIPER
 #include <caliper/cali.h>
 #include <caliper/cali-manager.h>
+#include <adiak.hpp>
 
 #define CALI_START \
-    std::string kstr = getName() + ":" + getVariantName(running_variant); \
-    CALI_MARK_BEGIN(kstr.c_str());
+    if(doCaliperTiming) { \
+      std::string kstr = getName() + ":" + getVariantName(running_variant); \
+      CALI_MARK_BEGIN(kstr.c_str()); \
+    }
 
 #define CALI_STOP \
-    std::string kstr = getName() + ":" + getVariantName(running_variant); \
-    CALI_MARK_END(kstr.c_str());
+    if(doCaliperTiming) { \
+      std::string kstr = getName() + ":" + getVariantName(running_variant); \
+      CALI_MARK_END(kstr.c_str()); \
+    }
 
 #else
 #define CALI_START
@@ -80,6 +85,11 @@ public:
   void setVariantDefined(VariantID vid);
 
   void execute(VariantID vid);
+
+#ifdef RAJAPERF_USE_CALIPER
+  void caliperOn() { doCaliperTiming = true; }
+  void caliperOff() { doCaliperTiming = false; } 
+#endif
 
   void startTimer() 
   { 
@@ -172,6 +182,10 @@ private:
   RAJA::Timer::ElapsedType tot_time[NumVariants];
 
   bool has_variant_to_run[NumVariants];
+
+#ifdef RAJAPERF_USE_CALIPER
+  bool doCaliperTiming = true; // warmup can use this to exclude timing
+#endif
 };
 
 }  // closing brace for rajaperf namespace

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -23,13 +23,13 @@
 
 #define CALI_START \
     if(doCaliperTiming) { \
-      std::string kstr = getName() + ":" + getVariantName(running_variant); \
+      std::string kstr = getName() + "." + getVariantName(running_variant); \
       CALI_MARK_BEGIN(kstr.c_str()); \
     }
 
 #define CALI_STOP \
     if(doCaliperTiming) { \
-      std::string kstr = getName() + ":" + getVariantName(running_variant); \
+      std::string kstr = getName() + "." + getVariantName(running_variant); \
       CALI_MARK_END(kstr.c_str()); \
     }
 

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -17,6 +17,12 @@
 
 #include <string>
 
+#ifdef RAJAPERF_USE_CALIPER
+#include <caliper/cali.h>
+#include <caliper/cali-manager.h>
+#include <adiak.hpp>
+#endif
+
 namespace rajaperf
 {
 

--- a/src/rajaperf_config.hpp.in
+++ b/src/rajaperf_config.hpp.in
@@ -27,23 +27,22 @@
 namespace rajaperf {
 
 struct configuration {
-static constexpr const char perfsuite_version[] = "@CMAKE_PROJECT_VERSION@";
-static constexpr const char raja_version[] = "@RAJA_LOADED@";
-static constexpr const char cmake_build_type[] = "@CMAKE_BUILD_TYPE@";
-static constexpr const char compiler[] = "@RAJAPERF_COMPILER@"; 
-static constexpr const char compiler_flags[] = "@CMAKE_CXX_FLAGS@"; 
-static constexpr const char compiler_flags_release[] = "@CMAKE_CXX_FLAGS_RELEASE@"; 
-static constexpr const char compiler_flags_relwithdebinfo[] = "@CMAKE_CXX_FLAGS_RELWITHDEBINFO@"; 
-static constexpr const char compiler_flags_debug[] = "@CMAKE_CXX_FLAGS_DEBUG@"; 
-static constexpr const char cuda_compiler_version[] = "@CMAKE_CUDA_COMPILER_VERSION@"; 
-static constexpr const char cuda_flags[] = "@CMAKE_CUDA_FLAGS@"; 
-static constexpr const char cuda_flags_release[] = "@CMAKE_CUDA_FLAGS_RELEASE@"; 
-static constexpr const char cuda_flags_relwithdebinfo[] = "@CMAKE_CUDA_FLAGS_RELWITHDEBINFO@"; 
-static constexpr const char cuda_flags_debug[] = "@CMAKE_CUDA_FLAGS_DEBUG@"; 
-static constexpr const char systype_build[] = "@RAJAPERF_BUILD_SYSTYPE@"; 
-static constexpr const char machine_build[] = "@RAJAPERF_BUILD_HOST@"; 
+constexpr static const char* perfsuite_version = "@CMAKE_PROJECT_VERSION@";
+constexpr static const char* raja_version = "@RAJA_LOADED@";
+constexpr static const char* cmake_build_type = "@CMAKE_BUILD_TYPE@";
+constexpr static const char* compiler = "@RAJAPERF_COMPILER@"; 
+constexpr static const char* compiler_flags = "@CMAKE_CXX_FLAGS@"; 
+constexpr static const char* compiler_flags_release = "@CMAKE_CXX_FLAGS_RELEASE@"; 
+constexpr static const char* compiler_flags_relwithdebinfo = "@CMAKE_CXX_FLAGS_RELWITHDEBINFO@"; 
+constexpr static const char* compiler_flags_debug = "@CMAKE_CXX_FLAGS_DEBUG@"; 
+constexpr static const char* cuda_compiler_version = "@CMAKE_CUDA_COMPILER_VERSION@"; 
+constexpr static const char* cuda_flags = "@CMAKE_CUDA_FLAGS@"; 
+constexpr static const char* cuda_flags_release = "@CMAKE_CUDA_FLAGS_RELEASE@"; 
+constexpr static const char* cuda_flags_relwithdebinfo = "@CMAKE_CUDA_FLAGS_RELWITHDEBINFO@"; 
+constexpr static const char* cuda_flags_debug = "@CMAKE_CUDA_FLAGS_DEBUG@"; 
+constexpr static const char* systype_build = "@RAJAPERF_BUILD_SYSTYPE@"; 
+constexpr static const char* machine_build = "@RAJAPERF_BUILD_HOST@"; 
 };
-
 } // closing brace for rajaperf namespace
 
 #endif  // closing endif for header file include guard

--- a/src/rajaperf_config.hpp.in
+++ b/src/rajaperf_config.hpp.in
@@ -27,41 +27,24 @@
 namespace rajaperf {
 
 struct configuration {
-
-// Version of RAJA Perf Suite (ex: 0.1.0)
-static const std::string perfsuite_version =
-"@RAJA_PERFSUITE_VERSION_MAJOR@" + std::string(".") +
-"@RAJA_PERFSUITE_VERSION_MINOR@" + std::string(".") +
-"@RAJA_PERFSUITE_VERSION_PATCHLEVEL@";
-
-// Version of RAJA used to build (ex: 0.2.4)
-static const std::string raja_version = 
-std::to_string(RAJA::RAJA_VERSION_MAJOR) + std::string(".") +
-std::to_string(RAJA::RAJA_VERSION_MINOR) + std::string(".") +
-std::to_string(RAJA::RAJA_VERSION_PATCH_LEVEL);
-
-// Systype and machine code was built on (ex: chaos_5_x64_64, rzhasgpu18)
-static const std::string systype_build = "@RAJAPERF_BUILD_SYSTYPE@";
-static const std::string machine_build = "@RAJAPERF_BUILD_HOST@";
-		
-// Compiler used to build (ex: gcc-4.9.3)
-static const std::string compiler = "@RAJAPERF_COMPILER@";
-
-// Command options used to build (ex: -Ofast -mavx)
-static const std::string compiler_options = "@RAJAPERF_COMPILER_OPTIONS@";
-		
-// Name of user who ran code
-std::string user_run;
-
-// Date, time code was run
-std::string date_run;
-
-// Systype and machine code ran on (ex: chaos_5_x64_64)
-std::string systype_run;
-std::string machine_run;
-		
+static constexpr const char perfsuite_version[] = "@CMAKE_PROJECT_VERSION@";
+static constexpr const char raja_version[] = "@RAJA_LOADED@";
+static constexpr const char cmake_build_type[] = "@CMAKE_BUILD_TYPE@";
+static constexpr const char compiler[] = "@RAJAPERF_COMPILER@"; 
+static constexpr const char compiler_flags[] = "@CMAKE_CXX_FLAGS@"; 
+static constexpr const char compiler_flags_release[] = "@CMAKE_CXX_FLAGS_RELEASE@"; 
+static constexpr const char compiler_flags_relwithdebinfo[] = "@CMAKE_CXX_FLAGS_RELWITHDEBINFO@"; 
+static constexpr const char compiler_flags_debug[] = "@CMAKE_CXX_FLAGS_DEBUG@"; 
+static constexpr const char cuda_compiler_version[] = "@CMAKE_CUDA_COMPILER_VERSION@"; 
+static constexpr const char cuda_flags[] = "@CMAKE_CUDA_FLAGS@"; 
+static constexpr const char cuda_flags_release[] = "@CMAKE_CUDA_FLAGS_RELEASE@"; 
+static constexpr const char cuda_flags_relwithdebinfo[] = "@CMAKE_CUDA_FLAGS_RELWITHDEBINFO@"; 
+static constexpr const char cuda_flags_debug[] = "@CMAKE_CUDA_FLAGS_DEBUG@"; 
+static constexpr const char systype_build[] = "@RAJAPERF_BUILD_SYSTYPE@"; 
+static constexpr const char machine_build[] = "@RAJAPERF_BUILD_HOST@"; 
 };
 
 } // closing brace for rajaperf namespace
 
 #endif  // closing endif for header file include guard
+


### PR DESCRIPTION
Add Caliper support for "by variant" Spot/Hatchet Analysis. Tree is Variant->Group->Kernel
Creates additional Adiak keys for Build Configuration via modified rajaperf_config.hpp 


I created some screenshots below showing Spot/Hatchet analysis for two datasets: clang and g++ respectively.
1: Adiak Keys used for selection criteria (compiler_suffix and variant checkmarked)
2: Overall Comparison group by compiler_suffix
3: Drilldown to Base_Seq across compiler (note legend change to highlight individual kernels)
4: Hatchet Tree for RAJA_Seq and Base_Seq
5: Hatchet Speedup for Base_OpenMP (note that trees must be completely identical - so we can compare Base_Seq between gcc and clang; but we cannot compute speedup for  Base_Seq vs RAJA_Seq either in one dataset, or across compilers or launch dates. I'm thinking of adding some Hatchet routines to allow this (essentially creating some new pseudo labeled trees to allow comparison).

![Rajaperf_caliper_keys](https://user-images.githubusercontent.com/12015127/122100506-1edec000-cdc8-11eb-8c72-ad87906a9001.PNG)

![Rajaperf_caliper_overall](https://user-images.githubusercontent.com/12015127/122100586-31f19000-cdc8-11eb-8896-4f4a9470893b.PNG)

![Rajaperf_caliper_drilldown](https://user-images.githubusercontent.com/12015127/122100820-73823b00-cdc8-11eb-8978-64f9c1dc1cde.PNG)


![Rajaperf_hatchet_tree](https://user-images.githubusercontent.com/12015127/122100625-39b13480-cdc8-11eb-8e4e-54ab8bc46fc5.PNG)

![Rajaperf_caliper_hatchet_speedup](https://user-images.githubusercontent.com/12015127/122100652-403fac00-cdc8-11eb-941d-a284afc2cc8c.PNG)



