### PR TITLE
Optionally output npasses min,max,ave timing

### DIFF
--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -883,8 +883,7 @@ void Executor::writeCSVReport(const string& filename, CSVRepMode mode,
     //
     // Print title line.
     //
-    file << getReportTitle(mode);
-    file << RunParams::CombinerOptToStr(combiner);
+    file << getReportTitle(mode, combiner);
 
     //
     // Wrtie CSV file contents for report.
@@ -1267,19 +1266,34 @@ void Executor::writeChecksumReport(const string& filename)
 }
 
 
-string Executor::getReportTitle(CSVRepMode mode)
+string Executor::getReportTitle(CSVRepMode mode, RunParams::CombinerOpt combiner)
 {
   string title;
+  switch ( combiner ) {
+    case RunParams::CombinerOpt::Average : {
+      title = string("Mean ");
+    }
+    break;
+    case RunParams::CombinerOpt::Minimum : {
+      title = string("Min ");
+    }
+    break;
+    case RunParams::CombinerOpt::Maximum : {
+      title = string("Max ");
+    }
+    break;
+    default : { cout << "\n Unknown CSV combiner mode = " << combiner << endl; }
+  }
   switch ( mode ) {
     case CSVRepMode::Timing : {
-      title = string("Mean Runtime Report (sec.) ");
+      title += string("Runtime Report (sec.) ");
       break;
     }
     case CSVRepMode::Speedup : {
       if ( haveReferenceVariant() ) {
-        title = string("Speedup Report (T_ref/T_var)") +
-                string(": ref var = ") + getVariantName(reference_vid) +
-                string(" ");
+        title += string("Speedup Report (T_ref/T_var)") +
+                 string(": ref var = ") + getVariantName(reference_vid) +
+                 string(" ");
       }
       break;
     }

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -60,8 +60,37 @@ void Executor::setupSuite()
 
   using Slist = list<string>;
   using Svector = vector<string>;
+  using COvector = vector<RunParams::CombinerOpt>;
   using KIDset = set<KernelID>;
   using VIDset = set<VariantID>;
+
+  //
+  // Determine which kernels to exclude from input.
+  // exclude_kern will be non-duplicated ordered set of IDs of kernel to exclude.
+  //
+  const Svector& npasses_combiner_input = run_params.getNpassesCombinerOptInput();
+  if ( !npasses_combiner_input.empty() ) {
+
+    COvector combiners;
+    Svector invalid;
+    for (const std::string& combiner_name : npasses_combiner_input) {
+
+      if (combiner_name == RunParams::CombinerOptToStr(RunParams::CombinerOpt::Average)) {
+        combiners.emplace_back(RunParams::CombinerOpt::Average);
+      } else if (combiner_name == RunParams::CombinerOptToStr(RunParams::CombinerOpt::Minimum)) {
+        combiners.emplace_back(RunParams::CombinerOpt::Minimum);
+      } else if (combiner_name == RunParams::CombinerOptToStr(RunParams::CombinerOpt::Maximum)) {
+        combiners.emplace_back(RunParams::CombinerOpt::Maximum);
+      } else {
+        invalid.emplace_back(combiner_name);
+      }
+
+    }
+
+    run_params.setNpassesCombinerOpts(combiners);
+    run_params.setInvalidNpassesCombinerOptInput(invalid);
+
+  }
 
   //
   // Determine which kernels to exclude from input.
@@ -476,8 +505,12 @@ void Executor::setupSuite()
   // A message will be emitted later so user can sort it out...
   //
 
-  if ( !(run_params.getInvalidKernelInput().empty()) ||
-       !(run_params.getInvalidExcludeKernelInput().empty()) ) {
+  if ( !(run_params.getInvalidNpassesCombinerOptInput().empty()) ) {
+
+    run_params.setInputState(RunParams::BadInput);
+
+  } else if ( !(run_params.getInvalidKernelInput().empty()) ||
+              !(run_params.getInvalidExcludeKernelInput().empty()) ) {
 
     run_params.setInputState(RunParams::BadInput);
 
@@ -789,12 +822,16 @@ void Executor::outputRunData()
   }
   out_fprefix = "./" + run_params.getOutputFilePrefix();
 
-  string filename = out_fprefix + "-timing.csv";
-  writeCSVReport(filename, CSVRepMode::Timing, 6 /* prec */);
+  string filename;
 
-  if ( haveReferenceVariant() ) {
-    filename = out_fprefix + "-speedup.csv";
-    writeCSVReport(filename, CSVRepMode::Speedup, 3 /* prec */);
+  for (RunParams::CombinerOpt combiner : run_params.getNpassesCombinerOpts()) {
+    filename = out_fprefix + "-timing-" + RunParams::CombinerOptToStr(combiner) + ".csv";
+    writeCSVReport(filename, CSVRepMode::Timing, combiner, 6 /* prec */);
+
+    if ( haveReferenceVariant() ) {
+      filename = out_fprefix + "-speedup-" + RunParams::CombinerOptToStr(combiner) + ".csv";
+      writeCSVReport(filename, CSVRepMode::Speedup, combiner, 3 /* prec */);
+    }
   }
 
   filename = out_fprefix + "-checksum.txt";
@@ -817,7 +854,7 @@ void Executor::outputRunData()
 
 
 void Executor::writeCSVReport(const string& filename, CSVRepMode mode,
-                              size_t prec)
+                              RunParams::CombinerOpt combiner, size_t prec)
 {
   ofstream file(filename.c_str(), ios::out | ios::trunc);
   if ( !file ) {
@@ -847,6 +884,7 @@ void Executor::writeCSVReport(const string& filename, CSVRepMode mode,
     // Print title line.
     //
     file << getReportTitle(mode);
+    file << RunParams::CombinerOptToStr(combiner);
 
     //
     // Wrtie CSV file contents for report.
@@ -885,7 +923,7 @@ void Executor::writeCSVReport(const string& filename, CSVRepMode mode,
           file << "Not run";
         } else {
           file << setprecision(prec) << std::fixed
-               << getReportDataEntry(mode, kern, vid);
+               << getReportDataEntry(mode, combiner, kern, vid);
         }
       }
       file << endl;
@@ -1251,20 +1289,49 @@ string Executor::getReportTitle(CSVRepMode mode)
 }
 
 long double Executor::getReportDataEntry(CSVRepMode mode,
+                                         RunParams::CombinerOpt combiner,
                                          KernelBase* kern,
                                          VariantID vid)
 {
   long double retval = 0.0;
   switch ( mode ) {
     case CSVRepMode::Timing : {
-      retval = kern->getTotTime(vid) / run_params.getNumPasses();
+      switch ( combiner ) {
+        case RunParams::CombinerOpt::Average : {
+          retval = kern->getTotTime(vid) / run_params.getNumPasses();
+        }
+        break;
+        case RunParams::CombinerOpt::Minimum : {
+          retval = kern->getMinTime(vid);
+        }
+        break;
+        case RunParams::CombinerOpt::Maximum : {
+          retval = kern->getMaxTime(vid);
+        }
+        break;
+        default : { cout << "\n Unknown CSV combiner mode = " << combiner << endl; }
+      }
       break;
     }
     case CSVRepMode::Speedup : {
       if ( haveReferenceVariant() ) {
         if ( kern->hasVariantDefined(reference_vid) &&
              kern->hasVariantDefined(vid) ) {
-          retval = kern->getTotTime(reference_vid) / kern->getTotTime(vid);
+          switch ( combiner ) {
+            case RunParams::CombinerOpt::Average : {
+              retval = kern->getTotTime(reference_vid) / kern->getTotTime(vid);
+            }
+            break;
+            case RunParams::CombinerOpt::Minimum : {
+              retval = kern->getMinTime(reference_vid) / kern->getMinTime(vid);
+            }
+            break;
+            case RunParams::CombinerOpt::Maximum : {
+              retval = kern->getMaxTime(reference_vid) / kern->getMaxTime(vid);
+            }
+            break;
+            default : { cout << "\n Unknown CSV combiner mode = " << combiner << endl; }
+          }
         } else {
           retval = 0.0;
         }

--- a/src/common/Executor.hpp
+++ b/src/common/Executor.hpp
@@ -63,9 +63,9 @@ private:
   void writeKernelInfoSummary(std::ostream& str, bool to_file) const;
 
   void writeCSVReport(const std::string& filename, CSVRepMode mode,
-                      size_t prec);
+                      RunParams::CombinerOpt combiner, size_t prec);
   std::string getReportTitle(CSVRepMode mode);
-  long double getReportDataEntry(CSVRepMode mode,
+  long double getReportDataEntry(CSVRepMode mode, RunParams::CombinerOpt combiner,
                                  KernelBase* kern, VariantID vid);
 
   void writeChecksumReport(const std::string& filename);

--- a/src/common/Executor.hpp
+++ b/src/common/Executor.hpp
@@ -64,7 +64,7 @@ private:
 
   void writeCSVReport(const std::string& filename, CSVRepMode mode,
                       RunParams::CombinerOpt combiner, size_t prec);
-  std::string getReportTitle(CSVRepMode mode);
+  std::string getReportTitle(CSVRepMode mode, RunParams::CombinerOpt combiner);
   long double getReportDataEntry(CSVRepMode mode, RunParams::CombinerOpt combiner,
                                  KernelBase* kern, VariantID vid);
 

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -29,6 +29,7 @@ RunParams::RunParams(int argc, char** argv)
  : input_state(Undefined),
    show_progress(false),
    npasses(1),
+   npasses_combiners(),
    rep_fact(1.0),
    size_meaning(SizeMeaning::Unset),
    size(0.0),
@@ -48,6 +49,8 @@ RunParams::RunParams(int argc, char** argv)
    invalid_feature_input(),
    exclude_feature_input(),
    invalid_exclude_feature_input(),
+   npasses_combiner_input(),
+   invalid_npasses_combiner_input(),
    outdir(),
    outfile_prefix("RAJAPerf")
 {
@@ -78,6 +81,18 @@ void RunParams::print(std::ostream& str) const
 {
   str << "\n show_progress = " << show_progress;
   str << "\n npasses = " << npasses;
+  str << "\n npasses combiners = ";
+  for (size_t j = 0; j < npasses_combiners.size(); ++j) {
+    str << "\n\t" << CombinerOptToStr(npasses_combiners[j]);
+  }
+  str << "\n npasses_combiners_input = ";
+  for (size_t j = 0; j < npasses_combiner_input.size(); ++j) {
+    str << "\n\t" << npasses_combiner_input[j];
+  }
+  str << "\n invalid_npasses_combiners_input = ";
+  for (size_t j = 0; j < invalid_npasses_combiner_input.size(); ++j) {
+    str << "\n\t" << invalid_npasses_combiner_input[j];
+  }
   str << "\n rep_fact = " << rep_fact;
   str << "\n size_meaning = " << SizeMeaningToStr(getSizeMeaning());
   str << "\n size = " << size;
@@ -213,6 +228,21 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
                   << " must give --npasses a value for number of passes (int)"
                   << std::endl;
         input_state = BadInput;
+      }
+
+    } else if ( opt == std::string("--npasses-combiners") ) {
+
+      bool done = false;
+      i++;
+      while ( i < argc && !done ) {
+        opt = std::string(argv[i]);
+        if ( opt.at(0) == '-' ) {
+          i--;
+          done = true;
+        } else {
+          npasses_combiner_input.push_back(opt);
+          ++i;
+        }
       }
 
     } else if ( opt == std::string("--repfact") ) {
@@ -467,6 +497,11 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
     size_meaning = SizeMeaning::Factor;
     size_factor = 1.0;
   }
+
+  // Default npasses_combiners if no input
+  if (npasses_combiner_input.empty()) {
+    npasses_combiners.emplace_back(CombinerOpt::Average);
+  }
 }
 
 
@@ -494,7 +529,13 @@ void RunParams::printHelpMessage(std::ostream& str) const
   str << "\t --npasses <int> [default is 1]\n"
       << "\t      (num passes through Suite)\n";
   str << "\t\t Example...\n"
-      << "\t\t --npasses 2 (runs complete Suite twice\n\n";
+      << "\t\t --npasses 2 (runs complete Suite twice)\n\n";
+
+  str << "\t --npasses-combiners <space-separated strings> [Default is average]\n"
+      << "\t      (Ways of combining npasses timing data into timing files)\n";
+  str << "\t\t Example...\n"
+      << "\t\t --npasses-combiners Average Minimum Maximum (produce average, min, and\n"
+      << "\t\t   max timing .csv files)\n\n";
 
   str << "\t --repfact <double> [default is 1.0]\n"
       << "\t      (multiplier on default # reps to run each kernel)\n";

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -46,6 +46,29 @@ public:
   };
 
   /*!
+   * \brief Enumeration indicating state of combiner options requested
+   */
+  enum CombinerOpt {
+    Average,      /*!< option requesting average */
+    Minimum,      /*!< option requesting minimum */
+    Maximum       /*!< option requesting maximum */
+  };
+
+  static std::string CombinerOptToStr(CombinerOpt co)
+  {
+    switch (co) {
+      case CombinerOpt::Average:
+        return "Average";
+      case CombinerOpt::Minimum:
+        return "Minimum";
+      case CombinerOpt::Maximum:
+        return "Maximum";
+      default:
+        return "Unknown";
+    }
+  }
+
+  /*!
    * \brief Enumeration indicating how to interpret size input
    */
   enum SizeMeaning {
@@ -89,6 +112,11 @@ public:
   int getNumPasses() const { return npasses; }
 
   double getRepFactor() const { return rep_fact; }
+
+  const std::vector<CombinerOpt>& getNpassesCombinerOpts() const
+  { return npasses_combiners; }
+  void setNpassesCombinerOpts( std::vector<CombinerOpt>& cvec )
+  { npasses_combiners = cvec; }
 
 
   SizeMeaning getSizeMeaning() const { return size_meaning; }
@@ -145,6 +173,13 @@ public:
   const std::vector<std::string>& getInvalidExcludeFeatureInput() const
                                   { return invalid_exclude_feature_input; }
 
+  const std::vector<std::string>& getNpassesCombinerOptInput() const
+                                  { return npasses_combiner_input; }
+  const std::vector<std::string>& getInvalidNpassesCombinerOptInput() const
+                                  { return invalid_npasses_combiner_input; }
+  void setInvalidNpassesCombinerOptInput( std::vector<std::string>& svec )
+                              { invalid_npasses_combiner_input = svec; }
+
   const std::string& getOutputDirName() const { return outdir; }
   const std::string& getOutputFilePrefix() const { return outfile_prefix; }
 
@@ -178,6 +213,9 @@ private:
 
   int npasses;           /*!< Number of passes through suite  */
 
+  std::vector<CombinerOpt> npasses_combiners;  /*!< Combiners to use when
+                              outputting timer data */
+
   double rep_fact;       /*!< pct of default kernel reps to run */
 
   SizeMeaning size_meaning; /*!< meaning of size value */
@@ -208,6 +246,9 @@ private:
   std::vector<std::string> invalid_feature_input;
   std::vector<std::string> exclude_feature_input;
   std::vector<std::string> invalid_exclude_feature_input;
+
+  std::vector<std::string> npasses_combiner_input;
+  std::vector<std::string> invalid_npasses_combiner_input;
 
   std::string outdir;          /*!< Output directory name. */
   std::string outfile_prefix;  /*!< Prefix for output data file names. */


### PR DESCRIPTION
# Add option to output min and max as well as average

Have the option to output the min, max, and/or average of
timing data using --npasses-combiner argument. Timing and speedup
csv files append the combiner method to their filename and print
the combiner method in the file.

- This PR is a feature
- It does the following:
  - Adds (specific feature) at the request of (project or person)
