### PR TITLE
Update ltimes default size to 1M

### DIFF
--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -22,13 +22,17 @@ LTIMES::LTIMES(const RunParams& params)
   : KernelBase(rajaperf::Apps_LTIMES, params)
 {
   m_num_d_default = 64;
-  m_num_z_default = 500;
+  m_num_z_default = 488;
   m_num_g_default = 32;
   m_num_m_default = 25;
 
-  setDefaultSize(m_num_d_default * m_num_m_default *
-                 m_num_g_default * m_num_z_default);
+  setDefaultSize(m_num_d_default * m_num_g_default * m_num_z_default);
   setDefaultReps(50);
+
+  m_num_z = run_params.getSizeFactor() * m_num_z_default;
+  m_num_g = m_num_g_default;
+  m_num_m = m_num_m_default;
+  m_num_d = m_num_d_default;
 
   setUsesFeature(Kernel); 
   setUsesFeature(View); 
@@ -57,13 +61,13 @@ LTIMES::~LTIMES()
 {
 }
 
+Index_type LTIMES::getItsPerRep() const
+{
+  return m_num_d * m_num_m * m_num_g * m_num_z ;
+}
+
 void LTIMES::setUp(VariantID vid)
 {
-  m_num_z = run_params.getSizeFactor() * m_num_z_default;
-  m_num_g = m_num_g_default;
-  m_num_m = m_num_m_default;
-  m_num_d = m_num_d_default;
-
   m_philen = m_num_m * m_num_g * m_num_z;
   m_elllen = m_num_d * m_num_m;
   m_psilen = m_num_d * m_num_g * m_num_z;

--- a/src/apps/LTIMES.hpp
+++ b/src/apps/LTIMES.hpp
@@ -111,6 +111,8 @@ public:
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
 
+  Index_type getItsPerRep() const;
+
   void runSeqVariant(VariantID vid);
   void runOpenMPVariant(VariantID vid);
   void runCudaVariant(VariantID vid);

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -22,13 +22,17 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   : KernelBase(rajaperf::Apps_LTIMES_NOVIEW, params)
 {
   m_num_d_default = 64;
-  m_num_z_default = 500;
+  m_num_z_default = 488;
   m_num_g_default = 32;
   m_num_m_default = 25;
 
-  setDefaultSize(m_num_d_default * m_num_m_default *
-                 m_num_g_default * m_num_z_default);
+  setDefaultSize(m_num_d_default * m_num_g_default * m_num_z_default);
   setDefaultReps(50);
+
+  m_num_z = run_params.getSizeFactor() * m_num_z_default;
+  m_num_g = m_num_g_default;
+  m_num_m = m_num_m_default;
+  m_num_d = m_num_d_default;
 
   setUsesFeature(Kernel);
 
@@ -56,13 +60,13 @@ LTIMES_NOVIEW::~LTIMES_NOVIEW()
 {
 }
 
+Index_type LTIMES_NOVIEW::getItsPerRep() const
+{
+  return m_num_d * m_num_m * m_num_g * m_num_z ;
+}
+
 void LTIMES_NOVIEW::setUp(VariantID vid)
 {
-  m_num_z = run_params.getSizeFactor() * m_num_z_default;
-  m_num_g = m_num_g_default;
-  m_num_m = m_num_m_default;
-  m_num_d = m_num_d_default;
-
   m_philen = m_num_m * m_num_g * m_num_z;
   m_elllen = m_num_d * m_num_m;
   m_psilen = m_num_d * m_num_g * m_num_z;

--- a/src/apps/LTIMES_NOVIEW.hpp
+++ b/src/apps/LTIMES_NOVIEW.hpp
@@ -61,6 +61,8 @@ public:
   void updateChecksum(VariantID vid);
   void tearDown(VariantID vid);
 
+  Index_type getItsPerRep() const;
+
   void runSeqVariant(VariantID vid);
   void runOpenMPVariant(VariantID vid);
   void runCudaVariant(VariantID vid);


### PR DESCRIPTION
After talking with @ajkunen calculate ltimes problem size without moments dimension. Changed the default num zones to get a default 1M problem size.