### PR TITLE
Hip Kernel Tuning

### DIFF
--- a/src/apps/FIR-Hip.cpp
+++ b/src/apps/FIR-Hip.cpp
@@ -28,7 +28,8 @@ namespace apps
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
+  const size_t base_hip_block_size = 128;
+  const size_t raja_hip_block_size = 1024;
 
 
 #if defined(USE_HIP_CONSTANT_MEMORY)
@@ -104,15 +105,15 @@ void FIR::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
 
 #if defined(USE_HIP_CONSTANT_MEMORY)
-       hipLaunchKernelGGL((fir), dim3(grid_size), dim3(block_size), 0, 0,  out, in,
+       hipLaunchKernelGGL((fir), dim3(grid_size), dim3(base_hip_block_size), 0, 0,  out, in,
                                        coefflen,
                                        iend );
        hipErrchk( hipGetLastError() );
 #else
-       hipLaunchKernelGGL((fir), dim3(grid_size), dim3(block_size), 0, 0,  out, in,
+       hipLaunchKernelGGL((fir), dim3(grid_size), dim3(base_hip_block_size), 0, 0,  out, in,
                                        coeff,
                                        coefflen,
                                        iend );
@@ -133,7 +134,7 @@ void FIR::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+       RAJA::forall< RAJA::hip_exec<raja_hip_block_size, true /*async*/> >(
          RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
          FIR_BODY;
        });

--- a/src/apps/HALOEXCHANGE-Hip.cpp
+++ b/src/apps/HALOEXCHANGE-Hip.cpp
@@ -24,7 +24,8 @@ namespace apps
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
+  const size_t base_hip_block_size = 256;
+  const size_t raja_hip_block_size = 1024;
 
 
 #define HALOEXCHANGE_DATA_SETUP_HIP \
@@ -88,8 +89,8 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
         Index_type  len  = pack_index_list_lengths[l];
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
-          dim3 nthreads_per_block(block_size);
-          dim3 nblocks((len + block_size-1) / block_size);
+          dim3 nthreads_per_block(base_hip_block_size);
+          dim3 nblocks((len + base_hip_block_size-1) / base_hip_block_size);
           hipLaunchKernelGGL((haloexchange_pack), nblocks, nthreads_per_block, 0, 0,
               buffer, list, var, len);
           hipErrchk( hipGetLastError() );
@@ -104,8 +105,8 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
         Index_type  len  = unpack_index_list_lengths[l];
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
-          dim3 nthreads_per_block(block_size);
-          dim3 nblocks((len + block_size-1) / block_size);
+          dim3 nthreads_per_block(base_hip_block_size);
+          dim3 nblocks((len + base_hip_block_size-1) / base_hip_block_size);
           hipLaunchKernelGGL((haloexchange_unpack), nblocks, nthreads_per_block, 0, 0,
               buffer, list, var, len);
           hipErrchk( hipGetLastError() );
@@ -123,7 +124,7 @@ void HALOEXCHANGE::runHipVariant(VariantID vid)
 
     HALOEXCHANGE_DATA_SETUP_HIP;
 
-    using EXEC_POL = RAJA::hip_exec<block_size, true /*async*/>;
+    using EXEC_POL = RAJA::hip_exec<raja_hip_block_size, true /*async*/>;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/apps/PRESSURE-Hip.cpp
+++ b/src/apps/PRESSURE-Hip.cpp
@@ -24,7 +24,8 @@ namespace apps
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
+  const size_t base_hip_block_size = 128;
+  const size_t raja_hip_block_size = 128;
 
 
 #define PRESSURE_DATA_SETUP_HIP \
@@ -80,14 +81,14 @@ void PRESSURE::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
 
-       hipLaunchKernelGGL((pressurecalc1), dim3(grid_size), dim3(block_size), 0, 0,  bvc, compression,
+       hipLaunchKernelGGL((pressurecalc1), dim3(grid_size), dim3(base_hip_block_size), 0, 0,  bvc, compression,
                                                  cls,
                                                  iend );
        hipErrchk( hipGetLastError() );
 
-       hipLaunchKernelGGL((pressurecalc2), dim3(grid_size), dim3(block_size), 0, 0,  p_new, bvc, e_old,
+       hipLaunchKernelGGL((pressurecalc2), dim3(grid_size), dim3(base_hip_block_size), 0, 0,  p_new, bvc, e_old,
                                                  vnewc,
                                                  p_cut, eosvmax, pmin,
                                                  iend );
@@ -109,11 +110,11 @@ void PRESSURE::runHipVariant(VariantID vid)
 
       RAJA::region<RAJA::seq_region>( [=]() {
 
-        RAJA::forall< RAJA::hip_exec<block_size, async> >(
+        RAJA::forall< RAJA::hip_exec<raja_hip_block_size, async> >(
           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
           PRESSURE_BODY1;
         });
-        RAJA::forall< RAJA::hip_exec<block_size, async> >(
+        RAJA::forall< RAJA::hip_exec<raja_hip_block_size, async> >(
           RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
           PRESSURE_BODY2;
         });

--- a/src/apps/VOL3D-Hip.cpp
+++ b/src/apps/VOL3D-Hip.cpp
@@ -26,7 +26,8 @@ namespace apps
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
+  const size_t base_hip_block_size = 256;
+  const size_t raja_hip_block_size = 1024;
 
 
 #define VOL3D_DATA_SETUP_HIP \
@@ -85,9 +86,9 @@ void VOL3D::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
 
-      hipLaunchKernelGGL((vol3d), dim3(grid_size), dim3(block_size), 0, 0, vol,
+      hipLaunchKernelGGL((vol3d), dim3(grid_size), dim3(base_hip_block_size), 0, 0, vol,
                                        x0, x1, x2, x3, x4, x5, x6, x7,
                                        y0, y1, y2, y3, y4, y5, y6, y7,
                                        z0, z1, z2, z3, z4, z5, z6, z7,
@@ -111,7 +112,7 @@ void VOL3D::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+      RAJA::forall< RAJA::hip_exec<base_hip_block_size, true /*async*/> >(
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
         VOL3D_BODY;
       });

--- a/src/basic/DAXPY-Hip.cpp
+++ b/src/basic/DAXPY-Hip.cpp
@@ -24,7 +24,8 @@ namespace basic
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
+  const size_t base_hip_block_size = 128;
+  const size_t raja_hip_block_size = 1024;
 
 
 #define DAXPY_DATA_SETUP_HIP \
@@ -62,8 +63,8 @@ void DAXPY::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      hipLaunchKernelGGL((daxpy),dim3(grid_size), dim3(block_size), 0, 0, y, x, a,
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
+      hipLaunchKernelGGL((daxpy),dim3(grid_size), dim3(base_hip_block_size), 0, 0, y, x, a,
                                         iend );
       hipErrchk( hipGetLastError() );
 
@@ -83,9 +84,9 @@ void DAXPY::runHipVariant(VariantID vid)
         DAXPY_BODY;
       };
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(daxpy_lambda)>,
-        grid_size, block_size, 0, 0, ibegin, iend, daxpy_lambda);
+        grid_size, base_hip_block_size, 0, 0, ibegin, iend, daxpy_lambda);
       hipErrchk( hipGetLastError() );
 
     }
@@ -100,7 +101,7 @@ void DAXPY::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+      RAJA::forall< RAJA::hip_exec<raja_hip_block_size, true /*async*/> >(
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
         DAXPY_BODY;
       });

--- a/src/basic/IF_QUAD-Hip.cpp
+++ b/src/basic/IF_QUAD-Hip.cpp
@@ -24,7 +24,8 @@ namespace basic
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
+  const size_t base_hip_block_size = 128;
+  const size_t raja_hip_block_size = 128;
 
 
 #define IF_QUAD_DATA_SETUP_HIP \
@@ -69,8 +70,8 @@ void IF_QUAD::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      hipLaunchKernelGGL((ifquad), dim3(grid_size), dim3(block_size), 0, 0,  x1, x2, a, b, c,
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
+      hipLaunchKernelGGL((ifquad), dim3(grid_size), dim3(base_hip_block_size), 0, 0,  x1, x2, a, b, c,
                                           iend );
       hipErrchk( hipGetLastError() );
 
@@ -90,9 +91,9 @@ void IF_QUAD::runHipVariant(VariantID vid)
         IF_QUAD_BODY;
       };
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(ifquad_lambda)>,
-        grid_size, block_size, 0, 0, ibegin, iend, ifquad_lambda);
+        grid_size, base_hip_block_size, 0, 0, ibegin, iend, ifquad_lambda);
       hipErrchk( hipGetLastError() );
 
     }
@@ -107,7 +108,7 @@ void IF_QUAD::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+      RAJA::forall< RAJA::hip_exec<raja_hip_block_size, true /*async*/> >(
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
         IF_QUAD_BODY;
       });

--- a/src/basic/INIT3-Hip.cpp
+++ b/src/basic/INIT3-Hip.cpp
@@ -24,7 +24,8 @@ namespace basic
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
+  const size_t base_hip_block_size = 128;
+  const size_t raja_hip_block_size = 1024;
 
 
 #define INIT3_DATA_SETUP_HIP \
@@ -70,8 +71,8 @@ void INIT3::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      hipLaunchKernelGGL((init3), dim3(grid_size), dim3(block_size), 0, 0,  out1, out2, out3, in1, in2,
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
+      hipLaunchKernelGGL((init3), dim3(grid_size), dim3(base_hip_block_size), 0, 0,  out1, out2, out3, in1, in2,
                                         iend );
       hipErrchk( hipGetLastError() );
 
@@ -91,9 +92,9 @@ void INIT3::runHipVariant(VariantID vid)
         INIT3_BODY;
       };
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(init3_lambda)>,
-        grid_size, block_size, 0, 0, ibegin, iend, init3_lambda);
+        grid_size, base_hip_block_size, 0, 0, ibegin, iend, init3_lambda);
       hipErrchk( hipGetLastError() );
 
     }
@@ -108,7 +109,7 @@ void INIT3::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+      RAJA::forall< RAJA::hip_exec<raja_hip_block_size, true /*async*/> >(
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
         INIT3_BODY;
       });

--- a/src/basic/MULADDSUB-Hip.cpp
+++ b/src/basic/MULADDSUB-Hip.cpp
@@ -24,7 +24,8 @@ namespace basic
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
+  const size_t base_hip_block_size = 128;
+  const size_t raja_hip_block_size = 1024;
 
 
 #define MULADDSUB_DATA_SETUP_HIP \
@@ -70,8 +71,8 @@ void MULADDSUB::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      hipLaunchKernelGGL((muladdsub), dim3(grid_size), dim3(block_size), 0, 0,
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
+      hipLaunchKernelGGL((muladdsub), dim3(grid_size), dim3(base_hip_block_size), 0, 0,
           out1, out2, out3, in1, in2, iend );
       hipErrchk( hipGetLastError() );
 
@@ -91,9 +92,9 @@ void MULADDSUB::runHipVariant(VariantID vid)
         MULADDSUB_BODY;
       };
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
       hipLaunchKernelGGL(lambda_hip_forall<decltype(muladdsub_lambda)>,
-        grid_size, block_size, 0, 0, ibegin, iend, muladdsub_lambda );
+        grid_size, base_hip_block_size, 0, 0, ibegin, iend, muladdsub_lambda );
       hipErrchk( hipGetLastError() );
 
     }
@@ -108,7 +109,7 @@ void MULADDSUB::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+      RAJA::forall< RAJA::hip_exec<raja_hip_block_size, true /*async*/> >(
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
         MULADDSUB_BODY;
       });

--- a/src/lcals/EOS-Hip.cpp
+++ b/src/lcals/EOS-Hip.cpp
@@ -24,7 +24,8 @@ namespace lcals
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
+  const size_t base_hip_block_size = 128;
+  const size_t raja_hip_block_size = 1024;
 
 
 #define EOS_DATA_SETUP_HIP \
@@ -66,8 +67,8 @@ void EOS::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       hipLaunchKernelGGL((eos), dim3(grid_size), dim3(block_size), 0, 0,  x, y, z, u,
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
+       hipLaunchKernelGGL((eos), dim3(grid_size), dim3(base_hip_block_size), 0, 0,  x, y, z, u,
                                        q, r, t,
                                        iend );
        hipErrchk( hipGetLastError() );
@@ -84,7 +85,7 @@ void EOS::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+       RAJA::forall< RAJA::hip_exec<raja_hip_block_size, true /*async*/> >(
          RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
          EOS_BODY;
        });

--- a/src/lcals/FIRST_SUM-Hip.cpp
+++ b/src/lcals/FIRST_SUM-Hip.cpp
@@ -24,8 +24,8 @@ namespace lcals
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
-
+  const size_t base_hip_block_size = 128;
+  const size_t raja_hip_block_size = 1024;
 
 #define FIRST_SUM_DATA_SETUP_HIP \
   allocAndInitHipDeviceData(x, m_x, m_N); \
@@ -61,8 +61,8 @@ void FIRST_SUM::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       hipLaunchKernelGGL(first_sum,grid_size, block_size, 0, 0, x, y,
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
+       hipLaunchKernelGGL(first_sum,grid_size, base_hip_block_size, 0, 0, x, y,
                                               iend );
        hipErrchk( hipGetLastError() );
 
@@ -78,7 +78,7 @@ void FIRST_SUM::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+       RAJA::forall< RAJA::hip_exec<raja_hip_block_size, true /*async*/> >(
          RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
          FIRST_SUM_BODY;
        });

--- a/src/lcals/INT_PREDICT-Hip.cpp
+++ b/src/lcals/INT_PREDICT-Hip.cpp
@@ -24,7 +24,8 @@ namespace lcals
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
+  const size_t base_hip_block_size = 1024;
+  const size_t raja_hip_block_size = 128;
 
 
 #define INT_PREDICT_DATA_SETUP_HIP \
@@ -63,8 +64,8 @@ void INT_PREDICT::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       hipLaunchKernelGGL((int_predict), dim3(grid_size), dim3(block_size), 0, 0,  px,
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
+       hipLaunchKernelGGL((int_predict), dim3(grid_size), dim3(base_hip_block_size), 0, 0,  px,
                                                dm22, dm23, dm24, dm25,
                                                dm26, dm27, dm28, c0,
                                                offset,
@@ -83,7 +84,7 @@ void INT_PREDICT::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+       RAJA::forall< RAJA::hip_exec<raja_hip_block_size, true /*async*/> >(
          RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
          INT_PREDICT_BODY;
        });

--- a/src/lcals/PLANCKIAN-Hip.cpp
+++ b/src/lcals/PLANCKIAN-Hip.cpp
@@ -25,7 +25,9 @@ namespace lcals
   //
   // Define thread block size for HIP execution
   //
-  const size_t block_size = 256;
+  const size_t base_hip_block_size = 128;
+  const size_t raja_hip_block_size = 1024;
+
 
 
 #define PLANCKIAN_DATA_SETUP_HIP \
@@ -69,8 +71,8 @@ void PLANCKIAN::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       hipLaunchKernelGGL((planckian), dim3(grid_size), dim3(block_size), 0, 0,  x, y,
+       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, base_hip_block_size);
+       hipLaunchKernelGGL((planckian), dim3(grid_size), dim3(base_hip_block_size), 0, 0,  x, y,
                                              u, v, w,
                                              iend );
        hipErrchk( hipGetLastError() );
@@ -87,7 +89,7 @@ void PLANCKIAN::runHipVariant(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+       RAJA::forall< RAJA::hip_exec<raja_hip_block_size, true /*async*/> >(
          RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
          PLANCKIAN_BODY;
        });


### PR DESCRIPTION
Beginning of kernel specific tuning. Split of blocksize definitions and set initial values from tuning sweeps in set of basic, lcals, and apps kernels. Can adding in problem size specific tuning once this is in for most/all kernels of interest.