### PR TITLE
Adding reduction and sort kernels to warmup set.

### DIFF
--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -12,8 +12,10 @@
 #include "common/KernelBase.hpp"
 #include "common/OutputUtils.hpp"
 
-// Warmup kernel to run first to remove startup overheads in timings
+// Warmup kernels to run first to help reduce startup overheads in timings
 #include "basic/DAXPY.hpp"
+#include "basic/REDUCE3_INT.hpp"
+#include "algorithm/SORT.hpp"
 
 #include <list>
 #include <vector>
@@ -523,26 +525,33 @@ void Executor::runSuite()
     return;
   }
 
-  cout << "\n\nRun warmup kernel...\n";
+  cout << "\n\nRun warmup kernels...\n";
 
-  KernelBase* warmup_kernel = new basic::DAXPY(run_params);
+  vector<KernelBase*> warmup_kernels;
 
-  for (size_t iv = 0; iv < variant_ids.size(); ++iv) {
-    VariantID vid = variant_ids[iv];
-    if ( run_params.showProgress() ) {
-      if ( warmup_kernel->hasVariantDefined(vid) ) {
-        cout << "   Running ";
-      } else {
-        cout << "   No ";
+  warmup_kernels.push_back(new basic::DAXPY(run_params)); 
+  warmup_kernels.push_back(new basic::REDUCE3_INT(run_params)); 
+  warmup_kernels.push_back(new algorithm::SORT(run_params)); 
+
+  for (size_t ik = 0; ik < warmup_kernels.size(); ++ik) {
+    KernelBase* warmup_kernel = warmup_kernels[ik];
+    cout << "Kernel : " << warmup_kernel->getName() << endl;
+    for (size_t iv = 0; iv < variant_ids.size(); ++iv) {
+      VariantID vid = variant_ids[iv];
+      if ( run_params.showProgress() ) {
+        if ( warmup_kernel->hasVariantDefined(vid) ) {
+          cout << "   Running ";
+        } else {
+          cout << "   No ";
+        }
+        cout << getVariantName(vid) << " variant" << endl;
       }
-      cout << getVariantName(vid) << " variant" << endl;
+      if ( warmup_kernel->hasVariantDefined(vid) ) {
+        warmup_kernel->execute(vid);
+      }
     }
-    if ( warmup_kernel->hasVariantDefined(vid) ) {
-      warmup_kernel->execute(vid);
-    }
+    delete warmup_kernels[ik];
   }
-
-  delete warmup_kernel;
 
 
   cout << "\n\nRunning specified kernels and variants...\n";


### PR DESCRIPTION
This PR adds two kernels to the set of warmuo kernels run to help reduce startup overhead when running timing experiments.

These two kernels were added since they use RAJA internally-acllocated memory.

This addresses: https://github.com/LLNL/RAJAPerf/issues/173