### PR TITLE
Remove used variables 

### DIFF
--- a/scripts/lc-builds/blueos_nvcc_gcc.sh
+++ b/scripts/lc-builds/blueos_nvcc_gcc.sh
@@ -41,7 +41,7 @@ module load cmake/3.14.5
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/gcc/gcc-${COMP_GCC_VER}/bin/g++ \
-  -DBLT_CXX_STD=c++11 \
+  -DBLT_CXX_STD=c++14 \
   -C ${RAJA_HOSTCONFIG} \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \

--- a/src/apps/DIFFUSION3DPA-Cuda.cpp
+++ b/src/apps/DIFFUSION3DPA-Cuda.cpp
@@ -37,7 +37,7 @@ namespace apps {
   deallocCudaDeviceData(X);                                                    \
   deallocCudaDeviceData(Y);
 
-__global__ void Diffusion3DPA(Index_type NE, const Real_ptr Basis,
+__global__ void Diffusion3DPA(const Real_ptr Basis,
                               const Real_ptr dBasis, const Real_ptr D,
                               const Real_ptr X, Real_ptr Y, bool symmetric) {
 
@@ -134,7 +134,7 @@ void DIFFUSION3DPA::runCudaVariant(VariantID vid) {
 
       dim3 nthreads_per_block(DPA_Q1D, DPA_Q1D, DPA_Q1D);
 
-      Diffusion3DPA<<<NE, nthreads_per_block>>>(NE, Basis, dBasis, D, X, Y,
+      Diffusion3DPA<<<NE, nthreads_per_block>>>(Basis, dBasis, D, X, Y,
                                                 symmetric);
 
       cudaErrchk(cudaGetLastError());

--- a/src/apps/DIFFUSION3DPA-Hip.cpp
+++ b/src/apps/DIFFUSION3DPA-Hip.cpp
@@ -37,7 +37,7 @@ namespace apps {
   deallocHipDeviceData(X);                                                     \
   deallocHipDeviceData(Y);
 
-__global__ void Diffusion3DPA(Index_type NE, const Real_ptr Basis,
+__global__ void Diffusion3DPA(const Real_ptr Basis,
                               const Real_ptr dBasis, const Real_ptr D,
                               const Real_ptr X, Real_ptr Y, bool symmetric) {
 
@@ -136,7 +136,7 @@ void DIFFUSION3DPA::runHipVariant(VariantID vid) {
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       hipLaunchKernelGGL((Diffusion3DPA), dim3(grid_size), dim3(block_size), 0,
-                         0, NE, Basis, dBasis, D, X, Y, symmetric);
+                         0, Basis, dBasis, D, X, Y, symmetric);
 
       hipErrchk(hipGetLastError());
     }

--- a/src/apps/MASS3DPA-Cuda.cpp
+++ b/src/apps/MASS3DPA-Cuda.cpp
@@ -37,7 +37,7 @@ namespace apps {
   deallocCudaDeviceData(X);                                              \
   deallocCudaDeviceData(Y);
 
-__global__ void Mass3DPA(Index_type NE, const Real_ptr B, const Real_ptr Bt,
+__global__ void Mass3DPA(const Real_ptr B, const Real_ptr Bt,
                          const Real_ptr D, const Real_ptr X, Real_ptr Y) {
 
   const int e = blockIdx.x;
@@ -116,7 +116,7 @@ void MASS3DPA::runCudaVariant(VariantID vid) {
 
       dim3 nthreads_per_block(MPA_Q1D, MPA_Q1D, 1);
 
-      Mass3DPA<<<NE, nthreads_per_block>>>(NE, B, Bt, D, X, Y);
+      Mass3DPA<<<NE, nthreads_per_block>>>(B, Bt, D, X, Y);
 
       cudaErrchk( cudaGetLastError() );
     }

--- a/src/apps/MASS3DPA-Hip.cpp
+++ b/src/apps/MASS3DPA-Hip.cpp
@@ -37,7 +37,7 @@ namespace apps {
   deallocHipDeviceData(X);                                                \
   deallocHipDeviceData(Y);
 
-__global__ void Mass3DPA(Index_type NE, const Real_ptr B, const Real_ptr Bt,
+__global__ void Mass3DPA(const Real_ptr B, const Real_ptr Bt,
                          const Real_ptr D, const Real_ptr X, Real_ptr Y) {
 
   const int e = hipBlockIdx_x;
@@ -118,7 +118,7 @@ void MASS3DPA::runHipVariant(VariantID vid) {
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       hipLaunchKernelGGL((Mass3DPA), dim3(grid_size), dim3(block_size), 0, 0,
-                         NE, B, Bt, D, X, Y);
+                         B, Bt, D, X, Y);
 
       hipErrchk( hipGetLastError() );
 


### PR DESCRIPTION
Remove unused variables + updates nvcc script to use C++14. Addresses https://github.com/LLNL/RAJAPerf/issues/216. 

Bad news about updating the nvcc script though. I now get warnings of the form: 

```
/RAJAPerf/tpl/RAJA/include/RAJA/pattern/tensor/internal/MatrixMatrixMultiply.hpp(102): warning: unrecognized GCC pragma

/RAJAPerf/tpl/RAJA/include/RAJA/pattern/tensor/internal/MatrixMatrixMultiply.hpp(107): warning: unrecognized GCC pragma
```

With the following build config: build_lc_blueos-nvcc10.2.89-sm_70-gcc8.3.1 