### PR TITLE
Fix HEAT_3D index mapping

### DIFF
--- a/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
@@ -159,11 +159,11 @@ void POLYBENCH_HEAT_3D::runCudaVariant(VariantID vid)
         RAJA::statement::CudaKernelFixedAsync<j_block_sz * k_block_sz,
           RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
                                    RAJA::cuda_block_y_direct,
-            RAJA::statement::Tile<0, RAJA::tile_fixed<k_block_sz>,
+            RAJA::statement::Tile<2, RAJA::tile_fixed<k_block_sz>,
                                      RAJA::cuda_block_x_direct,
-              RAJA::statement::For<2, RAJA::cuda_block_z_direct,      // i
+              RAJA::statement::For<0, RAJA::cuda_block_z_direct,      // i
                 RAJA::statement::For<1, RAJA::cuda_thread_y_direct,   // j
-                  RAJA::statement::For<0, RAJA::cuda_thread_x_direct, // k
+                  RAJA::statement::For<2, RAJA::cuda_thread_x_direct, // k
                     RAJA::statement::Lambda<0>
                   >
                 >

--- a/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
@@ -168,11 +168,11 @@ void POLYBENCH_HEAT_3D::runHipVariant(VariantID vid)
         RAJA::statement::HipKernelFixedAsync<j_block_sz * k_block_sz,
           RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
                                    RAJA::hip_block_y_direct,
-            RAJA::statement::Tile<0, RAJA::tile_fixed<k_block_sz>,
+            RAJA::statement::Tile<2, RAJA::tile_fixed<k_block_sz>,
                                      RAJA::hip_block_x_direct,
-              RAJA::statement::For<2, RAJA::hip_block_z_direct,      // i
+              RAJA::statement::For<0, RAJA::hip_block_z_direct,      // i
                 RAJA::statement::For<1, RAJA::hip_thread_y_direct,   // j
-                  RAJA::statement::For<0, RAJA::hip_thread_x_direct, // k
+                  RAJA::statement::For<2, RAJA::hip_thread_x_direct, // k
                     RAJA::statement::Lambda<0>
                   >
                 >


### PR DESCRIPTION
# Fix HEAT_3D index mapping

Reorder the hip and cuda RAJA variant index ordering to
get coalesced loads and stores

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes HEAT_3D performance issue
