### PR TITLE
Problem size and its per rep consistency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 set(ENABLE_TESTS Off CACHE BOOL "Enable BLT and RAJA tests")
 set(ENABLE_EXAMPLES Off CACHE BOOL "Enable RAJA examples")
-set(ENABLE_EXERCISES Off CACHE BOOL "Enable RAJA exercises")
+set(RAJA_ENABLE_EXERCISES Off CACHE BOOL "Enable RAJA exercises")
 
 set(CMAKE_CXX_STANDARD 11)
 set(BLT_CXX_STANDARD 11)

--- a/src/algorithm/SORT.hpp
+++ b/src/algorithm/SORT.hpp
@@ -42,9 +42,14 @@ public:
 
   ~SORT();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getRunSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/algorithm/SORTPAIRS.hpp
+++ b/src/algorithm/SORTPAIRS.hpp
@@ -41,9 +41,14 @@ public:
 
   ~SORTPAIRS();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getRunSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -60,16 +60,6 @@ DEL_DOT_VEC_2D::~DEL_DOT_VEC_2D()
   delete m_domain;
 }
 
-Index_type DEL_DOT_VEC_2D::getProblemSize() const
-{
-  return m_domain->n_real_zones;
-}
-
-Index_type DEL_DOT_VEC_2D::getItsPerRep() const
-{
-  return m_domain->n_real_zones;
-}
-
 void DEL_DOT_VEC_2D::setUp(VariantID vid)
 {
   allocAndInitDataConst(m_x, m_array_length, 0.0, vid);

--- a/src/apps/DEL_DOT_VEC_2D.hpp
+++ b/src/apps/DEL_DOT_VEC_2D.hpp
@@ -88,13 +88,14 @@
 
 #include "common/KernelBase.hpp"
 
+#include "AppsData.hpp"
+
 namespace rajaperf 
 {
 class RunParams;
 
 namespace apps
 {
-class ADomain;
 
 class DEL_DOT_VEC_2D : public KernelBase
 {
@@ -104,8 +105,15 @@ public:
 
   ~DEL_DOT_VEC_2D();
 
-  Index_type getProblemSize() const override;
-  Index_type getItsPerRep() const override;
+  Index_type getProblemSize() const 
+  {
+    return m_domain->n_real_zones;
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize();
+  }
 
   void setUp(VariantID vid);
   void updateChecksum(VariantID vid);

--- a/src/apps/ENERGY.hpp
+++ b/src/apps/ENERGY.hpp
@@ -194,9 +194,14 @@ public:
 
   ~ENERGY();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return 6 * getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/apps/FIR.hpp
+++ b/src/apps/FIR.hpp
@@ -69,14 +69,14 @@ public:
 
   ~FIR();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
   }
 
-  Index_type getItsPerRep() const override
+  Index_type getItsPerRep() const
   {
-    return getRunSize() - m_coefflen;
+    return getProblemSize() - m_coefflen;
   }
 
   void setUp(VariantID vid);

--- a/src/apps/HALOEXCHANGE.hpp
+++ b/src/apps/HALOEXCHANGE.hpp
@@ -84,18 +84,16 @@ public:
 
   ~HALOEXCHANGE();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return m_grid_dims[0] *
            m_grid_dims[1] *
            m_grid_dims[2];
   }
 
-  Index_type getItsPerRep() const override
+  Index_type getItsPerRep() const
   {
-    return m_num_vars * (m_var_size - m_grid_dims[0] *
-                                      m_grid_dims[1] *
-                                      m_grid_dims[2] );
+    return m_num_vars * (m_var_size - getProblemSize());
   }
 
   void setUp(VariantID vid);

--- a/src/apps/HALOEXCHANGE_FUSED.hpp
+++ b/src/apps/HALOEXCHANGE_FUSED.hpp
@@ -128,18 +128,16 @@ public:
 
   ~HALOEXCHANGE_FUSED();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return m_grid_dims[0] *
            m_grid_dims[1] *
            m_grid_dims[2];
   }
 
-  Index_type getItsPerRep() const override
+  Index_type getItsPerRep() const
   {
-    return m_num_vars * (m_var_size - m_grid_dims[0] *
-                                      m_grid_dims[1] *
-                                      m_grid_dims[2] );
+    return m_num_vars * (m_var_size - getProblemSize());
   }
 
   void setUp(VariantID vid);

--- a/src/apps/LTIMES.hpp
+++ b/src/apps/LTIMES.hpp
@@ -107,14 +107,14 @@ public:
 
   ~LTIMES();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return m_num_d * m_num_g * m_num_z;
   }
 
-  Index_type getItsPerRep() const override
+  Index_type getItsPerRep() const
   {
-    return m_num_d * m_num_m * m_num_g * m_num_z ;
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/apps/LTIMES_NOVIEW.hpp
+++ b/src/apps/LTIMES_NOVIEW.hpp
@@ -57,14 +57,14 @@ public:
 
   ~LTIMES_NOVIEW();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return m_num_d * m_num_g * m_num_z;
   }
 
-  Index_type getItsPerRep() const override
+  Index_type getItsPerRep() const
   {
-    return m_num_d * m_num_m * m_num_g * m_num_z ;
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/apps/PRESSURE.hpp
+++ b/src/apps/PRESSURE.hpp
@@ -63,9 +63,14 @@ public:
 
   ~PRESSURE();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return 2 * getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -58,16 +58,6 @@ VOL3D::~VOL3D()
   delete m_domain;
 }
 
-Index_type VOL3D::getProblemSize() const
-{
-  return m_domain->n_real_zones;
-}
-
-Index_type VOL3D::getItsPerRep() const
-{
-  return m_domain->lpz+1 - m_domain->fpz;
-}
-
 void VOL3D::setUp(VariantID vid)
 {
   allocAndInitDataConst(m_x, m_array_length, 0.0, vid);

--- a/src/apps/VOL3D.hpp
+++ b/src/apps/VOL3D.hpp
@@ -144,13 +144,14 @@
 
 #include "common/KernelBase.hpp"
 
+#include "AppsData.hpp"
+
 namespace rajaperf 
 {
 class RunParams;
 
 namespace apps
 {
-class ADomain;
 
 class VOL3D : public KernelBase
 {
@@ -160,8 +161,15 @@ public:
 
   ~VOL3D();
 
-  Index_type getProblemSize() const override;
-  Index_type getItsPerRep() const override;
+  Index_type getProblemSize() const 
+  {
+    return m_domain->n_real_zones;
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return m_domain->lpz+1 - m_domain->fpz;
+  }
 
   void setUp(VariantID vid);
   void updateChecksum(VariantID vid);

--- a/src/apps/WIP-COUPLE.cpp
+++ b/src/apps/WIP-COUPLE.cpp
@@ -43,16 +43,6 @@ COUPLE::~COUPLE()
   delete m_domain;
 }
 
-Index_type COUPLE::getProblemSize() const
-{
-  return m_domain->n_real_zones;
-}
-
-Index_type COUPLE::getItsPerRep() const
-{
-  return m_domain->n_real_zones;
-}
-
 void COUPLE::setUp(VariantID vid)
 {
   Index_type max_loop_index = m_domain->lrn;

--- a/src/apps/WIP-COUPLE.hpp
+++ b/src/apps/WIP-COUPLE.hpp
@@ -145,13 +145,14 @@ for (Index_type j = jmin; j < jmax; j++) { \
 
 #include "common/KernelBase.hpp"
 
+#include "AppsData.hpp"
+
 namespace rajaperf 
 {
 class RunParams;
 
 namespace apps
 {
-class ADomain;
 
 class COUPLE : public KernelBase
 {
@@ -161,8 +162,15 @@ public:
 
   ~COUPLE();
 
-  Index_type getProblemSize() const override;
-  Index_type getItsPerRep() const override;
+  Index_type getProblemSize() const 
+  { 
+    return m_domain->n_real_zones;
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
+  }
 
   void setUp(VariantID vid);
   void runKernel(VariantID vid);

--- a/src/basic/DAXPY.hpp
+++ b/src/basic/DAXPY.hpp
@@ -43,9 +43,14 @@ public:
 
   ~DAXPY();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/basic/IF_QUAD.hpp
+++ b/src/basic/IF_QUAD.hpp
@@ -60,9 +60,14 @@ public:
 
   ~IF_QUAD();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/basic/INIT3.hpp
+++ b/src/basic/INIT3.hpp
@@ -46,9 +46,14 @@ public:
 
   ~INIT3();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/basic/INIT_VIEW1D.hpp
+++ b/src/basic/INIT_VIEW1D.hpp
@@ -57,9 +57,14 @@ public:
 
   ~INIT_VIEW1D();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/basic/INIT_VIEW1D_OFFSET.hpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.hpp
@@ -56,9 +56,14 @@ public:
 
   ~INIT_VIEW1D_OFFSET();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/basic/MULADDSUB.hpp
+++ b/src/basic/MULADDSUB.hpp
@@ -49,9 +49,14 @@ public:
 
   ~MULADDSUB();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/basic/NESTED_INIT.hpp
+++ b/src/basic/NESTED_INIT.hpp
@@ -49,9 +49,14 @@ public:
 
   ~NESTED_INIT();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return m_array_length;
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/basic/PI_ATOMIC.hpp
+++ b/src/basic/PI_ATOMIC.hpp
@@ -45,9 +45,14 @@ public:
 
   ~PI_ATOMIC();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -47,9 +47,14 @@ public:
 
   ~PI_REDUCE();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/basic/REDUCE3_INT.hpp
+++ b/src/basic/REDUCE3_INT.hpp
@@ -61,9 +61,14 @@ public:
 
   ~REDUCE3_INT();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/basic/TRAP_INT.hpp
+++ b/src/basic/TRAP_INT.hpp
@@ -58,9 +58,14 @@ public:
 
   ~TRAP_INT();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const 
+  { 
+    return getProblemSize(); 
   }
 
   void setUp(VariantID vid);

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -44,20 +44,24 @@ KernelBase::~KernelBase()
 
 Index_type KernelBase::getRunSize() const
 { 
+  Index_type run_size = static_cast<Index_type>(0);
   if (run_params.getSizeMeaning() == RunParams::SizeMeaning::Factor) {
-    return static_cast<Index_type>(default_size*run_params.getSize());
+    run_size = static_cast<Index_type>(default_size*run_params.getSizeFactor());
   } else if (run_params.getSizeMeaning() == RunParams::SizeMeaning::Direct) {
-    return static_cast<Index_type>(run_params.getSize());
+    run_size = static_cast<Index_type>(run_params.getSize());
   }
+  return run_size;
 }
 
 Index_type KernelBase::getRunReps() const
 { 
+  Index_type run_reps = static_cast<Index_type>(0);
   if (run_params.getInputState() == RunParams::CheckRun) {
-    return static_cast<Index_type>(run_params.getCheckRunReps());
+    run_reps = static_cast<Index_type>(run_params.getCheckRunReps());
   } else {
-    return static_cast<Index_type>(default_reps*run_params.getRepFactor()); 
-  } 
+    run_reps = static_cast<Index_type>(default_reps*run_params.getRepFactor()); 
+  }
+  return run_reps;
 }
 
 void KernelBase::setVariantDefined(VariantID vid) 

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -111,13 +111,12 @@ public:
   // by each concrete kernel class.
   //
 
-  virtual Index_type getProblemSize() const = 0;
-
-  virtual Index_type getItsPerRep() const { return getRunSize(); }
-
   virtual void print(std::ostream& os) const; 
 
   virtual void runKernel(VariantID vid);
+
+  virtual Index_type getProblemSize() const = 0;
+  virtual Index_type getItsPerRep() const = 0;
 
   virtual void setUp(VariantID vid) = 0;
   virtual void updateChecksum(VariantID vid) = 0;

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -95,6 +95,8 @@ public:
 
   double getSize() const { return size; }
 
+  double getSizeFactor() const { return size_factor; }
+
   SizeSpec  getSizeSpec() const { return size_spec; }
 
   void  setSizeSpec(std::string inputString);
@@ -160,9 +162,13 @@ private:
   bool show_progress;    /*!< true -> show run progress; false -> do not */
 
   int npasses;           /*!< Number of passes through suite  */
+
   double rep_fact;       /*!< pct of default kernel reps to run */
+
   SizeMeaning size_meaning; /*!< meaning of size value */
-  double size;           /*!< size value */
+  double size;           /*!< kernel size to run (input option) */
+  double size_factor;    /*!< default kernel size multipier (input option) */
+
   double pf_tol;         /*!< pct RAJA variant run time can exceed base for
                               each PM case to pass/fail acceptance */
 

--- a/src/lcals/DIFF_PREDICT.hpp
+++ b/src/lcals/DIFF_PREDICT.hpp
@@ -84,9 +84,14 @@ public:
 
   ~DIFF_PREDICT();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/lcals/EOS.hpp
+++ b/src/lcals/EOS.hpp
@@ -53,9 +53,14 @@ public:
 
   ~EOS();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/lcals/FIRST_DIFF.hpp
+++ b/src/lcals/FIRST_DIFF.hpp
@@ -43,9 +43,14 @@ public:
 
   ~FIRST_DIFF();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/lcals/FIRST_MIN.hpp
+++ b/src/lcals/FIRST_MIN.hpp
@@ -72,9 +72,14 @@ public:
 
   ~FIRST_MIN();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/lcals/FIRST_SUM.hpp
+++ b/src/lcals/FIRST_SUM.hpp
@@ -46,9 +46,14 @@ public:
 
   ~FIRST_SUM();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/lcals/GEN_LIN_RECUR.hpp
+++ b/src/lcals/GEN_LIN_RECUR.hpp
@@ -67,9 +67,14 @@ public:
 
   ~GEN_LIN_RECUR();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/lcals/HYDRO_1D.hpp
+++ b/src/lcals/HYDRO_1D.hpp
@@ -48,9 +48,14 @@ public:
 
   ~HYDRO_1D();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/lcals/HYDRO_2D.hpp
+++ b/src/lcals/HYDRO_2D.hpp
@@ -144,9 +144,14 @@ public:
 
   ~HYDRO_2D();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return m_array_length;
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return 3 * getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/lcals/INT_PREDICT.hpp
+++ b/src/lcals/INT_PREDICT.hpp
@@ -63,9 +63,14 @@ public:
 
   ~INT_PREDICT();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/lcals/PLANCKIAN.hpp
+++ b/src/lcals/PLANCKIAN.hpp
@@ -48,9 +48,14 @@ public:
 
   ~PLANCKIAN();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/lcals/TRIDIAG_ELIM.hpp
+++ b/src/lcals/TRIDIAG_ELIM.hpp
@@ -48,9 +48,14 @@ public:
 
   ~TRIDIAG_ELIM();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/polybench/POLYBENCH_2MM.hpp
+++ b/src/polybench/POLYBENCH_2MM.hpp
@@ -118,7 +118,12 @@ public:
 
   ~POLYBENCH_2MM();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/polybench/POLYBENCH_3MM.hpp
+++ b/src/polybench/POLYBENCH_3MM.hpp
@@ -143,7 +143,13 @@ public:
   POLYBENCH_3MM(const RunParams& params);
 
   ~POLYBENCH_3MM();
-  Index_type getProblemSize() const override
+
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/polybench/POLYBENCH_ADI.hpp
+++ b/src/polybench/POLYBENCH_ADI.hpp
@@ -186,7 +186,12 @@ public:
 
   ~POLYBENCH_ADI();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/polybench/POLYBENCH_ATAX.hpp
+++ b/src/polybench/POLYBENCH_ATAX.hpp
@@ -106,10 +106,15 @@ public:
 
   ~POLYBENCH_ATAX();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return 0;
   }
+
+  Index_type getItsPerRep() const
+  {
+    return 0;
+  } 
 
   void setUp(VariantID vid);
   void updateChecksum(VariantID vid);

--- a/src/polybench/POLYBENCH_FDTD_2D.hpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.hpp
@@ -104,7 +104,12 @@ public:
 
   ~POLYBENCH_FDTD_2D();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.hpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.hpp
@@ -67,7 +67,12 @@ public:
 
   ~POLYBENCH_FLOYD_WARSHALL();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/polybench/POLYBENCH_GEMM.hpp
+++ b/src/polybench/POLYBENCH_GEMM.hpp
@@ -90,7 +90,12 @@ public:
 
   ~POLYBENCH_GEMM();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/polybench/POLYBENCH_GEMVER.hpp
+++ b/src/polybench/POLYBENCH_GEMVER.hpp
@@ -139,7 +139,12 @@ public:
 
   ~POLYBENCH_GEMVER();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/polybench/POLYBENCH_GESUMMV.hpp
+++ b/src/polybench/POLYBENCH_GESUMMV.hpp
@@ -89,7 +89,12 @@ public:
 
   ~POLYBENCH_GESUMMV();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/polybench/POLYBENCH_HEAT_3D.hpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.hpp
@@ -115,7 +115,12 @@ public:
 
   ~POLYBENCH_HEAT_3D();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/polybench/POLYBENCH_JACOBI_1D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.hpp
@@ -61,7 +61,12 @@ public:
 
   ~POLYBENCH_JACOBI_1D();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/polybench/POLYBENCH_JACOBI_2D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.hpp
@@ -81,7 +81,12 @@ public:
 
   ~POLYBENCH_JACOBI_2D();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/polybench/POLYBENCH_MVT.hpp
+++ b/src/polybench/POLYBENCH_MVT.hpp
@@ -103,7 +103,12 @@ public:
 
   ~POLYBENCH_MVT();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
+  {
+    return 0;
+  }
+
+  Index_type getItsPerRep() const
   {
     return 0;
   }

--- a/src/stream/ADD.hpp
+++ b/src/stream/ADD.hpp
@@ -43,9 +43,14 @@ public:
 
   ~ADD();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/stream/COPY.hpp
+++ b/src/stream/COPY.hpp
@@ -42,9 +42,14 @@ public:
 
   ~COPY();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -42,9 +42,14 @@ public:
 
   ~DOT();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/stream/MUL.hpp
+++ b/src/stream/MUL.hpp
@@ -43,9 +43,14 @@ public:
 
   ~MUL();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);

--- a/src/stream/TRIAD.hpp
+++ b/src/stream/TRIAD.hpp
@@ -44,9 +44,14 @@ public:
 
   ~TRIAD();
 
-  Index_type getProblemSize() const override
+  Index_type getProblemSize() const
   {
     return getRunSize();
+  }
+
+  Index_type getItsPerRep() const
+  {
+    return getProblemSize();
   }
 
   void setUp(VariantID vid);


### PR DESCRIPTION
This PR includes the following changes:

- Removes the use of the override qualifier for KernelBase methods that are specialized by concrete kernel implementations. These are now pure virtual in the base class and all kernel subclasses must implement them. 
- Attempt to make per-kernel definitions of problem size and its er rep consistent. Note that polybench kernels will be address in this regard in a subsequent PR.
- Added a size_fraction variable member to RunParams class and added more error checking for size and size fraction input.
- Disables building of RAJA exercises by default.

Next, I will work on the problem size and its per rep definitions for the polybench kernels and document the meanings of the items for kernel info in this issue: https://github.com/LLNL/RAJAPerf/issues/144