### PR TITLE
Add the ability to exclude kernels

### DIFF
--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -38,10 +38,16 @@ RunParams::RunParams(int argc, char** argv)
    reference_variant(),
    kernel_input(),
    invalid_kernel_input(),
+   exclude_kernel_input(),
+   invalid_exclude_kernel_input(),
    variant_input(),
    invalid_variant_input(),
+   exclude_variant_input(),
+   invalid_exclude_variant_input(),
    feature_input(),
    invalid_feature_input(),
+   exclude_feature_input(),
+   invalid_exclude_feature_input(),
    outdir(),
    outfile_prefix("RAJAPerf")
 {
@@ -70,19 +76,19 @@ RunParams::~RunParams()
  */
 void RunParams::print(std::ostream& str) const
 {
-  str << "\n show_progress = " << show_progress; 
-  str << "\n npasses = " << npasses; 
+  str << "\n show_progress = " << show_progress;
+  str << "\n npasses = " << npasses;
   str << "\n rep_fact = " << rep_fact;
   str << "\n size_meaning = " << SizeMeaningToStr(getSizeMeaning());
   str << "\n size = " << size;
   str << "\n size_factor = " << size_factor;
-  str << "\n pf_tol = " << pf_tol; 
-  str << "\n checkrun_reps = " << checkrun_reps; 
-  str << "\n reference_variant = " << reference_variant; 
-  str << "\n outdir = " << outdir; 
-  str << "\n outfile_prefix = " << outfile_prefix; 
+  str << "\n pf_tol = " << pf_tol;
+  str << "\n checkrun_reps = " << checkrun_reps;
+  str << "\n reference_variant = " << reference_variant;
+  str << "\n outdir = " << outdir;
+  str << "\n outfile_prefix = " << outfile_prefix;
 
-  str << "\n kernel_input = "; 
+  str << "\n kernel_input = ";
   for (size_t j = 0; j < kernel_input.size(); ++j) {
     str << "\n\t" << kernel_input[j];
   }
@@ -91,13 +97,31 @@ void RunParams::print(std::ostream& str) const
     str << "\n\t" << invalid_kernel_input[j];
   }
 
-  str << "\n variant_input = "; 
+  str << "\n exclude_kernel_input = ";
+  for (size_t j = 0; j < exclude_kernel_input.size(); ++j) {
+    str << "\n\t" << exclude_kernel_input[j];
+  }
+  str << "\n invalid_exclude_kernel_input = ";
+  for (size_t j = 0; j < invalid_exclude_kernel_input.size(); ++j) {
+    str << "\n\t" << invalid_exclude_kernel_input[j];
+  }
+
+  str << "\n variant_input = ";
   for (size_t j = 0; j < variant_input.size(); ++j) {
     str << "\n\t" << variant_input[j];
   }
-  str << "\n invalid_variant_input = "; 
+  str << "\n invalid_variant_input = ";
   for (size_t j = 0; j < invalid_variant_input.size(); ++j) {
     str << "\n\t" << invalid_variant_input[j];
+  }
+
+  str << "\n exclude_variant_input = ";
+  for (size_t j = 0; j < exclude_variant_input.size(); ++j) {
+    str << "\n\t" << exclude_variant_input[j];
+  }
+  str << "\n invalid_exclude_variant_input = ";
+  for (size_t j = 0; j < invalid_exclude_variant_input.size(); ++j) {
+    str << "\n\t" << invalid_exclude_variant_input[j];
   }
 
   str << "\n feature_input = ";
@@ -107,6 +131,15 @@ void RunParams::print(std::ostream& str) const
   str << "\n invalid_feature_input = ";
   for (size_t j = 0; j < invalid_feature_input.size(); ++j) {
     str << "\n\t" << invalid_feature_input[j];
+  }
+
+  str << "\n exclude_feature_input = ";
+  for (size_t j = 0; j < exclude_feature_input.size(); ++j) {
+    str << "\n\t" << exclude_feature_input[j];
+  }
+  str << "\n invalid_exclude_feature_input = ";
+  for (size_t j = 0; j < invalid_exclude_feature_input.size(); ++j) {
+    str << "\n\t" << invalid_exclude_feature_input[j];
   }
 
   str << std::endl;
@@ -142,14 +175,14 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
 
     } else if ( opt == std::string("--print-kernels") ||
                 opt == std::string("-pk") ) {
-     
-      printFullKernelNames(std::cout);     
+
+      printFullKernelNames(std::cout);
       input_state = InfoRequest;
- 
+
     } else if ( opt == std::string("--print-variants") ||
                 opt == std::string("-pv") ) {
 
-      printVariantNames(std::cout);     
+      printVariantNames(std::cout);
       input_state = InfoRequest;
 
     } else if ( opt == std::string("--print-features") ||
@@ -169,28 +202,28 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
 
       printKernelFeatures(std::cout);
       input_state = InfoRequest;
- 
+
     } else if ( opt == std::string("--npasses") ) {
 
       i++;
-      if ( i < argc ) { 
+      if ( i < argc ) {
         npasses = ::atoi( argv[i] );
       } else {
         std::cout << "\nBad input:"
-                  << " must give --npasses a value for number of passes (int)" 
-                  << std::endl; 
+                  << " must give --npasses a value for number of passes (int)"
+                  << std::endl;
         input_state = BadInput;
       }
 
     } else if ( opt == std::string("--repfact") ) {
 
       i++;
-      if ( i < argc ) { 
+      if ( i < argc ) {
         rep_fact = ::atof( argv[i] );
       } else {
         std::cout << "\nBad input:"
-                  << " must give --rep_fact a value (double)" 
-                  << std::endl;       
+                  << " must give --rep_fact a value (double)"
+                  << std::endl;
         input_state = BadInput;
       }
 
@@ -277,6 +310,22 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
         }
       }
 
+    } else if ( opt == std::string("--exclude-kernels") ||
+                opt == std::string("-ek") ) {
+
+      bool done = false;
+      i++;
+      while ( i < argc && !done ) {
+        opt = std::string(argv[i]);
+        if ( opt.at(0) == '-' ) {
+          i--;
+          done = true;
+        } else {
+          exclude_kernel_input.push_back(opt);
+          ++i;
+        }
+      }
+
     } else if ( std::string(argv[i]) == std::string("--variants") ||
                 std::string(argv[i]) == std::string("-v") ) {
 
@@ -293,6 +342,22 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
         }
       }
 
+    } else if ( std::string(argv[i]) == std::string("--exclude-variants") ||
+                std::string(argv[i]) == std::string("-ev") ) {
+
+      bool done = false;
+      i++;
+      while ( i < argc && !done ) {
+        opt = std::string(argv[i]);
+        if ( opt.at(0) == '-' ) {
+          i--;
+          done = true;
+        } else {
+          exclude_variant_input.push_back(opt);
+          ++i;
+        }
+      }
+
     } else if ( std::string(argv[i]) == std::string("--features") ||
                 std::string(argv[i]) == std::string("-f") ) {
 
@@ -305,6 +370,22 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
           done = true;
         } else {
           feature_input.push_back(opt);
+          ++i;
+        }
+      }
+
+    } else if ( std::string(argv[i]) == std::string("--exclude-features") ||
+                std::string(argv[i]) == std::string("-ef") ) {
+
+      bool done = false;
+      i++;
+      while ( i < argc && !done ) {
+        opt = std::string(argv[i]);
+        if ( opt.at(0) == '-' ) {
+          i--;
+          done = true;
+        } else {
+          exclude_feature_input.push_back(opt);
           ++i;
         }
       }
@@ -353,10 +434,10 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
        if (input_state != BadInput) {
          input_state = DryRun;
        }
-   
+
     } else if ( std::string(argv[i]) == std::string("--checkrun") ) {
 
-      input_state = CheckRun; 
+      input_state = CheckRun;
 
       i++;
       if ( i < argc ) {
@@ -370,10 +451,10 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
       }
 
     } else {
-     
+
       input_state = BadInput;
 
-      std::string huh(argv[i]);   
+      std::string huh(argv[i]);
       std::cout << "\nUnknown option: " << huh << std::endl;
       std::cout.flush();
 
@@ -392,7 +473,7 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
 void RunParams::printHelpMessage(std::ostream& str) const
 {
   str << "\nUsage: ./raja-perf.exe [options]\n";
-  str << "Valid options are:\n"; 
+  str << "Valid options are:\n";
 
   str << "\t --help, -h (print options with descriptions)\n\n";
 
@@ -411,7 +492,7 @@ void RunParams::printHelpMessage(std::ostream& str) const
       << "\t      (print names of features used by each kernel)\n\n";
 
   str << "\t --npasses <int> [default is 1]\n"
-      << "\t      (num passes through Suite)\n"; 
+      << "\t      (num passes through Suite)\n";
   str << "\t\t Example...\n"
       << "\t\t --npasses 2 (runs complete Suite twice\n\n";
 
@@ -438,23 +519,42 @@ void RunParams::printHelpMessage(std::ostream& str) const
       << "\t\t -pftol 0.2 (RAJA kernel variants that run 20% or more slower than Base variants will be reported as OVER_TOL in FOM report)\n\n";
 
   str << "\t --kernels, -k <space-separated strings> [Default is run all]\n"
-      << "\t      (names of individual kernels and/or groups of kernels to run)\n"; 
+      << "\t      (names of individual kernels and/or groups of kernels to run)\n";
   str << "\t\t Examples...\n"
       << "\t\t --kernels Polybench (run all kernels in Polybench group)\n"
       << "\t\t -k INIT3 MULADDSUB (run INIT3 and MULADDSUB kernels)\n"
-      << "\t\t -k INIT3 Apps (run INIT3 kernsl and all kernels in Apps group)\n\n";
+      << "\t\t -k INIT3 Apps (run INIT3 kernel and all kernels in Apps group)\n\n";
+
+  str << "\t --exclude-kernels, -ek <space-separated strings> [Default is exclude none]\n"
+      << "\t      (names of individual kernels and/or groups of kernels to exclude)\n";
+  str << "\t\t Examples...\n"
+      << "\t\t --exclude-kernels Polybench (exclude all kernels in Polybench group)\n"
+      << "\t\t -ek INIT3 MULADDSUB (exclude INIT3 and MULADDSUB kernels)\n"
+      << "\t\t -ek INIT3 Apps (exclude INIT3 kernel and all kernels in Apps group)\n\n";
 
   str << "\t --variants, -v <space-separated strings> [Default is run all]\n"
-      << "\t      (names of variants to run)\n"; 
+      << "\t      (names of variants to run)\n";
   str << "\t\t Examples...\n"
       << "\t\t --variants RAJA_CUDA (run all RAJA_CUDA kernel variants)\n"
       << "\t\t -v Base_Seq RAJA_CUDA (run Base_Seq and  RAJA_CUDA variants)\n\n";
+
+  str << "\t --exclude-variants, -ev <space-separated strings> [Default is exclude none]\n"
+      << "\t      (names of variants to exclude)\n";
+  str << "\t\t Examples...\n"
+      << "\t\t --exclude-variants RAJA_CUDA (exclude all RAJA_CUDA kernel variants)\n"
+      << "\t\t -ev Base_Seq RAJA_CUDA (exclude Base_Seq and  RAJA_CUDA variants)\n\n";
 
   str << "\t --features, -f <space-separated strings> [Default is run all]\n"
       << "\t      (names of features to run)\n";
   str << "\t\t Examples...\n"
       << "\t\t --features Forall (run all kernels that use RAJA forall)\n"
       << "\t\t -f Forall Reduction (run all kernels that use RAJA forall or RAJA reductions)\n\n";
+
+  str << "\t --exclude-features, -ef <space-separated strings> [Default is exclude none]\n"
+      << "\t      (names of features to exclude)\n";
+  str << "\t\t Examples...\n"
+      << "\t\t --exclude-features Forall (exclude all kernels that use RAJA forall)\n"
+      << "\t\t -ef Forall Reduction (exclude all kernels that use RAJA forall or RAJA reductions)\n\n";
 
   str << "\t --outdir, -od <string> [Default is current directory]\n"
       << "\t      (directory path for output data files)\n";
@@ -476,7 +576,7 @@ void RunParams::printHelpMessage(std::ostream& str) const
   str << "\t --dryrun (print summary of how Suite will run without running it)\n\n";
 
   str << "\t --checkrun <int> [default is 1]\n"
-<< "\t      (run each kernel a given number of times; usually to check things are working properly or to reduce aggregate execution time)\n"; 
+<< "\t      (run each kernel a given number of times; usually to check things are working properly or to reduce aggregate execution time)\n";
   str << "\t\t Example...\n"
       << "\t\t --checkrun 2 (run each kernel twice)\n\n";
 
@@ -572,7 +672,7 @@ void RunParams::printKernelFeatures(std::ostream& str) const
   str << "\nAvailable kernels and features each uses:";
   str << "\n-----------------------------------------\n";
   for (int kid = 0; kid < NumKernels; ++kid) {
-    KernelID tkid = static_cast<KernelID>(kid); 
+    KernelID tkid = static_cast<KernelID>(kid);
 /// RDH DISABLE COUPLE KERNEL
     if (tkid != Apps_COUPLE) {
       str << getFullKernelName(tkid) << std::endl;
@@ -584,7 +684,7 @@ void RunParams::printKernelFeatures(std::ostream& str) const
         }
       }  // loop over features
       delete kern;
-    }  
+    }
   }  // loop over kernels
   str.flush();
 }

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -37,11 +37,11 @@ public:
   enum InputOpt {
     InfoRequest,  /*!< option requesting information */
     DryRun,       /*!< report summary of how suite will run w/o running */
-    CheckRun,     /*!< run suite with small rep count to make sure 
+    CheckRun,     /*!< run suite with small rep count to make sure
                        everything works properly */
-    PerfRun,      /*!< input defines a valid performance run, 
+    PerfRun,      /*!< input defines a valid performance run,
                        suite will run as specified */
-    BadInput,     /*!< erroneous input given */ 
+    BadInput,     /*!< erroneous input given */
     Undefined     /*!< input not defined (yet) */
   };
 
@@ -71,7 +71,7 @@ public:
 //@{
 //! @name Methods to get/set input state
 
-  InputOpt getInputState() const { return input_state; } 
+  InputOpt getInputState() const { return input_state; }
 
   /*!
    * \brief Set whether run parameters (from input) are valid.
@@ -103,19 +103,33 @@ public:
 
   const std::string& getReferenceVariant() const { return reference_variant; }
 
-  const std::vector<std::string>& getKernelInput() const 
+  const std::vector<std::string>& getKernelInput() const
                                   { return kernel_input; }
   void setInvalidKernelInput( std::vector<std::string>& svec )
                               { invalid_kernel_input = svec; }
   const std::vector<std::string>& getInvalidKernelInput() const
                                   { return invalid_kernel_input; }
 
-  const std::vector<std::string>& getVariantInput() const 
+  const std::vector<std::string>& getExcludeKernelInput() const
+                                  { return exclude_kernel_input; }
+  void setInvalidExcludeKernelInput( std::vector<std::string>& svec )
+                              { invalid_exclude_kernel_input = svec; }
+  const std::vector<std::string>& getInvalidExcludeKernelInput() const
+                                  { return invalid_exclude_kernel_input; }
+
+  const std::vector<std::string>& getVariantInput() const
                                   { return variant_input; }
   void setInvalidVariantInput( std::vector<std::string>& svec )
                                { invalid_variant_input = svec; }
   const std::vector<std::string>& getInvalidVariantInput() const
                                   { return invalid_variant_input; }
+
+  const std::vector<std::string>& getExcludeVariantInput() const
+                                  { return exclude_variant_input; }
+  void setInvalidExcludeVariantInput( std::vector<std::string>& svec )
+                               { invalid_exclude_variant_input = svec; }
+  const std::vector<std::string>& getInvalidExcludeVariantInput() const
+                                  { return invalid_exclude_variant_input; }
 
   const std::vector<std::string>& getFeatureInput() const
                                   { return feature_input; }
@@ -123,6 +137,13 @@ public:
                                { invalid_feature_input = svec; }
   const std::vector<std::string>& getInvalidFeatureInput() const
                                   { return invalid_feature_input; }
+
+  const std::vector<std::string>& getExcludeFeatureInput() const
+                                  { return exclude_feature_input; }
+  void setInvalidExcludeFeatureInput( std::vector<std::string>& svec )
+                               { invalid_exclude_feature_input = svec; }
+  const std::vector<std::string>& getInvalidExcludeFeatureInput() const
+                                  { return invalid_exclude_feature_input; }
 
   const std::string& getOutputDirName() const { return outdir; }
   const std::string& getOutputFilePrefix() const { return outfile_prefix; }
@@ -169,18 +190,24 @@ private:
   int checkrun_reps;     /*!< Num reps each kernel is run in check run */
 
   std::string reference_variant;   /*!< Name of reference variant for speedup
-                                        calculations */ 
+                                        calculations */
 
   //
-  // Arrays to hold input strings for valid/invalid input. Helpful for  
+  // Arrays to hold input strings for valid/invalid input. Helpful for
   // debugging command line args.
   //
   std::vector<std::string> kernel_input;
   std::vector<std::string> invalid_kernel_input;
+  std::vector<std::string> exclude_kernel_input;
+  std::vector<std::string> invalid_exclude_kernel_input;
   std::vector<std::string> variant_input;
   std::vector<std::string> invalid_variant_input;
+  std::vector<std::string> exclude_variant_input;
+  std::vector<std::string> invalid_exclude_variant_input;
   std::vector<std::string> feature_input;
   std::vector<std::string> invalid_feature_input;
+  std::vector<std::string> exclude_feature_input;
+  std::vector<std::string> invalid_exclude_feature_input;
 
   std::string outdir;          /*!< Output directory name. */
   std::string outfile_prefix;  /*!< Prefix for output data file names. */


### PR DESCRIPTION
Add command line options to exclude kernels, features, and variants.
This is done by removing the excluded kernels or variants from the list of kernels and variants to run.

- This PR is a feature
- It does the following (modify list as needed):
  - Modifies RunParams to include exclude versions of args and Executor to remove the excluded from the list of what is run
  - Fixes #189 
  - Adds exclusion at the request of people trying to avoid running very slow kernels
