### PR TITLE
Use RAJA_UNROLL_COUNT macros

### DIFF
--- a/src/apps/FEM_MACROS.hpp
+++ b/src/apps/FEM_MACROS.hpp
@@ -8,9 +8,9 @@
 #ifndef RAJAPerf_FEM_MACROS_HPP
 #define RAJAPerf_FEM_MACROS_HPP
 
-#define RAJAPERF_DIRECT_PRAGMA(X) _Pragma(#X)
 #if defined(USE_RAJAPERF_UNROLL)
-#define RAJAPERF_UNROLL(N) RAJAPERF_DIRECT_PRAGMA(unroll(N))
+// If enabled uses RAJA's RAJA_UNROLL_COUNT which is always on
+#define RAJAPERF_UNROLL(N) RAJA_UNROLL_COUNT(N)
 #else
 #define RAJAPERF_UNROLL(N)
 #endif


### PR DESCRIPTION
This PR  builds on the RAJA_UNROLL_COUNT macros from https://github.com/LLNL/RAJA/pull/1241 . 
As those macros are always enabled we still have to guard them in macros for easy comparing between directive vs non directive version of the code. Resolves: https://github.com/LLNL/RAJAPerf/issues/214