### PR TITLE
Change to a more robust way to quiet unused variable warnings when openmp is turned off

### DIFF
--- a/src/algorithm/SORT-OMP.cpp
+++ b/src/algorithm/SORT-OMP.cpp
@@ -50,7 +50,7 @@ void SORT::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/algorithm/SORTPAIRS-OMP.cpp
+++ b/src/algorithm/SORTPAIRS-OMP.cpp
@@ -50,7 +50,7 @@ void SORTPAIRS::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/apps/DEL_DOT_VEC_2D-OMP.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-OMP.cpp
@@ -106,7 +106,7 @@ void DEL_DOT_VEC_2D::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/apps/ENERGY-OMP.cpp
+++ b/src/apps/ENERGY-OMP.cpp
@@ -178,7 +178,7 @@ void ENERGY::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/apps/FIR-OMP.cpp
+++ b/src/apps/FIR-OMP.cpp
@@ -93,7 +93,7 @@ void FIR::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/apps/HALOEXCHANGE-OMP.cpp
+++ b/src/apps/HALOEXCHANGE-OMP.cpp
@@ -164,7 +164,7 @@ void HALOEXCHANGE::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/apps/HALOEXCHANGE_FUSED-OMP.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED-OMP.cpp
@@ -301,7 +301,7 @@ void HALOEXCHANGE_FUSED::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/apps/LTIMES-OMP.cpp
+++ b/src/apps/LTIMES-OMP.cpp
@@ -121,7 +121,7 @@ void LTIMES::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/apps/LTIMES_NOVIEW-OMP.cpp
+++ b/src/apps/LTIMES_NOVIEW-OMP.cpp
@@ -115,7 +115,7 @@ void LTIMES_NOVIEW::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/apps/MASS3DPA-OMP.cpp
+++ b/src/apps/MASS3DPA-OMP.cpp
@@ -218,7 +218,7 @@ void MASS3DPA::runOpenMPVariant(VariantID vid) {
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/apps/PRESSURE-OMP.cpp
+++ b/src/apps/PRESSURE-OMP.cpp
@@ -117,7 +117,7 @@ void PRESSURE::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/apps/VOL3D-OMP.cpp
+++ b/src/apps/VOL3D-OMP.cpp
@@ -93,7 +93,7 @@ void VOL3D::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/DAXPY-OMP.cpp
+++ b/src/basic/DAXPY-OMP.cpp
@@ -87,7 +87,7 @@ void DAXPY::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/IF_QUAD-OMP.cpp
+++ b/src/basic/IF_QUAD-OMP.cpp
@@ -87,7 +87,7 @@ void IF_QUAD::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/INIT3-OMP.cpp
+++ b/src/basic/INIT3-OMP.cpp
@@ -87,7 +87,7 @@ void INIT3::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/INIT_VIEW1D-OMP.cpp
+++ b/src/basic/INIT_VIEW1D-OMP.cpp
@@ -93,7 +93,7 @@ void INIT_VIEW1D::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/INIT_VIEW1D_OFFSET-OMP.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-OMP.cpp
@@ -93,7 +93,7 @@ void INIT_VIEW1D_OFFSET::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/MAT_MAT_SHARED-OMP.cpp
+++ b/src/basic/MAT_MAT_SHARED-OMP.cpp
@@ -247,7 +247,7 @@ void MAT_MAT_SHARED::runOpenMPVariant(VariantID vid) {
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/MULADDSUB-OMP.cpp
+++ b/src/basic/MULADDSUB-OMP.cpp
@@ -87,7 +87,7 @@ void MULADDSUB::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/NESTED_INIT-OMP.cpp
+++ b/src/basic/NESTED_INIT-OMP.cpp
@@ -128,7 +128,7 @@ void NESTED_INIT::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/PI_ATOMIC-OMP.cpp
+++ b/src/basic/PI_ATOMIC-OMP.cpp
@@ -100,7 +100,7 @@ void PI_ATOMIC::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/PI_REDUCE-OMP.cpp
+++ b/src/basic/PI_REDUCE-OMP.cpp
@@ -103,7 +103,7 @@ void PI_REDUCE::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/REDUCE3_INT-OMP.cpp
+++ b/src/basic/REDUCE3_INT-OMP.cpp
@@ -120,7 +120,7 @@ void REDUCE3_INT::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/basic/TRAP_INT-OMP.cpp
+++ b/src/basic/TRAP_INT-OMP.cpp
@@ -116,7 +116,7 @@ void TRAP_INT::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/lcals/DIFF_PREDICT-OMP.cpp
+++ b/src/lcals/DIFF_PREDICT-OMP.cpp
@@ -87,7 +87,7 @@ void DIFF_PREDICT::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/lcals/EOS-OMP.cpp
+++ b/src/lcals/EOS-OMP.cpp
@@ -87,7 +87,7 @@ void EOS::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/lcals/FIRST_DIFF-OMP.cpp
+++ b/src/lcals/FIRST_DIFF-OMP.cpp
@@ -87,7 +87,7 @@ void FIRST_DIFF::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/lcals/FIRST_MIN-OMP.cpp
+++ b/src/lcals/FIRST_MIN-OMP.cpp
@@ -112,7 +112,7 @@ void FIRST_MIN::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/lcals/FIRST_SUM-OMP.cpp
+++ b/src/lcals/FIRST_SUM-OMP.cpp
@@ -87,7 +87,7 @@ void FIRST_SUM::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/lcals/GEN_LIN_RECUR-OMP.cpp
+++ b/src/lcals/GEN_LIN_RECUR-OMP.cpp
@@ -101,7 +101,7 @@ void GEN_LIN_RECUR::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/lcals/HYDRO_1D-OMP.cpp
+++ b/src/lcals/HYDRO_1D-OMP.cpp
@@ -88,7 +88,7 @@ void HYDRO_1D::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/lcals/HYDRO_2D-OMP.cpp
+++ b/src/lcals/HYDRO_2D-OMP.cpp
@@ -174,7 +174,7 @@ void HYDRO_2D::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/lcals/INT_PREDICT-OMP.cpp
+++ b/src/lcals/INT_PREDICT-OMP.cpp
@@ -87,7 +87,7 @@ void INT_PREDICT::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/lcals/PLANCKIAN-OMP.cpp
+++ b/src/lcals/PLANCKIAN-OMP.cpp
@@ -88,7 +88,7 @@ void PLANCKIAN::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/lcals/TRIDIAG_ELIM-OMP.cpp
+++ b/src/lcals/TRIDIAG_ELIM-OMP.cpp
@@ -87,7 +87,7 @@ void TRIDIAG_ELIM::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_2MM-OMP.cpp
+++ b/src/polybench/POLYBENCH_2MM-OMP.cpp
@@ -227,7 +227,7 @@ void POLYBENCH_2MM::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_3MM-OMP.cpp
+++ b/src/polybench/POLYBENCH_3MM-OMP.cpp
@@ -291,7 +291,7 @@ void POLYBENCH_3MM::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_ADI-OMP.cpp
+++ b/src/polybench/POLYBENCH_ADI-OMP.cpp
@@ -219,7 +219,7 @@ void POLYBENCH_ADI::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_ATAX-OMP.cpp
+++ b/src/polybench/POLYBENCH_ATAX-OMP.cpp
@@ -187,7 +187,7 @@ void POLYBENCH_ATAX::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_FDTD_2D-OMP.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-OMP.cpp
@@ -197,7 +197,7 @@ void POLYBENCH_FDTD_2D::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-OMP.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-OMP.cpp
@@ -141,7 +141,7 @@ void POLYBENCH_FLOYD_WARSHALL::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_GEMM-OMP.cpp
+++ b/src/polybench/POLYBENCH_GEMM-OMP.cpp
@@ -149,7 +149,7 @@ void POLYBENCH_GEMM::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_GEMVER-OMP.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-OMP.cpp
@@ -230,7 +230,7 @@ void POLYBENCH_GEMVER::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_GESUMMV-OMP.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-OMP.cpp
@@ -132,7 +132,7 @@ void POLYBENCH_GESUMMV::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_HEAT_3D-OMP.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-OMP.cpp
@@ -160,7 +160,7 @@ void POLYBENCH_HEAT_3D::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_JACOBI_1D-OMP.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-OMP.cpp
@@ -120,7 +120,7 @@ void POLYBENCH_JACOBI_1D::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_JACOBI_2D-OMP.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-OMP.cpp
@@ -152,7 +152,7 @@ void POLYBENCH_JACOBI_2D::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/polybench/POLYBENCH_MVT-OMP.cpp
+++ b/src/polybench/POLYBENCH_MVT-OMP.cpp
@@ -190,7 +190,7 @@ void POLYBENCH_MVT::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/stream/ADD-OMP.cpp
+++ b/src/stream/ADD-OMP.cpp
@@ -87,7 +87,7 @@ void ADD::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/stream/COPY-OMP.cpp
+++ b/src/stream/COPY-OMP.cpp
@@ -87,7 +87,7 @@ void COPY::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/stream/DOT-OMP.cpp
+++ b/src/stream/DOT-OMP.cpp
@@ -101,7 +101,7 @@ void DOT::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/stream/MUL-OMP.cpp
+++ b/src/stream/MUL-OMP.cpp
@@ -87,7 +87,7 @@ void MUL::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/stream/TRIAD-OMP.cpp
+++ b/src/stream/TRIAD-OMP.cpp
@@ -87,7 +87,7 @@ void TRIAD::runOpenMPVariant(VariantID vid)
   }
 
 #else 
-  (void) vid;
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 


### PR DESCRIPTION
This PR replaces casting variant id to void to using the more robust RAJA method.