### PR TITLE
Updating one of the lassen clang jobs to use clang-ibm

### DIFF
--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -11,7 +11,7 @@
 
 clang_11_0_0:
   variables:
-    SPEC: "%clang@11.0.0"
+    SPEC: "%clang@11.0.0-ibm"
   extends: .build_and_test_on_lassen
 
 clang_11_gcc_8:
@@ -42,7 +42,7 @@ xl_16_1_1_7_gcc_8_3_1:
 
 clang_11_cuda:
   variables:
-    SPEC: "+cuda cuda_arch=70 %clang@11.0.0 ^cuda@10.1.168"
+    SPEC: "+cuda cuda_arch=70 %clang@11.0.0-ibm ^cuda@10.1.168"
   extends: .build_and_test_on_lassen
 
 clang_11_gcc_8_cuda:


### PR DESCRIPTION
# Summary 

Updating a Lassen CI job to use a clang-ibm version

- This PR is a bugfix
- It does adds back in one of our clang-ibm version CI jobs. Earlier, spack was getting confused with the naming convention of clang vs. clang-ibm. That has been fixed within the radiuss submodule, so we are now adding back in one of the clang-ibm jobs that was removed.
