### PR TITLE
Default Kernel Sizes to 1M

### DIFF
--- a/src/algorithm/SORT.cpp
+++ b/src/algorithm/SORT.cpp
@@ -22,7 +22,7 @@ SORT::SORT(const RunParams& params)
   : KernelBase(rajaperf::Algorithm_SORT, params)
 {
    setDefaultSize(1000000);
-   setDefaultReps(50);
+   setDefaultReps(20);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( RAJA_Seq );

--- a/src/algorithm/SORT.cpp
+++ b/src/algorithm/SORT.cpp
@@ -21,7 +21,7 @@ namespace algorithm
 SORT::SORT(const RunParams& params)
   : KernelBase(rajaperf::Algorithm_SORT, params)
 {
-   setDefaultSize(100000);
+   setDefaultSize(1000000);
    setDefaultReps(50);
 
   setVariantDefined( Base_Seq );

--- a/src/algorithm/SORTPAIRS.cpp
+++ b/src/algorithm/SORTPAIRS.cpp
@@ -21,7 +21,7 @@ namespace algorithm
 SORTPAIRS::SORTPAIRS(const RunParams& params)
   : KernelBase(rajaperf::Algorithm_SORTPAIRS, params)
 {
-   setDefaultSize(100000);
+   setDefaultSize(1000000);
    setDefaultReps(50);
 
   setVariantDefined( Base_Seq );

--- a/src/algorithm/SORTPAIRS.cpp
+++ b/src/algorithm/SORTPAIRS.cpp
@@ -22,7 +22,7 @@ SORTPAIRS::SORTPAIRS(const RunParams& params)
   : KernelBase(rajaperf::Algorithm_SORTPAIRS, params)
 {
    setDefaultSize(1000000);
-   setDefaultReps(50);
+   setDefaultReps(20);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( RAJA_Seq );

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -13,6 +13,9 @@
 #include "AppsData.hpp"
 #include "common/DataUtils.hpp"
 
+#include <cmath>
+
+
 namespace rajaperf
 {
 namespace apps
@@ -22,10 +25,11 @@ namespace apps
 DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
   : KernelBase(rajaperf::Apps_DEL_DOT_VEC_2D, params)
 {
-  setDefaultSize(312);  // See rzmax in ADomain struct
-  setDefaultReps(1050);
+  setDefaultSize(1000*1000);  // See rzmax in ADomain struct
+  setDefaultReps(100);
 
-  m_domain = new ADomain(getRunSize(), /* ndims = */ 2);
+  Index_type rzmax = std::sqrt(getRunSize())+1;
+  m_domain = new ADomain(rzmax, /* ndims = */ 2);
 
   m_array_length = m_domain->nnalls;
 

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -21,8 +21,8 @@ namespace apps
 ENERGY::ENERGY(const RunParams& params)
   : KernelBase(rajaperf::Apps_ENERGY, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(1300);
+  setDefaultSize(1000000);
+  setDefaultReps(130);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -21,8 +21,8 @@ namespace apps
 FIR::FIR(const RunParams& params)
   : KernelBase(rajaperf::Apps_FIR, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(1600);
+  setDefaultSize(1000000);
+  setDefaultReps(160);
 
   m_coefflen = FIR_COEFFLEN;
 

--- a/src/apps/HALOEXCHANGE.cpp
+++ b/src/apps/HALOEXCHANGE.cpp
@@ -50,11 +50,25 @@ HALOEXCHANGE::HALOEXCHANGE(const RunParams& params)
   m_halo_width_default   = 1;
   m_num_vars_default     = 3;
 
-  setDefaultSize((m_grid_dims_default[0] + 2*m_halo_width_default) *
-                 (m_grid_dims_default[1] + 2*m_halo_width_default) *
-                 (m_grid_dims_default[2] + 2*m_halo_width_default) *
-                 m_num_vars_default);
+  setDefaultSize( m_grid_dims_default[0] *
+                  m_grid_dims_default[1] *
+                  m_grid_dims_default[2] );
   setDefaultReps(50);
+
+  double cbrt_size_fact = std::cbrt(run_params.getSizeFactor());
+
+  m_grid_dims[0] = cbrt_size_fact * m_grid_dims_default[0];
+  m_grid_dims[1] = cbrt_size_fact * m_grid_dims_default[1];
+  m_grid_dims[2] = cbrt_size_fact * m_grid_dims_default[2];
+  m_halo_width = m_halo_width_default;
+  m_num_vars   = m_num_vars_default;
+
+  m_grid_plus_halo_dims[0] = m_grid_dims[0] + 2*m_halo_width;
+  m_grid_plus_halo_dims[1] = m_grid_dims[1] + 2*m_halo_width;
+  m_grid_plus_halo_dims[2] = m_grid_dims[2] + 2*m_halo_width;
+  m_var_size = m_grid_plus_halo_dims[0] *
+               m_grid_plus_halo_dims[1] *
+               m_grid_plus_halo_dims[2] ;
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
@@ -78,23 +92,15 @@ HALOEXCHANGE::~HALOEXCHANGE()
 {
 }
 
+Index_type HALOEXCHANGE::getItsPerRep() const
+{
+  return m_num_vars * (m_var_size - m_grid_dims[0] *
+                                    m_grid_dims[1] *
+                                    m_grid_dims[2] );
+}
+
 void HALOEXCHANGE::setUp(VariantID vid)
 {
-  double cbrt_size_fact = std::cbrt(run_params.getSizeFactor());
-
-  m_grid_dims[0] = cbrt_size_fact * m_grid_dims_default[0];
-  m_grid_dims[1] = cbrt_size_fact * m_grid_dims_default[1];
-  m_grid_dims[2] = cbrt_size_fact * m_grid_dims_default[2];
-  m_halo_width = m_halo_width_default;
-  m_num_vars   = m_num_vars_default;
-
-  m_grid_plus_halo_dims[0] = m_grid_dims[0] + 2*m_halo_width;
-  m_grid_plus_halo_dims[1] = m_grid_dims[1] + 2*m_halo_width;
-  m_grid_plus_halo_dims[2] = m_grid_dims[2] + 2*m_halo_width;
-  m_var_size = m_grid_plus_halo_dims[0] *
-               m_grid_plus_halo_dims[1] *
-               m_grid_plus_halo_dims[2] ;
-
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
     allocAndInitData(m_vars[v], m_var_size, vid);

--- a/src/apps/HALOEXCHANGE.hpp
+++ b/src/apps/HALOEXCHANGE.hpp
@@ -84,6 +84,8 @@ public:
 
   ~HALOEXCHANGE();
 
+  Index_type getItsPerRep() const;
+
   void setUp(VariantID vid);
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);

--- a/src/apps/HALOEXCHANGE_FUSED.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED.cpp
@@ -50,11 +50,25 @@ HALOEXCHANGE_FUSED::HALOEXCHANGE_FUSED(const RunParams& params)
   m_halo_width_default   = 1;
   m_num_vars_default     = 3;
 
-  setDefaultSize((m_grid_dims_default[0] + 2*m_halo_width_default) *
-                 (m_grid_dims_default[1] + 2*m_halo_width_default) *
-                 (m_grid_dims_default[2] + 2*m_halo_width_default) *
-                 m_num_vars_default);
+  setDefaultSize( m_grid_dims_default[0] *
+                  m_grid_dims_default[1] *
+                  m_grid_dims_default[2] );
   setDefaultReps(50);
+
+  double cbrt_size_fact = std::cbrt(run_params.getSizeFactor());
+
+  m_grid_dims[0] = cbrt_size_fact * m_grid_dims_default[0];
+  m_grid_dims[1] = cbrt_size_fact * m_grid_dims_default[1];
+  m_grid_dims[2] = cbrt_size_fact * m_grid_dims_default[2];
+  m_halo_width = m_halo_width_default;
+  m_num_vars   = m_num_vars_default;
+
+  m_grid_plus_halo_dims[0] = m_grid_dims[0] + 2*m_halo_width;
+  m_grid_plus_halo_dims[1] = m_grid_dims[1] + 2*m_halo_width;
+  m_grid_plus_halo_dims[2] = m_grid_dims[2] + 2*m_halo_width;
+  m_var_size = m_grid_plus_halo_dims[0] *
+               m_grid_plus_halo_dims[1] *
+               m_grid_plus_halo_dims[2] ;
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
@@ -78,23 +92,15 @@ HALOEXCHANGE_FUSED::~HALOEXCHANGE_FUSED()
 {
 }
 
+Index_type HALOEXCHANGE_FUSED::getItsPerRep() const
+{
+  return m_num_vars * (m_var_size - m_grid_dims[0] *
+                                    m_grid_dims[1] *
+                                    m_grid_dims[2] );
+}
+
 void HALOEXCHANGE_FUSED::setUp(VariantID vid)
 {
-  double cbrt_size_fact = std::cbrt(run_params.getSizeFactor());
-
-  m_grid_dims[0] = cbrt_size_fact * m_grid_dims_default[0];
-  m_grid_dims[1] = cbrt_size_fact * m_grid_dims_default[1];
-  m_grid_dims[2] = cbrt_size_fact * m_grid_dims_default[2];
-  m_halo_width = m_halo_width_default;
-  m_num_vars   = m_num_vars_default;
-
-  m_grid_plus_halo_dims[0] = m_grid_dims[0] + 2*m_halo_width;
-  m_grid_plus_halo_dims[1] = m_grid_dims[1] + 2*m_halo_width;
-  m_grid_plus_halo_dims[2] = m_grid_dims[2] + 2*m_halo_width;
-  m_var_size = m_grid_plus_halo_dims[0] *
-               m_grid_plus_halo_dims[1] *
-               m_grid_plus_halo_dims[2] ;
-
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
     allocAndInitData(m_vars[v], m_var_size, vid);

--- a/src/apps/HALOEXCHANGE_FUSED.hpp
+++ b/src/apps/HALOEXCHANGE_FUSED.hpp
@@ -128,6 +128,8 @@ public:
 
   ~HALOEXCHANGE_FUSED();
 
+  Index_type getItsPerRep() const;
+
   void setUp(VariantID vid);
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);

--- a/src/apps/PRESSURE.cpp
+++ b/src/apps/PRESSURE.cpp
@@ -21,8 +21,8 @@ namespace apps
 PRESSURE::PRESSURE(const RunParams& params)
   : KernelBase(rajaperf::Apps_PRESSURE, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(7000);
+  setDefaultSize(1000000);
+  setDefaultReps(700);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -13,6 +13,9 @@
 #include "AppsData.hpp"
 #include "common/DataUtils.hpp"
 
+#include <cmath>
+
+
 namespace rajaperf 
 {
 namespace apps
@@ -22,10 +25,11 @@ namespace apps
 VOL3D::VOL3D(const RunParams& params)
   : KernelBase(rajaperf::Apps_VOL3D, params)
 {
-  setDefaultSize(64);  // See rzmax in ADomain struct
-  setDefaultReps(300);
+  setDefaultSize(100*100*100);  // See rzmax in ADomain struct
+  setDefaultReps(100);
 
-  m_domain = new ADomain(getRunSize(), /* ndims = */ 3);
+  Index_type rzmax = std::cbrt(getRunSize())+1;
+  m_domain = new ADomain(rzmax, /* ndims = */ 3);
 
   m_array_length = m_domain->nnalls;
 

--- a/src/basic/DAXPY.cpp
+++ b/src/basic/DAXPY.cpp
@@ -21,8 +21,8 @@ namespace basic
 DAXPY::DAXPY(const RunParams& params)
   : KernelBase(rajaperf::Basic_DAXPY, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(5000);
+  setDefaultSize(1000000);
+  setDefaultReps(500);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -21,8 +21,8 @@ namespace basic
 IF_QUAD::IF_QUAD(const RunParams& params)
   : KernelBase(rajaperf::Basic_IF_QUAD, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(1800);
+  setDefaultSize(1000000);
+  setDefaultReps(180);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/basic/INIT3.cpp
+++ b/src/basic/INIT3.cpp
@@ -21,8 +21,8 @@ namespace basic
 INIT3::INIT3(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT3, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(5000);
+  setDefaultSize(1000000);
+  setDefaultReps(500);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -21,8 +21,8 @@ namespace basic
 INIT_VIEW1D::INIT_VIEW1D(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT_VIEW1D, params)
 {
-  setDefaultSize(500000);
-  setDefaultReps(5000);
+  setDefaultSize(1000000);
+  setDefaultReps(2500);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -21,8 +21,8 @@ namespace basic
 INIT_VIEW1D_OFFSET::INIT_VIEW1D_OFFSET(const RunParams& params)
   : KernelBase(rajaperf::Basic_INIT_VIEW1D_OFFSET, params)
 {
-  setDefaultSize(500000);
-  setDefaultReps(5000);
+  setDefaultSize(1000000);
+  setDefaultReps(2500);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/basic/MULADDSUB.cpp
+++ b/src/basic/MULADDSUB.cpp
@@ -21,8 +21,8 @@ namespace basic
 MULADDSUB::MULADDSUB(const RunParams& params)
   : KernelBase(rajaperf::Basic_MULADDSUB, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(3500);
+  setDefaultSize(1000000);
+  setDefaultReps(350);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -24,9 +24,10 @@ namespace basic
 NESTED_INIT::NESTED_INIT(const RunParams& params)
   : KernelBase(rajaperf::Basic_NESTED_INIT, params)
 {
-  m_ni = 200;
-  m_nj = 200;
-  m_nk = m_nk_init = 25;
+  m_n_init = 100;
+  m_ni = m_n_init;
+  m_nj = m_n_init;
+  m_nk = m_n_init;
 
   setDefaultSize(m_ni * m_nj * m_nk);
   setDefaultReps(1000);
@@ -57,7 +58,10 @@ NESTED_INIT::~NESTED_INIT()
 
 void NESTED_INIT::setUp(VariantID vid)
 {
-  m_nk = m_nk_init * run_params.getSizeFactor();
+  auto n_final = m_n_init * std::cbrt(run_params.getSizeFactor());
+  m_ni = n_final;
+  m_nj = n_final;
+  m_nk = n_final;
   m_array_length = m_ni * m_nj * m_nk;
 
   allocAndInitDataConst(m_array, m_array_length, 0.0, vid);

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -24,12 +24,12 @@ namespace basic
 NESTED_INIT::NESTED_INIT(const RunParams& params)
   : KernelBase(rajaperf::Basic_NESTED_INIT, params)
 {
-  m_ni = 500;
-  m_nj = 500;
-  m_nk = m_nk_init = 50;
+  m_ni = 200;
+  m_nj = 200;
+  m_nk = m_nk_init = 25;
 
   setDefaultSize(m_ni * m_nj * m_nk);
-  setDefaultReps(100);
+  setDefaultReps(1000);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );
@@ -57,7 +57,7 @@ NESTED_INIT::~NESTED_INIT()
 
 void NESTED_INIT::setUp(VariantID vid)
 {
-  m_nk = m_nk_init * static_cast<Real_type>( getRunSize() ) / getDefaultSize();
+  m_nk = m_nk_init * run_params.getSizeFactor();
   m_array_length = m_ni * m_nj * m_nk;
 
   allocAndInitDataConst(m_array, m_array_length, 0.0, vid);

--- a/src/basic/NESTED_INIT.hpp
+++ b/src/basic/NESTED_INIT.hpp
@@ -67,7 +67,7 @@ private:
   Index_type m_ni;
   Index_type m_nj;
   Index_type m_nk;
-  Index_type m_nk_init;
+  Index_type m_n_init;
 };
 
 } // end namespace basic

--- a/src/basic/PI_ATOMIC.cpp
+++ b/src/basic/PI_ATOMIC.cpp
@@ -21,8 +21,8 @@ namespace basic
 PI_ATOMIC::PI_ATOMIC(const RunParams& params)
   : KernelBase(rajaperf::Basic_PI_ATOMIC, params)
 {
-  setDefaultSize(3000);
-  setDefaultReps(10000);
+  setDefaultSize(1000000);
+  setDefaultReps(50);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/basic/PI_REDUCE.cpp
+++ b/src/basic/PI_REDUCE.cpp
@@ -21,8 +21,8 @@ namespace basic
 PI_REDUCE::PI_REDUCE(const RunParams& params)
   : KernelBase(rajaperf::Basic_PI_REDUCE, params)
 {
-  setDefaultSize(3000);
-  setDefaultReps(10000);
+  setDefaultSize(1000000);
+  setDefaultReps(50);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/basic/REDUCE3_INT.cpp
+++ b/src/basic/REDUCE3_INT.cpp
@@ -27,7 +27,7 @@ REDUCE3_INT::REDUCE3_INT(const RunParams& params)
 //setDefaultReps(5000);
 // Set reps to low value until we resolve RAJA omp-target 
 // reduction performance issues
-  setDefaultReps(100);
+  setDefaultReps(50);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/basic/TRAP_INT.cpp
+++ b/src/basic/TRAP_INT.cpp
@@ -21,8 +21,8 @@ namespace basic
 TRAP_INT::TRAP_INT(const RunParams& params)
   : KernelBase(rajaperf::Basic_TRAP_INT, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(2000);
+  setDefaultSize(1000000);
+  setDefaultReps(50);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/lcals/DIFF_PREDICT.cpp
+++ b/src/lcals/DIFF_PREDICT.cpp
@@ -21,8 +21,8 @@ namespace lcals
 DIFF_PREDICT::DIFF_PREDICT(const RunParams& params)
   : KernelBase(rajaperf::Lcals_DIFF_PREDICT, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(2000);
+  setDefaultSize(1000000);
+  setDefaultReps(200);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -21,8 +21,8 @@ namespace lcals
 EOS::EOS(const RunParams& params)
   : KernelBase(rajaperf::Lcals_EOS, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(5000);
+  setDefaultSize(1000000);
+  setDefaultReps(500);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/lcals/FIRST_DIFF.cpp
+++ b/src/lcals/FIRST_DIFF.cpp
@@ -21,8 +21,8 @@ namespace lcals
 FIRST_DIFF::FIRST_DIFF(const RunParams& params)
   : KernelBase(rajaperf::Lcals_FIRST_DIFF, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(16000);
+  setDefaultSize(1000000);
+  setDefaultReps(2000);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/lcals/FIRST_SUM.cpp
+++ b/src/lcals/FIRST_SUM.cpp
@@ -21,8 +21,8 @@ namespace lcals
 FIRST_SUM::FIRST_SUM(const RunParams& params)
   : KernelBase(rajaperf::Lcals_FIRST_SUM, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(16000);
+  setDefaultSize(1000000);
+  setDefaultReps(2000);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/lcals/GEN_LIN_RECUR.cpp
+++ b/src/lcals/GEN_LIN_RECUR.cpp
@@ -21,8 +21,8 @@ namespace lcals
 GEN_LIN_RECUR::GEN_LIN_RECUR(const RunParams& params)
   : KernelBase(rajaperf::Lcals_GEN_LIN_RECUR, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(5000);
+  setDefaultSize(1000000);
+  setDefaultReps(500);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -22,7 +22,7 @@ HYDRO_1D::HYDRO_1D(const RunParams& params)
   : KernelBase(rajaperf::Lcals_HYDRO_1D, params)
 {
   setDefaultSize(1000000);
-  setDefaultReps(2000);
+  setDefaultReps(1000);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -21,8 +21,8 @@ namespace lcals
 HYDRO_1D::HYDRO_1D(const RunParams& params)
   : KernelBase(rajaperf::Lcals_HYDRO_1D, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(12500);
+  setDefaultSize(1000000);
+  setDefaultReps(2000);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -12,6 +12,9 @@
 
 #include "common/DataUtils.hpp"
 
+#include <cmath>
+
+
 namespace rajaperf 
 {
 namespace lcals
@@ -27,7 +30,7 @@ HYDRO_2D::HYDRO_2D(const RunParams& params)
   m_s = 0.0041;
   m_t = 0.0037;
 
-  setDefaultSize(m_jn);
+  setDefaultSize(m_kn * m_jn);
   setDefaultReps(200);
 
   setVariantDefined( Base_Seq );
@@ -54,7 +57,7 @@ HYDRO_2D::~HYDRO_2D()
 
 void HYDRO_2D::setUp(VariantID vid)
 {
-  m_kn = getRunSize();
+  m_jn = m_kn = std::sqrt(getRunSize());
   m_array_length = m_kn * m_jn;
 
   allocAndInitDataConst(m_zrout, m_array_length, 0.0, vid);

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -31,7 +31,7 @@ HYDRO_2D::HYDRO_2D(const RunParams& params)
   m_t = 0.0037;
 
   setDefaultSize(m_kn * m_jn);
-  setDefaultReps(200);
+  setDefaultReps(100);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/lcals/INT_PREDICT.cpp
+++ b/src/lcals/INT_PREDICT.cpp
@@ -21,8 +21,8 @@ namespace lcals
 INT_PREDICT::INT_PREDICT(const RunParams& params)
   : KernelBase(rajaperf::Lcals_INT_PREDICT, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(4000);
+  setDefaultSize(1000000);
+  setDefaultReps(400);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/lcals/PLANCKIAN.cpp
+++ b/src/lcals/PLANCKIAN.cpp
@@ -21,8 +21,8 @@ namespace lcals
 PLANCKIAN::PLANCKIAN(const RunParams& params)
   : KernelBase(rajaperf::Lcals_PLANCKIAN, params)
 {
-  setDefaultSize(100000);
-  setDefaultReps(460);
+  setDefaultSize(1000000);
+  setDefaultReps(50);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/lcals/TRIDIAG_ELIM.cpp
+++ b/src/lcals/TRIDIAG_ELIM.cpp
@@ -21,8 +21,8 @@ namespace lcals
 TRIDIAG_ELIM::TRIDIAG_ELIM(const RunParams& params)
   : KernelBase(rajaperf::Lcals_TRIDIAG_ELIM, params)
 {
-  setDefaultSize(200000);
-  setDefaultReps(5000);
+  setDefaultSize(1000000);
+  setDefaultReps(1000);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );


### PR DESCRIPTION
Change the default kernel size to about 1M.
Most kernels work on 1D arrays of the problem size so their default size was changed to 1M and their default repetitions scaled appropriately.
Some kernels work on 2D or 3D data. For the most part multidimensional kernels are changed to scale linearly in total size by scaling their dimensions evenly as a square or cube. This is a departure as some kernels previously scaled by changing a single dimension. Some other kernels scaled each dimension by the size factor creating quadratic or cubic total size scaling.
The LTIMES default kernel size and scaling is not changed.
The polybench kernels will be addressed in a separate PR.