### PR TITLE
Rework GPU kernel policies to allow arbitrary problem size runs.

### DIFF
--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -33,6 +33,10 @@ FIR::FIR(const RunParams& params)
   setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getItsPerRep() +
                   (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() );
   setFLOPsPerRep((2 * m_coefflen) * (getActualProblemSize() - m_coefflen));
+ 
+  checksum_scale_factor = 0.0001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Forall);
 
@@ -66,7 +70,7 @@ void FIR::setUp(VariantID vid)
 
 void FIR::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_out, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_out, getActualProblemSize(), checksum_scale_factor );
 }
 
 void FIR::tearDown(VariantID vid)

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -21,6 +21,21 @@ namespace rajaperf
 namespace apps
 {
 
+//
+// Define thread block size for CUDA execution
+//
+constexpr size_t z_block_sz = 2;
+constexpr size_t g_block_sz = 4;
+constexpr size_t m_block_sz = 32;
+
+#define LTIMES_THREADS_PER_BLOCK_CUDA \
+  dim3 nthreads_per_block(m_block_sz, g_block_sz, z_block_sz);
+
+#define LTIMES_NBLOCKS_CUDA \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz)));
+
 
 #define LTIMES_DATA_SETUP_CUDA \
   allocAndInitCudaDeviceData(phidat, m_phidat, m_philen); \
@@ -34,14 +49,31 @@ namespace apps
   deallocCudaDeviceData(psidat);
 
 __global__ void ltimes(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
-                       Index_type num_d, Index_type num_g, Index_type num_m)
+                       Index_type num_d, 
+                       Index_type num_m, Index_type num_g, Index_type num_z)
 {
-   Index_type m = threadIdx.x;
-   Index_type g = threadIdx.y;
-   Index_type z = blockIdx.z;
+   Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
+   Index_type g = blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type z = blockIdx.z * blockDim.z + threadIdx.z;
 
-   for (Index_type d = 0; d < num_d; ++d ) {
-     LTIMES_BODY;
+   if (m < num_m && g < num_g && z < num_z) {  
+     for (Index_type d = 0; d < num_d; ++d ) {
+       LTIMES_BODY;
+     }
+   }
+}
+
+template< typename Lambda >
+__global__ void ltimes_lam(Index_type num_d,
+                           Index_type num_m, Index_type num_g, Index_type num_z,
+                           Lambda body)
+{
+   Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
+   Index_type g = blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type z = blockIdx.z * blockDim.z + threadIdx.z;
+
+   if (m < num_m && g < num_g && z < num_z) {
+     body(z, g, m);
    }
 }
 
@@ -59,11 +91,12 @@ void LTIMES::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(num_m, num_g, 1);
-      dim3 nblocks(1, 1, num_z);
+      LTIMES_THREADS_PER_BLOCK_CUDA;
+      LTIMES_NBLOCKS_CUDA;
 
       ltimes<<<nblocks, nthreads_per_block>>>(phidat, elldat, psidat,
-                                              num_d, num_g, num_m);
+                                              num_d, 
+                                              num_m, num_g, num_z);
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -78,18 +111,17 @@ void LTIMES::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(num_m, num_g, 1);
-      dim3 nblocks(1, 1, num_z);
+      LTIMES_THREADS_PER_BLOCK_CUDA;
+      LTIMES_NBLOCKS_CUDA;
 
-      lambda_cuda_kernel<RAJA::cuda_block_z_direct, RAJA::cuda_thread_y_direct, RAJA::cuda_thread_x_direct>
-                        <<<nblocks, nthreads_per_block>>>(
-        0, num_z, 0, num_g, 0, num_m,
+      ltimes_lam<<<nblocks, nthreads_per_block>>>(num_d, 
+                                                  num_m, num_g, num_z,
         [=] __device__ (Index_type z, Index_type g, Index_type m) {
-
-        for (Index_type d = 0; d < num_d; ++d ) {
-          LTIMES_BODY;
+          for (Index_type d = 0; d < num_d; ++d ) {
+            LTIMES_BODY;
+          }
         }
-      });
+      );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -105,12 +137,21 @@ void LTIMES::runCudaVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<1, RAJA::cuda_block_z_direct,      //z
-            RAJA::statement::For<2, RAJA::cuda_thread_y_direct,    //g
-              RAJA::statement::For<3, RAJA::cuda_thread_x_direct, //m
-                RAJA::statement::For<0, RAJA::seq_exec,       //d
-                  RAJA::statement::Lambda<0>
+        RAJA::statement::CudaKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
+          RAJA::statement::Tile<1, RAJA::tile_fixed<z_block_sz>,
+                                   RAJA::cuda_block_z_direct,
+            RAJA::statement::Tile<2, RAJA::tile_fixed<g_block_sz>,
+                                     RAJA::cuda_block_y_direct, 
+              RAJA::statement::Tile<3, RAJA::tile_fixed<m_block_sz>,
+                                       RAJA::cuda_block_x_direct, 
+                RAJA::statement::For<1, RAJA::cuda_thread_z_direct,     //z
+                  RAJA::statement::For<2, RAJA::cuda_thread_y_direct,   //g
+                    RAJA::statement::For<3, RAJA::cuda_thread_x_direct, //m
+                      RAJA::statement::For<0, RAJA::seq_exec,           //d
+                        RAJA::statement::Lambda<0>
+                      >
+                    >
+                  >
                 >
               >
             >

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -64,8 +64,7 @@ __global__ void ltimes(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
 }
 
 template< typename Lambda >
-__global__ void ltimes_lam(Index_type num_d,
-                           Index_type num_m, Index_type num_g, Index_type num_z,
+__global__ void ltimes_lam(Index_type num_m, Index_type num_g, Index_type num_z,
                            Lambda body)
 {
    Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
@@ -114,8 +113,7 @@ void LTIMES::runCudaVariant(VariantID vid)
       LTIMES_THREADS_PER_BLOCK_CUDA;
       LTIMES_NBLOCKS_CUDA;
 
-      ltimes_lam<<<nblocks, nthreads_per_block>>>(num_d, 
-                                                  num_m, num_g, num_z,
+      ltimes_lam<<<nblocks, nthreads_per_block>>>(num_m, num_g, num_z,
         [=] __device__ (Index_type z, Index_type g, Index_type m) {
           for (Index_type d = 0; d < num_d; ++d ) {
             LTIMES_BODY;

--- a/src/apps/LTIMES-Hip.cpp
+++ b/src/apps/LTIMES-Hip.cpp
@@ -64,8 +64,7 @@ __global__ void ltimes(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
 }
 
 template< typename Lambda >
-__global__ void ltimes_lam(Index_type num_d,
-                           Index_type num_m, Index_type num_g, Index_type num_z,
+__global__ void ltimes_lam(Index_type num_m, Index_type num_g, Index_type num_z,
                            Lambda body)
 {
    Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
@@ -125,7 +124,6 @@ void LTIMES::runHipVariant(VariantID vid)
 
       hipLaunchKernelGGL((ltimes_lam<decltype(ltimes_lambda)>),
                          dim3(nblocks), dim3(nthreads_per_block), 0, 0,
-                         num_d,
                          num_m, num_g, num_z, ltimes_lambda);
       hipErrchk( hipGetLastError() );
 

--- a/src/apps/LTIMES-Hip.cpp
+++ b/src/apps/LTIMES-Hip.cpp
@@ -123,7 +123,7 @@ void LTIMES::runHipVariant(VariantID vid)
           }
         };
 
-      hipLaunchKernelGGL((ltime_lam<decltype(ltimes_lambda)>),
+      hipLaunchKernelGGL((ltimes_lam<decltype(ltimes_lambda)>),
                          dim3(nblocks), dim3(nthreads_per_block), 0, 0,
                          num_d,
                          num_m, num_g, num_z, ltimes_lambda);

--- a/src/apps/LTIMES-Hip.cpp
+++ b/src/apps/LTIMES-Hip.cpp
@@ -21,6 +21,21 @@ namespace rajaperf
 namespace apps
 {
 
+//
+// Define thread block size for Hip execution
+//
+constexpr size_t z_block_sz = 2;
+constexpr size_t g_block_sz = 4;
+constexpr size_t m_block_sz = 32;
+
+#define LTIMES_THREADS_PER_BLOCK_HIP \
+  dim3 nthreads_per_block(m_block_sz, g_block_sz, z_block_sz);
+
+#define LTIMES_NBLOCKS_HIP \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz)));
+
 
 #define LTIMES_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(phidat, m_phidat, m_philen); \
@@ -34,14 +49,31 @@ namespace apps
   deallocHipDeviceData(psidat);
 
 __global__ void ltimes(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
-                       Index_type num_d, Index_type num_g, Index_type num_m)
+                       Index_type num_d,
+                       Index_type num_m, Index_type num_g, Index_type num_z)
 {
-   Index_type m = threadIdx.x;
-   Index_type g = threadIdx.y;
-   Index_type z = blockIdx.z;
+   Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
+   Index_type g = blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type z = blockIdx.z * blockDim.z + threadIdx.z;
 
-   for (Index_type d = 0; d < num_d; ++d ) {
-     LTIMES_BODY;
+   if (m < num_m && g < num_g && z < num_z) {
+     for (Index_type d = 0; d < num_d; ++d ) {
+       LTIMES_BODY;
+     }
+   }
+}
+
+template< typename Lambda >
+__global__ void ltimes_lam(Index_type num_d,
+                           Index_type num_m, Index_type num_g, Index_type num_z,
+                           Lambda body)
+{
+   Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
+   Index_type g = blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type z = blockIdx.z * blockDim.z + threadIdx.z;
+
+   if (m < num_m && g < num_g && z < num_z) {
+     body(z, g, m);
    }
 }
 
@@ -59,11 +91,14 @@ void LTIMES::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(num_m, num_g, 1);
-      dim3 nblocks(1, 1, num_z);
+      LTIMES_THREADS_PER_BLOCK_HIP;
+      LTIMES_NBLOCKS_HIP;
 
-      hipLaunchKernelGGL((ltimes), dim3(nblocks), dim3(nthreads_per_block), 0, 0, phidat, elldat, psidat,
-                                              num_d, num_g, num_m);
+      hipLaunchKernelGGL((ltimes), 
+                         dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                         phidat, elldat, psidat,
+                         num_d, 
+                         num_m, num_g, num_z);
       hipErrchk( hipGetLastError() );
 
     }
@@ -78,20 +113,20 @@ void LTIMES::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(num_m, num_g, 1);
-      dim3 nblocks(1, 1, num_z);
+      LTIMES_THREADS_PER_BLOCK_HIP;
+      LTIMES_NBLOCKS_HIP;
 
-      auto ltimes_lambda = [=] __device__ (Index_type z, Index_type g, Index_type m) {
+      auto ltimes_lambda = 
+        [=] __device__ (Index_type z, Index_type g, Index_type m) {
+          for (Index_type d = 0; d < num_d; ++d ) {
+            LTIMES_BODY;
+          }
+        };
 
-        for (Index_type d = 0; d < num_d; ++d ) {
-          LTIMES_BODY;
-        }
-      };
-
-      auto kernel = lambda_hip_kernel<RAJA::hip_block_z_direct, RAJA::hip_thread_y_direct, RAJA::hip_thread_x_direct, decltype(ltimes_lambda)>;
-      hipLaunchKernelGGL(kernel,
-        nblocks, nthreads_per_block, 0, 0,
-        0, num_z, 0, num_g, 0, num_m, ltimes_lambda);
+      hipLaunchKernelGGL((ltime_lam<decltype(ltimes_lambda)>),
+                         dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                         num_d,
+                         num_m, num_g, num_z, ltimes_lambda);
       hipErrchk( hipGetLastError() );
 
     }
@@ -107,12 +142,21 @@ void LTIMES::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<1, RAJA::hip_block_z_direct,      //z
-            RAJA::statement::For<2, RAJA::hip_thread_y_direct,    //g
-              RAJA::statement::For<3, RAJA::hip_thread_x_direct, //m
-                RAJA::statement::For<0, RAJA::seq_exec,       //d
-                  RAJA::statement::Lambda<0>
+        RAJA::statement::HipKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
+          RAJA::statement::Tile<1, RAJA::tile_fixed<z_block_sz>,
+                                   RAJA::hip_block_z_direct,
+            RAJA::statement::Tile<2, RAJA::tile_fixed<g_block_sz>,
+                                     RAJA::hip_block_y_direct,
+              RAJA::statement::Tile<3, RAJA::tile_fixed<m_block_sz>,
+                                       RAJA::hip_block_x_direct,
+                RAJA::statement::For<1, RAJA::hip_thread_z_direct,     //z
+                  RAJA::statement::For<2, RAJA::hip_thread_y_direct,   //g
+                    RAJA::statement::For<3, RAJA::hip_thread_x_direct, //m
+                      RAJA::statement::For<0, RAJA::seq_exec,          //d
+                        RAJA::statement::Lambda<0>
+                      >
+                    >
+                  >
                 >
               >
             >
@@ -120,21 +164,21 @@ void LTIMES::runHipVariant(VariantID vid)
         >
       >;
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::kernel<EXEC_POL>( RAJA::make_tuple(IDRange(0, num_d),
-                                                 IZRange(0, num_z),
-                                                 IGRange(0, num_g),
-                                                 IMRange(0, num_m)),
-          [=] __device__ (ID d, IZ z, IG g, IM m) {
-          LTIMES_BODY_RAJA;
-        });
+      RAJA::kernel<EXEC_POL>( RAJA::make_tuple(IDRange(0, num_d),
+                                               IZRange(0, num_z),
+                                               IGRange(0, num_g),
+                                               IMRange(0, num_m)),
+        [=] __device__ (ID d, IZ z, IG g, IM m) {
+        LTIMES_BODY_RAJA;
+      });
 
-      }
-      stopTimer();
+    }
+    stopTimer();
 
-      LTIMES_DATA_TEARDOWN_HIP;
+    LTIMES_DATA_TEARDOWN_HIP;
 
   } else {
      std::cout << "\n LTIMES : Unknown Hip variant id = " << vid << std::endl;

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -52,6 +52,10 @@ LTIMES::LTIMES(const RunParams& params)
                   (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_psilen );
   setFLOPsPerRep(2 * m_num_z * m_num_g * m_num_m * m_num_d);
 
+  checksum_scale_factor = 0.001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() ); 
+
   setUsesFeature(Kernel);
   setUsesFeature(View);
 
@@ -88,7 +92,7 @@ void LTIMES::setUp(VariantID vid)
 
 void LTIMES::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_phidat, m_philen);
+  checksum[vid] += calcChecksum(m_phidat, m_philen, checksum_scale_factor );
 }
 
 void LTIMES::tearDown(VariantID vid)

--- a/src/apps/LTIMES.hpp
+++ b/src/apps/LTIMES.hpp
@@ -11,7 +11,7 @@
 ///
 /// for (Index_type z = 0; z < num_z; ++z ) {
 ///   for (Index_type g = 0; g < num_g; ++g ) {
-///     for (Index_type m = 0; z < num_m; ++m ) {
+///     for (Index_type m = 0; m < num_m; ++m ) {
 ///       for (Index_type d = 0; d < num_d; ++d ) {
 ///
 ///         phi[m+ (g * num_m) + (z * num_m * num_g)] +=

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -21,6 +21,22 @@ namespace rajaperf
 namespace apps
 {
 
+//
+// Define thread block size for CUDA execution
+//
+constexpr size_t z_block_sz = 2;
+constexpr size_t g_block_sz = 4;
+constexpr size_t m_block_sz = 32;
+
+#define LTIMES_NOVIEW_THREADS_PER_BLOCK_CUDA \
+  dim3 nthreads_per_block(m_block_sz, g_block_sz, z_block_sz);
+
+#define LTIMES_NOVIEW_NBLOCKS_CUDA \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz)));
+
+
 
 #define LTIMES_NOVIEW_DATA_SETUP_CUDA \
   allocAndInitCudaDeviceData(phidat, m_phidat, m_philen); \
@@ -34,15 +50,32 @@ namespace apps
   deallocCudaDeviceData(psidat);
 
 __global__ void ltimes_noview(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
-                              Index_type num_d, Index_type num_g, Index_type num_m)
+                              Index_type num_d,
+                              Index_type num_m, Index_type num_g, Index_type num_z)
 {
-  Index_type m = threadIdx.x;
-  Index_type g = threadIdx.y;
-  Index_type z = blockIdx.z;
+   Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
+   Index_type g = blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type z = blockIdx.z * blockDim.z + threadIdx.z;
 
-  for (Index_type d = 0; d < num_d; ++d ) {
-    LTIMES_NOVIEW_BODY;
-  }
+   if (m < num_m && g < num_g && z < num_z) {
+     for (Index_type d = 0; d < num_d; ++d ) {
+       LTIMES_NOVIEW_BODY;
+     }
+   }
+}
+
+template< typename Lambda >
+__global__ void ltimes_noview_lam(Index_type num_d,
+                                  Index_type num_m, Index_type num_g, Index_type num_z,
+                                  Lambda body)
+{
+   Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
+   Index_type g = blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type z = blockIdx.z * blockDim.z + threadIdx.z;
+
+   if (m < num_m && g < num_g && z < num_z) {
+     body(z, g, m);
+   }
 }
 
 
@@ -59,11 +92,12 @@ void LTIMES_NOVIEW::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(num_m, num_g, 1);
-      dim3 nblocks(1, 1, num_z);
+      LTIMES_NOVIEW_THREADS_PER_BLOCK_CUDA;
+      LTIMES_NOVIEW_NBLOCKS_CUDA;
 
       ltimes_noview<<<nblocks, nthreads_per_block>>>(phidat, elldat, psidat,
-                                                     num_d, num_g, num_m);
+                                                     num_d,
+                                                     num_m, num_g, num_z);
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -78,18 +112,17 @@ void LTIMES_NOVIEW::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(num_m, num_g, 1);
-      dim3 nblocks(1, 1, num_z);
+      LTIMES_NOVIEW_THREADS_PER_BLOCK_CUDA;
+      LTIMES_NOVIEW_NBLOCKS_CUDA;
 
-      lambda_cuda_kernel<RAJA::cuda_block_z_direct, RAJA::cuda_thread_y_direct, RAJA::cuda_thread_x_direct>
-                        <<<nblocks, nthreads_per_block>>>(
-        0, num_z, 0, num_g, 0, num_m,
+      ltimes_noview_lam<<<nblocks, nthreads_per_block>>>(num_d,
+                                                         num_m, num_g, num_z,
         [=] __device__ (Index_type z, Index_type g, Index_type m) {
-
-        for (Index_type d = 0; d < num_d; ++d ) {
-          LTIMES_NOVIEW_BODY;
+          for (Index_type d = 0; d < num_d; ++d ) {
+            LTIMES_NOVIEW_BODY;
+          }
         }
-      });
+      );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -103,12 +136,21 @@ void LTIMES_NOVIEW::runCudaVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<1, RAJA::cuda_block_z_direct,      //z
-            RAJA::statement::For<2, RAJA::cuda_thread_y_direct,    //g
-              RAJA::statement::For<3, RAJA::cuda_thread_x_direct, //m
-                RAJA::statement::For<0, RAJA::seq_exec,       //d
-                  RAJA::statement::Lambda<0>
+        RAJA::statement::CudaKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
+          RAJA::statement::Tile<1, RAJA::tile_fixed<z_block_sz>,
+                                   RAJA::cuda_block_z_direct,
+            RAJA::statement::Tile<2, RAJA::tile_fixed<g_block_sz>,
+                                     RAJA::cuda_block_y_direct,
+              RAJA::statement::Tile<3, RAJA::tile_fixed<m_block_sz>,
+                                       RAJA::cuda_block_x_direct,
+                RAJA::statement::For<1, RAJA::cuda_thread_z_direct,     //z
+                  RAJA::statement::For<2, RAJA::cuda_thread_y_direct,   //g
+                    RAJA::statement::For<3, RAJA::cuda_thread_x_direct, //m
+                      RAJA::statement::For<0, RAJA::seq_exec,           //d
+                        RAJA::statement::Lambda<0>
+                      >
+                    >
+                  >
                 >
               >
             >

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -65,8 +65,7 @@ __global__ void ltimes_noview(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
 }
 
 template< typename Lambda >
-__global__ void ltimes_noview_lam(Index_type num_d,
-                                  Index_type num_m, Index_type num_g, Index_type num_z,
+__global__ void ltimes_noview_lam(Index_type num_m, Index_type num_g, Index_type num_z,
                                   Lambda body)
 {
    Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
@@ -115,8 +114,7 @@ void LTIMES_NOVIEW::runCudaVariant(VariantID vid)
       LTIMES_NOVIEW_THREADS_PER_BLOCK_CUDA;
       LTIMES_NOVIEW_NBLOCKS_CUDA;
 
-      ltimes_noview_lam<<<nblocks, nthreads_per_block>>>(num_d,
-                                                         num_m, num_g, num_z,
+      ltimes_noview_lam<<<nblocks, nthreads_per_block>>>(num_m, num_g, num_z,
         [=] __device__ (Index_type z, Index_type g, Index_type m) {
           for (Index_type d = 0; d < num_d; ++d ) {
             LTIMES_NOVIEW_BODY;

--- a/src/apps/LTIMES_NOVIEW-Hip.cpp
+++ b/src/apps/LTIMES_NOVIEW-Hip.cpp
@@ -64,8 +64,7 @@ __global__ void ltimes_noview(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
 }
 
 template< typename Lambda >
-__global__ void ltimes_noview_lam(Index_type num_d,
-                                  Index_type num_m, Index_type num_g, Index_type num_z,
+__global__ void ltimes_noview_lam(Index_type num_m, Index_type num_g, Index_type num_z,
                                   Lambda body)
 {
    Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
@@ -125,7 +124,6 @@ void LTIMES_NOVIEW::runHipVariant(VariantID vid)
 
       hipLaunchKernelGGL((ltimes_noview_lam<decltype(ltimes_noview_lambda)>), 
                          dim3(nblocks), dim3(nthreads_per_block), 0, 0, 
-                         num_d,
                          num_m, num_g, num_z,
                          ltimes_noview_lambda);
       hipErrchk( hipGetLastError() );

--- a/src/apps/LTIMES_NOVIEW-Hip.cpp
+++ b/src/apps/LTIMES_NOVIEW-Hip.cpp
@@ -125,9 +125,9 @@ void LTIMES_NOVIEW::runHipVariant(VariantID vid)
 
       hipLaunchKernelGGL((ltimes_noview_lam<decltype(ltimes_noview_lambda)>), 
                          dim3(nblocks), dim3(nthreads_per_block), 0, 0, 
-                         phidat, elldat, psidat,
                          num_d,
-                         num_m, num_g, num_z);
+                         num_m, num_g, num_z,
+                         ltimes_noview_lambda);
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/apps/LTIMES_NOVIEW-Hip.cpp
+++ b/src/apps/LTIMES_NOVIEW-Hip.cpp
@@ -21,6 +21,21 @@ namespace rajaperf
 namespace apps
 {
 
+//
+// Define thread block size for Hip execution
+//
+constexpr size_t z_block_sz = 2;
+constexpr size_t g_block_sz = 4;
+constexpr size_t m_block_sz = 32;
+
+#define LTIMES_NOVIEW_THREADS_PER_BLOCK_HIP \
+  dim3 nthreads_per_block(m_block_sz, g_block_sz, z_block_sz);
+
+#define LTIMES_NOVIEW_NBLOCKS_HIP \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz)));
+
 
 #define LTIMES_NOVIEW_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(phidat, m_phidat, m_philen); \
@@ -34,14 +49,31 @@ namespace apps
   deallocHipDeviceData(psidat);
 
 __global__ void ltimes_noview(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
-                              Index_type num_d, Index_type num_g, Index_type num_m)
+                              Index_type num_d,
+                              Index_type num_m, Index_type num_g, Index_type num_z)
 {
-   Index_type m = threadIdx.x;
-   Index_type g = threadIdx.y;
-   Index_type z = blockIdx.z;
+   Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
+   Index_type g = blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type z = blockIdx.z * blockDim.z + threadIdx.z;
 
-   for (Index_type d = 0; d < num_d; ++d ) {
-     LTIMES_NOVIEW_BODY;
+   if (m < num_m && g < num_g && z < num_z) {
+     for (Index_type d = 0; d < num_d; ++d ) {
+       LTIMES_NOVIEW_BODY;
+     }
+   }
+}
+
+template< typename Lambda >
+__global__ void ltimes_noview_lam(Index_type num_d,
+                                  Index_type num_m, Index_type num_g, Index_type num_z,
+                                  Lambda body)
+{
+   Index_type m = blockIdx.x * blockDim.x + threadIdx.x;
+   Index_type g = blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type z = blockIdx.z * blockDim.z + threadIdx.z;
+
+   if (m < num_m && g < num_g && z < num_z) {
+     body(z, g, m);
    }
 }
 
@@ -59,11 +91,14 @@ void LTIMES_NOVIEW::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(num_m, num_g, 1);
-      dim3 nblocks(1, 1, num_z);
+      LTIMES_NOVIEW_THREADS_PER_BLOCK_HIP;
+      LTIMES_NOVIEW_NBLOCKS_HIP;
 
-      hipLaunchKernelGGL((ltimes_noview), dim3(nblocks), dim3(nthreads_per_block), 0, 0, phidat, elldat, psidat,
-                                                     num_d, num_g, num_m);
+      hipLaunchKernelGGL((ltimes_noview), 
+                         dim3(nblocks), dim3(nthreads_per_block), 0, 0, 
+                         phidat, elldat, psidat,
+                         num_d, 
+                         num_m, num_g, num_z);
       hipErrchk( hipGetLastError() );
 
     }
@@ -78,20 +113,21 @@ void LTIMES_NOVIEW::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(num_m, num_g, 1);
-      dim3 nblocks(1, 1, num_z);
+      LTIMES_NOVIEW_THREADS_PER_BLOCK_HIP;
+      LTIMES_NOVIEW_NBLOCKS_HIP;
 
-      auto ltimes_noview_lambda = [=] __device__ (Index_type z, Index_type g, Index_type m) {
-
-        for (Index_type d = 0; d < num_d; ++d ) {
-          LTIMES_NOVIEW_BODY;
-        }
+      auto ltimes_noview_lambda = 
+        [=] __device__ (Index_type z, Index_type g, Index_type m) {
+          for (Index_type d = 0; d < num_d; ++d ) {
+            LTIMES_NOVIEW_BODY;
+          }
       };
 
-      auto kernel = lambda_hip_kernel<RAJA::hip_block_z_direct, RAJA::hip_thread_y_direct, RAJA::hip_thread_x_direct, decltype(ltimes_noview_lambda)>;
-      hipLaunchKernelGGL(kernel,
-        nblocks, nthreads_per_block, 0, 0,
-        0, num_z, 0, num_g, 0, num_m, ltimes_noview_lambda);
+      hipLaunchKernelGGL((ltimes_noview_lam<decltype(ltimes_noview_lambda)>), 
+                         dim3(nblocks), dim3(nthreads_per_block), 0, 0, 
+                         phidat, elldat, psidat,
+                         num_d,
+                         num_m, num_g, num_z);
       hipErrchk( hipGetLastError() );
 
     }
@@ -105,12 +141,21 @@ void LTIMES_NOVIEW::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<1, RAJA::hip_block_z_direct,      //z
-            RAJA::statement::For<2, RAJA::hip_thread_y_direct,    //g
-              RAJA::statement::For<3, RAJA::hip_thread_x_direct, //m
-                RAJA::statement::For<0, RAJA::seq_exec,       //d
-                  RAJA::statement::Lambda<0>
+        RAJA::statement::HipKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
+          RAJA::statement::Tile<1, RAJA::tile_fixed<z_block_sz>,
+                                   RAJA::hip_block_z_direct,
+            RAJA::statement::Tile<2, RAJA::tile_fixed<g_block_sz>,
+                                     RAJA::hip_block_y_direct,
+              RAJA::statement::Tile<3, RAJA::tile_fixed<m_block_sz>,
+                                       RAJA::hip_block_x_direct,
+                RAJA::statement::For<1, RAJA::hip_thread_z_direct,     //z
+                  RAJA::statement::For<2, RAJA::hip_thread_y_direct,   //g
+                    RAJA::statement::For<3, RAJA::hip_thread_x_direct, //m
+                      RAJA::statement::For<0, RAJA::seq_exec,          //d
+                        RAJA::statement::Lambda<0>
+                      >
+                    >
+                  >
                 >
               >
             >
@@ -126,7 +171,7 @@ void LTIMES_NOVIEW::runHipVariant(VariantID vid)
                                                RAJA::RangeSegment(0, num_g),
                                                RAJA::RangeSegment(0, num_m)),
         [=] __device__ (Index_type d, Index_type z, Index_type g, Index_type m) {
-        LTIMES_NOVIEW_BODY;
+          LTIMES_NOVIEW_BODY;
       });
 
     }

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -52,6 +52,10 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
                   (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_psilen );
   setFLOPsPerRep(2 * m_num_z * m_num_g * m_num_m * m_num_d);
 
+  checksum_scale_factor = 0.001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
+
   setUsesFeature(Kernel);
 
   setVariantDefined( Base_Seq );
@@ -87,7 +91,7 @@ void LTIMES_NOVIEW::setUp(VariantID vid)
 
 void LTIMES_NOVIEW::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_phidat, m_philen);
+  checksum[vid] += calcChecksum(m_phidat, m_philen, checksum_scale_factor );
 }
 
 void LTIMES_NOVIEW::tearDown(VariantID vid)

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -42,6 +42,10 @@ VOL3D::VOL3D(const RunParams& params)
                   (0*sizeof(Real_type) + 3*sizeof(Real_type)) * (getItsPerRep() + 1+m_domain->jp+m_domain->kp) );
   setFLOPsPerRep(72 * (m_domain->lpz+1 - m_domain->fpz));
 
+  checksum_scale_factor = 0.001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
+
   setUsesFeature(Forall);
 
   setVariantDefined( Base_Seq );
@@ -85,7 +89,7 @@ void VOL3D::setUp(VariantID vid)
 
 void VOL3D::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_vol, m_array_length);
+  checksum[vid] += calcChecksum(m_vol, m_array_length, checksum_scale_factor );
 }
 
 void VOL3D::tearDown(VariantID vid)

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -31,6 +31,10 @@ IF_QUAD::IF_QUAD(const RunParams& params)
   setBytesPerRep( (2*sizeof(Real_type) + 3*sizeof(Real_type)) * getActualProblemSize() );
   setFLOPsPerRep(11 * getActualProblemSize()); // 1 sqrt
 
+  checksum_scale_factor = 0.0001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
+
   setUsesFeature(Forall);
 
   setVariantDefined( Base_Seq );
@@ -68,8 +72,8 @@ void IF_QUAD::setUp(VariantID vid)
 
 void IF_QUAD::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_x1, getActualProblemSize());
-  checksum[vid] += calcChecksum(m_x2, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_x1, getActualProblemSize(), checksum_scale_factor );
+  checksum[vid] += calcChecksum(m_x2, getActualProblemSize(), checksum_scale_factor );
 }
 
 void IF_QUAD::tearDown(VariantID vid)

--- a/src/basic/MAT_MAT_SHARED.cpp
+++ b/src/basic/MAT_MAT_SHARED.cpp
@@ -38,6 +38,10 @@ MAT_MAT_SHARED::MAT_MAT_SHARED(const RunParams &params)
   const Index_type no_blocks = RAJA_DIVIDE_CEILING_INT(m_N, TL_SZ);
   setFLOPsPerRep(2 * TL_SZ * TL_SZ * TL_SZ * no_tiles * no_blocks * no_blocks);
 
+  checksum_scale_factor = 10e-12 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
+
   setUsesFeature(Teams);
 
   setVariantDefined(Base_Seq);
@@ -67,7 +71,7 @@ void MAT_MAT_SHARED::setUp(VariantID vid) {
 }
 
 void MAT_MAT_SHARED::updateChecksum(VariantID vid) {
-  checksum[vid] += calcChecksum(m_C, m_N*m_N);
+  checksum[vid] += calcChecksum(m_C, m_N*m_N, checksum_scale_factor );
 }
 
 void MAT_MAT_SHARED::tearDown(VariantID vid) {

--- a/src/basic/MAT_MAT_SHARED.cpp
+++ b/src/basic/MAT_MAT_SHARED.cpp
@@ -18,11 +18,12 @@ namespace rajaperf {
 namespace basic {
 
 MAT_MAT_SHARED::MAT_MAT_SHARED(const RunParams &params)
-    : KernelBase(rajaperf::Basic_MAT_MAT_SHARED, params) {
+    : KernelBase(rajaperf::Basic_MAT_MAT_SHARED, params) 
+{
 
   m_N_default = 1000;
   setDefaultProblemSize(m_N_default*m_N_default);
-  setDefaultReps(50);
+  setDefaultReps(5);
 
   m_N = std::max(Index_type(std::sqrt(getTargetProblemSize())), Index_type(1));
 
@@ -38,9 +39,10 @@ MAT_MAT_SHARED::MAT_MAT_SHARED(const RunParams &params)
   const Index_type no_blocks = RAJA_DIVIDE_CEILING_INT(m_N, TL_SZ);
   setFLOPsPerRep(2 * TL_SZ * TL_SZ * TL_SZ * no_tiles * no_blocks * no_blocks);
 
-  checksum_scale_factor = 10e-12 *
+  checksum_scale_factor = 1e-6 *
               ( static_cast<Checksum_type>(getDefaultProblemSize()) /
                                            getActualProblemSize() );
+
 
   setUsesFeature(Teams);
 
@@ -65,9 +67,10 @@ MAT_MAT_SHARED::~MAT_MAT_SHARED() {}
 
 void MAT_MAT_SHARED::setUp(VariantID vid) {
   const Index_type NN = m_N * m_N;
-  allocAndInitData(m_A, NN, vid);
-  allocAndInitData(m_B, NN, vid);
-  allocAndInitData(m_C, NN, vid);
+
+  allocAndInitDataConst(m_A, NN, 1.0, vid);
+  allocAndInitDataConst(m_B, NN, 1.0, vid);
+  allocAndInitDataConst(m_C, NN, 0.0, vid);
 }
 
 void MAT_MAT_SHARED::updateChecksum(VariantID vid) {

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -47,7 +47,7 @@ __global__ void nested_init(Real_ptr array,
   }
 }
 
-template<typename Lambda >
+template< typename Lambda >
 __global__ void nested_init_lam(Index_type ni, Index_type nj, Index_type nk,
                                 Lambda body)
 { 

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -28,6 +28,15 @@ namespace basic
   constexpr size_t j_block_sz = 8;
   constexpr size_t k_block_sz = 1;
 
+#define NESTED_INIT_THREADS_PER_BLOCK_CUDA \
+  dim3 nthreads_per_block(i_block_sz, j_block_sz, k_block_sz);
+
+#define NESTED_INIT_NBLOCKS_CUDA \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, i_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nk, k_block_sz)));
+
+
 #define NESTED_INIT_DATA_SETUP_CUDA \
   allocAndInitCudaDeviceData(array, m_array, m_array_length);
 
@@ -74,11 +83,9 @@ void NESTED_INIT::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(i_block_sz, j_block_sz, k_block_sz);
-      dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, i_block_sz)),
-                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, j_block_sz)),
-                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nk, k_block_sz)));
-
+      NESTED_INIT_THREADS_PER_BLOCK_CUDA;
+      NESTED_INIT_NBLOCKS_CUDA;
+ 
       nested_init<<<nblocks, nthreads_per_block>>>(array,
                                                    ni, nj, nk);
       cudaErrchk( cudaGetLastError() );
@@ -95,10 +102,8 @@ void NESTED_INIT::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(i_block_sz, j_block_sz, k_block_sz);
-      dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, i_block_sz)),
-                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, j_block_sz)),
-                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nk, k_block_sz)));
+      NESTED_INIT_THREADS_PER_BLOCK_CUDA;
+      NESTED_INIT_NBLOCKS_CUDA;
 
       nested_init_lam<<<nblocks, nthreads_per_block>>>(ni, nj, nk,
         [=] __device__ (Index_type i, Index_type j, Index_type k) {

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -21,6 +21,13 @@ namespace rajaperf
 namespace basic
 {
 
+  //
+  // Define thread block size for CUDA execution
+  //
+  constexpr size_t i_block_sz = 32;
+  constexpr size_t j_block_sz = 8;
+  constexpr size_t k_block_sz = 1;
+
 #define NESTED_INIT_DATA_SETUP_CUDA \
   allocAndInitCudaDeviceData(array, m_array, m_array_length);
 
@@ -29,13 +36,28 @@ namespace basic
   deallocCudaDeviceData(array);
 
 __global__ void nested_init(Real_ptr array,
-                            Index_type ni, Index_type nj)
+                            Index_type ni, Index_type nj, Index_type nk)
 {
-  Index_type i = threadIdx.x;
-  Index_type j = blockIdx.y;
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  Index_type j = blockIdx.y * blockDim.y + threadIdx.y;
   Index_type k = blockIdx.z;
 
-  NESTED_INIT_BODY;
+  if ( i < ni && j < nj && k < nk ) {
+    NESTED_INIT_BODY;
+  }
+}
+
+template<typename Lambda >
+__global__ void nested_init_lam(Index_type ni, Index_type nj, Index_type nk,
+                                Lambda body)
+{ 
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  Index_type j = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type k = blockIdx.z;
+    
+  if ( i < ni && j < nj && k < nk ) {
+    body(i, j, k);
+  }
 }
 
 
@@ -52,11 +74,13 @@ void NESTED_INIT::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(ni, 1, 1);
-      dim3 nblocks(1, nj, nk);
+      dim3 nthreads_per_block(i_block_sz, j_block_sz, k_block_sz);
+      dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, i_block_sz)),
+                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, j_block_sz)),
+                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nk, k_block_sz)));
 
       nested_init<<<nblocks, nthreads_per_block>>>(array,
-                                                   ni, nj);
+                                                   ni, nj, nk);
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -71,14 +95,16 @@ void NESTED_INIT::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(ni, 1, 1);
-      dim3 nblocks(1, nj, nk);
+      dim3 nthreads_per_block(i_block_sz, j_block_sz, k_block_sz);
+      dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, i_block_sz)),
+                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, j_block_sz)),
+                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nk, k_block_sz)));
 
-      lambda_cuda_kernel<RAJA::cuda_thread_x_direct, RAJA::cuda_block_y_direct, RAJA::cuda_block_z_direct><<<nblocks, nthreads_per_block>>>(
-        0, ni, 0, nj, 0, nk,
+      nested_init_lam<<<nblocks, nthreads_per_block>>>(ni, nj, nk,
         [=] __device__ (Index_type i, Index_type j, Index_type k) {
-        NESTED_INIT_BODY;
-      });
+          NESTED_INIT_BODY;
+        }
+      );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -92,11 +118,17 @@ void NESTED_INIT::runCudaVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<2, RAJA::cuda_block_z_direct,      // k
-            RAJA::statement::For<1, RAJA::cuda_block_y_direct,    // j
-              RAJA::statement::For<0, RAJA::cuda_thread_x_direct, // i
-                RAJA::statement::Lambda<0>
+        RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
+          RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>, 
+                                   RAJA::cuda_block_y_direct,
+            RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>, 
+                                     RAJA::cuda_block_x_direct,
+              RAJA::statement::For<2, RAJA::cuda_block_z_direct,      // k
+                RAJA::statement::For<1, RAJA::cuda_thread_y_direct,   // j
+                  RAJA::statement::For<0, RAJA::cuda_thread_x_direct, // i 
+                    RAJA::statement::Lambda<0>
+                  >
+                >
               >
             >
           >

--- a/src/basic/NESTED_INIT-Hip.cpp
+++ b/src/basic/NESTED_INIT-Hip.cpp
@@ -21,6 +21,13 @@ namespace rajaperf
 namespace basic
 {
 
+  //
+  // Define thread block size for CUDA execution
+  //
+  constexpr size_t i_block_sz = 32;
+  constexpr size_t j_block_sz = 8;
+  constexpr size_t k_block_sz = 1;
+
 #define NESTED_INIT_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(array, m_array, m_array_length);
 
@@ -29,13 +36,28 @@ namespace basic
   deallocHipDeviceData(array);
 
 __global__ void nested_init(Real_ptr array,
-                            Index_type ni, Index_type nj)
+                            Index_type ni, Index_type nj, Index_type nk)
 {
-  Index_type i = threadIdx.x;
-  Index_type j = blockIdx.y;
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  Index_type j = blockIdx.y * blockDim.y + threadIdx.y;
   Index_type k = blockIdx.z;
 
-  NESTED_INIT_BODY;
+  if ( i < ni && j < nj && k < nk ) {
+    NESTED_INIT_BODY;
+  }
+}
+
+template<typename Lambda >
+__global__ void nested_init_lam(Index_type ni, Index_type nj, Index_type nk,
+                                Lambda body)
+{
+  Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+  Index_type j = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type k = blockIdx.z;
+
+  if ( i < ni && j < nj && k < nk ) {
+    body(i, j, k);
+  }
 }
 
 
@@ -52,11 +74,14 @@ void NESTED_INIT::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nthreads_per_block(ni, 1, 1);
-      dim3 nblocks(1, nj, nk);
+      dim3 nthreads_per_block(i_block_sz, j_block_sz, k_block_sz);
+      dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, i_block_sz)),
+                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, j_block_sz)),
+                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nk, k_block_sz)));
 
-      hipLaunchKernelGGL((nested_init), dim3(nblocks), dim3(nthreads_per_block), 0, 0, array,
-                                                   ni, nj);
+      hipLaunchKernelGGL((nested_init), 
+                         dim3(nblocks), dim3(nthreads_per_block), 0, 0, 
+                         array, ni, nj, nk);
       hipErrchk( hipGetLastError() );
 
     }
@@ -71,17 +96,18 @@ void NESTED_INIT::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      auto nested_init_lambda = [=] __device__ (Index_type i, Index_type j, Index_type k) {
-        NESTED_INIT_BODY;
-      };
+      dim3 nthreads_per_block(i_block_sz, j_block_sz, k_block_sz);
+      dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, i_block_sz)),
+                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, j_block_sz)),
+                   static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nk, k_block_sz)));
 
-      dim3 nthreads_per_block(ni, 1, 1);
-      dim3 nblocks(1, nj, nk);
-
-      auto kernel = lambda_hip_kernel<RAJA::hip_thread_x_direct, RAJA::hip_block_y_direct, RAJA::hip_block_z_direct, decltype(nested_init_lambda)>;
-      hipLaunchKernelGGL(kernel,
-        nblocks, nthreads_per_block, 0, 0,
-        0, ni, 0, nj, 0, nk, nested_init_lambda);
+      hipLaunchKernelGGL((nested_init_lam), 
+                         dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                         ni, nj, nk,
+        [=] __device__ (Index_type i, Index_type j, Index_type k) {
+          NESTED_INIT_BODY;
+        }
+      );
       hipErrchk( hipGetLastError() );
 
     }
@@ -95,16 +121,23 @@ void NESTED_INIT::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<2, RAJA::hip_block_z_direct,      // k
-            RAJA::statement::For<1, RAJA::hip_block_y_direct,    // j
-              RAJA::statement::For<0, RAJA::hip_thread_x_direct, // i
-                RAJA::statement::Lambda<0>
+       RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
+          RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
+                                   RAJA::hip_block_y_direct,
+            RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
+                                     RAJA::hip_block_x_direct,
+              RAJA::statement::For<2, RAJA::hip_block_z_direct,      // k
+                RAJA::statement::For<1, RAJA::hip_thread_y_direct,   // j
+                  RAJA::statement::For<0, RAJA::hip_thread_x_direct, // i
+                    RAJA::statement::Lambda<0>
+                  >
+                >
               >
             >
           >
         >
-      >;
+      >; 
+
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/basic/NESTED_INIT-Hip.cpp
+++ b/src/basic/NESTED_INIT-Hip.cpp
@@ -96,18 +96,19 @@ void NESTED_INIT::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      auto nested_init_lambda = [=] __device__ (Index_type i, Index_type j, 
+                                                Index_type k) {
+        NESTED_INIT_BODY;
+      };
+
       dim3 nthreads_per_block(i_block_sz, j_block_sz, k_block_sz);
       dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, i_block_sz)),
                    static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, j_block_sz)),
                    static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nk, k_block_sz)));
 
-      hipLaunchKernelGGL((nested_init_lam), 
+      hipLaunchKernelGGL((nested_init_lam< decltype(nested_init_lambda) >), 
                          dim3(nblocks), dim3(nthreads_per_block), 0, 0,
-                         ni, nj, nk,
-        [=] __device__ (Index_type i, Index_type j, Index_type k) {
-          NESTED_INIT_BODY;
-        }
-      );
+                         ni, nj, nk, nested_init_lambda);
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -79,41 +79,6 @@ __device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_block_z_direct>() 
 }
 
 /*!
- * \brief Simple kernel cuda kernel that runs a lambda.
- */
-template < typename I_Index, typename J_Index, typename Lambda >
-__global__ void lambda_cuda_kernel(Index_type ibegin, Index_type iend,
-                                   Index_type jbegin, Index_type jend,
-                                   Lambda body)
-{
-  Index_type i = ibegin + lambda_cuda_get_index<I_Index>();
-  Index_type j = jbegin + lambda_cuda_get_index<J_Index>();
-  if (i < iend) {
-    if (j < jend) {
-      body(i, j);
-    }
-  }
-}
-///
-template < typename I_Index, typename J_Index, typename K_Index, typename Lambda >
-__global__ void lambda_cuda_kernel(Index_type ibegin, Index_type iend,
-                                   Index_type jbegin, Index_type jend,
-                                   Index_type kbegin, Index_type kend,
-                                   Lambda body)
-{
-  Index_type i = ibegin + lambda_cuda_get_index<I_Index>();
-  Index_type j = jbegin + lambda_cuda_get_index<J_Index>();
-  Index_type k = kbegin + lambda_cuda_get_index<K_Index>();
-  if (i < iend) {
-    if (j < jend) {
-      if (k < kend) {
-        body(i, j, k);
-      }
-    }
-  }
-}
-
-/*!
  * \brief Copy given hptr (host) data to CUDA device (dptr).
  *
  * Method assumes both host and device data arrays are allocated

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -392,7 +392,7 @@ void Executor::reportRunSummary(ostream& str) const
     str << "\nHow suite will be run:" << endl;
     str << "\t # passes = " << run_params.getNumPasses() << endl;
     if (run_params.getSizeMeaning() == RunParams::SizeMeaning::Factor) {
-      str << "\t Kernel size factor = " << run_params.getSize() << endl;
+      str << "\t Kernel size factor = " << run_params.getSizeFactor() << endl;
     } else if (run_params.getSizeMeaning() == RunParams::SizeMeaning::Direct) {
       str << "\t Kernel size = " << run_params.getSize() << endl;
     }

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -75,41 +75,6 @@ __device__ inline Index_type lambda_hip_get_index<RAJA::hip_block_z_direct>() {
 }
 
 /*!
- * \brief Simple multi-dimensional hip kernel that runs a lambda.
- */
-template < typename I_Index, typename J_Index, typename Lambda >
-__global__ void lambda_hip_kernel(Index_type ibegin, Index_type iend,
-                                  Index_type jbegin, Index_type jend,
-                                  Lambda body)
-{
-  Index_type i = ibegin + lambda_hip_get_index<I_Index>();
-  Index_type j = jbegin + lambda_hip_get_index<J_Index>();
-  if (i < iend) {
-    if (j < jend) {
-      body(i, j);
-    }
-  }
-}
-///
-template < typename I_Index, typename J_Index, typename K_Index, typename Lambda >
-__global__ void lambda_hip_kernel(Index_type ibegin, Index_type iend,
-                                  Index_type jbegin, Index_type jend,
-                                  Index_type kbegin, Index_type kend,
-                                  Lambda body)
-{
-  Index_type i = ibegin + lambda_hip_get_index<I_Index>();
-  Index_type j = jbegin + lambda_hip_get_index<J_Index>();
-  Index_type k = kbegin + lambda_hip_get_index<K_Index>();
-  if (i < iend) {
-    if (j < jend) {
-      if (k < kend) {
-        body(i, j, k);
-      }
-    }
-  }
-}
-
-/*!
  * \brief Copy given hptr (host) data to HIP device (dptr).
  *
  * Method assumes both host and device data arrays are allocated

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -40,6 +40,8 @@ KernelBase::KernelBase(KernelID kid, const RunParams& params) :
 
   running_variant = NumVariants;
 
+  checksum_scale_factor = 1.0;
+
   for (size_t vid = 0; vid < NumVariants; ++vid) {
     checksum[vid] = 0.0;
     num_exec[vid] = 0;

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -162,6 +162,7 @@ protected:
   const RunParams& run_params;
 
   Checksum_type checksum[NumVariants];
+  Checksum_type checksum_scale_factor;
 
 private:
   KernelBase() = delete;

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -83,8 +83,6 @@ public:
     { return has_variant_defined[vid]; }
 
 
-  SizeSpec getSizeSpec() {return run_params.getSizeSpec();}
-
   //
   // Methods to get information about kernel execution for reports
   // containing kernel execution information

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -23,37 +23,6 @@ namespace rajaperf
 class KernelBase;
 class RunParams;
 
-/*!
- *******************************************************************************
- *
- * \brief Enumeration defining size specification for the polybench kernels
- *
- * Polybench comes with a spec file to setup the iteration space for 
- * various sizes: Mini, Small, Medium, Large, Extralarge
- *
- * We adapt those entries within this perfsuite.
- *
- * The default size is Medium, which can be overridden at run-time.
- *
- * An example partial entry from that file showing the MINI and SMALL spec 
- * for the kernel 3mm is:
- *
- * kernel	category	datatype	params	MINI	SMALL	MEDIUM	LARGE	EXTRALARGE
- * 3mm	linear-algebra/kernels	double	NI NJ NK NL NM	16 18 20 22 24	40 50 60 70 80 .... 
- * *
- *******************************************************************************
- */
-enum SizeSpec {
-  
-  Mini = 0,
-  Small,
-  Medium,
-  Large,
-  Extralarge,
-  Specundefined
-
-};
-
 
 /*!
  *******************************************************************************

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -35,8 +35,6 @@ RunParams::RunParams(int argc, char** argv)
    size_factor(0.0),
    pf_tol(0.1),
    checkrun_reps(1),
-   size_spec(Specundefined),
-   size_spec_string("SPECUNDEFINED"),
    reference_variant(),
    kernel_input(),
    invalid_kernel_input(),
@@ -80,7 +78,6 @@ void RunParams::print(std::ostream& str) const
   str << "\n size_factor = " << size_factor;
   str << "\n pf_tol = " << pf_tol; 
   str << "\n checkrun_reps = " << checkrun_reps; 
-  str << "\n size_spec_string = " << size_spec_string;  
   str << "\n reference_variant = " << reference_variant; 
   str << "\n outdir = " << outdir; 
   str << "\n outfile_prefix = " << outfile_prefix; 
@@ -251,16 +248,6 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
         input_state = BadInput;
       }
 
-    } else if (opt == std::string("--sizespec") ) {
-      i++;
-      if ( i < argc ) {
-        setSizeSpec(argv[i]);
-      } else {
-        std::cout << "\nBad input:"
-                  << " must give --sizespec a value for size specification: one of  MINI,SMALL,MEDIUM,LARGE,EXTRALARGE (string : any case)"
-                  << std::endl;
-        input_state = BadInput;
-      }
     } else if ( opt == std::string("--pass-fail-tol") ||
                 opt == std::string("-pftol") ) {
 
@@ -445,9 +432,6 @@ void RunParams::printHelpMessage(std::ostream& str) const
   str << "\t\t Example...\n"
       << "\t\t --size 1000000 (runs kernels with size ~1,000,000)\n\n";
 
-  str << "\t --sizespec <string> [one of : mini,small,medium,large,extralarge (anycase) -- default is medium]\n"
-      << "\t      (used to set specific sizes for polybench kernels)\n\n"; 
-
   str << "\t --pass-fail-tol, -pftol <double> [default is 0.1; i.e., 10%]\n"
       << "\t      (slowdown tolerance for RAJA vs. Base variants in FOM report)\n";
   str << "\t\t Example...\n"
@@ -603,48 +587,6 @@ void RunParams::printKernelFeatures(std::ostream& str) const
     }  
   }  // loop over kernels
   str.flush();
-}
-
-const std::string& RunParams::getSizeSpecString()
-{
-  switch(size_spec) {
-    case Mini:
-      size_spec_string = "MINI";
-      break;
-    case Small:
-      size_spec_string = "SMALL";
-      break;
-    case Medium:
-      size_spec_string = "MEDIUM";
-      break;
-    case Large:
-      size_spec_string = "LARGE";
-      break;
-    case Extralarge:
-      size_spec_string = "EXTRALARGE";
-      break;
-    default:
-      size_spec_string = "SPECUNDEFINED";
-  }
-  return size_spec_string;
-}
-
-void RunParams::setSizeSpec(std::string inputString)
-{
-  for (auto & c: inputString) c = std::toupper(c);
-  if (inputString == "MINI")
-    size_spec = Mini;
-  else if (inputString == "SMALL")
-    size_spec = Small;
-  else if (inputString == "MEDIUM")
-    size_spec = Medium;
-  else if (inputString == "LARGE")
-    size_spec = Large;
-  else if (inputString == "EXTRALARGE")
-    size_spec = Extralarge;
-  else
-    size_spec = Specundefined;
-  std::cout << "Size Specification : " << getSizeSpecString() << std::endl;
 }
 
 }  // closing brace for rajaperf namespace

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -97,12 +97,6 @@ public:
 
   double getSizeFactor() const { return size_factor; }
 
-  SizeSpec  getSizeSpec() const { return size_spec; }
-
-  void  setSizeSpec(std::string inputString);
-
-  const std::string& getSizeSpecString();
-
   double getPFTolerance() const { return pf_tol; }
 
   int getCheckRunReps() const { return checkrun_reps; }
@@ -173,10 +167,6 @@ private:
                               each PM case to pass/fail acceptance */
 
   int checkrun_reps;     /*!< Num reps each kernel is run in check run */
-
-  SizeSpec size_spec;    /*!< optional use/parse polybench spec file for size */
-
-  std::string size_spec_string;
 
   std::string reference_variant;   /*!< Name of reference variant for speedup
                                         calculations */ 

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -35,6 +35,10 @@ EOS::EOS(const RunParams& params)
                   (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_array_length );
   setFLOPsPerRep(16 * getActualProblemSize());
 
+  checksum_scale_factor = 0.0001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
+
   setUsesFeature(Forall);
 
   setVariantDefined( Base_Seq );
@@ -73,7 +77,7 @@ void EOS::setUp(VariantID vid)
 
 void EOS::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_x, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_x, getActualProblemSize(), checksum_scale_factor );
 }
 
 void EOS::tearDown(VariantID vid)

--- a/src/lcals/GEN_LIN_RECUR.cpp
+++ b/src/lcals/GEN_LIN_RECUR.cpp
@@ -35,6 +35,10 @@ GEN_LIN_RECUR::GEN_LIN_RECUR(const RunParams& params)
   setFLOPsPerRep((3 +
                   3 ) * getActualProblemSize());
 
+  checksum_scale_factor = 0.01 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
+
   setUsesFeature(Forall);
 
   setVariantDefined( Base_Seq );
@@ -71,7 +75,7 @@ void GEN_LIN_RECUR::setUp(VariantID vid)
 
 void GEN_LIN_RECUR::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_b5, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_b5, getActualProblemSize(), checksum_scale_factor );
 }
 
 void GEN_LIN_RECUR::tearDown(VariantID vid)

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -34,6 +34,10 @@ HYDRO_1D::HYDRO_1D(const RunParams& params)
                   (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * (getActualProblemSize()+1) );
   setFLOPsPerRep(5 * getActualProblemSize());
 
+  checksum_scale_factor = 0.001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
+
   setUsesFeature(Forall);
 
   setVariantDefined( Base_Seq );
@@ -71,7 +75,7 @@ void HYDRO_1D::setUp(VariantID vid)
 
 void HYDRO_1D::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_x, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_x, getActualProblemSize(), checksum_scale_factor );
 }
 
 void HYDRO_1D::tearDown(VariantID vid)

--- a/src/lcals/HYDRO_2D-Cuda.cpp
+++ b/src/lcals/HYDRO_2D-Cuda.cpp
@@ -21,6 +21,21 @@ namespace rajaperf
 namespace lcals
 {
 
+  //
+  // Define thread block size for CUDA execution
+  //
+  constexpr size_t j_block_sz = 32;
+  constexpr size_t k_block_sz = 8;
+
+#define HYDRO_2D_THREADS_PER_BLOCK_CUDA \
+  dim3 nthreads_per_block(j_block_sz, k_block_sz, 1);
+
+#define HYDRO_2D_NBLOCKS_CUDA \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(jn-2, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(kn-2, k_block_sz)), \
+               static_cast<size_t>(1));
+
+
 #define HYDRO_2D_DATA_SETUP_CUDA \
 \
   allocAndInitCudaDeviceData(zadat, m_za, m_array_length); \
@@ -34,6 +49,7 @@ namespace lcals
   allocAndInitCudaDeviceData(zzdat, m_zz, m_array_length); \
   allocAndInitCudaDeviceData(zroutdat, m_zrout, m_array_length); \
   allocAndInitCudaDeviceData(zzoutdat, m_zzout, m_array_length);
+
 
 #define HYDRO_2D_DATA_TEARDOWN_CUDA \
   getCudaDeviceData(m_zrout, zroutdat, m_array_length); \
@@ -55,9 +71,10 @@ __global__ void hydro_2d1(Real_ptr zadat, Real_ptr zbdat,
                           Real_ptr zrdat, Real_ptr zmdat,
                           Index_type jn, Index_type kn)
 {
-   Index_type k = blockIdx.y;
-   Index_type j = threadIdx.x;
-   if (k > 0 && k < kn-1 && j > 0 && j < jn-1) {
+   Index_type k = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+
+   if (k < kn-1 && j < jn-1) {
      HYDRO_2D_BODY1;
    }
 }
@@ -68,9 +85,10 @@ __global__ void hydro_2d2(Real_ptr zudat, Real_ptr zvdat,
                           Real_type s,
                           Index_type jn, Index_type kn)
 {
-   Index_type k = blockIdx.y;
-   Index_type j = threadIdx.x;
-   if (k > 0 && k < kn-1 && j > 0 && j < jn-1) {
+   Index_type k = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+
+   if (k < kn-1 && j < jn-1) {
      HYDRO_2D_BODY2;
    }
 }
@@ -81,9 +99,10 @@ __global__ void hydro_2d3(Real_ptr zroutdat, Real_ptr zzoutdat,
                           Real_type t,
                           Index_type jn, Index_type kn)
 {
-   Index_type k = blockIdx.y;
-   Index_type j = threadIdx.x;
-   if (k > 0 && k < kn-1 && j > 0 && j < jn-1) {
+   Index_type k = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+
+   if (k < kn-1 && j < jn-1) {
      HYDRO_2D_BODY3;
    }
 }
@@ -106,25 +125,25 @@ void HYDRO_2D::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       dim3 nthreads_per_block(jn, 1, 1);
-       dim3 nblocks(1, kn, 1);
+      HYDRO_2D_THREADS_PER_BLOCK_CUDA;
+      HYDRO_2D_NBLOCKS_CUDA;
+ 
+      hydro_2d1<<<nblocks, nthreads_per_block>>>(zadat, zbdat,
+                                                 zpdat, zqdat, zrdat, zmdat,
+                                                 jn, kn);
+      cudaErrchk( cudaGetLastError() );
 
-       hydro_2d1<<<nblocks, nthreads_per_block>>>(zadat, zbdat,
-                                                  zpdat, zqdat, zrdat, zmdat,
-                                                  jn, kn);
-       cudaErrchk( cudaGetLastError() );
+      hydro_2d2<<<nblocks, nthreads_per_block>>>(zudat, zvdat,
+                                                 zadat, zbdat, zzdat, zrdat,
+                                                 s,
+                                                 jn, kn);
+      cudaErrchk( cudaGetLastError() );
 
-       hydro_2d2<<<nblocks, nthreads_per_block>>>(zudat, zvdat,
-                                                  zadat, zbdat, zzdat, zrdat,
-                                                  s,
-                                                  jn, kn);
-       cudaErrchk( cudaGetLastError() );
-
-       hydro_2d3<<<nblocks, nthreads_per_block>>>(zroutdat, zzoutdat,
-                                                  zrdat, zudat, zzdat, zvdat,
-                                                  t,
-                                                  jn, kn);
-       cudaErrchk( cudaGetLastError() );
+      hydro_2d3<<<nblocks, nthreads_per_block>>>(zroutdat, zzoutdat,
+                                                 zrdat, zudat, zzdat, zvdat,
+                                                 t,
+                                                 jn, kn);
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();
@@ -137,17 +156,23 @@ void HYDRO_2D::runCudaVariant(VariantID vid)
 
     HYDRO_2D_VIEWS_RAJA;
 
-      using EXECPOL =
-        RAJA::KernelPolicy<
-          RAJA::statement::CudaKernelAsync<
-            RAJA::statement::For<0, RAJA::cuda_block_y_direct,  // k
-              RAJA::statement::For<1, RAJA::cuda_thread_x_direct,  // j
-                RAJA::statement::Lambda<0>
+    using EXECPOL =
+      RAJA::KernelPolicy<
+        RAJA::statement::CudaKernelFixedAsync<j_block_sz * k_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<k_block_sz>, 
+                                   RAJA::cuda_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>, 
+                                   RAJA::cuda_block_x_direct,
+              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // k
+                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // j
+                  RAJA::statement::Lambda<0>
+                >
               >
             >
           >
-        >;
-
+        >
+      >;
+      
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 

--- a/src/lcals/HYDRO_2D-Hip.cpp
+++ b/src/lcals/HYDRO_2D-Hip.cpp
@@ -21,6 +21,21 @@ namespace rajaperf
 namespace lcals
 {
 
+  //
+  // Define thread block size for Hip execution
+  //
+  constexpr size_t j_block_sz = 32;
+  constexpr size_t k_block_sz = 8;
+
+#define HYDRO_2D_THREADS_PER_BLOCK_HIP \
+  dim3 nthreads_per_block(j_block_sz, k_block_sz, 1);
+
+#define HYDRO_2D_NBLOCKS_HIP \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(jn-2, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(kn-2, k_block_sz)), \
+               static_cast<size_t>(1));
+
+
 #define HYDRO_2D_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(zadat, m_za, m_array_length); \
   allocAndInitHipDeviceData(zbdat, m_zb, m_array_length); \
@@ -33,6 +48,7 @@ namespace lcals
   allocAndInitHipDeviceData(zzdat, m_zz, m_array_length); \
   allocAndInitHipDeviceData(zroutdat, m_zrout, m_array_length); \
   allocAndInitHipDeviceData(zzoutdat, m_zzout, m_array_length);
+
 
 #define HYDRO_2D_DATA_TEARDOWN_HIP \
   getHipDeviceData(m_zrout, zroutdat, m_array_length); \
@@ -54,9 +70,10 @@ __global__ void hydro_2d1(Real_ptr zadat, Real_ptr zbdat,
                           Real_ptr zrdat, Real_ptr zmdat,
                           Index_type jn, Index_type kn)
 {
-   Index_type k = blockIdx.y;
-   Index_type j = threadIdx.x;
-   if (k > 0 && k < kn-1 && j > 0 && j < jn-1) {
+   Index_type k = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+
+   if (k < kn-1 && j < jn-1) {
      HYDRO_2D_BODY1;
    }
 }
@@ -67,9 +84,10 @@ __global__ void hydro_2d2(Real_ptr zudat, Real_ptr zvdat,
                           Real_type s,
                           Index_type jn, Index_type kn)
 {
-   Index_type k = blockIdx.y;
-   Index_type j = threadIdx.x;
-   if (k > 0 && k < kn-1 && j > 0 && j < jn-1) {
+   Index_type k = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+
+   if (k < kn-1 && j < jn-1) {
      HYDRO_2D_BODY2;
    }
 }
@@ -80,9 +98,10 @@ __global__ void hydro_2d3(Real_ptr zroutdat, Real_ptr zzoutdat,
                           Real_type t,
                           Index_type jn, Index_type kn)
 {
-   Index_type k = blockIdx.y;
-   Index_type j = threadIdx.x;
-   if (k > 0 && k < kn-1 && j > 0 && j < jn-1) {
+   Index_type k = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+
+   if (k < kn-1 && j < jn-1) {
      HYDRO_2D_BODY3;
    }
 }
@@ -105,27 +124,30 @@ void HYDRO_2D::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       dim3 nthreads_per_block(jn, 1, 1);
-       dim3 nblocks(1, kn, 1);
+      HYDRO_2D_THREADS_PER_BLOCK_HIP;
+      HYDRO_2D_NBLOCKS_HIP;
 
-       hipLaunchKernelGGL((hydro_2d1), dim3(nblocks), dim3(nthreads_per_block), 0, 0,
-                                                  zadat, zbdat,
-                                                  zpdat, zqdat, zrdat, zmdat,
-                                                  jn, kn);
+      hipLaunchKernelGGL((hydro_2d1), 
+                         dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                         zadat, zbdat,
+                         zpdat, zqdat, zrdat, zmdat,
+                         jn, kn);
        hipErrchk( hipGetLastError() );
 
-       hipLaunchKernelGGL((hydro_2d2), dim3(nblocks), dim3(nthreads_per_block), 0, 0,
-                                                  zudat, zvdat,
-                                                  zadat, zbdat, zzdat, zrdat,
-                                                  s,
-                                                  jn, kn);
+       hipLaunchKernelGGL((hydro_2d2), 
+                          dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                          zudat, zvdat,
+                          zadat, zbdat, zzdat, zrdat,
+                          s,
+                          jn, kn);
        hipErrchk( hipGetLastError() );
 
-       hipLaunchKernelGGL((hydro_2d3), dim3(nblocks), dim3(nthreads_per_block), 0, 0,
-                                                  zroutdat, zzoutdat,
-                                                  zrdat, zudat, zzdat, zvdat,
-                                                  t,
-                                                  jn, kn);
+       hipLaunchKernelGGL((hydro_2d3), 
+                          dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                          zroutdat, zzoutdat,
+                          zrdat, zudat, zzdat, zvdat,
+                          t,
+                          jn, kn);
        hipErrchk( hipGetLastError() );
 
     }
@@ -139,16 +161,22 @@ void HYDRO_2D::runHipVariant(VariantID vid)
 
     HYDRO_2D_VIEWS_RAJA;
 
-      using EXECPOL =
-        RAJA::KernelPolicy<
-          RAJA::statement::HipKernelAsync<
-            RAJA::statement::For<0, RAJA::hip_block_y_direct,  // k
-              RAJA::statement::For<1, RAJA::hip_thread_x_direct,  // j
-                RAJA::statement::Lambda<0>
+    using EXECPOL =
+      RAJA::KernelPolicy<
+        RAJA::statement::HipKernelFixedAsync<j_block_sz * k_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<k_block_sz>,
+                                   RAJA::hip_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
+                                   RAJA::hip_block_x_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // k
+                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // j
+                  RAJA::statement::Lambda<0>
+                >
               >
             >
           >
-        >;
+        >
+      >;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -49,6 +49,10 @@ HYDRO_2D::HYDRO_2D(const RunParams& params)
                   26 +
                   4  ) * (m_jn-2)*(m_kn-2));
 
+  checksum_scale_factor = 0.001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
+
   setUsesFeature(Kernel);
 
   setVariantDefined( Base_Seq );
@@ -90,8 +94,8 @@ void HYDRO_2D::setUp(VariantID vid)
 
 void HYDRO_2D::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_zzout, m_array_length);
-  checksum[vid] += calcChecksum(m_zrout, m_array_length);
+  checksum[vid] += calcChecksum(m_zzout, m_array_length, checksum_scale_factor );
+  checksum[vid] += calcChecksum(m_zrout, m_array_length, checksum_scale_factor );
 }
 
 void HYDRO_2D::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_2MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_2MM-Cuda.cpp
@@ -1,4 +1,4 @@
- //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 // Copyright (c) 2017-21, Lawrence Livermore National Security, LLC
 // and RAJA Performance Suite project contributors.
 // See the RAJAPerf/COPYRIGHT file for details.
@@ -21,6 +21,26 @@ namespace rajaperf
 namespace polybench
 {
 
+//
+// Define thread block size for CUDA execution
+//
+constexpr size_t out_block_sz = 8;
+constexpr size_t in_block_sz = 32;
+
+#define POLY_2MM_THREADS_PER_BLOCK_CUDA \
+  dim3 nthreads_per_block(in_block_sz, out_block_sz, 1);
+
+#define POLY_2MM_1_NBLOCKS_CUDA \
+  dim3 nblocks1(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, in_block_sz)), \
+                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, out_block_sz)), \
+                static_cast<size_t>(1));
+
+#define POLY_2MM_2_NBLOCKS_CUDA \
+  dim3 nblocks2(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nl, in_block_sz)), \
+                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, out_block_sz)), \
+                static_cast<size_t>(1));
+
+
 #define POLYBENCH_2MM_DATA_SETUP_CUDA \
   allocAndInitCudaDeviceData(tmp, m_tmp, m_ni * m_nj); \
   allocAndInitCudaDeviceData(A, m_A, m_ni * m_nk); \
@@ -40,30 +60,58 @@ namespace polybench
 
 __global__ void poly_2mm_1(Real_ptr tmp, Real_ptr A, Real_ptr B,
                            Real_type alpha,
-                           Index_type nj, Index_type nk)
+                           Index_type ni, Index_type nj, Index_type nk)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-   POLYBENCH_2MM_BODY1;
-   for (Index_type k=0; k < nk; ++k) {
-     POLYBENCH_2MM_BODY2;
-   }
-   POLYBENCH_2MM_BODY3;
+  if ( i < ni && j < nj ) {
+    POLYBENCH_2MM_BODY1;
+    for (Index_type k=0; k < nk; ++k) {
+      POLYBENCH_2MM_BODY2;
+    }
+    POLYBENCH_2MM_BODY3;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_2mm_1_lam(Index_type ni, Index_type nj, Index_type nk,
+                               Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < ni && j < nj ) {
+    body(i, j); 
+  }
 }
 
 __global__ void poly_2mm_2(Real_ptr tmp, Real_ptr C, Real_ptr D,
                            Real_type beta,
-                           Index_type nl, Index_type nj)
+                           Index_type ni,  Index_type nl, Index_type nj)
 {
-   Index_type i = blockIdx.y;
-   Index_type l = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
 
-   POLYBENCH_2MM_BODY4;
-   for (Index_type j=0; j < nj; ++j) {
-     POLYBENCH_2MM_BODY5;
-   }
-   POLYBENCH_2MM_BODY6;
+  if ( i < ni && l < nl ) {
+    POLYBENCH_2MM_BODY4;
+    for (Index_type j=0; j < nj; ++j) {
+      POLYBENCH_2MM_BODY5;
+    }
+    POLYBENCH_2MM_BODY6;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_2mm_2_lam(Index_type ni,  Index_type nl, Index_type nj,
+                               Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < ni && l < nl ) {
+    body(i, l);
+  }
 }
 
 
@@ -80,16 +128,16 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nblocks1(1, ni, 1);
-      dim3 nthreads_per_block1(nj, 1, 1);
-      poly_2mm_1<<<nblocks1, nthreads_per_block1>>>(tmp, A, B, alpha,
-                                                    nj, nk);
+      POLY_2MM_THREADS_PER_BLOCK_CUDA;
+
+      POLY_2MM_1_NBLOCKS_CUDA;
+      poly_2mm_1<<<nblocks1, nthreads_per_block>>>(tmp, A, B, alpha,
+                                                   ni, nj, nk);
       cudaErrchk( cudaGetLastError() );
 
-      dim3 nblocks2(1, ni, 1);
-      dim3 nthreads_per_block2(nl, 1, 1);
-      poly_2mm_2<<<nblocks2, nthreads_per_block2>>>(tmp, C, D, beta,
-                                                    nl, nj);
+      POLY_2MM_2_NBLOCKS_CUDA;
+      poly_2mm_2<<<nblocks2, nthreads_per_block>>>(tmp, C, D, beta,
+                                                   ni, nl, nj);
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -104,34 +152,30 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nblocks1(1, ni, 1);
-      dim3 nthreads_per_block1(nj, 1, 1);
-      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
-                        <<<nblocks1, nthreads_per_block1>>>(
-        0, ni, 0, nj,
-        [=] __device__ (Index_type i, Index_type j) {
+      POLY_2MM_THREADS_PER_BLOCK_CUDA;
 
-        POLYBENCH_2MM_BODY1;
-        for (Index_type k=0; k < nk; ++k) {
-          POLYBENCH_2MM_BODY2;
+      POLY_2MM_1_NBLOCKS_CUDA;
+      poly_2mm_1_lam<<<nblocks1, nthreads_per_block>>>(ni, nj, nk,
+        [=] __device__ (Index_type i, Index_type j) {
+          POLYBENCH_2MM_BODY1;
+          for (Index_type k=0; k < nk; ++k) {
+            POLYBENCH_2MM_BODY2;
+          }
+          POLYBENCH_2MM_BODY3;
         }
-        POLYBENCH_2MM_BODY3;
-      });
+      );
       cudaErrchk( cudaGetLastError() );
 
-      dim3 nblocks2(1, ni, 1);
-      dim3 nthreads_per_block2(nl, 1, 1);
-      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
-                        <<<nblocks2, nthreads_per_block2>>>(
-        0, ni, 0, nl,
+      POLY_2MM_2_NBLOCKS_CUDA;
+      poly_2mm_2_lam<<<nblocks2, nthreads_per_block>>>(ni, nl, nj,
         [=] __device__ (Index_type i, Index_type l) {
-
-        POLYBENCH_2MM_BODY4;
-        for (Index_type j=0; j < nj; ++j) {
-          POLYBENCH_2MM_BODY5;
+          POLYBENCH_2MM_BODY4;
+          for (Index_type j=0; j < nj; ++j) {
+            POLYBENCH_2MM_BODY5;
+          }
+          POLYBENCH_2MM_BODY6;
         }
-        POLYBENCH_2MM_BODY6;
-      });
+      );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -147,14 +191,20 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<0, RAJA::cuda_block_y_direct,
-            RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
-              RAJA::statement::Lambda<0, RAJA::Params<0>>,
-              RAJA::statement::For<2, RAJA::seq_exec,
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
+        RAJA::statement::CudaKernelFixedAsync<out_block_sz * in_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<out_block_sz>,
+                                   RAJA::cuda_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<in_block_sz>,
+                                     RAJA::cuda_block_x_direct,
+              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // outer
+                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // inner
+                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
+                  RAJA::statement::For<2, RAJA::seq_exec,
+                    RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+                  >,
+                  RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
+                >
+              >
             >
           >
         >

--- a/src/polybench/POLYBENCH_2MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_2MM-Cuda.cpp
@@ -75,7 +75,7 @@ __global__ void poly_2mm_1(Real_ptr tmp, Real_ptr A, Real_ptr B,
 }
 
 template< typename Lambda >
-__global__ void poly_2mm_1_lam(Index_type ni, Index_type nj, Index_type nk,
+__global__ void poly_2mm_1_lam(Index_type ni, Index_type nj,
                                Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -103,7 +103,7 @@ __global__ void poly_2mm_2(Real_ptr tmp, Real_ptr C, Real_ptr D,
 }
 
 template< typename Lambda >
-__global__ void poly_2mm_2_lam(Index_type ni,  Index_type nl, Index_type nj,
+__global__ void poly_2mm_2_lam(Index_type ni,  Index_type nl,
                                Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -155,7 +155,7 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
       POLY_2MM_THREADS_PER_BLOCK_CUDA;
 
       POLY_2MM_1_NBLOCKS_CUDA;
-      poly_2mm_1_lam<<<nblocks1, nthreads_per_block>>>(ni, nj, nk,
+      poly_2mm_1_lam<<<nblocks1, nthreads_per_block>>>(ni, nj,
         [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_2MM_BODY1;
           for (Index_type k=0; k < nk; ++k) {
@@ -167,7 +167,7 @@ void POLYBENCH_2MM::runCudaVariant(VariantID vid)
       cudaErrchk( cudaGetLastError() );
 
       POLY_2MM_2_NBLOCKS_CUDA;
-      poly_2mm_2_lam<<<nblocks2, nthreads_per_block>>>(ni, nl, nj,
+      poly_2mm_2_lam<<<nblocks2, nthreads_per_block>>>(ni, nl,
         [=] __device__ (Index_type i, Index_type l) {
           POLYBENCH_2MM_BODY4;
           for (Index_type j=0; j < nj; ++j) {

--- a/src/polybench/POLYBENCH_2MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_2MM-Hip.cpp
@@ -182,7 +182,7 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
       POLY_2MM_2_NBLOCKS_HIP;
       hipLaunchKernelGGL((poly_2mm_2_lam<decltype(poly_2mm_2_lambda)>),
                          dim3(nblocks2), dim3(nthreads_per_block), 0, 0,
-                         ni, nj, nj, poly_2mm_2_lambda);
+                         ni, nl, nj, poly_2mm_2_lambda);
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_2MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_2MM-Hip.cpp
@@ -138,7 +138,7 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
 
       POLY_2MM_2_NBLOCKS_HIP;
       hipLaunchKernelGGL((poly_2mm_2), 
-                         dim3(nblocks2), dim3(nthreads_per_block2), 0, 0,
+                         dim3(nblocks2), dim3(nthreads_per_block), 0, 0,
                          tmp, C, D, beta,
                          ni, nl, nj);
       hipErrchk( hipGetLastError() );
@@ -155,7 +155,7 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      POLY_2MM_THREADS_PER_BLOCK_CUDA;
+      POLY_2MM_THREADS_PER_BLOCK_HIP;
 
       auto poly_2mm_1_lambda = [=] __device__ (Index_type i, Index_type j) {
         POLYBENCH_2MM_BODY1;
@@ -165,7 +165,7 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
         POLYBENCH_2MM_BODY3;
       };
 
-      POLY_2MM_1_NBLOCKS_CUDA;      
+      POLY_2MM_1_NBLOCKS_HIP;      
       hipLaunchKernelGGL((poly_2mm_1_lam<decltype(poly_2mm_1_lambda)>),
                          dim3(nblocks1), dim3(nthreads_per_block), 0, 0,
                          ni, nj, nk, poly_2mm_1_lambda);
@@ -179,7 +179,7 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
         POLYBENCH_2MM_BODY6;
       };
 
-      POLY_2MM_2_NBLOCKS_CUDA;
+      POLY_2MM_2_NBLOCKS_HIP;
       hipLaunchKernelGGL((poly_2mm_2_lam<decltype(poly_2mm_2_lambda)>),
                          dim3(nblocks2), dim3(nthreads_per_block), 0, 0,
                          ni, nj, nj, poly_2mm_2_lambda);

--- a/src/polybench/POLYBENCH_2MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_2MM-Hip.cpp
@@ -21,6 +21,26 @@ namespace rajaperf
 namespace polybench
 {
 
+//
+// Define thread block size for Hip execution
+//
+constexpr size_t out_block_sz = 8;
+constexpr size_t in_block_sz = 32;
+
+#define POLY_2MM_THREADS_PER_BLOCK_HIP \
+  dim3 nthreads_per_block(in_block_sz, out_block_sz, 1);
+
+#define POLY_2MM_1_NBLOCKS_HIP \
+  dim3 nblocks1(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, in_block_sz)), \
+                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, out_block_sz)), \
+                static_cast<size_t>(1));
+
+#define POLY_2MM_2_NBLOCKS_HIP \
+  dim3 nblocks2(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nl, in_block_sz)), \
+                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, out_block_sz)), \
+                static_cast<size_t>(1));
+
+
 #define POLYBENCH_2MM_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(tmp, m_tmp, m_ni * m_nj); \
   allocAndInitHipDeviceData(A, m_A, m_ni * m_nk); \
@@ -37,33 +57,60 @@ namespace polybench
   deallocHipDeviceData(C); \
   deallocHipDeviceData(D);
 
-
 __global__ void poly_2mm_1(Real_ptr tmp, Real_ptr A, Real_ptr B,
                            Real_type alpha,
-                           Index_type nj, Index_type nk)
+                           Index_type ni, Index_type nj, Index_type nk)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-   POLYBENCH_2MM_BODY1;
-   for (Index_type k=0; k < nk; ++k) {
-     POLYBENCH_2MM_BODY2;
-   }
-   POLYBENCH_2MM_BODY3;
+  if ( i < ni && j < nj ) {
+    POLYBENCH_2MM_BODY1;
+    for (Index_type k=0; k < nk; ++k) {
+      POLYBENCH_2MM_BODY2;
+    }
+    POLYBENCH_2MM_BODY3;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_2mm_1_lam(Index_type ni, Index_type nj, Index_type nk,
+                               Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < ni && j < nj ) {
+    body(i, j);
+  }
 }
 
 __global__ void poly_2mm_2(Real_ptr tmp, Real_ptr C, Real_ptr D,
                            Real_type beta,
-                           Index_type nl, Index_type nj)
+                           Index_type ni,  Index_type nl, Index_type nj)
 {
-   Index_type i = blockIdx.y;
-   Index_type l = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
 
-   POLYBENCH_2MM_BODY4;
-   for (Index_type j=0; j < nj; ++j) {
-     POLYBENCH_2MM_BODY5;
-   }
-   POLYBENCH_2MM_BODY6;
+  if ( i < ni && l < nl ) {
+    POLYBENCH_2MM_BODY4;
+    for (Index_type j=0; j < nj; ++j) {
+      POLYBENCH_2MM_BODY5;
+    }
+    POLYBENCH_2MM_BODY6;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_2mm_2_lam(Index_type ni,  Index_type nl, Index_type nj,
+                               Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < ni && l < nl ) {
+    body(i, l);
+  }
 }
 
 
@@ -80,18 +127,20 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nblocks1(1, ni, 1);
-      dim3 nthreads_per_block1(nj, 1, 1);
-      hipLaunchKernelGGL((poly_2mm_1), dim3(nblocks1), dim3(nthreads_per_block1), 0, 0,
-                                                    tmp, A, B, alpha,
-                                                    nj, nk);
+      POLY_2MM_THREADS_PER_BLOCK_HIP;
+
+      POLY_2MM_1_NBLOCKS_HIP;
+      hipLaunchKernelGGL((poly_2mm_1), 
+                         dim3(nblocks1), dim3(nthreads_per_block), 0, 0,
+                         tmp, A, B, alpha,
+                         ni, nj, nk);
       hipErrchk( hipGetLastError() );
 
-      dim3 nblocks2(1, ni, 1);
-      dim3 nthreads_per_block2(nl, 1, 1);
-      hipLaunchKernelGGL((poly_2mm_2), dim3(nblocks2), dim3(nthreads_per_block2), 0, 0,
-                                                    tmp, C, D, beta,
-                                                    nl, nj);
+      POLY_2MM_2_NBLOCKS_HIP;
+      hipLaunchKernelGGL((poly_2mm_2), 
+                         dim3(nblocks2), dim3(nthreads_per_block2), 0, 0,
+                         tmp, C, D, beta,
+                         ni, nl, nj);
       hipErrchk( hipGetLastError() );
 
     }
@@ -106,8 +155,9 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      auto poly_2mm_1_lambda = [=] __device__ (Index_type i, Index_type j) {
+      POLY_2MM_THREADS_PER_BLOCK_CUDA;
 
+      auto poly_2mm_1_lambda = [=] __device__ (Index_type i, Index_type j) {
         POLYBENCH_2MM_BODY1;
         for (Index_type k=0; k < nk; ++k) {
           POLYBENCH_2MM_BODY2;
@@ -115,16 +165,13 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
         POLYBENCH_2MM_BODY3;
       };
 
-      dim3 nblocks1(1, ni, 1);
-      dim3 nthreads_per_block1(nj, 1, 1);
-      auto kernel1 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_2mm_1_lambda)>;
-      hipLaunchKernelGGL(kernel1,
-        nblocks1, nthreads_per_block1, 0, 0,
-        0, ni, 0, nj, poly_2mm_1_lambda);
+      POLY_2MM_1_NBLOCKS_CUDA;      
+      hipLaunchKernelGGL((poly_2mm_1_lam<decltype(poly_2mm_1_lambda)>),
+                         dim3(nblocks1), dim3(nthreads_per_block), 0, 0,
+                         ni, nj, nk, poly_2mm_1_lambda);
       hipErrchk( hipGetLastError() );
-
+ 
       auto poly_2mm_2_lambda = [=] __device__ (Index_type i, Index_type l) {
-
         POLYBENCH_2MM_BODY4;
         for (Index_type j=0; j < nj; ++j) {
           POLYBENCH_2MM_BODY5;
@@ -132,12 +179,10 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
         POLYBENCH_2MM_BODY6;
       };
 
-      dim3 nblocks2(1, ni, 1);
-      dim3 nthreads_per_block2(nl, 1, 1);
-      auto kernel2 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_2mm_2_lambda)>;
-      hipLaunchKernelGGL(kernel2,
-        nblocks2, nthreads_per_block2, 0, 0,
-        0, ni, 0, nl, poly_2mm_2_lambda);
+      POLY_2MM_2_NBLOCKS_CUDA;
+      hipLaunchKernelGGL((poly_2mm_2_lam<decltype(poly_2mm_2_lambda)>),
+                         dim3(nblocks2), dim3(nthreads_per_block), 0, 0,
+                         ni, nj, nj, poly_2mm_2_lambda);
       hipErrchk( hipGetLastError() );
 
     }
@@ -153,14 +198,20 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_y_direct,
-            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
-              RAJA::statement::Lambda<0, RAJA::Params<0>>,
-              RAJA::statement::For<2, RAJA::seq_exec,
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
+        RAJA::statement::HipKernelFixedAsync<out_block_sz * in_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<out_block_sz>,
+                                   RAJA::hip_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<in_block_sz>,
+                                     RAJA::hip_block_x_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // outer
+                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // inner
+                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
+                  RAJA::statement::For<2, RAJA::seq_exec,
+                    RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+                  >,
+                  RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
+                >
+              >
             >
           >
         >

--- a/src/polybench/POLYBENCH_2MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_2MM-Hip.cpp
@@ -74,7 +74,7 @@ __global__ void poly_2mm_1(Real_ptr tmp, Real_ptr A, Real_ptr B,
 }
 
 template< typename Lambda >
-__global__ void poly_2mm_1_lam(Index_type ni, Index_type nj, Index_type nk,
+__global__ void poly_2mm_1_lam(Index_type ni, Index_type nj,
                                Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -102,7 +102,7 @@ __global__ void poly_2mm_2(Real_ptr tmp, Real_ptr C, Real_ptr D,
 }
 
 template< typename Lambda >
-__global__ void poly_2mm_2_lam(Index_type ni,  Index_type nl, Index_type nj,
+__global__ void poly_2mm_2_lam(Index_type ni,  Index_type nl,
                                Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -168,7 +168,7 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
       POLY_2MM_1_NBLOCKS_HIP;      
       hipLaunchKernelGGL((poly_2mm_1_lam<decltype(poly_2mm_1_lambda)>),
                          dim3(nblocks1), dim3(nthreads_per_block), 0, 0,
-                         ni, nj, nk, poly_2mm_1_lambda);
+                         ni, nj, poly_2mm_1_lambda);
       hipErrchk( hipGetLastError() );
  
       auto poly_2mm_2_lambda = [=] __device__ (Index_type i, Index_type l) {
@@ -182,7 +182,7 @@ void POLYBENCH_2MM::runHipVariant(VariantID vid)
       POLY_2MM_2_NBLOCKS_HIP;
       hipLaunchKernelGGL((poly_2mm_2_lam<decltype(poly_2mm_2_lambda)>),
                          dim3(nblocks2), dim3(nthreads_per_block), 0, 0,
-                         ni, nl, nj, poly_2mm_2_lambda);
+                         ni, nl, poly_2mm_2_lambda);
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -22,6 +22,7 @@ namespace polybench
 POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_2MM, params)
 {
+#if 0 
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps = 0;
   switch(lsizespec) {
@@ -51,8 +52,13 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  m_alpha = 1.5;
+  m_beta = 1.2;
 
+  setDefaultProblemSize( std::max( m_ni*m_nj, m_ni*m_nl ) );
+  setDefaultReps(run_reps);
+
+#else 
   Index_type ni_default = 1000;
   Index_type nj_default = 1000;
   Index_type nk_default = 1120;
@@ -60,7 +66,7 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
 
   setDefaultProblemSize( std::max( ni_default*nj_default, 
                                    ni_default*nl_default ) );
-  setDefaultReps(4);
+  setDefaultReps(2);
 
   m_ni = std::sqrt( getTargetProblemSize() ) + 1;
   m_nj = m_ni;
@@ -69,14 +75,6 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
 
   m_alpha = 1.5;
   m_beta = 1.2;
-
-#else  // this is what we have now...
-
-  m_alpha = 1.5;
-  m_beta = 1.2;
-
-  setDefaultProblemSize( std::max( m_ni*m_nj, m_ni*m_nl ) );
-  setDefaultReps(run_reps);
 
 #endif
 
@@ -94,6 +92,10 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
   setFLOPsPerRep(3 * m_ni*m_nj*m_nk +
                  2 * m_ni*m_nj*m_nl );
 
+  checksum_scale_factor = 0.000001 * 
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
+                                       
   setUsesFeature(Kernel);
 
   setVariantDefined( Base_Seq );
@@ -132,7 +134,7 @@ void POLYBENCH_2MM::setUp(VariantID vid)
 
 void POLYBENCH_2MM::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_D, m_ni * m_nl);
+  checksum[vid] += calcChecksum(m_D, m_ni * m_nl, checksum_scale_factor );
 }
 
 void POLYBENCH_2MM::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -22,43 +22,6 @@ namespace polybench
 POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_2MM, params)
 {
-#if 0 
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0;
-  switch(lsizespec) {
-    case Mini:
-      m_ni=16; m_nj=18; m_nk=22; m_nl=24;
-      run_reps = 10000;
-      break;
-    case Small:
-      m_ni=40; m_nj=50; m_nk=70; m_nl=80;
-      run_reps = 1000;
-      break;
-    case Medium:
-      m_ni=180; m_nj=190; m_nk=210; m_nl=220;
-      run_reps = 100;
-      break;
-    case Large:
-      m_ni=800; m_nj=900; m_nk=1100; m_nl=1200;
-      run_reps = 1;
-      break;
-    case Extralarge:
-      m_ni=1600; m_nj=1800; m_nk=2200; m_nl=2400;
-      run_reps = 1;
-      break;
-    default:
-      m_ni=180; m_nj=190; m_nk=210; m_nl=220;
-      run_reps = 100;
-      break;
-  }
-
-  m_alpha = 1.5;
-  m_beta = 1.2;
-
-  setDefaultProblemSize( std::max( m_ni*m_nj, m_ni*m_nl ) );
-  setDefaultReps(run_reps);
-
-#else 
   Index_type ni_default = 1000;
   Index_type nj_default = 1000;
   Index_type nk_default = 1120;
@@ -76,7 +39,6 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
   m_alpha = 1.5;
   m_beta = 1.2;
 
-#endif
 
   setActualProblemSize( std::max( m_ni*m_nj, m_ni*m_nl ) );
 

--- a/src/polybench/POLYBENCH_3MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_3MM-Cuda.cpp
@@ -21,6 +21,31 @@ namespace rajaperf
 namespace polybench
 {
 
+//
+// Define thread block size for CUDA execution
+//
+constexpr size_t out_block_sz = 8;
+constexpr size_t in_block_sz = 32;
+
+#define POLY_3MM_THREADS_PER_BLOCK_CUDA \
+  dim3 nthreads_per_block(in_block_sz, out_block_sz, 1);
+
+#define POLY_3MM_1_NBLOCKS_CUDA \
+  dim3 nblocks1(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, in_block_sz)), \
+                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, out_block_sz)), \
+                static_cast<size_t>(1));
+
+#define POLY_3MM_2_NBLOCKS_CUDA \
+  dim3 nblocks2(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nl, in_block_sz)), \
+                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, out_block_sz)), \
+                static_cast<size_t>(1));
+
+#define POLY_3MM_3_NBLOCKS_CUDA \
+  dim3 nblocks3(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nl, in_block_sz)), \
+                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, out_block_sz)), \
+                static_cast<size_t>(1));
+
+
 #define POLYBENCH_3MM_DATA_SETUP_CUDA \
   allocAndInitCudaDeviceData(A, m_A, m_ni * m_nk); \
   allocAndInitCudaDeviceData(B, m_B, m_nk * m_nj); \
@@ -42,43 +67,86 @@ namespace polybench
   deallocCudaDeviceData(G);
 
 __global__ void poly_3mm_1(Real_ptr E, Real_ptr A, Real_ptr B,
-                           Index_type nj, Index_type nk)
+                           Index_type ni, Index_type nj, Index_type nk)
 {
-  Index_type i = blockIdx.y;
-  Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-  POLYBENCH_3MM_BODY1;
-  for (Index_type k=0; k < nk; ++k) {
-    POLYBENCH_3MM_BODY2;
+  if ( i < ni && j < nj ) {
+    POLYBENCH_3MM_BODY1;
+    for (Index_type k=0; k < nk; ++k) {
+      POLYBENCH_3MM_BODY2;
+    }
+    POLYBENCH_3MM_BODY3;
   }
-  POLYBENCH_3MM_BODY3;
+}
+
+template< typename Lambda >
+__global__ void poly_3mm_1_lam(Index_type ni, Index_type nj, Index_type nk,
+                               Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < ni && j < nj ) {
+    body(i, j);
+  }
 }
 
 __global__ void poly_3mm_2(Real_ptr F, Real_ptr C, Real_ptr D,
-                           Index_type nl, Index_type nm)
+                           Index_type nj, Index_type nl, Index_type nm)
 {
-  Index_type j = blockIdx.y;
-  Index_type l = threadIdx.x;
+  Index_type j = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
 
-  POLYBENCH_3MM_BODY4;
-  for (Index_type m=0; m < nm; ++m) {
-    POLYBENCH_3MM_BODY5;
+  if ( j < nj && l < nl ) {
+    POLYBENCH_3MM_BODY4;
+    for (Index_type m=0; m < nm; ++m) {
+      POLYBENCH_3MM_BODY5;
+    }
+    POLYBENCH_3MM_BODY6;
   }
-  POLYBENCH_3MM_BODY6;
+}
+
+template< typename Lambda >
+__global__ void poly_3mm_2_lam(Index_type nj, Index_type nl, Index_type nm,
+                               Lambda body)
+{
+  Index_type j = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( j < nj && l < nl ) {
+    body(j, l);
+  }
 }
 
 __global__ void poly_3mm_3(Real_ptr G, Real_ptr E, Real_ptr F,
-                           Index_type nl, Index_type nj)
+                           Index_type ni, Index_type nl, Index_type nj)
 {
-  Index_type i = blockIdx.y;
-  Index_type l = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
 
-  POLYBENCH_3MM_BODY7;
-  for (Index_type j=0; j < nj; ++j) {
-    POLYBENCH_3MM_BODY8;
+  if ( i < ni && l < nl ) {
+    POLYBENCH_3MM_BODY7;
+    for (Index_type j=0; j < nj; ++j) {
+      POLYBENCH_3MM_BODY8;
+    }
+    POLYBENCH_3MM_BODY9;
   }
-  POLYBENCH_3MM_BODY9;
 }
+
+template< typename Lambda >
+__global__ void poly_3mm_3_lam(Index_type ni, Index_type nl, Index_type nj,
+                               Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < ni && l < nl ) {
+    body(i, l);
+  }
+}
+
 
 
 void POLYBENCH_3MM::runCudaVariant(VariantID vid)
@@ -94,22 +162,21 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nblocks1(1, ni, 1);
-      dim3 nthreads_per_block1(nj, 1, 1);
-      poly_3mm_1<<<nblocks1, nthreads_per_block1>>>(E, A, B,
-                                                    nj, nk);
+      POLY_3MM_THREADS_PER_BLOCK_CUDA;
+
+      POLY_3MM_1_NBLOCKS_CUDA;
+      poly_3mm_1<<<nblocks1, nthreads_per_block>>>(E, A, B,
+                                                   ni, nj, nk);
       cudaErrchk( cudaGetLastError() );
 
-      dim3 nblocks2(1, nj, 1);
-      dim3 nthreads_per_block2(nl, 1, 1);
-      poly_3mm_2<<<nblocks2, nthreads_per_block2>>>(F, C, D,
-                                                    nl, nm);
+      POLY_3MM_2_NBLOCKS_CUDA;
+      poly_3mm_2<<<nblocks2, nthreads_per_block>>>(F, C, D,
+                                                   nj, nl, nm);
       cudaErrchk( cudaGetLastError() );
 
-      dim3 nblocks3(1, ni, 1);
-      dim3 nthreads_per_block3(nl, 1, 1);
-      poly_3mm_3<<<nblocks3, nthreads_per_block3>>>(G, E, F,
-                                                    nl, nj);
+      POLY_3MM_3_NBLOCKS_CUDA;
+      poly_3mm_3<<<nblocks3, nthreads_per_block>>>(G, E, F,
+                                                   ni, nl, nj);
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -124,49 +191,42 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nblocks1(1, ni, 1);
-      dim3 nthreads_per_block1(nj, 1, 1);
-      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
-                <<<nblocks1, nthreads_per_block1>>>(
-        0, ni, 0, nj,
+      POLY_3MM_THREADS_PER_BLOCK_CUDA;
+
+      POLY_3MM_1_NBLOCKS_CUDA;
+      poly_3mm_1_lam<<<nblocks1, nthreads_per_block>>>(ni, nj, nk,
         [=] __device__ (Index_type i, Index_type j) {
-
-        POLYBENCH_3MM_BODY1;
-        for (Index_type k=0; k < nk; ++k) {
-          POLYBENCH_3MM_BODY2;
+          POLYBENCH_3MM_BODY1;
+          for (Index_type k=0; k < nk; ++k) {
+            POLYBENCH_3MM_BODY2;
+          }
+          POLYBENCH_3MM_BODY3;
         }
-        POLYBENCH_3MM_BODY3;
-      });
+      );
       cudaErrchk( cudaGetLastError() );
 
-      dim3 nblocks2(1, nj, 1);
-      dim3 nthreads_per_block2(nl, 1, 1);
-      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
-                <<<nblocks2, nthreads_per_block2>>>(
-        0, nj, 0, nl,
+      POLY_3MM_2_NBLOCKS_CUDA;
+      poly_3mm_2_lam<<<nblocks2, nthreads_per_block>>>(nj, nl, nm,
         [=] __device__ (Index_type j, Index_type l) {
-
-        POLYBENCH_3MM_BODY4;
-        for (Index_type m=0; m < nm; ++m) {
-          POLYBENCH_3MM_BODY5;
+          POLYBENCH_3MM_BODY4;
+          for (Index_type m=0; m < nm; ++m) {
+            POLYBENCH_3MM_BODY5;
+          }
+          POLYBENCH_3MM_BODY6;
         }
-        POLYBENCH_3MM_BODY6;
-      });
+      );
       cudaErrchk( cudaGetLastError() );
 
-      dim3 nblocks3(1, ni, 1);
-      dim3 nthreads_per_block3(nl, 1, 1);
-      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
-                <<<nblocks3, nthreads_per_block3>>>(
-        0, ni, 0, nl,
+      POLY_3MM_3_NBLOCKS_CUDA;
+      poly_3mm_3_lam<<<nblocks3, nthreads_per_block>>>(ni, nl, nj,
         [=] __device__ (Index_type i, Index_type l) {
-
-        POLYBENCH_3MM_BODY7;
-        for (Index_type j=0; j < nj; ++j) {
-          POLYBENCH_3MM_BODY8;
+          POLYBENCH_3MM_BODY7;
+          for (Index_type j=0; j < nj; ++j) {
+            POLYBENCH_3MM_BODY8;
+          }
+          POLYBENCH_3MM_BODY9;
         }
-        POLYBENCH_3MM_BODY9;
-      });
+      );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -182,14 +242,20 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<0, RAJA::cuda_block_x_direct,
-            RAJA::statement::For<1, RAJA::cuda_thread_y_direct,
-              RAJA::statement::Lambda<0, RAJA::Params<0>>,
-              RAJA::statement::For<2, RAJA::seq_exec,
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
+        RAJA::statement::CudaKernelFixedAsync<out_block_sz * in_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<out_block_sz>,
+                                   RAJA::cuda_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<in_block_sz>,
+                                     RAJA::cuda_block_x_direct,
+              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // outer
+                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // inner
+                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
+                  RAJA::statement::For<2, RAJA::seq_exec,
+                    RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+                  >,
+                  RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
+                >
+              >
             >
           >
         >

--- a/src/polybench/POLYBENCH_3MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_3MM-Cuda.cpp
@@ -82,7 +82,7 @@ __global__ void poly_3mm_1(Real_ptr E, Real_ptr A, Real_ptr B,
 }
 
 template< typename Lambda >
-__global__ void poly_3mm_1_lam(Index_type ni, Index_type nj, Index_type nk,
+__global__ void poly_3mm_1_lam(Index_type ni, Index_type nj,
                                Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -109,7 +109,7 @@ __global__ void poly_3mm_2(Real_ptr F, Real_ptr C, Real_ptr D,
 }
 
 template< typename Lambda >
-__global__ void poly_3mm_2_lam(Index_type nj, Index_type nl, Index_type nm,
+__global__ void poly_3mm_2_lam(Index_type nj, Index_type nl,
                                Lambda body)
 {
   Index_type j = blockIdx.y * blockDim.y + threadIdx.y;
@@ -136,7 +136,7 @@ __global__ void poly_3mm_3(Real_ptr G, Real_ptr E, Real_ptr F,
 }
 
 template< typename Lambda >
-__global__ void poly_3mm_3_lam(Index_type ni, Index_type nl, Index_type nj,
+__global__ void poly_3mm_3_lam(Index_type ni, Index_type nl,
                                Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -194,7 +194,7 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
       POLY_3MM_THREADS_PER_BLOCK_CUDA;
 
       POLY_3MM_1_NBLOCKS_CUDA;
-      poly_3mm_1_lam<<<nblocks1, nthreads_per_block>>>(ni, nj, nk,
+      poly_3mm_1_lam<<<nblocks1, nthreads_per_block>>>(ni, nj,
         [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_3MM_BODY1;
           for (Index_type k=0; k < nk; ++k) {
@@ -206,7 +206,7 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
       cudaErrchk( cudaGetLastError() );
 
       POLY_3MM_2_NBLOCKS_CUDA;
-      poly_3mm_2_lam<<<nblocks2, nthreads_per_block>>>(nj, nl, nm,
+      poly_3mm_2_lam<<<nblocks2, nthreads_per_block>>>(nj, nl,
         [=] __device__ (Index_type j, Index_type l) {
           POLYBENCH_3MM_BODY4;
           for (Index_type m=0; m < nm; ++m) {
@@ -218,7 +218,7 @@ void POLYBENCH_3MM::runCudaVariant(VariantID vid)
       cudaErrchk( cudaGetLastError() );
 
       POLY_3MM_3_NBLOCKS_CUDA;
-      poly_3mm_3_lam<<<nblocks3, nthreads_per_block>>>(ni, nl, nj,
+      poly_3mm_3_lam<<<nblocks3, nthreads_per_block>>>(ni, nl,
         [=] __device__ (Index_type i, Index_type l) {
           POLYBENCH_3MM_BODY7;
           for (Index_type j=0; j < nj; ++j) {

--- a/src/polybench/POLYBENCH_3MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_3MM-Hip.cpp
@@ -21,6 +21,31 @@ namespace rajaperf
 namespace polybench
 {
 
+//
+// Define thread block size for Hip execution
+//
+constexpr size_t out_block_sz = 8;
+constexpr size_t in_block_sz = 32;
+
+#define POLY_3MM_THREADS_PER_BLOCK_HIP \
+  dim3 nthreads_per_block(in_block_sz, out_block_sz, 1);
+
+#define POLY_3MM_1_NBLOCKS_HIP \
+  dim3 nblocks1(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, in_block_sz)), \
+                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, out_block_sz)), \
+                static_cast<size_t>(1));
+
+#define POLY_3MM_2_NBLOCKS_HIP \
+  dim3 nblocks2(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nl, in_block_sz)), \
+                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, out_block_sz)), \
+                static_cast<size_t>(1));
+
+#define POLY_3MM_3_NBLOCKS_HIP \
+  dim3 nblocks3(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nl, in_block_sz)), \
+                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, out_block_sz)), \
+                static_cast<size_t>(1));
+
+
 #define POLYBENCH_3MM_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(A, m_A, m_ni * m_nk); \
   allocAndInitHipDeviceData(B, m_B, m_nk * m_nj); \
@@ -42,42 +67,84 @@ namespace polybench
   deallocHipDeviceData(G);
 
 __global__ void poly_3mm_1(Real_ptr E, Real_ptr A, Real_ptr B,
-                           Index_type nj, Index_type nk)
+                           Index_type ni, Index_type nj, Index_type nk)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-   POLYBENCH_3MM_BODY1;
-   for (Index_type k=0; k < nk; ++k) {
-     POLYBENCH_3MM_BODY2;
-   }
-   POLYBENCH_3MM_BODY3;
+  if ( i < ni && j < nj ) {
+    POLYBENCH_3MM_BODY1;
+    for (Index_type k=0; k < nk; ++k) {
+      POLYBENCH_3MM_BODY2;
+    }
+    POLYBENCH_3MM_BODY3;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_3mm_1_lam(Index_type ni, Index_type nj, Index_type nk,
+                               Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < ni && j < nj ) {
+    body(i, j);
+  }
 }
 
 __global__ void poly_3mm_2(Real_ptr F, Real_ptr C, Real_ptr D,
-                           Index_type nl, Index_type nm)
+                           Index_type nj, Index_type nl, Index_type nm)
 {
-   Index_type j = blockIdx.y;
-   Index_type l = threadIdx.x;
+  Index_type j = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
 
-   POLYBENCH_3MM_BODY4;
-   for (Index_type m=0; m < nm; ++m) {
-     POLYBENCH_3MM_BODY5;
-   }
-   POLYBENCH_3MM_BODY6;
+  if ( j < nj && l < nl ) {
+    POLYBENCH_3MM_BODY4;
+    for (Index_type m=0; m < nm; ++m) {
+      POLYBENCH_3MM_BODY5;
+    }
+    POLYBENCH_3MM_BODY6;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_3mm_2_lam(Index_type nj, Index_type nl, Index_type nm,
+                               Lambda body)
+{
+  Index_type j = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( j < nj && l < nl ) {
+    body(j, l);
+  }
 }
 
 __global__ void poly_3mm_3(Real_ptr G, Real_ptr E, Real_ptr F,
-                           Index_type nl, Index_type nj)
+                           Index_type ni, Index_type nl, Index_type nj)
 {
-   Index_type i = blockIdx.y;
-   Index_type l = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
 
-   POLYBENCH_3MM_BODY7;
-   for (Index_type j=0; j < nj; ++j) {
-     POLYBENCH_3MM_BODY8;
-   }
-   POLYBENCH_3MM_BODY9;
+  if ( i < ni && l < nl ) {
+    POLYBENCH_3MM_BODY7;
+    for (Index_type j=0; j < nj; ++j) {
+      POLYBENCH_3MM_BODY8;
+    }
+    POLYBENCH_3MM_BODY9;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_3mm_3_lam(Index_type ni, Index_type nl, Index_type nj,
+                               Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type l = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < ni && l < nl ) {
+    body(i, l);
+  }
 }
 
 
@@ -94,25 +161,27 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nblocks1(1, ni, 1);
-      dim3 nthreads_per_block1(nj, 1, 1);
-      hipLaunchKernelGGL((poly_3mm_1), dim3(nblocks1) , dim3(nthreads_per_block1), 0, 0,
-                                                    E, A, B,
-                                                    nj, nk);
+      POLY_3MM_THREADS_PER_BLOCK_HIP;
+
+      POLY_3MM_1_NBLOCKS_HIP;     
+      hipLaunchKernelGGL((poly_3mm_1), 
+                         dim3(nblocks1) , dim3(nthreads_per_block), 0, 0,
+                         E, A, B,
+                         ni, nj, nk);
       hipErrchk( hipGetLastError() );
 
-      dim3 nblocks2(1, nj, 1);
-      dim3 nthreads_per_block2(nl, 1, 1);
-      hipLaunchKernelGGL((poly_3mm_2), dim3(nblocks2), dim3(nthreads_per_block2), 0, 0,
-                                                    F, C, D,
-                                                    nl, nm);
+      POLY_3MM_2_NBLOCKS_HIP;
+      hipLaunchKernelGGL((poly_3mm_2), 
+                         dim3(nblocks2), dim3(nthreads_per_block), 0, 0,
+                         F, C, D,
+                         nj, nl, nm);
       hipErrchk( hipGetLastError() );
 
-      dim3 nblocks3(1, ni, 1);
-      dim3 nthreads_per_block3(nl, 1, 1);
-      hipLaunchKernelGGL((poly_3mm_3), dim3(nblocks3), dim3(nthreads_per_block3), 0, 0,
-                                                    G, E, F,
-                                                    nl, nj);
+      POLY_3MM_3_NBLOCKS_HIP;
+      hipLaunchKernelGGL((poly_3mm_3), 
+                         dim3(nblocks3), dim3(nthreads_per_block3), 0, 0,
+                         G, E, F,
+                         ni, nl, nj);
       hipErrchk( hipGetLastError() );
 
     }
@@ -127,8 +196,9 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      auto poly_3mm_1_lambda = [=] __device__ (Index_type i, Index_type j) {
+      POLY_3MM_THREADS_PER_BLOCK_HIP;
 
+      auto poly_3mm_1_lambda = [=] __device__ (Index_type i, Index_type j) {
         POLYBENCH_3MM_BODY1;
         for (Index_type k=0; k < nk; ++k) {
           POLYBENCH_3MM_BODY2;
@@ -136,16 +206,13 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
         POLYBENCH_3MM_BODY3;
       };
 
-      dim3 nblocks1(1, ni, 1);
-      dim3 nthreads_per_block1(nj, 1, 1);
-      auto kernel1 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_3mm_1_lambda)>;
-      hipLaunchKernelGGL(kernel1,
-        nblocks1, nthreads_per_block1, 0, 0,
-        0, ni, 0, nj, poly_3mm_1_lambda);
+      POLY_3MM_1_NBLOCKS_HIP;
+      hipLaunchKernelGGL((poly_3mm_1_lam<decltype(poly_3mm_1_lambda)>),
+                         dim3(nblocks1), dim3(nthreads_per_block), 0, 0,
+                         ni, nj, nk, poly_3mm_1_lambda);
       hipErrchk( hipGetLastError() );
 
       auto poly_3mm_2_lambda = [=] __device__ (Index_type j, Index_type l) {
-
         POLYBENCH_3MM_BODY4;
         for (Index_type m=0; m < nm; ++m) {
           POLYBENCH_3MM_BODY5;
@@ -153,16 +220,13 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
         POLYBENCH_3MM_BODY6;
       };
 
-      dim3 nblocks2(1, nj, 1);
-      dim3 nthreads_per_block2(nl, 1, 1);
-      auto kernel2 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_3mm_2_lambda)>;
-      hipLaunchKernelGGL(kernel2,
-        nblocks2, nthreads_per_block2, 0, 0,
-        0, nj, 0, nl, poly_3mm_2_lambda);
+      POLY_3MM_2_NBLOCKS_HIP;
+      hipLaunchKernelGGL((poly_3mm_2_lam<decltype(poly_3mm_2_lambda)>),
+                         dim3(nblocks1), dim3(nthreads_per_block), 0, 0,
+                         nj, nl, nm, poly_3mm_2_lambda);
       hipErrchk( hipGetLastError() );
 
       auto poly_3mm_3_lambda = [=] __device__ (Index_type i, Index_type l) {
-
         POLYBENCH_3MM_BODY7;
         for (Index_type j=0; j < nj; ++j) {
           POLYBENCH_3MM_BODY8;
@@ -170,12 +234,10 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
         POLYBENCH_3MM_BODY9;
       };
 
-      dim3 nblocks3(1, ni, 1);
-      dim3 nthreads_per_block3(nl, 1, 1);
-      auto kernel3 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_3mm_3_lambda)>;
-      hipLaunchKernelGGL(kernel3,
-        nblocks3, nthreads_per_block3, 0, 0,
-        0, ni, 0, nl, poly_3mm_3_lambda);
+      POLY_3MM_3_NBLOCKS_HIP;
+      hipLaunchKernelGGL((poly_3mm_3_lam<decltype(poly_3mm_3_lambda)>),
+                         dim3(nblocks1), dim3(nthreads_per_block), 0, 0,
+                         ni, nl, nj, poly_3mm_3_lambda);
       hipErrchk( hipGetLastError() );
 
     }
@@ -191,18 +253,24 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_x_direct,
-            RAJA::statement::For<1, RAJA::hip_thread_y_direct,
-              RAJA::statement::Lambda<0, RAJA::Params<0>>,
-              RAJA::statement::For<2, RAJA::seq_exec,
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
+        RAJA::statement::HipKernelFixedAsync<out_block_sz * in_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<out_block_sz>,
+                                   RAJA::hip_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<in_block_sz>,
+                                     RAJA::hip_block_x_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // outer
+                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // inner
+                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
+                  RAJA::statement::For<2, RAJA::seq_exec,
+                    RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+                  >,
+                  RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
+                >
+              >
             >
           >
         >
-      >;
+      >; 
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/polybench/POLYBENCH_3MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_3MM-Hip.cpp
@@ -82,7 +82,7 @@ __global__ void poly_3mm_1(Real_ptr E, Real_ptr A, Real_ptr B,
 }
 
 template< typename Lambda >
-__global__ void poly_3mm_1_lam(Index_type ni, Index_type nj, Index_type nk,
+__global__ void poly_3mm_1_lam(Index_type ni, Index_type nj,
                                Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -109,7 +109,7 @@ __global__ void poly_3mm_2(Real_ptr F, Real_ptr C, Real_ptr D,
 }
 
 template< typename Lambda >
-__global__ void poly_3mm_2_lam(Index_type nj, Index_type nl, Index_type nm,
+__global__ void poly_3mm_2_lam(Index_type nj, Index_type nl,
                                Lambda body)
 {
   Index_type j = blockIdx.y * blockDim.y + threadIdx.y;
@@ -136,7 +136,7 @@ __global__ void poly_3mm_3(Real_ptr G, Real_ptr E, Real_ptr F,
 }
 
 template< typename Lambda >
-__global__ void poly_3mm_3_lam(Index_type ni, Index_type nl, Index_type nj,
+__global__ void poly_3mm_3_lam(Index_type ni, Index_type nl,
                                Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -209,7 +209,7 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
       POLY_3MM_1_NBLOCKS_HIP;
       hipLaunchKernelGGL((poly_3mm_1_lam<decltype(poly_3mm_1_lambda)>),
                          dim3(nblocks1), dim3(nthreads_per_block), 0, 0,
-                         ni, nj, nk, poly_3mm_1_lambda);
+                         ni, nj, poly_3mm_1_lambda);
       hipErrchk( hipGetLastError() );
 
       auto poly_3mm_2_lambda = [=] __device__ (Index_type j, Index_type l) {
@@ -223,7 +223,7 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
       POLY_3MM_2_NBLOCKS_HIP;
       hipLaunchKernelGGL((poly_3mm_2_lam<decltype(poly_3mm_2_lambda)>),
                          dim3(nblocks2), dim3(nthreads_per_block), 0, 0,
-                         nj, nl, nm, poly_3mm_2_lambda);
+                         nj, nl, poly_3mm_2_lambda);
       hipErrchk( hipGetLastError() );
 
       auto poly_3mm_3_lambda = [=] __device__ (Index_type i, Index_type l) {
@@ -237,7 +237,7 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
       POLY_3MM_3_NBLOCKS_HIP;
       hipLaunchKernelGGL((poly_3mm_3_lam<decltype(poly_3mm_3_lambda)>),
                          dim3(nblocks3), dim3(nthreads_per_block), 0, 0,
-                         ni, nl, nj, poly_3mm_3_lambda);
+                         ni, nl, poly_3mm_3_lambda);
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_3MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_3MM-Hip.cpp
@@ -179,7 +179,7 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
 
       POLY_3MM_3_NBLOCKS_HIP;
       hipLaunchKernelGGL((poly_3mm_3), 
-                         dim3(nblocks3), dim3(nthreads_per_block3), 0, 0,
+                         dim3(nblocks3), dim3(nthreads_per_block), 0, 0,
                          G, E, F,
                          ni, nl, nj);
       hipErrchk( hipGetLastError() );

--- a/src/polybench/POLYBENCH_3MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_3MM-Hip.cpp
@@ -222,7 +222,7 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
 
       POLY_3MM_2_NBLOCKS_HIP;
       hipLaunchKernelGGL((poly_3mm_2_lam<decltype(poly_3mm_2_lambda)>),
-                         dim3(nblocks1), dim3(nthreads_per_block), 0, 0,
+                         dim3(nblocks2), dim3(nthreads_per_block), 0, 0,
                          nj, nl, nm, poly_3mm_2_lambda);
       hipErrchk( hipGetLastError() );
 
@@ -236,7 +236,7 @@ void POLYBENCH_3MM::runHipVariant(VariantID vid)
 
       POLY_3MM_3_NBLOCKS_HIP;
       hipLaunchKernelGGL((poly_3mm_3_lam<decltype(poly_3mm_3_lambda)>),
-                         dim3(nblocks1), dim3(nthreads_per_block), 0, 0,
+                         dim3(nblocks3), dim3(nthreads_per_block), 0, 0,
                          ni, nl, nj, poly_3mm_3_lambda);
       hipErrchk( hipGetLastError() );
 

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -23,41 +23,6 @@ namespace polybench
 POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_3MM, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  switch(lsizespec) {
-    case Mini:
-      m_ni=16; m_nj=18; m_nk=20; m_nl=22; m_nm=24;
-      m_run_reps = 100000;
-      break;
-    case Small:
-      m_ni=40; m_nj=50; m_nk=60; m_nl=70; m_nm=80;
-      m_run_reps = 5000;
-      break;
-    case Medium:
-      m_ni=180; m_nj=190; m_nk=200; m_nl=210; m_nm=220;
-      m_run_reps = 100;
-      break;
-    case Large:
-      m_ni=800; m_nj=900; m_nk=1000; m_nl=1100; m_nm=1200;
-      m_run_reps = 1;
-      break;
-    case Extralarge:
-      m_ni=1600; m_nj=1800; m_nk=2000; m_nl=2200; m_nm=2400;
-      m_run_reps = 1;
-      break;
-    default:
-      m_ni=180; m_nj=190; m_nk=200; m_nl=210; m_nm=220;
-      m_run_reps = 100;
-      break;
-  }
-
-  setDefaultProblemSize( std::max( std::max( m_ni*m_nj, m_nj*m_nl), m_ni*m_nl ) );
-
-  setDefaultReps(m_run_reps);
-
-#else
-
   Index_type ni_default = 1000;
   Index_type nj_default = 1000;
   Index_type nk_default = 1010;
@@ -76,7 +41,6 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   m_nl = m_ni;
   m_nm = nm_default;
 
-#endif
 
   setActualProblemSize( std::max( std::max( m_ni*m_nj, m_nj*m_nl ), 
                                   m_ni*m_nl ) );

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -23,6 +23,7 @@ namespace polybench
 POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_3MM, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   switch(lsizespec) {
     case Mini:
@@ -51,7 +52,11 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  setDefaultProblemSize( std::max( std::max( m_ni*m_nj, m_nj*m_nl), m_ni*m_nl ) );
+
+  setDefaultReps(m_run_reps);
+
+#else
 
   Index_type ni_default = 1000;
   Index_type nj_default = 1000;
@@ -63,19 +68,13 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
                                              nj_default*nl_default ), 
                                   ni_default*nl_default ) );
   setDefaultProblemSize( ni_default * nj_default );
-  setDefaultReps(4);
+  setDefaultReps(2);
 
   m_ni = std::sqrt( getTargetProblemSize() ) + 1;
   m_nj = m_ni;
   m_nk = nk_default;
   m_nl = m_ni;
   m_nm = nm_default;
-
-#else  // this is what we have now...
-
-  setDefaultProblemSize( std::max( std::max( m_ni*m_nj, m_nj*m_nl), m_ni*m_nl ) );
-
-  setDefaultReps(m_run_reps);
 
 #endif
 
@@ -98,6 +97,10 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   setFLOPsPerRep(2 * m_ni*m_nj*m_nk +
                  2 * m_nj*m_nl*m_nm +
                  2 * m_ni*m_nj*m_nl );
+
+  checksum_scale_factor = 0.000000001 * 
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Kernel);
 
@@ -139,7 +142,7 @@ void POLYBENCH_3MM::setUp(VariantID vid)
 
 void POLYBENCH_3MM::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_G, m_ni * m_nl);
+  checksum[vid] += calcChecksum(m_G, m_ni * m_nl, checksum_scale_factor );
 }
 
 void POLYBENCH_3MM::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_ADI-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ADI-Cuda.cpp
@@ -76,6 +76,16 @@ __global__ void adi2(const Index_type n,
   }
 }
 
+template< typename Lambda >
+__global__ void adi_lam(const Index_type n,
+                        Lambda body)
+{
+  Index_type i = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n-1) {
+    body(i);
+  }
+}
+
 
 void POLYBENCH_ADI::runCudaVariant(VariantID vid)
 {
@@ -122,35 +132,34 @@ void POLYBENCH_ADI::runCudaVariant(VariantID vid)
 
         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(n-2, block_size);
 
-        lambda_cuda_forall<<<grid_size, block_size>>>(
-          1, n-1,
+        adi_lam<<<grid_size, block_size>>>(n,
           [=] __device__ (Index_type i) {
-
-          POLYBENCH_ADI_BODY2;
-          for (Index_type j = 1; j < n-1; ++j) {
-             POLYBENCH_ADI_BODY3;
+            POLYBENCH_ADI_BODY2;
+            for (Index_type j = 1; j < n-1; ++j) {
+              POLYBENCH_ADI_BODY3;
+            }
+            POLYBENCH_ADI_BODY4;
+            for (Index_type k = n-2; k >= 1; --k) {
+              POLYBENCH_ADI_BODY5;
+            }
           }
-          POLYBENCH_ADI_BODY4;
-          for (Index_type k = n-2; k >= 1; --k) {
-             POLYBENCH_ADI_BODY5;
-          }
-        });
+        );
         cudaErrchk( cudaGetLastError() );
 
-        lambda_cuda_forall<<<grid_size, block_size>>>(
-          1, n-1,
+        adi_lam<<<grid_size, block_size>>>(n,
           [=] __device__ (Index_type i) {
-
-          POLYBENCH_ADI_BODY6;
-          for (Index_type j = 1; j < n-1; ++j) {
-            POLYBENCH_ADI_BODY7;
+            POLYBENCH_ADI_BODY6;
+            for (Index_type j = 1; j < n-1; ++j) {
+              POLYBENCH_ADI_BODY7;
+            }
+            POLYBENCH_ADI_BODY8;
+            for (Index_type k = n-2; k >= 1; --k) {
+              POLYBENCH_ADI_BODY9;
+            }
           }
-          POLYBENCH_ADI_BODY8;
-          for (Index_type k = n-2; k >= 1; --k) {
-            POLYBENCH_ADI_BODY9;
-          }
-        });
+        );
         cudaErrchk( cudaGetLastError() );
+
       }  // tstep loop
 
     }
@@ -166,7 +175,7 @@ void POLYBENCH_ADI::runCudaVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelAsync<
+        RAJA::statement::CudaKernelFixedAsync<block_size,
           RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
                                    RAJA::cuda_block_x_direct,
             RAJA::statement::For<0, RAJA::cuda_thread_x_direct,

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -20,44 +20,6 @@ namespace polybench
 POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
   : KernelBase(rajaperf::Polybench_ADI, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps;
-  switch(lsizespec) {
-    case Mini:
-      m_n=20; m_tsteps=1;
-      run_reps = 10000;
-      break;
-    case Small:
-      m_n=60; m_tsteps=40;
-      run_reps = 500;
-      break;
-    case Medium:
-      m_n=200; m_tsteps=100;
-      run_reps = 20;
-      break;
-    case Large:
-      m_n=1000; m_tsteps=500;
-      run_reps = 1;
-      break;
-    case Extralarge:
-      m_n=2000; m_tsteps=1000;
-      run_reps = 1;
-      break;
-    default:
-      m_n=200; m_tsteps=100;
-      run_reps = 20;
-      break;
-  }
-
-  setDefaultProblemSize( (m_n-2)*(m_n-2) );
-  setDefaultReps(run_reps);
-
-  setItsPerRep( m_tsteps * ( (m_n-2)*(m_n-2 + m_n-2) +
-                             (m_n-2)*(m_n-2 + m_n-2) ) );
-
-#else
-
   Index_type n_default = 1000;
   
   setDefaultProblemSize( (n_default-2) * (n_default-2) );
@@ -68,7 +30,6 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
 
   setItsPerRep( m_tsteps * ( (m_n-2) + (m_n-2) ) );
 
-#endif
 
   setActualProblemSize( (m_n-2) * (m_n-2) );
 

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -20,6 +20,7 @@ namespace polybench
 POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
   : KernelBase(rajaperf::Polybench_ADI, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps;
   switch(lsizespec) {
@@ -49,7 +50,13 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  setDefaultProblemSize( (m_n-2)*(m_n-2) );
+  setDefaultReps(run_reps);
+
+  setItsPerRep( m_tsteps * ( (m_n-2)*(m_n-2 + m_n-2) +
+                             (m_n-2)*(m_n-2 + m_n-2) ) );
+
+#else
 
   Index_type n_default = 1000;
   
@@ -61,13 +68,6 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
 
   setItsPerRep( m_tsteps * ( (m_n-2) + (m_n-2) ) );
 
-#else // this is what we have now...
-
-  setDefaultProblemSize( (m_n-2)*(m_n-2) );
-  setDefaultReps(run_reps);
-
-  setItsPerRep( m_tsteps * ( (m_n-2)*(m_n-2 + m_n-2) +
-                             (m_n-2)*(m_n-2 + m_n-2) ) );
 #endif
 
   setActualProblemSize( (m_n-2) * (m_n-2) );
@@ -77,6 +77,10 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
                                (3*sizeof(Real_type ) + 3*sizeof(Real_type )) * m_n * (m_n-2) ) );
   setFLOPsPerRep( m_tsteps * ( (15 + 2) * (m_n-2)*(m_n-2) +
                                (15 + 2) * (m_n-2)*(m_n-2) ) );
+
+  checksum_scale_factor = 0.0000001 * 
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Kernel);
 
@@ -114,7 +118,7 @@ void POLYBENCH_ADI::setUp(VariantID vid)
 
 void POLYBENCH_ADI::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_U, m_n * m_n);
+  checksum[vid] += calcChecksum(m_U, m_n * m_n, checksum_scale_factor );
 }
 
 void POLYBENCH_ADI::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_ATAX-Hip.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Hip.cpp
@@ -128,9 +128,9 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
         POLYBENCH_ATAX_BODY3;
       };
 
-      hipLaunchKernelGGL(poly_atax_lam<decltype(poly_atax_1_lambda)>,
+      hipLaunchKernelGGL((poly_atax_lam<decltype(poly_atax_1_lambda)>),
         dim3(grid_size), dim3(block_size), 0, 0,
-        0, N, poly_atax_1_lambda);
+        N, poly_atax_1_lambda);
       hipErrchk( hipGetLastError() );
 
       auto poly_atax_2_lambda = [=] __device__ (Index_type j) {
@@ -141,9 +141,9 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
         POLYBENCH_ATAX_BODY6;
       };
 
-      hipLaunchKernelGGL(poly_atax_lam<decltype(poly_atax_2_lambda)>,
+      hipLaunchKernelGGL((poly_atax_lam<decltype(poly_atax_2_lambda)>),
         dim3(grid_size), dim3(block_size), 0, 0,
-        0, N, poly_atax_2_lambda);
+        N, poly_atax_2_lambda);
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_ATAX-Hip.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Hip.cpp
@@ -22,7 +22,7 @@ namespace polybench
 {
 
   //
-  // Define thread block size for HIP execution
+  // Define thread block size for Hip execution
   //
   const size_t block_size = 256;
 
@@ -69,6 +69,17 @@ __global__ void poly_atax_2(Real_ptr A, Real_ptr tmp, Real_ptr y,
    }
 }
 
+template< typename Lambda >
+__global__ void poly_atax_lam(Index_type N,
+                              Lambda body)
+{
+  Index_type ti = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (ti < N) {
+    body(ti);
+  }
+}
+
 
 void POLYBENCH_ATAX::runHipVariant(VariantID vid)
 {
@@ -85,12 +96,14 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
 
-      hipLaunchKernelGGL((poly_atax_1), dim3(grid_size), dim3(block_size), 0, 0,
-                                      A, x, y, tmp, N);
+      hipLaunchKernelGGL((poly_atax_1), 
+                         dim3(grid_size), dim3(block_size), 0, 0,
+                         A, x, y, tmp, N);
       hipErrchk( hipGetLastError() );
 
-      hipLaunchKernelGGL((poly_atax_2), dim3(grid_size), dim3(block_size), 0, 0,
-                                      A, tmp, y, N);
+      hipLaunchKernelGGL((poly_atax_2), 
+                         dim3(grid_size), dim3(block_size), 0, 0,
+                         A, tmp, y, N);
       hipErrchk( hipGetLastError() );
 
     }
@@ -108,7 +121,6 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
 
       auto poly_atax_1_lambda = [=] __device__ (Index_type i) {
-
         POLYBENCH_ATAX_BODY1;
         for (Index_type j = 0; j < N; ++j ) {
           POLYBENCH_ATAX_BODY2;
@@ -116,13 +128,12 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
         POLYBENCH_ATAX_BODY3;
       };
 
-      hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_atax_1_lambda)>,
-        grid_size, block_size, 0, 0,
+      hipLaunchKernelGGL(poly_atax_lam<decltype(poly_atax_1_lambda)>,
+        dim3(grid_size), dim3(block_size), 0, 0,
         0, N, poly_atax_1_lambda);
       hipErrchk( hipGetLastError() );
 
       auto poly_atax_2_lambda = [=] __device__ (Index_type j) {
-
         POLYBENCH_ATAX_BODY4;
         for (Index_type i = 0; i < N; ++i ) {
           POLYBENCH_ATAX_BODY5;
@@ -130,8 +141,8 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
         POLYBENCH_ATAX_BODY6;
       };
 
-      hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_atax_2_lambda)>,
-        grid_size, block_size, 0, 0,
+      hipLaunchKernelGGL(poly_atax_lam<decltype(poly_atax_2_lambda)>,
+        dim3(grid_size), dim3(block_size), 0, 0,
         0, N, poly_atax_2_lambda);
       hipErrchk( hipGetLastError() );
 
@@ -148,7 +159,7 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
 
     using EXEC_POL1 =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
+        RAJA::statement::HipKernelFixedAsync<block_size,
           RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
                                    RAJA::hip_block_x_direct,
             RAJA::statement::For<0, RAJA::hip_thread_x_direct,
@@ -164,7 +175,7 @@ void POLYBENCH_ATAX::runHipVariant(VariantID vid)
 
     using EXEC_POL2 =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
+        RAJA::statement::HipKernelFixedAsync<block_size,
           RAJA::statement::Tile<1, RAJA::tile_fixed<block_size>,
                                    RAJA::hip_block_x_direct,
             RAJA::statement::For<1, RAJA::hip_thread_x_direct,

--- a/src/polybench/POLYBENCH_ATAX.cpp
+++ b/src/polybench/POLYBENCH_ATAX.cpp
@@ -21,6 +21,7 @@ namespace polybench
 POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
   : KernelBase(rajaperf::Polybench_ATAX, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps = 0;
   switch(lsizespec) {
@@ -50,7 +51,10 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  setDefaultProblemSize( m_N );
+  setDefaultReps(run_reps);
+
+#else
 
   Index_type N_default = 2100;
 
@@ -58,10 +62,6 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
   setDefaultReps(100);
 
   m_N = std::sqrt( getTargetProblemSize() )+1;
-
-#else  // this is what we have now...
-  setDefaultProblemSize( m_N );
-  setDefaultReps(run_reps);
 
 #endif
 
@@ -76,6 +76,10 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
                   (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N * m_N );
   setFLOPsPerRep(2 * m_N*m_N +
                  2 * m_N*m_N );
+
+  checksum_scale_factor = 0.001 * 
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Kernel);
 
@@ -114,7 +118,7 @@ void POLYBENCH_ATAX::setUp(VariantID vid)
 
 void POLYBENCH_ATAX::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_y, m_N);
+  checksum[vid] += calcChecksum(m_y, m_N, checksum_scale_factor );
 }
 
 void POLYBENCH_ATAX::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_ATAX.cpp
+++ b/src/polybench/POLYBENCH_ATAX.cpp
@@ -21,41 +21,6 @@ namespace polybench
 POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
   : KernelBase(rajaperf::Polybench_ATAX, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0;
-  switch(lsizespec) {
-    case Mini:
-      m_N=42;
-      run_reps = 10000;
-      break;
-    case Small:
-      m_N=124;
-      run_reps = 1000;
-      break;
-    case Medium:
-      m_N=410;
-      run_reps = 100;
-      break;
-    case Large:
-      m_N=2100;
-      run_reps = 1;
-      break;
-    case Extralarge:
-      m_N=2200;
-      run_reps = 1;
-      break;
-    default:
-      m_N=2100;
-      run_reps = 100;
-      break;
-  }
-
-  setDefaultProblemSize( m_N );
-  setDefaultReps(run_reps);
-
-#else
-
   Index_type N_default = 2100;
 
   setDefaultProblemSize( N_default * N_default );
@@ -63,7 +28,6 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
 
   m_N = std::sqrt( getTargetProblemSize() )+1;
 
-#endif
 
   setActualProblemSize( m_N * m_N ); 
 

--- a/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
@@ -26,6 +26,18 @@ namespace polybench
   //
   const size_t block_size = 256;
 
+  constexpr size_t j_block_sz = 32;
+  constexpr size_t i_block_sz = 8;
+
+#define FDTD_2D_THREADS_PER_BLOCK_CUDA \
+  dim3 nthreads_per_block234(j_block_sz, i_block_sz, 1);
+
+#define FDTD_2D_NBLOCKS_CUDA \
+  dim3 nblocks234(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ny, j_block_sz)), \
+                  static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nx, i_block_sz)), \
+                  static_cast<size_t>(1));
+
+
 #define POLYBENCH_FDTD_2D_DATA_SETUP_CUDA \
   allocAndInitCudaDeviceData(hz, m_hz, m_nx * m_ny); \
   allocAndInitCudaDeviceData(ex, m_ex, m_nx * m_ny); \
@@ -50,37 +62,74 @@ __global__ void poly_fdtd2d_1(Real_ptr ey, Real_ptr fict,
   }
 }
 
-__global__ void poly_fdtd2d_2(Real_ptr ey, Real_ptr hz, Index_type ny)
+__global__ void poly_fdtd2d_2(Real_ptr ey, Real_ptr hz, 
+                              Index_type nx, Index_type ny)
 {
-  Index_type i = blockIdx.y;
-  Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-  if (i > 0) {
+  if (i > 0 && i < nx && j < ny) {
     POLYBENCH_FDTD_2D_BODY2;
   }
 }
 
-__global__ void poly_fdtd2d_3(Real_ptr ex, Real_ptr hz, Index_type ny)
+template< typename Lambda >
+__global__ void poly_fdtd2d_2_lam(Index_type nx, Index_type ny,
+                                  Lambda body)
 {
-  Index_type i = blockIdx.y;
-  Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-  if (j > 0) {
+  if (i > 0 && i < nx && j < ny) {
+    body(i, j); 
+  }
+}
+
+__global__ void poly_fdtd2d_3(Real_ptr ex, Real_ptr hz,
+                              Index_type nx, Index_type ny)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (i < nx && j > 0 && j < ny) {
     POLYBENCH_FDTD_2D_BODY3;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_fdtd2d_3_lam(Index_type nx, Index_type ny,
+                                  Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (i < nx && j > 0 && j < ny) {
+    body(i, j);
   }
 }
 
 __global__ void poly_fdtd2d_4(Real_ptr hz, Real_ptr ex, Real_ptr ey,
                               Index_type nx, Index_type ny)
 {
-  Index_type i = blockIdx.y;
-  Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
   if (i < nx-1 && j < ny-1) {
     POLYBENCH_FDTD_2D_BODY4;
   }
 }
 
+template< typename Lambda >
+__global__ void poly_fdtd2d_4_lam(Index_type nx, Index_type ny,
+                                  Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (i < nx-1 && j < ny-1) {
+    body(i, j);
+  }
+}
 
 
 void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
@@ -99,20 +148,20 @@ void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
       for (t = 0; t < tsteps; ++t) {
 
         const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
+
         poly_fdtd2d_1<<<grid_size1, block_size>>>(ey, fict, ny, t);
         cudaErrchk( cudaGetLastError() );
 
-        dim3 nblocks234(1, nx, 1);
-        dim3 nthreads_per_block234(ny, 1, 1);
-        poly_fdtd2d_2<<<nblocks234, nthreads_per_block234>>>(ey, hz, ny);
+        FDTD_2D_THREADS_PER_BLOCK_CUDA;
+        FDTD_2D_NBLOCKS_CUDA;
+
+        poly_fdtd2d_2<<<nblocks234, nthreads_per_block234>>>(ey, hz, nx, ny);
         cudaErrchk( cudaGetLastError() );
 
-        poly_fdtd2d_3<<<nblocks234, nthreads_per_block234>>>(ex, hz, ny);
-
+        poly_fdtd2d_3<<<nblocks234, nthreads_per_block234>>>(ex, hz, nx, ny);
         cudaErrchk( cudaGetLastError() );
 
         poly_fdtd2d_4<<<nblocks234, nthreads_per_block234>>>(hz, ex, ey, nx, ny);
-
         cudaErrchk( cudaGetLastError() );
 
       } // tstep loop
@@ -132,34 +181,36 @@ void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
       for (t = 0; t < tsteps; ++t) {
 
         const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
+
         lambda_cuda_forall<<<grid_size1, block_size>>>(
           0, ny,
           [=] __device__ (Index_type j) {
             POLYBENCH_FDTD_2D_BODY1;
         });
 
-        dim3 nblocks234(1, nx, 1);
-        dim3 nthreads_per_block234(ny, 1, 1);
-        lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
-                          <<<nblocks234, nthreads_per_block234>>>(
-          1, nx, 0, ny,
+        FDTD_2D_THREADS_PER_BLOCK_CUDA;
+        FDTD_2D_NBLOCKS_CUDA;
+
+        poly_fdtd2d_2_lam<<<nblocks234, nthreads_per_block234>>>(nx, ny,
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_FDTD_2D_BODY2;
-        });
+          }
+        );
+        cudaErrchk( cudaGetLastError() );
 
-        lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
-                          <<<nblocks234, nthreads_per_block234>>>(
-          0, nx, 1, ny,
+        poly_fdtd2d_3_lam<<<nblocks234, nthreads_per_block234>>>(nx, ny,
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_FDTD_2D_BODY3;
-        });
+          }
+        );
+        cudaErrchk( cudaGetLastError() );
 
-        lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
-                          <<<nblocks234, nthreads_per_block234>>>(
-          0, nx-1, 0, ny-1,
+        poly_fdtd2d_4_lam<<<nblocks234, nthreads_per_block234>>>(nx, ny,
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_FDTD_2D_BODY4;
-        });
+          }
+        );
+        cudaErrchk( cudaGetLastError() );
 
       } // tstep loop
 
@@ -178,10 +229,16 @@ void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
 
     using EXEC_POL234 =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<0, RAJA::cuda_block_y_direct,
-            RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
-              RAJA::statement::Lambda<0>
+        RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
+                                   RAJA::cuda_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
+                                     RAJA::cuda_block_x_direct,
+              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // i
+                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // j
+                  RAJA::statement::Lambda<0>
+                >
+              >
             >
           >
         >

--- a/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
@@ -62,6 +62,16 @@ __global__ void poly_fdtd2d_1(Real_ptr ey, Real_ptr fict,
   }
 }
 
+template< typename Lambda >
+__global__ void poly_fdtd2d_1_lam(Index_type ny, Lambda body)
+{
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (j < ny) {
+    body(j);
+  }
+}
+
 __global__ void poly_fdtd2d_2(Real_ptr ey, Real_ptr hz, 
                               Index_type nx, Index_type ny)
 {
@@ -182,11 +192,11 @@ void POLYBENCH_FDTD_2D::runCudaVariant(VariantID vid)
 
         const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
 
-        lambda_cuda_forall<<<grid_size1, block_size>>>(
-          0, ny,
+        poly_fdtd2d_1_lam<<<grid_size1, block_size>>>(ny,
           [=] __device__ (Index_type j) {
             POLYBENCH_FDTD_2D_BODY1;
-        });
+          }
+        );
 
         FDTD_2D_THREADS_PER_BLOCK_CUDA;
         FDTD_2D_NBLOCKS_CUDA;

--- a/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
@@ -192,7 +192,7 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
             POLYBENCH_FDTD_2D_BODY1;
         };
 
-        hipLaunchKernelGGL(poly_fdtd2d_2_lam<decltype(poly_fdtd2d_1_lambda)>,
+        hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_fdtd2d_1_lambda)>,
           grid_size1, block_size, 0, 0,
           0, ny, poly_fdtd2d_1_lambda);
         hipErrchk( hipGetLastError() );
@@ -212,7 +212,7 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
 
         auto poly_fdtd2d_3_lambda = 
           [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_FDTD_2D_BODY2;
+            POLYBENCH_FDTD_2D_BODY3;
           };
 
         hipLaunchKernelGGL((poly_fdtd2d_3_lam<decltype(poly_fdtd2d_3_lambda)>),
@@ -222,7 +222,7 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
   
         auto poly_fdtd2d_4_lambda = 
           [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_FDTD_2D_BODY2;
+            POLYBENCH_FDTD_2D_BODY4;
           };
 
         hipLaunchKernelGGL((poly_fdtd2d_4_lam<decltype(poly_fdtd2d_4_lambda)>),

--- a/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
@@ -22,9 +22,20 @@ namespace polybench
 {
 
   //
-  // Define thread block size for HIP execution
+  // Define thread block size for Hip execution
   //
   const size_t block_size = 256;
+
+  constexpr size_t j_block_sz = 32;
+  constexpr size_t i_block_sz = 8;
+
+#define FDTD_2D_THREADS_PER_BLOCK_HIP \
+  dim3 nthreads_per_block234(j_block_sz, i_block_sz, 1);
+
+#define FDTD_2D_NBLOCKS_HIP \
+  dim3 nblocks234(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ny, j_block_sz)), \
+                  static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nx, i_block_sz)), \
+                  static_cast<size_t>(1));
 
 #define POLYBENCH_FDTD_2D_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(hz, m_hz, m_nx * m_ny); \
@@ -50,37 +61,74 @@ __global__ void poly_fdtd2d_1(Real_ptr ey, Real_ptr fict,
    }
 }
 
-__global__ void poly_fdtd2d_2(Real_ptr ey, Real_ptr hz, Index_type ny)
+__global__ void poly_fdtd2d_2(Real_ptr ey, Real_ptr hz,
+                              Index_type nx, Index_type ny)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-   if (i > 0) {
-     POLYBENCH_FDTD_2D_BODY2;
-   }
+  if (i > 0 && i < nx && j < ny) {
+    POLYBENCH_FDTD_2D_BODY2;
+  }
 }
 
-__global__ void poly_fdtd2d_3(Real_ptr ex, Real_ptr hz, Index_type ny)
+template< typename Lambda >
+__global__ void poly_fdtd2d_2_lam(Index_type nx, Index_type ny,
+                                  Lambda body)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-   if (j > 0) {
-     POLYBENCH_FDTD_2D_BODY3;
-   }
+  if (i > 0 && i < nx && j < ny) {
+    body(i, j);
+  }
+}
+
+__global__ void poly_fdtd2d_3(Real_ptr ex, Real_ptr hz,
+                              Index_type nx, Index_type ny)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (i < nx && j > 0 && j < ny) {
+    POLYBENCH_FDTD_2D_BODY3;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_fdtd2d_3_lam(Index_type nx, Index_type ny,
+                                  Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (i < nx && j > 0 && j < ny) {
+    body(i, j);
+  }
 }
 
 __global__ void poly_fdtd2d_4(Real_ptr hz, Real_ptr ex, Real_ptr ey,
                               Index_type nx, Index_type ny)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-   if (i < nx-1 && j < ny-1) {
-     POLYBENCH_FDTD_2D_BODY4;
-   }
+  if (i < nx-1 && j < ny-1) {
+    POLYBENCH_FDTD_2D_BODY4;
+  }
 }
 
+template< typename Lambda >
+__global__ void poly_fdtd2d_4_lam(Index_type nx, Index_type ny,
+                                  Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (i < nx-1 && j < ny-1) {
+    body(i, j);
+  }
+}
 
 
 void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
@@ -99,21 +147,27 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
       for (t = 0; t < tsteps; ++t) {
 
         const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
-        hipLaunchKernelGGL((poly_fdtd2d_1), dim3(grid_size1), dim3(block_size), 0, 0, ey, fict, ny, t);
+        hipLaunchKernelGGL((poly_fdtd2d_1), 
+                           dim3(grid_size1), dim3(block_size), 0, 0, 
+                           ey, fict, ny, t);
         hipErrchk( hipGetLastError() );
 
-        dim3 nblocks234(1, nx, 1);
-        dim3 nthreads_per_block234(ny, 1, 1);
-        hipLaunchKernelGGL((poly_fdtd2d_2), dim3(nblocks234), dim3(nthreads_per_block234),
-                                    0, 0, ey, hz, ny);
+        FDTD_2D_THREADS_PER_BLOCK_HIP;
+        FDTD_2D_NBLOCKS_HIP;
+
+        hipLaunchKernelGGL((poly_fdtd2d_2), 
+                           dim3(nblocks234), dim3(nthreads_per_block234), 0, 0,
+                           ey, hz, nx, ny);
         hipErrchk( hipGetLastError() );
 
-        hipLaunchKernelGGL((poly_fdtd2d_3), dim3(nblocks234), dim3(nthreads_per_block234),
-                                    0, 0, ex, hz, ny);
+        hipLaunchKernelGGL((poly_fdtd2d_3), 
+                           dim3(nblocks234), dim3(nthreads_per_block234), 0, 0,
+                           ex, hz, nx, ny);
         hipErrchk( hipGetLastError() );
 
-        hipLaunchKernelGGL((poly_fdtd2d_4), dim3(nblocks234), dim3(nthreads_per_block234),
-                                    0, 0, hz, ex, ey, nx, ny);
+        hipLaunchKernelGGL((poly_fdtd2d_4), 
+                           dim3(nblocks234), dim3(nthreads_per_block234), 0, 0,
+                           hz, ex, ey, nx, ny);
         hipErrchk( hipGetLastError() );
 
       } // tstep loop
@@ -132,46 +186,48 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
 
       for (t = 0; t < tsteps; ++t) {
 
+        const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
+
         auto poly_fdtd2d_1_lambda = [=] __device__ (Index_type j) {
             POLYBENCH_FDTD_2D_BODY1;
         };
 
-        const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
         hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_fdtd2d_1_lambda)>,
           grid_size1, block_size, 0, 0,
           0, ny, poly_fdtd2d_1_lambda);
         hipErrchk( hipGetLastError() );
 
-        auto poly_fdtd2d_2_lambda = [=] __device__ (Index_type i, Index_type j) {
+        FDTD_2D_THREADS_PER_BLOCK_HIP;
+        FDTD_2D_NBLOCKS_HIP;
+
+        auto poly_fdtd2d_2_lambda = 
+          [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_FDTD_2D_BODY2;
-        };
+          };
 
-        dim3 nblocks234(1, nx, 1);
-        dim3 nthreads_per_block234(ny, 1, 1);
-        auto kernel2 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_fdtd2d_2_lambda)>;
-        hipLaunchKernelGGL(kernel2,
-          nblocks234, nthreads_per_block234, 0, 0,
-          1, nx, 0, ny, poly_fdtd2d_2_lambda);
+        hipLaunchKernelGGL((poly_fdtd2d_2_lam<decltype(poly_fdtd2d_2_lambda)>),
+                           dim3(nblocks234), dim3(nthreads_per_block234), 0, 0,
+                           nx, ny, poly_fdtd2d_2_lambda);
         hipErrchk( hipGetLastError() );
 
-        auto poly_fdtd2d_3_lambda = [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_FDTD_2D_BODY3;
-        };
+        auto poly_fdtd2d_3_lambda = 
+          [=] __device__ (Index_type i, Index_type j) {
+            POLYBENCH_FDTD_2D_BODY2;
+          };
 
-        auto kernel3 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_fdtd2d_3_lambda)>;
-        hipLaunchKernelGGL(kernel3,
-          nblocks234, nthreads_per_block234, 0, 0,
-          0, nx, 1, ny, poly_fdtd2d_3_lambda);
+        hipLaunchKernelGGL((poly_fdtd2d_3_lam<decltype(poly_fdtd2d_3_lambda)>),
+                           dim3(nblocks234), dim3(nthreads_per_block234), 0, 0,
+                           nx, ny, poly_fdtd2d_3_lambda);
         hipErrchk( hipGetLastError() );
+  
+        auto poly_fdtd2d_4_lambda = 
+          [=] __device__ (Index_type i, Index_type j) {
+            POLYBENCH_FDTD_2D_BODY2;
+          };
 
-        auto poly_fdtd2d_4_lambda = [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_FDTD_2D_BODY4;
-        };
-
-        auto kernel4 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_fdtd2d_4_lambda)>;
-        hipLaunchKernelGGL(kernel4,
-          nblocks234, nthreads_per_block234, 0, 0,
-          0, nx-1, 0, ny-1, poly_fdtd2d_4_lambda);
+        hipLaunchKernelGGL((poly_fdtd2d_4_lam<decltype(poly_fdtd2d_4_lambda)>),
+                           dim3(nblocks234), dim3(nthreads_per_block234), 0, 0,
+                           nx, ny, poly_fdtd2d_4_lambda);
         hipErrchk( hipGetLastError() );
 
       } // tstep loop
@@ -191,10 +247,16 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
 
     using EXEC_POL234 =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_y_direct,
-            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
-              RAJA::statement::Lambda<0>
+        RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
+                                   RAJA::hip_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
+                                     RAJA::hip_block_x_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // i
+                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // j
+                  RAJA::statement::Lambda<0>
+                >
+              >
             >
           >
         >

--- a/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
@@ -192,7 +192,7 @@ void POLYBENCH_FDTD_2D::runHipVariant(VariantID vid)
             POLYBENCH_FDTD_2D_BODY1;
         };
 
-        hipLaunchKernelGGL(lambda_hip_forall<decltype(poly_fdtd2d_1_lambda)>,
+        hipLaunchKernelGGL(poly_fdtd2d_2_lam<decltype(poly_fdtd2d_1_lambda)>,
           grid_size1, block_size, 0, 0,
           0, ny, poly_fdtd2d_1_lambda);
         hipErrchk( hipGetLastError() );

--- a/src/polybench/POLYBENCH_FDTD_2D.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.cpp
@@ -24,6 +24,7 @@ namespace polybench
 POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_FDTD_2D, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps;
   switch(lsizespec) {
@@ -53,7 +54,10 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  setDefaultProblemSize( std::max( (m_nx-1)*m_ny, m_nx*(m_ny-1) ) );
+  setDefaultReps(run_reps);
+
+#else
 
   Index_type nx_default = 1000;
   Index_type ny_default = 1000;
@@ -65,11 +69,6 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
   m_nx = std::sqrt( getTargetProblemSize() ) + 1;
   m_ny = m_nx;
   m_tsteps = 40;
-
-#else // this is what we have now...
-
-  setDefaultProblemSize( std::max( (m_nx-1)*m_ny, m_nx*(m_ny-1) ) );
-  setDefaultReps(run_reps);
 
 #endif
 
@@ -96,6 +95,10 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
                                3 * (m_nx-1)*m_ny +
                                3 * m_nx*(m_ny-1) +
                                5 * (m_nx-1)*(m_ny-1) ) );
+
+  checksum_scale_factor = 0.001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Kernel);
 
@@ -133,7 +136,7 @@ void POLYBENCH_FDTD_2D::setUp(VariantID vid)
 
 void POLYBENCH_FDTD_2D::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_hz, m_nx * m_ny);
+  checksum[vid] += calcChecksum(m_hz, m_nx * m_ny, checksum_scale_factor);
 }
 
 void POLYBENCH_FDTD_2D::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_FDTD_2D.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.cpp
@@ -24,41 +24,6 @@ namespace polybench
 POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_FDTD_2D, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps;
-  switch(lsizespec) {
-    case Mini:
-      m_nx=20; m_ny=30; m_tsteps=20;
-      run_reps = 10000;
-      break;
-    case Small:
-      m_nx=60; m_ny=80; m_tsteps=40;
-      run_reps = 500;
-      break;
-    case Medium:
-      m_nx=200; m_ny=240; m_tsteps=100;
-      run_reps = 200;
-      break;
-    case Large:
-      m_nx=800; m_ny=1000; m_tsteps=500;
-      run_reps = 1;
-      break;
-    case Extralarge:
-      m_nx=2000; m_ny=2600; m_tsteps=1000;
-      run_reps = 1;
-      break;
-    default:
-      m_nx=800; m_ny=1000; m_tsteps=60;
-      run_reps = 10;
-      break;
-  }
-
-  setDefaultProblemSize( std::max( (m_nx-1)*m_ny, m_nx*(m_ny-1) ) );
-  setDefaultReps(run_reps);
-
-#else
-
   Index_type nx_default = 1000;
   Index_type ny_default = 1000;
 
@@ -70,7 +35,6 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
   m_ny = m_nx;
   m_tsteps = 40;
 
-#endif
 
   setActualProblemSize( std::max( (m_nx-1)*m_ny, m_nx*(m_ny-1) ) ); 
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
@@ -58,8 +58,7 @@ __global__ void poly_floyd_warshall(Real_ptr pout, Real_ptr pin,
 }
 
 template< typename Lambda >
-__global__ void poly_floyd_warshall_lam(Index_type k,
-                                        Index_type N, 
+__global__ void poly_floyd_warshall_lam(Index_type N, 
                                         Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -112,7 +111,7 @@ void POLYBENCH_FLOYD_WARSHALL::runCudaVariant(VariantID vid)
         POLY_FLOYD_WARSHALL_THREADS_PER_BLOCK_CUDA;
         POLY_FLOYD_WARSHALL_NBLOCKS_CUDA;
 
-        poly_floyd_warshall_lam<<<nblocks, nthreads_per_block>>>(k, N,
+        poly_floyd_warshall_lam<<<nblocks, nthreads_per_block>>>(N,
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_FLOYD_WARSHALL_BODY;
           }

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
@@ -19,6 +19,21 @@ namespace rajaperf
 namespace polybench
 {
 
+//
+// Define thread block size for Hip execution
+//
+constexpr size_t i_block_sz = 8;
+constexpr size_t j_block_sz = 32;
+
+#define POLY_FLOYD_WARSHALL_THREADS_PER_BLOCK_HIP \
+  dim3 nthreads_per_block(j_block_sz, i_block_sz, 1);
+
+#define POLY_FLOYD_WARSHALL_NBLOCKS_HIP \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N, i_block_sz)), \
+               static_cast<size_t>(1));
+
+
 #define POLYBENCH_FLOYD_WARSHALL_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(pin, m_pin, m_N * m_N); \
   allocAndInitHipDeviceData(pout, m_pout, m_N * m_N);
@@ -29,15 +44,29 @@ namespace polybench
   deallocHipDeviceData(pin); \
   deallocHipDeviceData(pout);
 
-
 __global__ void poly_floyd_warshall(Real_ptr pout, Real_ptr pin,
                                     Index_type k,
                                     Index_type N)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-   POLYBENCH_FLOYD_WARSHALL_BODY;
+  if ( i < N && j < N ) {
+    POLYBENCH_FLOYD_WARSHALL_BODY;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_floyd_warshall_lam(Index_type k,
+                                        Index_type N,
+                                        Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < N && j < N ) {
+    body(i, j);
+  }
 }
 
 
@@ -56,10 +85,13 @@ void POLYBENCH_FLOYD_WARSHALL::runHipVariant(VariantID vid)
 
       for (Index_type k = 0; k < N; ++k) {
 
-        dim3 nblocks1(1, N, 1);
-        dim3 nthreads_per_block1(N, 1, 1);
-        hipLaunchKernelGGL((poly_floyd_warshall),dim3(nblocks1), dim3(nthreads_per_block1),0,0,pout, pin,
-                                                               k, N);
+        POLY_FLOYD_WARSHALL_THREADS_PER_BLOCK_HIP;
+        POLY_FLOYD_WARSHALL_NBLOCKS_HIP;
+
+        hipLaunchKernelGGL((poly_floyd_warshall),
+                           dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                           pout, pin,
+                           k, N);
         hipErrchk( hipGetLastError() );
 
       }
@@ -78,17 +110,18 @@ void POLYBENCH_FLOYD_WARSHALL::runHipVariant(VariantID vid)
 
       for (Index_type k = 0; k < N; ++k) {
 
-        auto poly_floyd_warshall_lambda = [=] __device__ (Index_type i, Index_type j) {
+        auto poly_floyd_warshall_lambda = 
+          [=] __device__ (Index_type i, Index_type j) {
+            POLYBENCH_FLOYD_WARSHALL_BODY;
+          };
 
-          POLYBENCH_FLOYD_WARSHALL_BODY;
-        };
+        POLY_FLOYD_WARSHALL_THREADS_PER_BLOCK_HIP;
+        POLY_FLOYD_WARSHALL_NBLOCKS_HIP; 
 
-        dim3 nblocks1(1, N, 1);
-        dim3 nthreads_per_block1(N, 1, 1);
-        auto kernel = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_floyd_warshall_lambda)>;
-        hipLaunchKernelGGL(kernel,
-          nblocks1, nthreads_per_block1,0,0,
-          0, N, 0, N, poly_floyd_warshall_lambda);
+        hipLaunchKernelGGL(
+          (poly_floyd_warshall_lam<decltype(poly_floyd_warshall_lambda)>),
+          dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+          k, N, poly_floyd_warshall_lambda);
         hipErrchk( hipGetLastError() );
 
       }
@@ -107,10 +140,16 @@ void POLYBENCH_FLOYD_WARSHALL::runHipVariant(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::For<0, RAJA::seq_exec,
-          RAJA::statement::HipKernelAsync<
-            RAJA::statement::For<1, RAJA::hip_block_y_direct,
-              RAJA::statement::For<2, RAJA::hip_thread_x_direct,
-                RAJA::statement::Lambda<0>
+          RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<i_block_sz>,
+                                     RAJA::hip_block_y_direct,
+              RAJA::statement::Tile<2, RAJA::tile_fixed<j_block_sz>,
+                                       RAJA::hip_block_x_direct,
+                RAJA::statement::For<1, RAJA::hip_thread_y_direct,   // i
+                  RAJA::statement::For<2, RAJA::hip_thread_x_direct, // j
+                    RAJA::statement::Lambda<0>
+                  >
+                >
               >
             >
           >

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
@@ -57,8 +57,7 @@ __global__ void poly_floyd_warshall(Real_ptr pout, Real_ptr pin,
 }
 
 template< typename Lambda >
-__global__ void poly_floyd_warshall_lam(Index_type k,
-                                        Index_type N,
+__global__ void poly_floyd_warshall_lam(Index_type N,
                                         Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -121,7 +120,7 @@ void POLYBENCH_FLOYD_WARSHALL::runHipVariant(VariantID vid)
         hipLaunchKernelGGL(
           (poly_floyd_warshall_lam<decltype(poly_floyd_warshall_lambda)>),
           dim3(nblocks), dim3(nthreads_per_block), 0, 0,
-          k, N, poly_floyd_warshall_lambda);
+          N, poly_floyd_warshall_lambda);
         hipErrchk( hipGetLastError() );
 
       }

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
@@ -21,6 +21,7 @@ namespace polybench
 POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
   : KernelBase(rajaperf::Polybench_FLOYD_WARSHALL, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps = 0;
   switch(lsizespec) {
@@ -50,7 +51,10 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  setDefaultProblemSize( m_N*m_N );
+  setDefaultReps(run_reps);
+
+#else
 
   Index_type N_default = 1000;
 
@@ -58,11 +62,6 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
   setDefaultReps(8);
 
   m_N = std::sqrt( getTargetProblemSize() ) + 1;
-
-#else  // this is what we have now...
-
-  setDefaultProblemSize( m_N*m_N );
-  setDefaultReps(run_reps);
 
 #endif
 
@@ -72,6 +71,10 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
   setKernelsPerRep(1);
   setBytesPerRep( (1*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N * m_N );
   setFLOPsPerRep(1 * m_N*m_N*m_N );
+
+  checksum_scale_factor = 1.0 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Kernel);
 
@@ -108,7 +111,7 @@ void POLYBENCH_FLOYD_WARSHALL::setUp(VariantID vid)
 
 void POLYBENCH_FLOYD_WARSHALL::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_pout, m_N*m_N);
+  checksum[vid] += calcChecksum(m_pout, m_N*m_N, checksum_scale_factor );
 }
 
 void POLYBENCH_FLOYD_WARSHALL::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
@@ -21,41 +21,6 @@ namespace polybench
 POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
   : KernelBase(rajaperf::Polybench_FLOYD_WARSHALL, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0;
-  switch(lsizespec) {
-    case Mini:
-      m_N=60;
-      run_reps = 100000;
-      break;
-    case Small:
-      m_N=180;
-      run_reps = 1000;
-      break;
-    case Medium:
-      m_N=500;
-      run_reps = 100;
-      break;
-    case Large:
-      m_N=2800;
-      run_reps = 1;
-      break;
-    case Extralarge:
-      m_N=5600;
-      run_reps = 1;
-      break;
-    default:
-      m_N=300;
-      run_reps = 60;
-      break;
-  }
-
-  setDefaultProblemSize( m_N*m_N );
-  setDefaultReps(run_reps);
-
-#else
-
   Index_type N_default = 1000;
 
   setDefaultProblemSize( N_default * N_default ); 
@@ -63,7 +28,6 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
 
   m_N = std::sqrt( getTargetProblemSize() ) + 1;
 
-#endif
 
   setActualProblemSize( m_N * m_N );
 

--- a/src/polybench/POLYBENCH_GEMM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Cuda.cpp
@@ -67,7 +67,7 @@ __global__ void poly_gemm(Real_ptr C, Real_ptr A, Real_ptr B,
 }
 
 template< typename Lambda >
-__global__ void poly_gemm_lam(Index_type ni, Index_type nj, Index_type nk,
+__global__ void poly_gemm_lam(Index_type ni, Index_type nj,
                               Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -115,7 +115,7 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
       POLY_GEMM_THREADS_PER_BLOCK_CUDA;
       POLY_GEMM_NBLOCKS_CUDA;
 
-      poly_gemm_lam<<<nblocks, nthreads_per_block>>>(ni, nj, nk,
+      poly_gemm_lam<<<nblocks, nthreads_per_block>>>(ni, nj,
         [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_GEMM_BODY1;
           POLYBENCH_GEMM_BODY2;

--- a/src/polybench/POLYBENCH_GEMM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Cuda.cpp
@@ -21,6 +21,21 @@ namespace rajaperf
 namespace polybench
 {
 
+//
+// Define thread block size for CUDA execution
+//
+constexpr size_t i_block_sz = 8;
+constexpr size_t j_block_sz = 32;
+
+#define POLY_GEMM_THREADS_PER_BLOCK_CUDA \
+  dim3 nthreads_per_block(j_block_sz, i_block_sz, 1);
+
+#define POLY_GEMM_NBLOCKS_CUDA \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, i_block_sz)), \
+               static_cast<size_t>(1));
+
+
 #define POLYBENCH_GEMM_DATA_SETUP_CUDA \
   allocAndInitCudaDeviceData(A, m_A, ni*nk); \
   allocAndInitCudaDeviceData(B, m_B, nk*nj); \
@@ -36,17 +51,31 @@ namespace polybench
 
 __global__ void poly_gemm(Real_ptr C, Real_ptr A, Real_ptr B,
                           Real_type alpha, Real_type beta,
-                          Index_type nj, Index_type nk)
+                          Index_type ni, Index_type nj, Index_type nk)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-   POLYBENCH_GEMM_BODY1;
-   POLYBENCH_GEMM_BODY2;
-   for (Index_type k = 0; k < nk; ++k ) {
-     POLYBENCH_GEMM_BODY3;
-   }
-   POLYBENCH_GEMM_BODY4;
+  if ( i < ni && j < nj ) {
+    POLYBENCH_GEMM_BODY1;
+    POLYBENCH_GEMM_BODY2;
+    for (Index_type k = 0; k < nk; ++k ) {
+      POLYBENCH_GEMM_BODY3;
+    }
+    POLYBENCH_GEMM_BODY4;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_gemm_lam(Index_type ni, Index_type nj, Index_type nk,
+                              Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < ni && j < nj ) {
+    body(i, j);
+  }
 }
 
 
@@ -63,12 +92,12 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nblocks(1, ni, 1);
-      dim3 nthreads_per_block(nj, 1, 1);
+      POLY_GEMM_THREADS_PER_BLOCK_CUDA;
+      POLY_GEMM_NBLOCKS_CUDA; 
 
       poly_gemm<<<nblocks, nthreads_per_block>>>(C, A, B,
                                                  alpha, beta,
-                                                 nj, nk);
+                                                 ni, nj, nk);
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -83,21 +112,19 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nblocks(1, ni, 1);
-      dim3 nthreads_per_block(nj, 1, 1);
+      POLY_GEMM_THREADS_PER_BLOCK_CUDA;
+      POLY_GEMM_NBLOCKS_CUDA;
 
-      lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
-                        <<<nblocks, nthreads_per_block>>>(
-        0, ni, 0, nj,
+      poly_gemm_lam<<<nblocks, nthreads_per_block>>>(ni, nj, nk,
         [=] __device__ (Index_type i, Index_type j) {
-
-        POLYBENCH_GEMM_BODY1;
-        POLYBENCH_GEMM_BODY2;
-        for (Index_type k = 0; k < nk; ++k ) {
-          POLYBENCH_GEMM_BODY3;
+          POLYBENCH_GEMM_BODY1;
+          POLYBENCH_GEMM_BODY2;
+          for (Index_type k = 0; k < nk; ++k ) {
+            POLYBENCH_GEMM_BODY3;
+          }
+          POLYBENCH_GEMM_BODY4;
         }
-        POLYBENCH_GEMM_BODY4;
-      });
+      );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -113,15 +140,21 @@ void POLYBENCH_GEMM::runCudaVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<0, RAJA::cuda_block_y_direct,
-            RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
-              RAJA::statement::Lambda<0, RAJA::Params<0>>,
-              RAJA::statement::Lambda<1, RAJA::Segs<0,1>>,
-              RAJA::statement::For<2, RAJA::seq_exec,
-                RAJA::statement::Lambda<2, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<3, RAJA::Segs<0,1>, RAJA::Params<0>>
+        RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
+                                   RAJA::cuda_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
+                                     RAJA::cuda_block_x_direct,
+              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // i
+                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // j
+                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
+                  RAJA::statement::Lambda<1, RAJA::Segs<0,1>>,
+                  RAJA::statement::For<2, RAJA::seq_exec,           // k
+                    RAJA::statement::Lambda<2, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+                  >,
+                  RAJA::statement::Lambda<3, RAJA::Segs<0,1>, RAJA::Params<0>>
+                >
+              >
             >
           >
         >

--- a/src/polybench/POLYBENCH_GEMM-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Hip.cpp
@@ -125,7 +125,7 @@ void POLYBENCH_GEMM::runHipVariant(VariantID vid)
         POLYBENCH_GEMM_BODY4;
       };
 
-      hipLaunchKernelGGL((poly_gemm_lam), 
+      hipLaunchKernelGGL((poly_gemm_lam<decltype(poly_gemm_lambda)>), 
         dim3(nblocks), dim3(nthreads_per_block), 0, 0,
         ni, nj, nk, poly_gemm_lambda);
       hipErrchk( hipGetLastError() );

--- a/src/polybench/POLYBENCH_GEMM-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Hip.cpp
@@ -21,6 +21,21 @@ namespace rajaperf
 namespace polybench
 {
 
+//
+// Define thread block size for Hip execution
+//
+constexpr size_t i_block_sz = 8;
+constexpr size_t j_block_sz = 32;
+
+#define POLY_GEMM_THREADS_PER_BLOCK_HIP \
+  dim3 nthreads_per_block(j_block_sz, i_block_sz, 1);
+
+#define POLY_GEMM_NBLOCKS_HIP \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(nj, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(ni, i_block_sz)), \
+               static_cast<size_t>(1));
+
+
 #define POLYBENCH_GEMM_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(A, m_A, ni*nk); \
   allocAndInitHipDeviceData(B, m_B, nk*nj); \
@@ -36,17 +51,31 @@ namespace polybench
 
 __global__ void poly_gemm(Real_ptr C, Real_ptr A, Real_ptr B,
                           Real_type alpha, Real_type beta,
-                          Index_type nj, Index_type nk)
+                          Index_type ni, Index_type nj, Index_type nk)
 {
-   Index_type i = blockIdx.y;
-   Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-   POLYBENCH_GEMM_BODY1;
-   POLYBENCH_GEMM_BODY2;
-   for (Index_type k = 0; k < nk; ++k ) {
-     POLYBENCH_GEMM_BODY3;
-   }
-   POLYBENCH_GEMM_BODY4;
+  if ( i < ni && j < nj ) {
+    POLYBENCH_GEMM_BODY1;
+    POLYBENCH_GEMM_BODY2;
+    for (Index_type k = 0; k < nk; ++k ) {
+      POLYBENCH_GEMM_BODY3;
+    }
+    POLYBENCH_GEMM_BODY4;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_gemm_lam(Index_type ni, Index_type nj, Index_type nk,
+                              Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < ni && j < nj ) {
+    body(i, j);
+  }
 }
 
 
@@ -63,12 +92,13 @@ void POLYBENCH_GEMM::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nblocks(1, ni, 1);
-      dim3 nthreads_per_block(nj, 1, 1);
+      POLY_GEMM_THREADS_PER_BLOCK_HIP;
+      POLY_GEMM_NBLOCKS_HIP; 
 
-      hipLaunchKernelGGL((poly_gemm), dim3(nblocks), dim3(nthreads_per_block), 0,0,C, A, B,
-                                                 alpha, beta,
-                                                 nj, nk);
+      hipLaunchKernelGGL((poly_gemm), 
+                         dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                         C, A, B, alpha, beta,
+                         ni, nj, nk);
       hipErrchk( hipGetLastError() );
 
     }
@@ -83,8 +113,10 @@ void POLYBENCH_GEMM::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      auto poly_gemm_lambda = [=] __device__ (Index_type i, Index_type j) {
+      POLY_GEMM_THREADS_PER_BLOCK_HIP;
+      POLY_GEMM_NBLOCKS_HIP; 
 
+      auto poly_gemm_lambda = [=] __device__ (Index_type i, Index_type j) {
         POLYBENCH_GEMM_BODY1;
         POLYBENCH_GEMM_BODY2;
         for (Index_type k = 0; k < nk; ++k ) {
@@ -93,13 +125,9 @@ void POLYBENCH_GEMM::runHipVariant(VariantID vid)
         POLYBENCH_GEMM_BODY4;
       };
 
-      dim3 nblocks(1, ni, 1);
-      dim3 nthreads_per_block(nj, 1, 1);
-
-      auto kernel = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_gemm_lambda)>;
-      hipLaunchKernelGGL(kernel,
-        nblocks, nthreads_per_block, 0, 0,
-        0, ni, 0, nj, poly_gemm_lambda);
+      hipLaunchKernelGGL((poly_gemm_lam), 
+        dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+        ni, nj, nk, poly_gemm_lambda);
       hipErrchk( hipGetLastError() );
 
     }
@@ -115,15 +143,21 @@ void POLYBENCH_GEMM::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_y_direct,
-            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
-              RAJA::statement::Lambda<0, RAJA::Params<0>>,
-              RAJA::statement::Lambda<1, RAJA::Segs<0,1>>,
-              RAJA::statement::For<2, RAJA::seq_exec,
-                RAJA::statement::Lambda<2, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<3, RAJA::Segs<0,1>, RAJA::Params<0>>
+        RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
+                                   RAJA::hip_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
+                                     RAJA::hip_block_x_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // i
+                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // j
+                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
+                  RAJA::statement::Lambda<1, RAJA::Segs<0,1>>,
+                  RAJA::statement::For<2, RAJA::seq_exec,           // k
+                    RAJA::statement::Lambda<2, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+                  >,
+                  RAJA::statement::Lambda<3, RAJA::Segs<0,1>, RAJA::Params<0>>
+                >
+              >
             >
           >
         >

--- a/src/polybench/POLYBENCH_GEMM-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Hip.cpp
@@ -67,7 +67,7 @@ __global__ void poly_gemm(Real_ptr C, Real_ptr A, Real_ptr B,
 }
 
 template< typename Lambda >
-__global__ void poly_gemm_lam(Index_type ni, Index_type nj, Index_type nk,
+__global__ void poly_gemm_lam(Index_type ni, Index_type nj,
                               Lambda body)
 {
   Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
@@ -127,7 +127,7 @@ void POLYBENCH_GEMM::runHipVariant(VariantID vid)
 
       hipLaunchKernelGGL((poly_gemm_lam<decltype(poly_gemm_lambda)>), 
         dim3(nblocks), dim3(nthreads_per_block), 0, 0,
-        ni, nj, nk, poly_gemm_lambda);
+        ni, nj, poly_gemm_lambda);
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_GEMM.cpp
+++ b/src/polybench/POLYBENCH_GEMM.cpp
@@ -21,44 +21,6 @@ namespace polybench
 POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GEMM, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0;
-  switch(lsizespec) {
-    case Mini:
-      m_ni = 20; m_nj = 25; m_nk = 30;
-      run_reps = 10000;
-      break;
-    case Small:
-      m_ni = 60; m_nj = 70; m_nk = 80;
-      run_reps = 1000;
-      break;
-    case Medium:
-      m_ni = 200; m_nj = 220; m_nk = 240;
-      run_reps = 100;
-      break;
-    case Large:
-      m_ni = 1000; m_nj = 1100; m_nk = 1200;
-      run_reps = 1;
-      break;
-    case Extralarge:
-      m_ni = 2000; m_nj = 2300; m_nk = 2600;
-      run_reps = 1;
-      break;
-    default:
-      m_ni = 200; m_nj = 220; m_nk = 240;
-      run_reps = 100;
-      break;
-  }
-
-  m_alpha = 0.62;
-  m_beta = 1.002;
-
-  setDefaultProblemSize( m_ni * m_nj );
-  setDefaultReps(run_reps);
-
-#else
-
   Index_type ni_default = 1000;
   Index_type nj_default = 1000;
   Index_type nk_default = 1200;
@@ -73,7 +35,6 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
   m_alpha = 0.62;
   m_beta = 1.002;
 
-#endif
 
   setActualProblemSize( m_ni * m_nj );
 

--- a/src/polybench/POLYBENCH_GEMM.cpp
+++ b/src/polybench/POLYBENCH_GEMM.cpp
@@ -21,6 +21,7 @@ namespace polybench
 POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GEMM, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps = 0;
   switch(lsizespec) {
@@ -50,13 +51,19 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  m_alpha = 0.62;
+  m_beta = 1.002;
+
+  setDefaultProblemSize( m_ni * m_nj );
+  setDefaultReps(run_reps);
+
+#else
 
   Index_type ni_default = 1000;
   Index_type nj_default = 1000;
   Index_type nk_default = 1200;
 
-  setDefaultProblemSize( ni_default * nj_default ) );
+  setDefaultProblemSize( ni_default * nj_default );
   setDefaultReps(4);
 
   m_ni = std::sqrt( getTargetProblemSize() ) + 1;
@@ -65,14 +72,6 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
   
   m_alpha = 0.62;
   m_beta = 1.002;
-
-#else // this is what we have now...
-
-  m_alpha = 0.62;
-  m_beta = 1.002;
-
-  setDefaultProblemSize( m_ni * m_nj );
-  setDefaultReps(run_reps);
 
 #endif
 
@@ -85,6 +84,10 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
                   (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nj * m_nk );
   setFLOPsPerRep((1 +
                   3 * m_nk) * m_ni*m_nj);
+
+  checksum_scale_factor = 0.001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Kernel);
 
@@ -122,7 +125,7 @@ void POLYBENCH_GEMM::setUp(VariantID vid)
 
 void POLYBENCH_GEMM::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_C, m_ni * m_nj);
+  checksum[vid] += calcChecksum(m_C, m_ni * m_nj, checksum_scale_factor );
 }
 
 void POLYBENCH_GEMM::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
@@ -155,7 +155,7 @@ void POLYBENCH_GEMVER::runCudaVariant(VariantID vid)
                                                         n);
       cudaErrchk( cudaGetLastError() );
 
-      size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
+      size_t grid_size = RAJA_DIVIDE_CEILING_INT(n, block_size);
 
       poly_gemmver_2<<<grid_size, block_size>>>(A, x, y,
                                                 beta,
@@ -193,7 +193,7 @@ void POLYBENCH_GEMVER::runCudaVariant(VariantID vid)
       );
       cudaErrchk( cudaGetLastError() );
 
-      size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
+      size_t grid_size = RAJA_DIVIDE_CEILING_INT(n, block_size);
 
       poly_gemmver_234_lam<<<grid_size, block_size>>>(n,
         [=] __device__ (Index_type i) {

--- a/src/polybench/POLYBENCH_GEMVER-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Hip.cpp
@@ -207,7 +207,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
           POLYBENCH_GEMVER_BODY4;
       };
 
-      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_2_lambda)>,
+      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_2_lambda)>),
         dim3(grid_size), dim3(block_size), 0, 0,
         n, poly_gemmver_2_lambda);
       hipErrchk( hipGetLastError() );
@@ -216,7 +216,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
           POLYBENCH_GEMVER_BODY5;
       };
 
-      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_3_lambda)>,
+      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_3_lambda)>),
         dim3(grid_size), dim3(block_size), 0, 0,
         n, poly_gemmver_3_lambda);
       hipErrchk( hipGetLastError() );
@@ -229,7 +229,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
           POLYBENCH_GEMVER_BODY8;
       };
 
-      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_4_lambda)>,
+      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_4_lambda)>),
         dim3(grid_size), dim3(block_size), 0, 0,
         n, poly_gemmver_4_lambda);
       hipErrchk( hipGetLastError() );
@@ -312,7 +312,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
         }
       );
 
-      RAJA::kernel_param<EXEC_POL4>(
+      RAJA::kernel_param<EXEC_POL24>(
         RAJA::make_tuple(RAJA::RangeSegment{0, n},
                          RAJA::RangeSegment{0, n}),
         RAJA::tuple<Real_type>{0.0},

--- a/src/polybench/POLYBENCH_GEMVER-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Hip.cpp
@@ -192,12 +192,12 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
           POLYBENCH_GEMVER_BODY1;
       };
 
-      hipLaunchKernelGGL((poly_gemmver_1_lam<decltype(poly_gemmver_1_lambda)>),
+      hipLaunchKernelGGL(poly_gemmver_1_lam<decltype(poly_gemmver_1_lambda)>,
                          dim3(nblocks1), dim3(nthreads_per_block1), 0, 0,
                          n, poly_gemmver_1_lambda); 
       hipErrchk( hipGetLastError() );
 
-      size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
+      size_t grid_size = RAJA_DIVIDE_CEILING_INT(n, block_size);
 
       auto poly_gemmver_2_lambda = [=] __device__ (Index_type i) {
           POLYBENCH_GEMVER_BODY2;
@@ -207,7 +207,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
           POLYBENCH_GEMVER_BODY4;
       };
 
-      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_2_lambda)>),
+      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_2_lambda)>,
         dim3(grid_size), dim3(block_size), 0, 0,
         n, poly_gemmver_2_lambda);
       hipErrchk( hipGetLastError() );
@@ -216,7 +216,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
           POLYBENCH_GEMVER_BODY5;
       };
 
-      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_3_lambda)>),
+      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_3_lambda)>,
         dim3(grid_size), dim3(block_size), 0, 0,
         n, poly_gemmver_3_lambda);
       hipErrchk( hipGetLastError() );
@@ -229,7 +229,7 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
           POLYBENCH_GEMVER_BODY8;
       };
 
-      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_4_lambda)>),
+      hipLaunchKernelGGL(poly_gemmver_234_lam<decltype(poly_gemmver_4_lambda)>,
         dim3(grid_size), dim3(block_size), 0, 0,
         n, poly_gemmver_4_lambda);
       hipErrchk( hipGetLastError() );

--- a/src/polybench/POLYBENCH_GEMVER-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Hip.cpp
@@ -176,8 +176,8 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      GEMVER_THREADS_PER_BLOCK_CUDA;
-      GEMVER_NBLOCKS_CUDA;
+      GEMVER_THREADS_PER_BLOCK_HIP;
+      GEMVER_NBLOCKS_HIP;
 
       auto poly_gemmver_1_lambda = [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_GEMVER_BODY1;

--- a/src/polybench/POLYBENCH_GEMVER-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Hip.cpp
@@ -22,9 +22,21 @@ namespace polybench
 {
 
 //
-// Define thread block size for HIP execution
+// Define thread block size for Hip execution
 //
 const size_t block_size = 256;
+
+constexpr size_t i_block_sz = 8;
+constexpr size_t j_block_sz = 32;
+
+#define GEMVER_THREADS_PER_BLOCK_HIP \
+  dim3 nthreads_per_block1(j_block_sz, i_block_sz, 1);
+
+#define GEMVER_NBLOCKS_HIP \
+  dim3 nblocks1(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(n, j_block_sz)), \
+                static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(n, i_block_sz)), \
+                static_cast<size_t>(1));
+
 
 #define POLYBENCH_GEMVER_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(A, m_A, m_n * m_n); \
@@ -55,10 +67,23 @@ __global__ void poly_gemmver_1(Real_ptr A,
                                Real_ptr u2, Real_ptr v2,
                                Index_type n)
 {
-  Index_type i = blockIdx.y;
-  Index_type j = threadIdx.x;
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
 
-  POLYBENCH_GEMVER_BODY1;
+  if (i < n && j < n) {
+    POLYBENCH_GEMVER_BODY1;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_gemmver_1_lam(Index_type n, Lambda body)
+{
+  Index_type i = blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = blockIdx.x * blockDim.x + threadIdx.x;
+
+  if (i < n && j < n) {
+    body(i, j);
+  }
 }
 
 __global__ void poly_gemmver_2(Real_ptr A,
@@ -114,30 +139,31 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      dim3 nblocks(1, n, 1);
-      dim3 nthreads_per_block(n, 1, 1);
-      hipLaunchKernelGGL((poly_gemmver_1) , dim3(nblocks), dim3(nthreads_per_block), 0, 0,
-                                A, u1, v1, u2, v2, n);
+      GEMVER_THREADS_PER_BLOCK_HIP;
+      GEMVER_NBLOCKS_HIP;
+
+      hipLaunchKernelGGL((poly_gemmver_1), 
+                         dim3(nblocks1), dim3(nthreads_per_block1), 0, 0,
+                         A, u1, v1, u2, v2, n);
       hipErrchk( hipGetLastError() );
 
       size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
 
-      hipLaunchKernelGGL((poly_gemmver_2), dim3(grid_size), dim3(block_size), 0, 0,
-                                                A, x, y,
-                                                beta,
-                                                n);
+      hipLaunchKernelGGL((poly_gemmver_2), 
+                         dim3(grid_size), dim3(block_size), 0, 0,
+                         A, x, y, beta, n);
       hipErrchk( hipGetLastError() );
 
-      hipLaunchKernelGGL((poly_gemmver_3), dim3(grid_size), dim3(block_size), 0, 0,
-                                                x, z,
-                                                n);
+      hipLaunchKernelGGL((poly_gemmver_3), 
+                         dim3(grid_size), dim3(block_size), 0, 0,
+                         x, z, n);
       hipErrchk( hipGetLastError() );
 
-      hipLaunchKernelGGL((poly_gemmver_4), dim3(grid_size), dim3(block_size), 0, 0,
-                                                A, x, w,
-                                                alpha,
-                                                n);
+      hipLaunchKernelGGL((poly_gemmver_4), 
+                         dim3(grid_size), dim3(block_size), 0, 0,
+                         A, x, w, alpha, n);
       hipErrchk( hipGetLastError() );
+
     }
     stopTimer();
 
@@ -150,16 +176,16 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      GEMVER_THREADS_PER_BLOCK_CUDA;
+      GEMVER_NBLOCKS_CUDA;
+
       auto poly_gemmver_1_lambda = [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_GEMVER_BODY1;
       };
 
-      dim3 nblocks(1, n, 1);
-      dim3 nthreads_per_block(n, 1, 1);
-      auto kernel1 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_gemmver_1_lambda)>;
-      hipLaunchKernelGGL(kernel1,
-        nblocks, nthreads_per_block, 0, 0,
-        0, n, 0, n, poly_gemmver_1_lambda);
+      hipLaunchKernelGGL((poly_gemmver_1_lam<decltype(poly_gemmver_1_lambda)>),
+                         dim3(nblocks1), dim3(nthreads_per_block1), 0, 0,
+                         n, poly_gemmver_1_lambda); 
       hipErrchk( hipGetLastError() );
 
       size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
@@ -212,14 +238,20 @@ void POLYBENCH_GEMVER::runHipVariant(VariantID vid)
 
     using EXEC_POL1 =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_y_direct,
-            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
-              RAJA::statement::Lambda<0>
+        RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
+                                   RAJA::hip_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
+                                     RAJA::hip_block_x_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // i
+                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // j
+                  RAJA::statement::Lambda<0>
+                >
+              >
             >
           >
         >
-      >;
+      >;      
 
     using EXEC_POL2 =
       RAJA::KernelPolicy<

--- a/src/polybench/POLYBENCH_GEMVER-OMP.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-OMP.cpp
@@ -140,7 +140,7 @@ void POLYBENCH_GEMVER::runOpenMPVariant(VariantID vid)
       auto poly_gemver_lam1 = [=] (Index_type i, Index_type j) {
                                    POLYBENCH_GEMVER_BODY1_RAJA;
                                   };
-      auto poly_gemver_lam2 = [=] (Real_type &dot) {
+      auto poly_gemver_lam2 = [=] (Index_type /* i */, Real_type &dot) {
                                    POLYBENCH_GEMVER_BODY2_RAJA;
                                   };
       auto poly_gemver_lam3 = [=] (Index_type i, Index_type j, Real_type &dot) {
@@ -171,20 +171,7 @@ void POLYBENCH_GEMVER::runOpenMPVariant(VariantID vid)
           >
         >;
 
-      using EXEC_POL2 =
-        RAJA::KernelPolicy<
-          RAJA::statement::For<0, RAJA::omp_parallel_for_exec,
-            RAJA::statement::Lambda<0, RAJA::Params<0>>,
-            RAJA::statement::For<1, RAJA::loop_exec,
-              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
-            >,
-            RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
-          >
-        >;
-
-      using EXEC_POL3 = RAJA::loop_exec;
-
-      using EXEC_POL4 =
+      using EXEC_POL24 =
         RAJA::KernelPolicy<
           RAJA::statement::For<0, RAJA::omp_parallel_for_exec,
             RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
@@ -195,6 +182,8 @@ void POLYBENCH_GEMVER::runOpenMPVariant(VariantID vid)
           >
         >;
 
+      using EXEC_POL3 = RAJA::loop_exec;
+
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
@@ -203,7 +192,7 @@ void POLYBENCH_GEMVER::runOpenMPVariant(VariantID vid)
           poly_gemver_lam1
         );
 
-        RAJA::kernel_param<EXEC_POL2>(
+        RAJA::kernel_param<EXEC_POL24>(
           RAJA::make_tuple(RAJA::RangeSegment{0, n},
                            RAJA::RangeSegment{0, n}),
           RAJA::tuple<Real_type>{0.0},
@@ -217,7 +206,7 @@ void POLYBENCH_GEMVER::runOpenMPVariant(VariantID vid)
           poly_gemver_lam5
         );
 
-        RAJA::kernel_param<EXEC_POL4>(
+        RAJA::kernel_param<EXEC_POL24>(
           RAJA::make_tuple(RAJA::RangeSegment{0, n},
                            RAJA::RangeSegment{0, n}),
           RAJA::tuple<Real_type>{0.0},

--- a/src/polybench/POLYBENCH_GEMVER-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-OMPTarget.cpp
@@ -120,18 +120,7 @@ void POLYBENCH_GEMVER::runOpenMPTargetVariant(VariantID vid)
         >
       >;
 
-    using EXEC_POL2 =
-      RAJA::KernelPolicy<
-        RAJA::statement::For<0, RAJA::omp_target_parallel_for_exec<threads_per_team>,
-          RAJA::statement::Lambda<0, RAJA::Params<0>>,
-          RAJA::statement::For<1, RAJA::seq_exec,
-            RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
-          >,
-          RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
-        >
-      >;
-
-    using EXEC_POL4 =
+    using EXEC_POL24 =
       RAJA::KernelPolicy<
         RAJA::statement::For<0, RAJA::omp_target_parallel_for_exec<threads_per_team>,
           RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
@@ -141,7 +130,7 @@ void POLYBENCH_GEMVER::runOpenMPTargetVariant(VariantID vid)
           RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
         >
       >;
-  
+
     using EXEC_POL3 = RAJA::omp_target_parallel_for_exec<threads_per_team>;
 
     startTimer();
@@ -154,12 +143,12 @@ void POLYBENCH_GEMVER::runOpenMPTargetVariant(VariantID vid)
         }
       );
 
-      RAJA::kernel_param<EXEC_POL2>(
+      RAJA::kernel_param<EXEC_POL24>(
         RAJA::make_tuple(RAJA::RangeSegment{0, n},
                          RAJA::RangeSegment{0, n}),
         RAJA::tuple<Real_type>{0.0},
 
-        [=] (Real_type &dot) {
+        [=] (Index_type /* i */, Real_type &dot) {
           POLYBENCH_GEMVER_BODY2_RAJA;
         },
         [=] (Index_type i, Index_type j, Real_type &dot) {
@@ -176,7 +165,7 @@ void POLYBENCH_GEMVER::runOpenMPTargetVariant(VariantID vid)
         }
       );
 
-      RAJA::kernel_param<EXEC_POL4>(
+      RAJA::kernel_param<EXEC_POL24>(
         RAJA::make_tuple(RAJA::RangeSegment{0, n},
                          RAJA::RangeSegment{0, n}),
         RAJA::tuple<Real_type>{0.0},

--- a/src/polybench/POLYBENCH_GEMVER-Seq.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Seq.cpp
@@ -131,7 +131,7 @@ void POLYBENCH_GEMVER::runSeqVariant(VariantID vid)
       auto poly_gemver_lam1 = [=] (Index_type i, Index_type j) {
                                    POLYBENCH_GEMVER_BODY1_RAJA;
                                   };
-      auto poly_gemver_lam2 = [=] (Real_type &dot) {
+      auto poly_gemver_lam2 = [=] (Index_type /* i */, Real_type &dot) {
                                    POLYBENCH_GEMVER_BODY2_RAJA;
                                   };
       auto poly_gemver_lam3 = [=] (Index_type i, Index_type j, Real_type &dot) {
@@ -162,20 +162,7 @@ void POLYBENCH_GEMVER::runSeqVariant(VariantID vid)
           >
         >;
 
-      using EXEC_POL2 =
-        RAJA::KernelPolicy<
-          RAJA::statement::For<0, RAJA::loop_exec,
-            RAJA::statement::Lambda<0, RAJA::Params<0>>,
-            RAJA::statement::For<1, RAJA::loop_exec,
-              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
-            >,
-            RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
-          >
-        >;
-
-      using EXEC_POL3 = RAJA::loop_exec;
-
-      using EXEC_POL4 =
+      using EXEC_POL24 =
         RAJA::KernelPolicy<
           RAJA::statement::For<0, RAJA::loop_exec,
             RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
@@ -186,6 +173,8 @@ void POLYBENCH_GEMVER::runSeqVariant(VariantID vid)
           >
         >;
 
+      using EXEC_POL3 = RAJA::loop_exec;
+
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
@@ -194,7 +183,7 @@ void POLYBENCH_GEMVER::runSeqVariant(VariantID vid)
           poly_gemver_lam1
         );
         
-        RAJA::kernel_param<EXEC_POL2>( 
+        RAJA::kernel_param<EXEC_POL24>( 
           RAJA::make_tuple(RAJA::RangeSegment{0, n},
                            RAJA::RangeSegment{0, n}),
           RAJA::tuple<Real_type>{0.0},
@@ -208,7 +197,7 @@ void POLYBENCH_GEMVER::runSeqVariant(VariantID vid)
           poly_gemver_lam5
         );
 
-        RAJA::kernel_param<EXEC_POL4>( 
+        RAJA::kernel_param<EXEC_POL24>( 
           RAJA::make_tuple(RAJA::RangeSegment{0, n},
                            RAJA::RangeSegment{0, n}),
           RAJA::tuple<Real_type>{0.0},

--- a/src/polybench/POLYBENCH_GEMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMVER.cpp
@@ -21,6 +21,7 @@ namespace polybench
 POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GEMVER, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps = 0;
   switch(lsizespec) {
@@ -50,25 +51,23 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  m_alpha = 1.5;
+  m_beta = 1.2;
+
+  setDefaultProblemSize( m_n*m_n );
+  setDefaultReps(run_reps);
+
+#else
 
   Index_type n_default = 1000;
 
-  setDefaultProblemSize( n_default * n_default ) );
+  setDefaultProblemSize( n_default * n_default );
   setDefaultReps(20);
 
   m_n =  std::sqrt( getTargetProblemSize() ) + 1;
 
   m_alpha = 1.5;
   m_beta = 1.2;
-
-#else // this is what we have now...
-
-  m_alpha = 1.5;
-  m_beta = 1.2;
-
-  setDefaultProblemSize( m_n*m_n );
-  setDefaultReps(run_reps);
 
 #endif
 
@@ -93,6 +92,10 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
                  3 * m_n*m_n +
                  1 * m_n +
                  3 * m_n*m_n );
+
+  checksum_scale_factor = 0.001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Forall);
   setUsesFeature(Kernel);
@@ -138,7 +141,7 @@ void POLYBENCH_GEMVER::setUp(VariantID vid)
 
 void POLYBENCH_GEMVER::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_w, m_n);
+  checksum[vid] += calcChecksum(m_w, m_n, checksum_scale_factor );
 }
 
 void POLYBENCH_GEMVER::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_GEMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMVER.cpp
@@ -21,44 +21,6 @@ namespace polybench
 POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GEMVER, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0;
-  switch(lsizespec) {
-    case Mini:
-      m_n=40;
-      run_reps = 200;
-      break;
-    case Small:
-      m_n=120;
-      run_reps = 200;
-      break;
-    case Medium:
-      m_n=400;
-      run_reps = 20;
-      break;
-    case Large:
-      m_n=2000;
-      run_reps = 20;
-      break;
-    case Extralarge:
-      m_n=4000;
-      run_reps = 5;
-      break;
-    default:
-      m_n=800;
-      run_reps = 40;
-      break;
-  }
-
-  m_alpha = 1.5;
-  m_beta = 1.2;
-
-  setDefaultProblemSize( m_n*m_n );
-  setDefaultReps(run_reps);
-
-#else
-
   Index_type n_default = 1000;
 
   setDefaultProblemSize( n_default * n_default );
@@ -69,7 +31,6 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
   m_alpha = 1.5;
   m_beta = 1.2;
 
-#endif
 
   setActualProblemSize( m_n * m_n );
 

--- a/src/polybench/POLYBENCH_GEMVER.hpp
+++ b/src/polybench/POLYBENCH_GEMVER.hpp
@@ -15,10 +15,14 @@
 ///   }
 /// }
 ///
+/// Note: this part of the kernel is modified to avoid 
+///       excessively large checksums   
 /// for (Index_type i = 0; i < N; i++) {
+///   Real_type dot = 0.0;
 ///   for (Index_type j = 0; j < N; j++) {
-///     x[i] = x[i] + beta * A[j][i] * y[j];
+///     dot += beta * A[j][i] * y[j];
 ///   }
+///   x[i] = dot;
 /// }
 ///
 /// for (Index_type i = 0; i < N; i++) {
@@ -94,7 +98,7 @@
   xview(i) += zview(i);
 
 #define POLYBENCH_GEMVER_BODY6_RAJA \
-  dot = w[i];
+  dot = wview(i);
 
 #define POLYBENCH_GEMVER_BODY7_RAJA \
   dot +=  alpha * Aview(i,j) * xview(j);

--- a/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
@@ -92,12 +92,12 @@ void POLYBENCH_GESUMMV::runCudaVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelAsync<
+        RAJA::statement::CudaKernelFixedAsync<block_size,
           RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
                                    RAJA::cuda_block_x_direct,
-            RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+            RAJA::statement::For<0, RAJA::cuda_thread_x_direct,  // i
               RAJA::statement::Lambda<0, RAJA::Params<0,1>>,
-              RAJA::statement::For<1, RAJA::seq_exec,
+              RAJA::statement::For<1, RAJA::seq_exec,            // j
                 RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0,1>>
               >,
               RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0,1>>

--- a/src/polybench/POLYBENCH_GESUMMV-Hip.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Hip.cpp
@@ -73,10 +73,12 @@ void POLYBENCH_GESUMMV::runHipVariant(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
 
-      hipLaunchKernelGGL((poly_gesummv), dim3(grid_size), dim3(block_size),0,0,x, y,
-                                              A, B,
-                                              alpha, beta,
-                                              N);
+      hipLaunchKernelGGL((poly_gesummv), 
+                         dim3(grid_size), dim3(block_size),0,0,
+                         x, y,
+                         A, B,
+                         alpha, beta,
+                         N);
       hipErrchk( hipGetLastError() );
 
     }
@@ -92,7 +94,7 @@ void POLYBENCH_GESUMMV::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
+        RAJA::statement::HipKernelFixedAsync<block_size,
           RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
                                    RAJA::hip_block_x_direct,
             RAJA::statement::For<0, RAJA::hip_thread_x_direct,

--- a/src/polybench/POLYBENCH_GESUMMV-OMP.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-OMP.cpp
@@ -96,9 +96,9 @@ void POLYBENCH_GESUMMV::runOpenMPVariant(VariantID vid)
 
       using EXEC_POL =
         RAJA::KernelPolicy<
-          RAJA::statement::For<0, RAJA::omp_parallel_for_exec,
+          RAJA::statement::For<0, RAJA::omp_parallel_for_exec,   // i
             RAJA::statement::Lambda<0, RAJA::Params<0,1>>,
-            RAJA::statement::For<1, RAJA::loop_exec,
+            RAJA::statement::For<1, RAJA::loop_exec,             // j
               RAJA::statement::Lambda<1, RAJA::Segs<0, 1>, RAJA::Params<0,1>>
             >,
             RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0,1>>

--- a/src/polybench/POLYBENCH_GESUMMV-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-OMPTarget.cpp
@@ -80,9 +80,9 @@ void POLYBENCH_GESUMMV::runOpenMPTargetVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::For<0, RAJA::omp_target_parallel_for_exec<threads_per_team>,
+        RAJA::statement::For<0, RAJA::omp_target_parallel_for_exec<threads_per_team>,   // i
           RAJA::statement::Lambda<0, RAJA::Params<0,1>>,
-          RAJA::statement::For<1, RAJA::seq_exec,
+          RAJA::statement::For<1, RAJA::seq_exec,     // j
             RAJA::statement::Lambda<1,  RAJA::Segs<0,1>, RAJA::Params<0,1>>
           >,
           RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0,1>>

--- a/src/polybench/POLYBENCH_GESUMMV-Seq.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Seq.cpp
@@ -93,9 +93,9 @@ void POLYBENCH_GESUMMV::runSeqVariant(VariantID vid)
 
       using EXEC_POL =
         RAJA::KernelPolicy<
-          RAJA::statement::For<0, RAJA::loop_exec,
+          RAJA::statement::For<0, RAJA::loop_exec,         // i
             RAJA::statement::Lambda<0, RAJA::Params<0,1>>,
-            RAJA::statement::For<1, RAJA::loop_exec,
+            RAJA::statement::For<1, RAJA::loop_exec,       // j
               RAJA::statement::Lambda<1, RAJA::Segs<0, 1>, RAJA::Params<0,1>>
             >,
             RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0,1>>

--- a/src/polybench/POLYBENCH_GESUMMV.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV.cpp
@@ -21,6 +21,7 @@ namespace polybench
 POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GESUMMV, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps = 0;
   switch(lsizespec) {
@@ -50,7 +51,13 @@ POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  m_alpha = 0.62;
+  m_beta = 1.002;
+
+  setDefaultProblemSize( m_N * m_N );
+  setDefaultReps(run_reps);
+
+#else
 
   Index_type N_default = 1000;
 
@@ -61,14 +68,6 @@ POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
 
   m_alpha = 0.62;
   m_beta = 1.002;
-
-#else // this is what we have now...
-
-  m_alpha = 0.62;
-  m_beta = 1.002;
-
-  setDefaultProblemSize( m_N * m_N );
-  setDefaultReps(run_reps);
 
 #endif
 

--- a/src/polybench/POLYBENCH_GESUMMV.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV.cpp
@@ -21,44 +21,6 @@ namespace polybench
 POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GESUMMV, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0;
-  switch(lsizespec) {
-    case Mini:
-      m_N = 30;
-      run_reps = 10000;
-      break;
-    case Small:
-      m_N = 90;
-      run_reps = 1000;
-      break;
-    case Medium:
-      m_N = 250;
-      run_reps = 100;
-      break;
-    case Large:
-      m_N = 1300;
-      run_reps = 1;
-      break;
-    case Extralarge:
-      m_N = 2800;
-      run_reps = 1;
-      break;
-    default:
-      m_N = 1600;
-      run_reps = 120;
-      break;
-  }
-
-  m_alpha = 0.62;
-  m_beta = 1.002;
-
-  setDefaultProblemSize( m_N * m_N );
-  setDefaultReps(run_reps);
-
-#else
-
   Index_type N_default = 1000;
 
   setDefaultProblemSize( N_default * N_default );
@@ -69,7 +31,6 @@ POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
   m_alpha = 0.62;
   m_beta = 1.002;
 
-#endif
 
   setActualProblemSize( m_N * m_N );
 

--- a/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
@@ -28,6 +28,15 @@ namespace polybench
   constexpr size_t j_block_sz = 8;
   constexpr size_t k_block_sz = 32;
 
+#define HEAT_3D_THREADS_PER_BLOCK_CUDA \
+  dim3 nthreads_per_block(k_block_sz, j_block_sz, i_block_sz);
+
+#define HEAT_3D_NBLOCKS_CUDA \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, k_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, i_block_sz)));
+
+
 #define POLYBENCH_HEAT_3D_DATA_SETUP_CUDA \
   allocAndInitCudaDeviceData(A, m_Ainit, m_N*m_N*m_N); \
   allocAndInitCudaDeviceData(B, m_Binit, m_N*m_N*m_N);
@@ -90,17 +99,13 @@ void POLYBENCH_HEAT_3D::runCudaVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        dim3 nthreads_per_block(k_block_sz, j_block_sz, i_block_sz);
-        dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, k_block_sz)),
-                     static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, j_block_sz)),
-                     static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, i_block_sz)));
+        HEAT_3D_THREADS_PER_BLOCK_CUDA;
+        HEAT_3D_NBLOCKS_CUDA;
 
         poly_heat_3D_1<<<nblocks, nthreads_per_block>>>(A, B, N);
-
         cudaErrchk( cudaGetLastError() );
 
         poly_heat_3D_2<<<nblocks, nthreads_per_block>>>(A, B, N);
-
         cudaErrchk( cudaGetLastError() );
 
       }
@@ -119,10 +124,8 @@ void POLYBENCH_HEAT_3D::runCudaVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        dim3 nthreads_per_block(k_block_sz, j_block_sz, i_block_sz);
-        dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, k_block_sz)),
-                     static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, j_block_sz)),
-                     static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, i_block_sz)));
+        HEAT_3D_THREADS_PER_BLOCK_CUDA;
+        HEAT_3D_NBLOCKS_CUDA;
 
         poly_heat_3D_lam<<<nblocks, nthreads_per_block>>>(N,
           [=] __device__ (Index_type i, Index_type j, Index_type k) {

--- a/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
@@ -21,6 +21,13 @@ namespace rajaperf
 namespace polybench
 {
 
+  //
+  // Define thread block size for Hip execution
+  //
+  constexpr size_t i_block_sz = 1;
+  constexpr size_t j_block_sz = 8;
+  constexpr size_t k_block_sz = 32;
+
 #define POLYBENCH_HEAT_3D_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(A, m_Ainit, m_N*m_N*m_N); \
   allocAndInitHipDeviceData(B, m_Binit, m_N*m_N*m_N);
@@ -35,9 +42,9 @@ namespace polybench
 
 __global__ void poly_heat_3D_1(Real_ptr A, Real_ptr B, Index_type N)
 {
-   Index_type i = 1 + blockIdx.y;
-   Index_type j = 1 + blockIdx.z;
-   Index_type k = 1 + threadIdx.x;
+   Index_type i = 1 + blockIdx.z;
+   Index_type j = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type k = 1 + blockIdx.x * blockDim.x + threadIdx.x;
 
    if (i < N-1 && j < N-1 && k < N-1) {
      POLYBENCH_HEAT_3D_BODY1;
@@ -46,12 +53,24 @@ __global__ void poly_heat_3D_1(Real_ptr A, Real_ptr B, Index_type N)
 
 __global__ void poly_heat_3D_2(Real_ptr A, Real_ptr B, Index_type N)
 {
-   Index_type i = 1 + blockIdx.y;
-   Index_type j = 1 + blockIdx.z;
-   Index_type k = 1 + threadIdx.x;
+   Index_type i = 1 + blockIdx.z;
+   Index_type j = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type k = 1 + blockIdx.x * blockDim.x + threadIdx.x;
 
    if (i < N-1 && j < N-1 && k < N-1) {
      POLYBENCH_HEAT_3D_BODY2;
+   }
+}
+
+template< typename Lambda >
+__global__ void poly_heat_3D_lam(Index_type N, Lambda body)
+{
+   Index_type i = 1 + blockIdx.z;
+   Index_type j = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+   Index_type k = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+
+   if (i < N-1 && j < N-1 && k < N-1) {
+     body(i, j, k);
    }
 }
 
@@ -71,13 +90,19 @@ void POLYBENCH_HEAT_3D::runHipVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        dim3 nblocks(1, N-2, N-2);
-        dim3 nthreads_per_block(N-2, 1, 1);
+        dim3 nthreads_per_block(k_block_sz, j_block_sz, i_block_sz);
+        dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, k_block_sz)),
+                     static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, j_block_sz)),
+                     static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, i_block_sz)));
 
-        hipLaunchKernelGGL((poly_heat_3D_1),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
+        hipLaunchKernelGGL((poly_heat_3D_1), 
+                           dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                           A, B, N);
         hipErrchk( hipGetLastError() );
 
-        hipLaunchKernelGGL((poly_heat_3D_2),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
+        hipLaunchKernelGGL((poly_heat_3D_2),
+                           dim3(nblocks), dim3(nthreads_per_block), 0, 0, 
+                           A, B, N);
         hipErrchk( hipGetLastError() );
 
       }
@@ -96,29 +121,28 @@ void POLYBENCH_HEAT_3D::runHipVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        dim3 nblocks(1, N-2, N-2);
-        dim3 nthreads_per_block(N-2, 1, 1);
-
-        auto poly_heat_3D_1_lambda = [=] __device__ (Index_type i, Index_type j, Index_type k) {
-
+        auto poly_heat_3D_1_lambda = [=] __device__ (Index_type i, Index_type j,
+                                                     Index_type k) {
           POLYBENCH_HEAT_3D_BODY1;
         };
 
-        auto kernel1 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_block_z_direct, RAJA::hip_thread_x_direct, decltype(poly_heat_3D_1_lambda)>;
-        hipLaunchKernelGGL(kernel1,
-          nblocks, nthreads_per_block, 0, 0,
-          1, N-1, 1, N-1, 1, N-1, poly_heat_3D_1_lambda);
-        hipErrchk( hipGetLastError() );
-
-        auto poly_heat_3D_2_lambda = [=] __device__ (Index_type i, Index_type j, Index_type k) {
-
+        auto poly_heat_3D_2_lambda = [=] __device__ (Index_type i, Index_type j,                                                     Index_type k) {
           POLYBENCH_HEAT_3D_BODY2;
         };
 
-        auto kernel2 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_block_z_direct, RAJA::hip_thread_x_direct, decltype(poly_heat_3D_2_lambda)>;
-        hipLaunchKernelGGL(kernel2,
-          nblocks, nthreads_per_block, 0, 0,
-          1, N-1, 1, N-1, 1, N-1, poly_heat_3D_2_lambda);
+        dim3 nthreads_per_block(k_block_sz, j_block_sz, i_block_sz);
+        dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, k_block_sz)),
+                     static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, j_block_sz)),
+                     static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, i_block_sz))); 
+
+        hipLaunchKernelGGL((poly_heat_3D_lam<decltype(poly_heat_3D_1_lambda)>),
+                           dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                           N, poly_heat_3D_1_lambda);
+        hipErrchk( hipGetLastError() );
+
+        hipLaunchKernelGGL((poly_heat_3D_lam<decltype(poly_heat_3D_2_lambda)>),
+                           dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                           N, poly_heat_3D_2_lambda);
         hipErrchk( hipGetLastError() );
 
       }
@@ -136,20 +160,17 @@ void POLYBENCH_HEAT_3D::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_z_direct,
-            RAJA::statement::For<1, RAJA::hip_block_y_direct,
-              RAJA::statement::For<2, RAJA::hip_thread_x_direct,
-                RAJA::statement::Lambda<0>
-              >
-            >
-          >
-        >,
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_z_direct,
-            RAJA::statement::For<1, RAJA::hip_block_y_direct,
-              RAJA::statement::For<2, RAJA::hip_thread_x_direct,
-                RAJA::statement::Lambda<1>
+        RAJA::statement::HipKernelFixedAsync<j_block_sz * k_block_sz,
+          RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
+                                   RAJA::hip_block_y_direct,
+            RAJA::statement::Tile<0, RAJA::tile_fixed<k_block_sz>,
+                                     RAJA::hip_block_x_direct,
+              RAJA::statement::For<2, RAJA::hip_block_z_direct,      // i
+                RAJA::statement::For<1, RAJA::hip_thread_y_direct,   // j
+                  RAJA::statement::For<0, RAJA::hip_thread_x_direct, // k
+                    RAJA::statement::Lambda<0>
+                  >
+                >
               >
             >
           >
@@ -166,7 +187,12 @@ void POLYBENCH_HEAT_3D::runHipVariant(VariantID vid)
                                                  RAJA::RangeSegment{1, N-1}),
           [=] __device__ (Index_type i, Index_type j, Index_type k) {
             POLYBENCH_HEAT_3D_BODY1_RAJA;
-          },
+          }
+        );
+
+        RAJA::kernel<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                                                 RAJA::RangeSegment{1, N-1},
+                                                 RAJA::RangeSegment{1, N-1}),
           [=] __device__ (Index_type i, Index_type j, Index_type k) {
             POLYBENCH_HEAT_3D_BODY2_RAJA;
           }

--- a/src/polybench/POLYBENCH_HEAT_3D-OMP.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-OMP.cpp
@@ -112,25 +112,12 @@ void POLYBENCH_HEAT_3D::runOpenMPVariant(VariantID vid)
 
       POLYBENCH_HEAT_3D_VIEWS_RAJA;
 
-      auto poly_heat3d_lam1 = [=](Index_type i, Index_type j, Index_type k) {
-                                POLYBENCH_HEAT_3D_BODY1_RAJA;
-                              };
-      auto poly_heat3d_lam2 = [=](Index_type i, Index_type j, Index_type k) {
-                                POLYBENCH_HEAT_3D_BODY2_RAJA;
-                              };
-     
       using EXEC_POL =
         RAJA::KernelPolicy<
           RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
                                     RAJA::ArgList<0, 1>,
             RAJA::statement::For<2, RAJA::loop_exec,
               RAJA::statement::Lambda<0>
-            >
-          >,
-          RAJA::statement::Collapse<RAJA::omp_parallel_collapse_exec,
-                                    RAJA::ArgList<0, 1>,
-            RAJA::statement::For<2, RAJA::loop_exec,
-              RAJA::statement::Lambda<1>
             >
           >
         >;
@@ -143,9 +130,17 @@ void POLYBENCH_HEAT_3D::runOpenMPVariant(VariantID vid)
           RAJA::kernel<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
                                                    RAJA::RangeSegment{1, N-1},
                                                    RAJA::RangeSegment{1, N-1}),
+            [=](Index_type i, Index_type j, Index_type k) {
+              POLYBENCH_HEAT_3D_BODY1_RAJA;
+            }
+          );
 
-            poly_heat3d_lam1,
-            poly_heat3d_lam2
+          RAJA::kernel<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                                                   RAJA::RangeSegment{1, N-1},
+                                                   RAJA::RangeSegment{1, N-1}),
+            [=](Index_type i, Index_type j, Index_type k) {
+              POLYBENCH_HEAT_3D_BODY2_RAJA;
+            }
           );
 
         }

--- a/src/polybench/POLYBENCH_HEAT_3D-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-OMPTarget.cpp
@@ -89,10 +89,6 @@ void POLYBENCH_HEAT_3D::runOpenMPTargetVariant(VariantID vid)
         RAJA::statement::Collapse<RAJA::omp_target_parallel_collapse_exec,
                                   RAJA::ArgList<0, 1, 2>,
           RAJA::statement::Lambda<0>
-        >,
-        RAJA::statement::Collapse<RAJA::omp_target_parallel_collapse_exec,
-                                  RAJA::ArgList<0, 1, 2>,
-          RAJA::statement::Lambda<1>
         >
       >;
 
@@ -106,7 +102,12 @@ void POLYBENCH_HEAT_3D::runOpenMPTargetVariant(VariantID vid)
                                                  RAJA::RangeSegment{1, N-1}),
           [=] (Index_type i, Index_type j, Index_type k) {
             POLYBENCH_HEAT_3D_BODY1_RAJA;
-          },
+          }
+        );
+
+        RAJA::kernel<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                                                 RAJA::RangeSegment{1, N-1},
+                                                 RAJA::RangeSegment{1, N-1}),
           [=] (Index_type i, Index_type j, Index_type k) {
             POLYBENCH_HEAT_3D_BODY2_RAJA;
           }

--- a/src/polybench/POLYBENCH_HEAT_3D-Seq.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Seq.cpp
@@ -107,26 +107,12 @@ void POLYBENCH_HEAT_3D::runSeqVariant(VariantID vid)
 
       POLYBENCH_HEAT_3D_VIEWS_RAJA;
 
-      auto poly_heat3d_lam1 = [=](Index_type i, Index_type j, Index_type k) {
-                                POLYBENCH_HEAT_3D_BODY1_RAJA;
-                              };
-      auto poly_heat3d_lam2 = [=](Index_type i, Index_type j, Index_type k) {
-                                POLYBENCH_HEAT_3D_BODY2_RAJA;
-                              };
-
       using EXEC_POL =
         RAJA::KernelPolicy<
           RAJA::statement::For<0, RAJA::loop_exec,
             RAJA::statement::For<1, RAJA::loop_exec,
               RAJA::statement::For<2, RAJA::loop_exec,
                 RAJA::statement::Lambda<0>
-              >
-            >
-          >,
-          RAJA::statement::For<0, RAJA::loop_exec,
-            RAJA::statement::For<1, RAJA::loop_exec,
-              RAJA::statement::For<2, RAJA::loop_exec,
-                RAJA::statement::Lambda<1>
               >
             >
           >
@@ -141,8 +127,20 @@ void POLYBENCH_HEAT_3D::runSeqVariant(VariantID vid)
                                                    RAJA::RangeSegment{1, N-1},
                                                    RAJA::RangeSegment{1, N-1}),
 
-            poly_heat3d_lam1,
-            poly_heat3d_lam2
+            [=](Index_type i, Index_type j, Index_type k) {
+              POLYBENCH_HEAT_3D_BODY1_RAJA;
+            }
+
+          );
+
+          RAJA::kernel<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                                                   RAJA::RangeSegment{1, N-1},
+                                                   RAJA::RangeSegment{1, N-1}),
+
+            [=](Index_type i, Index_type j, Index_type k) {
+              POLYBENCH_HEAT_3D_BODY2_RAJA;
+            }
+
           );
 
         }

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -22,6 +22,7 @@ namespace polybench
 POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_HEAT_3D, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps = 0;
 //
@@ -68,21 +69,19 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  setDefaultProblemSize( (m_N-2) * (m_N-2) * (m_N-2) );
+  setDefaultReps(run_reps);
+
+#else
 
   Index_type N_default = 100;
 
   setDefaultProblemSize( (N_default-2)*(N_default-2)*(N_default-2) );
-  setDefaultReps(10);
+  setDefaultReps(20);
 
   m_N = std::cbrt( getTargetProblemSize() ) + 1;
   m_tsteps = 20;
   m_factor = 0.0001;
-
-#else // this is what we have now...
-
-  setDefaultProblemSize( (m_N-2) * (m_N-2) * (m_N-2) );
-  setDefaultReps(run_reps);
 
 #endif
 
@@ -100,6 +99,10 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
                                (m_N * m_N * m_N - 12*(m_N-2) - 8) ) );
   setFLOPsPerRep( m_tsteps * ( 15 * (m_N-2) * (m_N-2) * (m_N-2) +
                                15 * (m_N-2) * (m_N-2) * (m_N-2) ) );
+
+  checksum_scale_factor = 1.0 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Kernel);
 
@@ -138,8 +141,8 @@ void POLYBENCH_HEAT_3D::setUp(VariantID vid)
 
 void POLYBENCH_HEAT_3D::updateChecksum(VariantID vid)
 {
-  checksum[vid] += m_factor * calcChecksum(m_A, m_N*m_N*m_N);
-  checksum[vid] += m_factor * calcChecksum(m_B, m_N*m_N*m_N);
+  checksum[vid] += m_factor * calcChecksum(m_A, m_N*m_N*m_N, checksum_scale_factor );
+  checksum[vid] += m_factor * calcChecksum(m_B, m_N*m_N*m_N, checksum_scale_factor );
 }
 
 void POLYBENCH_HEAT_3D::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -22,58 +22,6 @@ namespace polybench
 POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_HEAT_3D, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0;
-//
-// Note: 'factor' was added to keep the checksums (which can get very large
-//       for this kernel) within a reasonable range for comparison across
-//       variants.
-//
-  switch(lsizespec) {
-    case Mini:
-      m_N=10;
-      m_tsteps=20;
-      run_reps = 1000;
-      m_factor = 0.1;
-      break;
-    case Small:
-      m_N=20;
-      m_tsteps=40;
-      run_reps = 500;
-      m_factor = 0.01;
-      break;
-    case Medium:
-      m_N=40;
-      m_tsteps=100;
-      run_reps = 300;
-      m_factor = 0.001;
-      break;
-    case Large:
-      m_N=120;
-      m_tsteps=50;
-      run_reps = 10;
-      m_factor = 0.0001;
-      break;
-    case Extralarge:
-      m_N=400;
-      m_tsteps=10;
-      run_reps = 1;
-      m_factor = 0.00001;
-      break;
-    default:
-      m_N=120;
-      m_tsteps=20;
-      run_reps = 10;
-      m_factor = 0.0001;
-      break;
-  }
-
-  setDefaultProblemSize( (m_N-2) * (m_N-2) * (m_N-2) );
-  setDefaultReps(run_reps);
-
-#else
-
   Index_type N_default = 100;
 
   setDefaultProblemSize( (N_default-2)*(N_default-2)*(N_default-2) );
@@ -81,9 +29,7 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
 
   m_N = std::cbrt( getTargetProblemSize() ) + 1;
   m_tsteps = 20;
-  m_factor = 0.0001;
 
-#endif
 
   setActualProblemSize( (m_N-2) * (m_N-2) * (m_N-2) );
 
@@ -100,7 +46,7 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
   setFLOPsPerRep( m_tsteps * ( 15 * (m_N-2) * (m_N-2) * (m_N-2) +
                                15 * (m_N-2) * (m_N-2) * (m_N-2) ) );
 
-  checksum_scale_factor = 1.0 *
+  checksum_scale_factor = 0.0001 *
               ( static_cast<Checksum_type>(getDefaultProblemSize()) /
                                            getActualProblemSize() );
 
@@ -141,8 +87,8 @@ void POLYBENCH_HEAT_3D::setUp(VariantID vid)
 
 void POLYBENCH_HEAT_3D::updateChecksum(VariantID vid)
 {
-  checksum[vid] += m_factor * calcChecksum(m_A, m_N*m_N*m_N, checksum_scale_factor );
-  checksum[vid] += m_factor * calcChecksum(m_B, m_N*m_N*m_N, checksum_scale_factor );
+  checksum[vid] += calcChecksum(m_A, m_N*m_N*m_N, checksum_scale_factor );
+  checksum[vid] += calcChecksum(m_B, m_N*m_N*m_N, checksum_scale_factor );
 }
 
 void POLYBENCH_HEAT_3D::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_HEAT_3D.hpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.hpp
@@ -129,8 +129,6 @@ private:
   Index_type m_N;
   Index_type m_tsteps;
 
-  Real_type m_factor;
-
   Real_ptr m_A;
   Real_ptr m_B;
   Real_ptr m_Ainit;

--- a/src/polybench/POLYBENCH_JACOBI_1D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.cpp
@@ -21,47 +21,6 @@ namespace polybench
 POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_JACOBI_1D, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0;
-  switch(lsizespec) {
-    case Mini:
-      m_N=300;
-      m_tsteps=20;
-      run_reps = 10000;
-      break;
-    case Small:
-      m_N=1200;
-      m_tsteps=100;
-      run_reps = 1000;
-      break;
-    case Medium:
-      m_N=4000;
-      m_tsteps=100;
-      run_reps = 100;
-      break;
-    case Large:
-      m_N=200000;
-      m_tsteps=50;
-      run_reps = 1;
-      break;
-    case Extralarge:
-      m_N=2000000;
-      m_tsteps=10;
-      run_reps = 20;
-      break;
-    default:
-      m_N=4000000;
-      m_tsteps=10;
-      run_reps = 10;
-      break;
-  }
-
-  setDefaultProblemSize( m_N-2 );
-  setDefaultReps(run_reps);
-
-#else
-
   Index_type N_default = 1000000;
 
   setDefaultProblemSize( N_default-2 );
@@ -70,7 +29,6 @@ POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
   m_N = getTargetProblemSize(); 
   m_tsteps = 16;
 
-#endif
 
   setActualProblemSize( m_N-2 );
 

--- a/src/polybench/POLYBENCH_JACOBI_1D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.cpp
@@ -21,6 +21,7 @@ namespace polybench
 POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_JACOBI_1D, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps = 0;
   switch(lsizespec) {
@@ -56,20 +57,18 @@ POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  setDefaultProblemSize( m_N-2 );
+  setDefaultReps(run_reps);
+
+#else
 
   Index_type N_default = 1000000;
 
   setDefaultProblemSize( N_default-2 );
-  setDefaultReps(20);
+  setDefaultReps(100);
  
   m_N = getTargetProblemSize(); 
   m_tsteps = 16;
-
-#else // this is what we have now...
-
-  setDefaultProblemSize( m_N-2 );
-  setDefaultReps(run_reps);
 
 #endif
 
@@ -87,6 +86,10 @@ POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
                                m_N ) );
   setFLOPsPerRep( m_tsteps * ( 3 * (m_N-2) +
                                3 * (m_N-2) ) );
+
+  checksum_scale_factor = 0.0001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Forall);
 
@@ -123,8 +126,8 @@ void POLYBENCH_JACOBI_1D::setUp(VariantID vid)
 
 void POLYBENCH_JACOBI_1D::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_A, m_N);
-  checksum[vid] += calcChecksum(m_B, m_N);
+  checksum[vid] += calcChecksum(m_A, m_N, checksum_scale_factor );
+  checksum[vid] += calcChecksum(m_B, m_N, checksum_scale_factor );
 }
 
 void POLYBENCH_JACOBI_1D::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
@@ -21,6 +21,21 @@ namespace rajaperf
 namespace polybench
 {
 
+  //
+  // Define thread block size for CUDA execution
+  //
+  constexpr size_t i_block_sz = 8;
+  constexpr size_t j_block_sz = 32;
+
+#define JACOBI_2D_THREADS_PER_BLOCK_CUDA \
+  dim3 nthreads_per_block(j_block_sz, i_block_sz, 1);
+
+#define JACOBI_2D_NBLOCKS_CUDA \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, i_block_sz)), \
+               static_cast<size_t>(1));
+
+
 #define POLYBENCH_JACOBI_2D_DATA_SETUP_CUDA \
   allocAndInitCudaDeviceData(A, m_Ainit, m_N*m_N); \
   allocAndInitCudaDeviceData(B, m_Binit, m_N*m_N);
@@ -35,8 +50,8 @@ namespace polybench
 
 __global__ void poly_jacobi_2D_1(Real_ptr A, Real_ptr B, Index_type N)
 {
-  Index_type i = 1 + blockIdx.y;
-  Index_type j = 1 + threadIdx.x;
+  Index_type i = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
 
   if ( i < N-1 && j < N-1 ) {
     POLYBENCH_JACOBI_2D_BODY1;
@@ -45,12 +60,23 @@ __global__ void poly_jacobi_2D_1(Real_ptr A, Real_ptr B, Index_type N)
 
 __global__ void poly_jacobi_2D_2(Real_ptr A, Real_ptr B, Index_type N)
 {
-   Index_type i = 1 + blockIdx.y;
-   Index_type j = 1 + threadIdx.x;
+  Index_type i = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
 
-   if ( i < N-1 && j < N-1 ) {
-     POLYBENCH_JACOBI_2D_BODY2;
-   }
+  if ( i < N-1 && j < N-1 ) {
+    POLYBENCH_JACOBI_2D_BODY2;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_jacobi_2D_lam(Index_type N, Lambda body)
+{
+  Index_type i = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < N-1 && j < N-1 ) {
+    body(i, j);
+  }
 }
 
 
@@ -69,8 +95,8 @@ void POLYBENCH_JACOBI_2D::runCudaVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        dim3 nblocks(1, N-2, 1);
-        dim3 nthreads_per_block(N-2, 1, 1);
+        JACOBI_2D_THREADS_PER_BLOCK_CUDA;
+        JACOBI_2D_NBLOCKS_CUDA;
 
         poly_jacobi_2D_1<<<nblocks, nthreads_per_block>>>(A, B, N);
         cudaErrchk( cudaGetLastError() );
@@ -94,25 +120,21 @@ void POLYBENCH_JACOBI_2D::runCudaVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        dim3 nblocks(1, N-2, 1);
-        dim3 nthreads_per_block(N-2, 1, 1);
+        JACOBI_2D_THREADS_PER_BLOCK_CUDA;
+        JACOBI_2D_NBLOCKS_CUDA;
 
-        lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
-                          <<<nblocks, nthreads_per_block>>>(
-          1, N-1, 1, N-1,
+        poly_jacobi_2D_lam<<<nblocks, nthreads_per_block>>>(N,
           [=] __device__ (Index_type i, Index_type j) {
-
-          POLYBENCH_JACOBI_2D_BODY1;
-        });
+            POLYBENCH_JACOBI_2D_BODY1;
+          }
+        );
         cudaErrchk( cudaGetLastError() );
 
-        lambda_cuda_kernel<RAJA::cuda_block_y_direct, RAJA::cuda_thread_x_direct>
-                          <<<nblocks, nthreads_per_block>>>(
-          1, N-1, 1, N-1,
+        poly_jacobi_2D_lam<<<nblocks, nthreads_per_block>>>(N,
           [=] __device__ (Index_type i, Index_type j) {
-
-          POLYBENCH_JACOBI_2D_BODY2;
-        });
+            POLYBENCH_JACOBI_2D_BODY2;
+          }
+        );
         cudaErrchk( cudaGetLastError() );
 
       }
@@ -130,32 +152,35 @@ void POLYBENCH_JACOBI_2D::runCudaVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<0, RAJA::cuda_block_y_direct,
-            RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
-              RAJA::statement::Lambda<0>
-            >
-          >
-        >,
-        RAJA::statement::CudaKernelAsync<
-          RAJA::statement::For<0, RAJA::cuda_block_y_direct,
-            RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
-              RAJA::statement::Lambda<1>
+        RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
+                                   RAJA::cuda_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
+                                     RAJA::cuda_block_x_direct,
+              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // i
+                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // j
+                  RAJA::statement::Lambda<0>
+                >
+              >
             >
           >
         >
-      >;
+      >;        
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        RAJA::kernel<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                                                 RAJA::RangeSegment{1, N-1}),
+        RAJA::kernel<EXEC_POL>(RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                                                RAJA::RangeSegment{1, N-1}),
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_JACOBI_2D_BODY1_RAJA;
-          },
+          }
+        );
+
+         RAJA::kernel<EXEC_POL>(RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                                                 RAJA::RangeSegment{1, N-1}),
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_JACOBI_2D_BODY2_RAJA;
           }

--- a/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
@@ -132,9 +132,9 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
             POLYBENCH_JACOBI_2D_BODY1;
           };
 
-        hipLaunchKernelGGL((poly_jacobi_2d_lam<decltype(poly_jacobi_2D_1_lambda)>),
-                           dim3(nblocks1), dim3(nthreads_per_block1), 0, 0,
-                           n, poly_jacobi_2D_1_lambda);
+        hipLaunchKernelGGL((poly_jacobi_2D_lam<decltype(poly_jacobi_2D_1_lambda)>),
+                           dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                           N, poly_jacobi_2D_1_lambda);
         hipErrchk( hipGetLastError() );
 
         auto poly_jacobi_2D_2_lambda = 
@@ -142,9 +142,9 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
             POLYBENCH_JACOBI_2D_BODY2;
           };
 
-        hipLaunchKernelGGL((poly_jacobi_2d_lam<decltype(poly_jacobi_2D_2_lambda)>),
-                           dim3(nblocks1), dim3(nthreads_per_block1), 0, 0,
-                           n, poly_jacobi_2D_2_lambda);
+        hipLaunchKernelGGL((poly_jacobi_2D_lam<decltype(poly_jacobi_2D_2_lambda)>),
+                           dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                           N, poly_jacobi_2D_2_lambda);
         hipErrchk( hipGetLastError() );
 
       }
@@ -162,13 +162,13 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
+        RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
           RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
-                                   RAJA::cuda_block_y_direct,
+                                   RAJA::hip_block_y_direct,
             RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                     RAJA::cuda_block_x_direct,
-              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // i
-                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // j
+                                     RAJA::hip_block_x_direct,
+              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // i
+                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // j
                   RAJA::statement::Lambda<0>
                 >
               >

--- a/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
@@ -21,6 +21,21 @@ namespace rajaperf
 namespace polybench
 {
 
+  //
+  // Define thread block size for Hip execution
+  //
+  constexpr size_t i_block_sz = 8;
+  constexpr size_t j_block_sz = 32;
+
+#define JACOBI_2D_THREADS_PER_BLOCK_HIP \
+  dim3 nthreads_per_block(j_block_sz, i_block_sz, 1);
+
+#define JACOBI_2D_NBLOCKS_HIP \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, i_block_sz)), \
+               static_cast<size_t>(1));
+
+
 #define POLYBENCH_JACOBI_2D_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(A, m_Ainit, m_N*m_N); \
   allocAndInitHipDeviceData(B, m_Binit, m_N*m_N);
@@ -35,22 +50,33 @@ namespace polybench
 
 __global__ void poly_jacobi_2D_1(Real_ptr A, Real_ptr B, Index_type N)
 {
-   Index_type i = 1 + blockIdx.y;
-   Index_type j = 1 + threadIdx.x;
+  Index_type i = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
 
-   if ( i < N-1 && j < N-1 ) {
-     POLYBENCH_JACOBI_2D_BODY1;
-   }
+  if ( i < N-1 && j < N-1 ) {
+    POLYBENCH_JACOBI_2D_BODY1;
+  }
 }
 
 __global__ void poly_jacobi_2D_2(Real_ptr A, Real_ptr B, Index_type N)
 {
-   Index_type i = 1 + blockIdx.y;
-   Index_type j = 1 + threadIdx.x;
+  Index_type i = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
 
-   if ( i < N-1 && j < N-1 ) {
-     POLYBENCH_JACOBI_2D_BODY2;
-   }
+  if ( i < N-1 && j < N-1 ) {
+    POLYBENCH_JACOBI_2D_BODY2;
+  }
+}
+
+template< typename Lambda >
+__global__ void poly_jacobi_2D_lam(Index_type N, Lambda body)
+{
+  Index_type i = 1 + blockIdx.y * blockDim.y + threadIdx.y;
+  Index_type j = 1 + blockIdx.x * blockDim.x + threadIdx.x;
+
+  if ( i < N-1 && j < N-1 ) {
+    body(i, j);
+  }
 }
 
 
@@ -69,13 +95,17 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        dim3 nblocks(1, N-2, 1);
-        dim3 nthreads_per_block(N-2, 1, 1);
+        JACOBI_2D_THREADS_PER_BLOCK_HIP;
+        JACOBI_2D_NBLOCKS_HIP;
 
-        hipLaunchKernelGGL((poly_jacobi_2D_1),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
+        hipLaunchKernelGGL((poly_jacobi_2D_1),
+                           dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                           A, B, N);
         hipErrchk( hipGetLastError() );
 
-        hipLaunchKernelGGL((poly_jacobi_2D_2),dim3(nblocks), dim3(nthreads_per_block),0,0,A, B, N);
+        hipLaunchKernelGGL((poly_jacobi_2D_2),
+                           dim3(nblocks), dim3(nthreads_per_block), 0, 0,
+                           A, B, N);
         hipErrchk( hipGetLastError() );
 
       }
@@ -94,29 +124,27 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        dim3 nblocks(1, N-2, 1);
-        dim3 nthreads_per_block(N-2, 1, 1);
+        JACOBI_2D_THREADS_PER_BLOCK_HIP;
+        JACOBI_2D_NBLOCKS_HIP;
 
-        auto poly_jacobi_2D_1_kernel = [=] __device__ (Index_type i, Index_type j) {
+        auto poly_jacobi_2D_1_lambda = 
+          [=] __device__ (Index_type i, Index_type j) {
+            POLYBENCH_JACOBI_2D_BODY1;
+          };
 
-          POLYBENCH_JACOBI_2D_BODY1;
-        };
-
-        auto kernel1 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_jacobi_2D_1_kernel)>;
-        hipLaunchKernelGGL(kernel1,
-          nblocks, nthreads_per_block, 0, 0,
-          1, N-1, 1, N-1, poly_jacobi_2D_1_kernel);
+        hipLaunchKernelGGL((poly_jacobi_2d_lam<decltype(poly_jacobi_2D_1_lambda)>),
+                           dim3(nblocks1), dim3(nthreads_per_block1), 0, 0,
+                           n, poly_jacobi_2D_1_lambda);
         hipErrchk( hipGetLastError() );
 
-        auto poly_jacobi_2D_2_kernel = [=] __device__ (Index_type i, Index_type j) {
+        auto poly_jacobi_2D_2_lambda = 
+          [=] __device__ (Index_type i, Index_type j) {
+            POLYBENCH_JACOBI_2D_BODY2;
+          };
 
-          POLYBENCH_JACOBI_2D_BODY2;
-        };
-
-        auto kernel2 = lambda_hip_kernel<RAJA::hip_block_y_direct, RAJA::hip_thread_x_direct, decltype(poly_jacobi_2D_2_kernel)>;
-        hipLaunchKernelGGL(kernel2,
-          nblocks, nthreads_per_block, 0, 0,
-          1, N-1, 1, N-1, poly_jacobi_2D_2_kernel);
+        hipLaunchKernelGGL((poly_jacobi_2d_lam<decltype(poly_jacobi_2D_2_lambda)>),
+                           dim3(nblocks1), dim3(nthreads_per_block1), 0, 0,
+                           n, poly_jacobi_2D_2_lambda);
         hipErrchk( hipGetLastError() );
 
       }
@@ -134,17 +162,16 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_y_direct,
-            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
-              RAJA::statement::Lambda<0>
-            >
-          >
-        >,
-        RAJA::statement::HipKernelAsync<
-          RAJA::statement::For<0, RAJA::hip_block_y_direct,
-            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
-              RAJA::statement::Lambda<1>
+        RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
+          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
+                                   RAJA::cuda_block_y_direct,
+            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
+                                     RAJA::cuda_block_x_direct,
+              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // i
+                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // j
+                  RAJA::statement::Lambda<0>
+                >
+              >
             >
           >
         >
@@ -155,11 +182,15 @@ void POLYBENCH_JACOBI_2D::runHipVariant(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        RAJA::kernel<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                                                 RAJA::RangeSegment{1, N-1}),
+        RAJA::kernel<EXEC_POL>(RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                                                RAJA::RangeSegment{1, N-1}),
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_JACOBI_2D_BODY1_RAJA;
-          },
+          }
+        );
+
+        RAJA::kernel<EXEC_POL>(RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                                                RAJA::RangeSegment{1, N-1}),
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_JACOBI_2D_BODY2_RAJA;
           }

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -21,47 +21,6 @@ namespace polybench
 POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_JACOBI_2D, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0;
-  switch(lsizespec) {
-    case Mini:
-      m_N=30;
-      m_tsteps=20;
-      run_reps = 1000;
-      break;
-    case Small:
-      m_N=90;
-      m_tsteps=40;
-      run_reps = 500;
-      break;
-    case Medium:
-      m_N=250;
-      m_tsteps=100;
-      run_reps = 300;
-      break;
-    case Large:
-      m_N=1500;
-      m_tsteps=20;
-      run_reps = 10;
-      break;
-    case Extralarge:
-      m_N=2800;
-      m_tsteps=10;
-      run_reps = 1;
-      break;
-    default:
-      m_N=1000;
-      m_tsteps=40;
-      run_reps = 10;
-      break;
-  }
-
-  setDefaultProblemSize( (m_N-2) * (m_N-2) );
-  setDefaultReps(run_reps);
-
-#else
-
   Index_type N_default = 1000;
 
   setDefaultProblemSize( N_default * N_default );
@@ -70,7 +29,6 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
   m_N = std::sqrt( getTargetProblemSize() ) + 1;
   m_tsteps = 40;
 
-#endif
 
   setActualProblemSize( (m_N-2) * (m_N-2) );
 

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -21,6 +21,7 @@ namespace polybench
 POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_JACOBI_2D, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps = 0;
   switch(lsizespec) {
@@ -56,20 +57,18 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  setDefaultProblemSize( (m_N-2) * (m_N-2) );
+  setDefaultReps(run_reps);
+
+#else
 
   Index_type N_default = 1000;
 
   setDefaultProblemSize( N_default * N_default );
-  setDefaultReps(10);
+  setDefaultReps(50);
 
   m_N = std::sqrt( getTargetProblemSize() ) + 1;
   m_tsteps = 40;
-
-#else // this is what we have now...
-
-  setDefaultProblemSize( (m_N-2) * (m_N-2) );
-  setDefaultReps(run_reps);
 
 #endif
 
@@ -87,6 +86,10 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
                                (m_N * m_N  - 4) ) );
   setFLOPsPerRep( m_tsteps * ( 5 * (m_N-2)*(m_N-2) +
                                5 * (m_N -2)*(m_N-2) ) );
+
+  checksum_scale_factor = 0.0001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Kernel);
 
@@ -125,8 +128,8 @@ void POLYBENCH_JACOBI_2D::setUp(VariantID vid)
 
 void POLYBENCH_JACOBI_2D::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_A, m_N*m_N);
-  checksum[vid] += calcChecksum(m_B, m_N*m_N);
+  checksum[vid] += calcChecksum(m_A, m_N*m_N, checksum_scale_factor );
+  checksum[vid] += calcChecksum(m_B, m_N*m_N, checksum_scale_factor );
 }
 
 void POLYBENCH_JACOBI_2D::tearDown(VariantID vid)

--- a/src/polybench/POLYBENCH_MVT-Cuda.cpp
+++ b/src/polybench/POLYBENCH_MVT-Cuda.cpp
@@ -107,12 +107,12 @@ void POLYBENCH_MVT::runCudaVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelAsync<
+        RAJA::statement::CudaKernelFixedAsync<block_size,
           RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
                                    RAJA::cuda_block_x_direct,
-            RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
+            RAJA::statement::For<0, RAJA::cuda_thread_x_direct,  // i
               RAJA::statement::Lambda<0, RAJA::Params<0>>,
-              RAJA::statement::For<1, RAJA::seq_exec,
+              RAJA::statement::For<1, RAJA::seq_exec,            // j
                 RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
               >,
               RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>

--- a/src/polybench/POLYBENCH_MVT-Hip.cpp
+++ b/src/polybench/POLYBENCH_MVT-Hip.cpp
@@ -22,7 +22,7 @@ namespace polybench
 {
 
   //
-  // Define thread block size for HIP execution
+  // Define thread block size for Hip execution
   //
   const size_t block_size = 256;
 
@@ -88,10 +88,14 @@ void POLYBENCH_MVT::runHipVariant(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
 
-      hipLaunchKernelGGL((poly_mvt_1),dim3(grid_size), dim3(block_size),0,0,A, x1, y1, N);
+      hipLaunchKernelGGL((poly_mvt_1),
+                         dim3(grid_size), dim3(block_size), 0, 0,
+                         A, x1, y1, N);
       hipErrchk( hipGetLastError() );
 
-      hipLaunchKernelGGL((poly_mvt_2),dim3(grid_size), dim3(block_size),0,0,A, x2, y2, N);
+      hipLaunchKernelGGL((poly_mvt_2),
+                         dim3(grid_size), dim3(block_size), 0, 0,
+                         A, x2, y2, N);
       hipErrchk( hipGetLastError() );
 
     }
@@ -107,12 +111,12 @@ void POLYBENCH_MVT::runHipVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::HipKernelAsync<
+        RAJA::statement::HipKernelFixedAsync<block_size,
           RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
                                    RAJA::hip_block_x_direct,
-            RAJA::statement::For<0, RAJA::hip_thread_x_direct,
+            RAJA::statement::For<0, RAJA::hip_thread_x_direct,  // i
               RAJA::statement::Lambda<0, RAJA::Params<0>>,
-              RAJA::statement::For<1, RAJA::seq_exec,
+              RAJA::statement::For<1, RAJA::seq_exec,           // j
                 RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
               >,
               RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>

--- a/src/polybench/POLYBENCH_MVT-OMP.cpp
+++ b/src/polybench/POLYBENCH_MVT-OMP.cpp
@@ -139,9 +139,9 @@ void POLYBENCH_MVT::runOpenMPVariant(VariantID vid)
 
       using EXEC_POL =
         RAJA::KernelPolicy<
-          RAJA::statement::For<0, RAJA::omp_for_nowait_static_exec< >,
-            RAJA::statement::Lambda<0, RAJA::Params<0>>,
-            RAJA::statement::For<1, RAJA::loop_exec,
+          RAJA::statement::For<0, RAJA::omp_for_nowait_static_exec< >, // i
+            RAJA::statement::Lambda<0, RAJA::Params<0>>,  
+            RAJA::statement::For<1, RAJA::loop_exec,                   // j
               RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
             >,
             RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>

--- a/src/polybench/POLYBENCH_MVT-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_MVT-OMPTarget.cpp
@@ -93,9 +93,9 @@ void POLYBENCH_MVT::runOpenMPTargetVariant(VariantID vid)
 
     using EXEC_POL =
       RAJA::KernelPolicy<
-        RAJA::statement::For<0, RAJA::omp_target_parallel_for_exec<threads_per_team>,
+        RAJA::statement::For<0, RAJA::omp_target_parallel_for_exec<threads_per_team>,   // i
           RAJA::statement::Lambda<0, RAJA::Params<0>>,
-          RAJA::statement::For<1, RAJA::seq_exec,
+          RAJA::statement::For<1, RAJA::seq_exec,   // j
             RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
           >,
           RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>

--- a/src/polybench/POLYBENCH_MVT-Seq.cpp
+++ b/src/polybench/POLYBENCH_MVT-Seq.cpp
@@ -125,9 +125,9 @@ void POLYBENCH_MVT::runSeqVariant(VariantID vid)
 
       using EXEC_POL =
         RAJA::KernelPolicy<
-          RAJA::statement::For<0, RAJA::loop_exec,
+          RAJA::statement::For<0, RAJA::loop_exec,    // i   
             RAJA::statement::Lambda<0, RAJA::Params<0>>,
-            RAJA::statement::For<1, RAJA::loop_exec,
+            RAJA::statement::For<1, RAJA::loop_exec,  // j 
               RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
             >,
             RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>

--- a/src/polybench/POLYBENCH_MVT.cpp
+++ b/src/polybench/POLYBENCH_MVT.cpp
@@ -21,41 +21,6 @@ namespace polybench
 POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
   : KernelBase(rajaperf::Polybench_MVT, params)
 {
-#if 0
-  SizeSpec lsizespec = KernelBase::getSizeSpec();
-  int run_reps = 0;
-  switch(lsizespec) {
-    case Mini:
-      m_N=40;
-      run_reps = 10000;
-      break;
-    case Small:
-      m_N=120;
-      run_reps = 1000;
-      break;
-    case Medium:
-      m_N=1000;
-      run_reps = 100;
-      break;
-    case Large:
-      m_N=2000;
-      run_reps = 40;
-      break;
-    case Extralarge:
-      m_N=4000;
-      run_reps = 10;
-      break;
-    default:
-      m_N=4000;
-      run_reps = 10;
-      break;
-  }
-
-  setDefaultProblemSize( m_N );
-  setDefaultReps(run_reps);
-
-#else
-
   Index_type N_default = 1000;
 
   setDefaultProblemSize( N_default * N_default );
@@ -63,7 +28,6 @@ POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
 
   m_N = std::sqrt( getTargetProblemSize() ) + 1;
 
-#endif
 
   setActualProblemSize( m_N * m_N );
 

--- a/src/polybench/POLYBENCH_MVT.cpp
+++ b/src/polybench/POLYBENCH_MVT.cpp
@@ -21,6 +21,7 @@ namespace polybench
 POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
   : KernelBase(rajaperf::Polybench_MVT, params)
 {
+#if 0
   SizeSpec lsizespec = KernelBase::getSizeSpec();
   int run_reps = 0;
   switch(lsizespec) {
@@ -50,19 +51,17 @@ POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
       break;
   }
 
-#if 0 // we want this...
+  setDefaultProblemSize( m_N );
+  setDefaultReps(run_reps);
+
+#else
 
   Index_type N_default = 1000;
 
   setDefaultProblemSize( N_default * N_default );
-  setDefaultReps(16);
+  setDefaultReps(100);
 
   m_N = std::sqrt( getTargetProblemSize() ) + 1;
-
-#else // this is what we have now...
-
-  setDefaultProblemSize( m_N );
-  setDefaultReps(run_reps);
 
 #endif
 
@@ -76,6 +75,10 @@ POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
                   (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N * m_N );
   setFLOPsPerRep(2 * m_N*m_N +
                  2 * m_N*m_N );
+
+  checksum_scale_factor = 1.0 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
 
   setUsesFeature(Kernel);
 
@@ -113,8 +116,8 @@ void POLYBENCH_MVT::setUp(VariantID vid)
 
 void POLYBENCH_MVT::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_x1, m_N);
-  checksum[vid] += calcChecksum(m_x2, m_N);
+  checksum[vid] += calcChecksum(m_x1, m_N, checksum_scale_factor );
+  checksum[vid] += calcChecksum(m_x2, m_N, checksum_scale_factor );
 }
 
 void POLYBENCH_MVT::tearDown(VariantID vid)

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -32,6 +32,10 @@ TRIAD::TRIAD(const RunParams& params)
                   getActualProblemSize() );
   setFLOPsPerRep(2 * getActualProblemSize());
 
+  checksum_scale_factor = 0.001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
+
   setUsesFeature( Forall );
 
   setVariantDefined( Base_Seq );
@@ -68,7 +72,7 @@ void TRIAD::setUp(VariantID vid)
 
 void TRIAD::updateChecksum(VariantID vid)
 {
-  checksum[vid] += calcChecksum(m_a, getActualProblemSize());
+  checksum[vid] += calcChecksum(m_a, getActualProblemSize(), checksum_scale_factor );
 }
 
 void TRIAD::tearDown(VariantID vid)


### PR DESCRIPTION
This PR does the following:

1. modifies GPU policies for all nested loop kernels so that arbitrary problem sizes may be run
2. makes RAJA and non-RAJA variants mapped to blocks and threads consistent
3. adds checksum scaling to a bunch of kernels so that checksum differences should be < 1e-8 for all kernels to be considered correct.