### PR TITLE
Task/kab163/setup multiproject ci

### DIFF
--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -12,7 +12,6 @@
 clang_11_0_0:
   variables:
     SPEC: "%clang@11.0.0"
-    MULTI_PROJECT: "On"
   extends: .build_and_test_on_lassen
 
 clang_11_gcc_8:

--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -12,6 +12,7 @@
 clang_11_0_0:
   variables:
     SPEC: "%clang@11.0.0"
+    MULTI_PROJECT: "On"
   extends: .build_and_test_on_lassen
 
 clang_11_gcc_8:

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -117,8 +117,6 @@ then
     then
       cd tpl/RAJA  
       git pull origin develop
-      git checkout "task/kab163/set-up-multi-project-ci"
-      git pull
       cd -
     fi
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -116,6 +116,7 @@ then
     if [[ -n ${raja_version} ]]
     then
       cd tpl/RAJA  
+      git pull origin develop
       git checkout "task/kab163/set-up-multi-project-ci"
       git pull
       cd -

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -56,11 +56,6 @@ then
         prefix_opt="--prefix=${prefix}"
     fi
 
-    if [[ -n ${raja_version} ]]
-    then
-      spec="${spec} ^raja@${raja_version}"
-    fi
-
     python scripts/uberenv/uberenv.py --spec="${spec}" ${prefix_opt}
 
 fi
@@ -117,15 +112,21 @@ then
     # Map CPU core allocations
     declare -A core_counts=(["lassen"]=40 ["ruby"]=28 ["corona"]=32)
 
+    # If using Multi-project, set up the submodule
+    if [[ -n ${raja_version} ]]
+    then
+      cd tpl/RAJA  
+      git checkout "task/kab163/set-up-multi-project-ci"
+      git pull
+      cd -
+    fi
+
     # If building, then delete everything first
     # NOTE: 'cmake --build . -j core_counts' attempts to reduce individual build resources.
     #       If core_counts does not contain hostname, then will default to '-j ', which should
     #       use max cores.
     rm -rf ${build_dir} 2>/dev/null
     mkdir -p ${build_dir} && cd ${build_dir}
-
-    #git checkout "task/kab163/set-up-multi-project-ci"
-    #git pull
 
     date
     cmake \

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -19,6 +19,7 @@ build_root=${BUILD_ROOT:-""}
 hostconfig=${HOST_CONFIG:-""}
 spec=${SPEC:-""}
 job_unique_id=${CI_JOB_ID:-""}
+raja_version=${UPDATE_RAJA:-""}
 
 sys_type=${SYS_TYPE:-""}
 py_env_path=${PYTHON_ENVIRONMENT_PATH:-""}
@@ -53,6 +54,11 @@ then
         prefix="${prefix}/${job_unique_id}"
         mkdir -p ${prefix}
         prefix_opt="--prefix=${prefix}"
+    fi
+
+    if [[ -n ${raja_version} ]]
+    then
+      spec="${spec} ^raja@${raja_version}"
     fi
 
     python scripts/uberenv/uberenv.py --spec="${spec}" ${prefix_opt}
@@ -117,6 +123,9 @@ then
     #       use max cores.
     rm -rf ${build_dir} 2>/dev/null
     mkdir -p ${build_dir} && cd ${build_dir}
+
+    #git checkout "task/kab163/set-up-multi-project-ci"
+    #git pull
 
     date
     cmake \


### PR DESCRIPTION
Establishing a multi-project gitlab CI pipeline with RAJA

- This PR is a new Gitlab CI feature
- It adds a multi-project pipeline to the RAJAPerf Gitlab CI so that when a new update is pushed to the RAJA submodule, it will trigger a RAJAPerf pipeline in the CI
