### PR TITLE
Fix kernel arguments in mat mat multiply with shared memory

### DIFF
--- a/src/basic/MAT_MAT_SHARED-Cuda.cpp
+++ b/src/basic/MAT_MAT_SHARED-Cuda.cpp
@@ -80,7 +80,7 @@ void MAT_MAT_SHARED::runCudaVariant(VariantID vid) {
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      mat_mat_shared<<<grid_size, block_size>>>(N, A, B, C);
+      mat_mat_shared<<<grid_size, block_size>>>(N, C, A, B);
 
       cudaErrchk( cudaGetLastError() );
     }

--- a/src/basic/MAT_MAT_SHARED-Hip.cpp
+++ b/src/basic/MAT_MAT_SHARED-Hip.cpp
@@ -81,7 +81,7 @@ void MAT_MAT_SHARED::runHipVariant(VariantID vid) {
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       hipLaunchKernelGGL((mat_mat_shared), dim3(grid_size), dim3(block_size), 0, 0,
-                         N, A, B, C);
+                         N, C, A, B);
 
       hipErrchk( hipGetLastError() );
     }


### PR DESCRIPTION
The kernel arguments were out of order leading to incorrect output. 