### PR TITLE
Use one buffer in REDUCE3_INT Base variants

### DIFF
--- a/src/basic/REDUCE3_INT-Cuda.cpp
+++ b/src/basic/REDUCE3_INT-Cuda.cpp
@@ -94,52 +94,44 @@ void REDUCE3_INT::runCudaVariant(VariantID vid)
 
     REDUCE3_INT_DATA_SETUP_CUDA;
 
-    Int_ptr vsum;
-    allocAndInitCudaDeviceData(vsum, &m_vsum_init, 1);
-    Int_ptr vmin;
-    allocAndInitCudaDeviceData(vmin, &m_vmin_init, 1);
-    Int_ptr vmax;
-    allocAndInitCudaDeviceData(vmax, &m_vmax_init, 1);
+    Int_ptr vmem_init;
+    allocCudaPinnedData(vmem_init, 3);
+
+    Int_ptr vmem;
+    allocCudaDeviceData(vmem, 3);
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      initCudaDeviceData(vsum, &m_vsum_init, 1);
-      initCudaDeviceData(vmin, &m_vmin_init, 1);
-      initCudaDeviceData(vmax, &m_vmax_init, 1);
+      vmem_init[0] = m_vsum_init;
+      vmem_init[1] = m_vmin_init;
+      vmem_init[2] = m_vmax_init;
+      cudaErrchk( cudaMemcpyAsync( vmem, vmem_init, 3*sizeof(Int_type),
+                                   cudaMemcpyHostToDevice ) );
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       reduce3int<<<grid_size, block_size,
                    3*sizeof(Int_type)*block_size>>>(vec,
-                                                    vsum, m_vsum_init,
-                                                    vmin, m_vmin_init,
-                                                    vmax, m_vmax_init,
+                                                    vmem + 0, m_vsum_init,
+                                                    vmem + 1, m_vmin_init,
+                                                    vmem + 2, m_vmax_init,
                                                     iend );
       cudaErrchk( cudaGetLastError() );
 
-      Int_type lsum;
-      Int_ptr plsum = &lsum;
-      getCudaDeviceData(plsum, vsum, 1);
-      m_vsum += lsum;
-
-      Int_type lmin;
-      Int_ptr plmin = &lmin;
-      getCudaDeviceData(plmin, vmin, 1);
-      m_vmin = RAJA_MIN(m_vmin, lmin);
-
-      Int_type lmax;
-      Int_ptr plmax = &lmax;
-      getCudaDeviceData(plmax, vmax, 1);
-      m_vmax = RAJA_MAX(m_vmax, lmax);
+      Int_type lmem[3];
+      Int_ptr plmem = &lmem[0];
+      getCudaDeviceData(plmem, vmem, 3);
+      m_vsum += lmem[0];
+      m_vmin = RAJA_MIN(m_vmin, lmem[1]);
+      m_vmax = RAJA_MAX(m_vmax, lmem[2]);
 
     }
     stopTimer();
 
     REDUCE3_INT_DATA_TEARDOWN_CUDA;
 
-    deallocCudaDeviceData(vsum);
-    deallocCudaDeviceData(vmin);
-    deallocCudaDeviceData(vmax);
+    deallocCudaDeviceData(vmem);
+    deallocCudaPinnedData(vmem_init);
 
   } else if ( vid == RAJA_CUDA ) {
 

--- a/src/basic/REDUCE3_INT-Hip.cpp
+++ b/src/basic/REDUCE3_INT-Hip.cpp
@@ -94,51 +94,44 @@ void REDUCE3_INT::runHipVariant(VariantID vid)
 
     REDUCE3_INT_DATA_SETUP_HIP;
 
-    Int_ptr vsum;
-    allocAndInitHipDeviceData(vsum, &m_vsum_init, 1);
-    Int_ptr vmin;
-    allocAndInitHipDeviceData(vmin, &m_vmin_init, 1);
-    Int_ptr vmax;
-    allocAndInitHipDeviceData(vmax, &m_vmax_init, 1);
+    Int_ptr vmem_init;
+    allocHipPinnedData(vmem_init, 3);
+
+    Int_ptr vmem;
+    allocHipDeviceData(vmem, 3);
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      initHipDeviceData(vsum, &m_vsum_init, 1);
-      initHipDeviceData(vmin, &m_vmin_init, 1);
-      initHipDeviceData(vmax, &m_vmax_init, 1);
+      vmem_init[0] = m_vsum_init;
+      vmem_init[1] = m_vmin_init;
+      vmem_init[2] = m_vmax_init;
+      hipErrchk( hipMemcpyAsync( vmem, vmem_init, 3*sizeof(Int_type),
+                                 hipMemcpyHostToDevice ) );
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      hipLaunchKernelGGL((reduce3int), dim3(grid_size), dim3(block_size), 3*sizeof(Int_type)*block_size, 0, vec,
-                                                    vsum, m_vsum_init,
-                                                    vmin, m_vmin_init,
-                                                    vmax, m_vmax_init,
+      hipLaunchKernelGGL((reduce3int), dim3(grid_size), dim3(block_size), 3*sizeof(Int_type)*block_size, 0,
+                                                    vec,
+                                                    vmem + 0, m_vsum_init,
+                                                    vmem + 1, m_vmin_init,
+                                                    vmem + 2, m_vmax_init,
                                                     iend );
       hipErrchk( hipGetLastError() );
 
-      Int_type lsum;
-      Int_ptr plsum = &lsum;
-      getHipDeviceData(plsum, vsum, 1);
-      m_vsum += lsum;
-
-      Int_type lmin;
-      Int_ptr plmin = &lmin;
-      getHipDeviceData(plmin, vmin, 1);
-      m_vmin = RAJA_MIN(m_vmin, lmin);
-
-      Int_type lmax;
-      Int_ptr plmax = &lmax;
-      getHipDeviceData(plmax, vmax, 1);
-      m_vmax = RAJA_MAX(m_vmax, lmax);
+      Int_type lmem[3];
+      Int_ptr plmem = &lmem[0];
+      getHipDeviceData(plmem, vmem, 3);
+      m_vsum += lmem[0];
+      m_vmin = RAJA_MIN(m_vmin, lmem[1]);
+      m_vmax = RAJA_MAX(m_vmax, lmem[2]);
 
     }
     stopTimer();
 
     REDUCE3_INT_DATA_TEARDOWN_HIP;
 
-    deallocHipDeviceData(vsum);
-    deallocHipDeviceData(vmin);
-    deallocHipDeviceData(vmax);
+    deallocHipDeviceData(vmem);
+    deallocHipPinnedData(vmem_init);
 
   } else if ( vid == RAJA_HIP ) {
 


### PR DESCRIPTION
Optimize REDUCE3_INT cuda and hip variants so they only use a single buffer. This reduces the number of copies improving performance.