### PR TITLE
Cast variant id to void to prevent compiler warnings when openmp is disabled

### DIFF
--- a/src/algorithm/SORT-OMP.cpp
+++ b/src/algorithm/SORT-OMP.cpp
@@ -49,6 +49,8 @@ void SORT::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/algorithm/SORTPAIRS-OMP.cpp
+++ b/src/algorithm/SORTPAIRS-OMP.cpp
@@ -49,6 +49,8 @@ void SORTPAIRS::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/apps/DEL_DOT_VEC_2D-OMP.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-OMP.cpp
@@ -105,6 +105,8 @@ void DEL_DOT_VEC_2D::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/apps/ENERGY-OMP.cpp
+++ b/src/apps/ENERGY-OMP.cpp
@@ -177,6 +177,8 @@ void ENERGY::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/apps/FIR-OMP.cpp
+++ b/src/apps/FIR-OMP.cpp
@@ -92,6 +92,8 @@ void FIR::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/apps/HALOEXCHANGE-OMP.cpp
+++ b/src/apps/HALOEXCHANGE-OMP.cpp
@@ -163,6 +163,8 @@ void HALOEXCHANGE::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/apps/HALOEXCHANGE_FUSED-OMP.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED-OMP.cpp
@@ -300,6 +300,8 @@ void HALOEXCHANGE_FUSED::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/apps/LTIMES-OMP.cpp
+++ b/src/apps/LTIMES-OMP.cpp
@@ -120,6 +120,8 @@ void LTIMES::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/apps/LTIMES_NOVIEW-OMP.cpp
+++ b/src/apps/LTIMES_NOVIEW-OMP.cpp
@@ -114,6 +114,8 @@ void LTIMES_NOVIEW::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/apps/MASS3DPA-OMP.cpp
+++ b/src/apps/MASS3DPA-OMP.cpp
@@ -216,6 +216,9 @@ void MASS3DPA::runOpenMPVariant(VariantID vid) {
     std::cout << "\n MASS3DPA : Unknown OpenMP variant id = " << vid
               << std::endl;
   }
+
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/apps/PRESSURE-OMP.cpp
+++ b/src/apps/PRESSURE-OMP.cpp
@@ -116,6 +116,8 @@ void PRESSURE::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/apps/VOL3D-OMP.cpp
+++ b/src/apps/VOL3D-OMP.cpp
@@ -92,6 +92,8 @@ void VOL3D::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/DAXPY-OMP.cpp
+++ b/src/basic/DAXPY-OMP.cpp
@@ -86,6 +86,8 @@ void DAXPY::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/IF_QUAD-OMP.cpp
+++ b/src/basic/IF_QUAD-OMP.cpp
@@ -86,6 +86,8 @@ void IF_QUAD::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/INIT3-OMP.cpp
+++ b/src/basic/INIT3-OMP.cpp
@@ -86,6 +86,8 @@ void INIT3::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/INIT_VIEW1D-OMP.cpp
+++ b/src/basic/INIT_VIEW1D-OMP.cpp
@@ -92,6 +92,8 @@ void INIT_VIEW1D::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/INIT_VIEW1D_OFFSET-OMP.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-OMP.cpp
@@ -92,6 +92,8 @@ void INIT_VIEW1D_OFFSET::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/MAT_MAT_SHARED-OMP.cpp
+++ b/src/basic/MAT_MAT_SHARED-OMP.cpp
@@ -246,6 +246,8 @@ void MAT_MAT_SHARED::runOpenMPVariant(VariantID vid) {
   }
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/MULADDSUB-OMP.cpp
+++ b/src/basic/MULADDSUB-OMP.cpp
@@ -86,6 +86,8 @@ void MULADDSUB::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/NESTED_INIT-OMP.cpp
+++ b/src/basic/NESTED_INIT-OMP.cpp
@@ -127,6 +127,8 @@ void NESTED_INIT::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/PI_ATOMIC-OMP.cpp
+++ b/src/basic/PI_ATOMIC-OMP.cpp
@@ -99,6 +99,8 @@ void PI_ATOMIC::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/PI_REDUCE-OMP.cpp
+++ b/src/basic/PI_REDUCE-OMP.cpp
@@ -102,6 +102,8 @@ void PI_REDUCE::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/REDUCE3_INT-OMP.cpp
+++ b/src/basic/REDUCE3_INT-OMP.cpp
@@ -119,6 +119,8 @@ void REDUCE3_INT::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/basic/TRAP_INT-OMP.cpp
+++ b/src/basic/TRAP_INT-OMP.cpp
@@ -115,6 +115,8 @@ void TRAP_INT::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/lcals/DIFF_PREDICT-OMP.cpp
+++ b/src/lcals/DIFF_PREDICT-OMP.cpp
@@ -86,6 +86,8 @@ void DIFF_PREDICT::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/lcals/EOS-OMP.cpp
+++ b/src/lcals/EOS-OMP.cpp
@@ -86,6 +86,8 @@ void EOS::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/lcals/FIRST_DIFF-OMP.cpp
+++ b/src/lcals/FIRST_DIFF-OMP.cpp
@@ -86,6 +86,8 @@ void FIRST_DIFF::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/lcals/FIRST_MIN-OMP.cpp
+++ b/src/lcals/FIRST_MIN-OMP.cpp
@@ -111,6 +111,8 @@ void FIRST_MIN::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/lcals/FIRST_SUM-OMP.cpp
+++ b/src/lcals/FIRST_SUM-OMP.cpp
@@ -86,6 +86,8 @@ void FIRST_SUM::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/lcals/GEN_LIN_RECUR-OMP.cpp
+++ b/src/lcals/GEN_LIN_RECUR-OMP.cpp
@@ -100,6 +100,8 @@ void GEN_LIN_RECUR::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/lcals/HYDRO_1D-OMP.cpp
+++ b/src/lcals/HYDRO_1D-OMP.cpp
@@ -87,6 +87,8 @@ void HYDRO_1D::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/lcals/HYDRO_2D-OMP.cpp
+++ b/src/lcals/HYDRO_2D-OMP.cpp
@@ -173,6 +173,8 @@ void HYDRO_2D::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/lcals/INT_PREDICT-OMP.cpp
+++ b/src/lcals/INT_PREDICT-OMP.cpp
@@ -86,6 +86,8 @@ void INT_PREDICT::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/lcals/PLANCKIAN-OMP.cpp
+++ b/src/lcals/PLANCKIAN-OMP.cpp
@@ -87,6 +87,8 @@ void PLANCKIAN::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/lcals/TRIDIAG_ELIM-OMP.cpp
+++ b/src/lcals/TRIDIAG_ELIM-OMP.cpp
@@ -86,6 +86,8 @@ void TRIDIAG_ELIM::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_2MM-OMP.cpp
+++ b/src/polybench/POLYBENCH_2MM-OMP.cpp
@@ -226,6 +226,8 @@ void POLYBENCH_2MM::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_3MM-OMP.cpp
+++ b/src/polybench/POLYBENCH_3MM-OMP.cpp
@@ -290,6 +290,8 @@ void POLYBENCH_3MM::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_ADI-OMP.cpp
+++ b/src/polybench/POLYBENCH_ADI-OMP.cpp
@@ -218,6 +218,8 @@ void POLYBENCH_ADI::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_ATAX-OMP.cpp
+++ b/src/polybench/POLYBENCH_ATAX-OMP.cpp
@@ -186,6 +186,8 @@ void POLYBENCH_ATAX::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_FDTD_2D-OMP.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-OMP.cpp
@@ -196,6 +196,8 @@ void POLYBENCH_FDTD_2D::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-OMP.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-OMP.cpp
@@ -140,6 +140,8 @@ void POLYBENCH_FLOYD_WARSHALL::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_GEMM-OMP.cpp
+++ b/src/polybench/POLYBENCH_GEMM-OMP.cpp
@@ -148,6 +148,8 @@ void POLYBENCH_GEMM::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_GEMVER-OMP.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-OMP.cpp
@@ -240,6 +240,8 @@ void POLYBENCH_GEMVER::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_GESUMMV-OMP.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-OMP.cpp
@@ -131,6 +131,8 @@ void POLYBENCH_GESUMMV::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_HEAT_3D-OMP.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-OMP.cpp
@@ -164,6 +164,8 @@ void POLYBENCH_HEAT_3D::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_JACOBI_1D-OMP.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-OMP.cpp
@@ -119,6 +119,8 @@ void POLYBENCH_JACOBI_1D::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_JACOBI_2D-OMP.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-OMP.cpp
@@ -151,6 +151,8 @@ void POLYBENCH_JACOBI_2D::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/polybench/POLYBENCH_MVT-OMP.cpp
+++ b/src/polybench/POLYBENCH_MVT-OMP.cpp
@@ -189,6 +189,8 @@ void POLYBENCH_MVT::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/stream/ADD-OMP.cpp
+++ b/src/stream/ADD-OMP.cpp
@@ -86,6 +86,8 @@ void ADD::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/stream/COPY-OMP.cpp
+++ b/src/stream/COPY-OMP.cpp
@@ -86,6 +86,8 @@ void COPY::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/stream/DOT-OMP.cpp
+++ b/src/stream/DOT-OMP.cpp
@@ -100,6 +100,8 @@ void DOT::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/stream/MUL-OMP.cpp
+++ b/src/stream/MUL-OMP.cpp
@@ -86,6 +86,8 @@ void MUL::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 

--- a/src/stream/TRIAD-OMP.cpp
+++ b/src/stream/TRIAD-OMP.cpp
@@ -86,6 +86,8 @@ void TRIAD::runOpenMPVariant(VariantID vid)
 
   }
 
+#else 
+  (void) vid;
 #endif
 }
 


### PR DESCRIPTION
This PR casts the variant id argument to void where necessary to prevent compiler warnings for unused variables when openmp is disabled. This addresses https://github.com/LLNL/RAJAPerf/issues/171