### PR TITLE
Fix leak in HALOEXCHANGE_FUSED

### DIFF
--- a/src/apps/HALOEXCHANGE_FUSED-OMP.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED-OMP.cpp
@@ -213,6 +213,8 @@ void HALOEXCHANGE_FUSED::runOpenMPVariant(VariantID vid)
       }
       stopTimer();
 
+      HALOEXCHANGE_FUSED_MANUAL_LAMBDA_FUSER_TEARDOWN;
+
       break;
     }
 
@@ -300,7 +302,7 @@ void HALOEXCHANGE_FUSED::runOpenMPVariant(VariantID vid)
 
   }
 
-#else 
+#else
   RAJA_UNUSED_VAR(vid);
 #endif
 }


### PR DESCRIPTION
Tear down manual lambda fuser in OMP variant.
Thanks @kab163 for finding this via gitlab CI.