### PR TITLE
Add algorithm reduce sum kernel

### DIFF
--- a/scripts/sweep_size.sh
+++ b/scripts/sweep_size.sh
@@ -8,18 +8,18 @@ SIZE_RATIO=2
 ################################################################################
 #
 # Usage:
-#     srun -n1 --exclusive sweep.sh -x raja-perf.exe [-- raja perf args]
+#     srun -n1 --exclusive sweep.sh -x raja-perf.exe [-- <raja perf args>]
 #
 # Parse any args for this script and consume them using shift
 # leave the raja perf arguments if any for later use
 #
 # Examples:
-#     lalloc 1 lrun -n1 sweep.sh -x raja-perf.exe -- args
+#     lalloc 1 lrun -n1 sweep.sh -x raja-perf.exe -- <args>
 #       # run a sweep of default problem sizes with executable `raja-perf.exe`
 #       # with args `args`
 #
 #     srun -n1 --exclusive sweep.sh -x raja-perf.exe --size-min 1000
-#            --size-max 10000 --size-ratio 2 -- args
+#            --size-max 10000 --size-ratio 2 -- <args>
 #       # run a sweep of problem sizes 1K to 10K with ratio 2 (1K, 2K, 4K, 8K)
 #       # with executable `raja-perf.exe` with args `args`
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -207,6 +207,9 @@ blt_add_executable(
   algorithm/SORT-Seq.cpp
   algorithm/SORTPAIRS.cpp
   algorithm/SORTPAIRS-Seq.cpp
+  algorithm/REDUCE_SUM.cpp
+  algorithm/REDUCE_SUM-Seq.cpp
+  algorithm/REDUCE_SUM-OMPTarget.cpp
   DEPENDS_ON ${RAJA_PERFSUITE_DEPENDS}
 )
 

--- a/src/algorithm/CMakeLists.txt
+++ b/src/algorithm/CMakeLists.txt
@@ -18,5 +18,11 @@ blt_add_library(
           SORTPAIRS-Hip.cpp
           SORTPAIRS-Cuda.cpp
           SORTPAIRS-OMP.cpp
+          REDUCE_SUM.cpp
+          REDUCE_SUM-Seq.cpp
+          REDUCE_SUM-Hip.cpp
+          REDUCE_SUM-Cuda.cpp
+          REDUCE_SUM-OMP.cpp
+          REDUCE_SUM-OMPTarget.cpp
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/algorithm/REDUCE_SUM-Cuda.cpp
+++ b/src/algorithm/REDUCE_SUM-Cuda.cpp
@@ -31,42 +31,7 @@ namespace algorithm
   deallocCudaDeviceData(x);
 
 
-template < size_t block_size >
-void REDUCE_SUM::runCudaVariantImpl(VariantID vid)
-{
-  const Index_type run_reps = getRunReps();
-  const Index_type ibegin = 0;
-  const Index_type iend = getActualProblemSize();
-
-  REDUCE_SUM_DATA_SETUP;
-
-  if ( vid == RAJA_CUDA ) {
-
-    REDUCE_SUM_DATA_SETUP_CUDA;
-
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> sum(m_sum_init);
-
-      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
-        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-          REDUCE_SUM_BODY;
-      });
-
-      m_sum = sum.get();
-
-    }
-    stopTimer();
-
-    REDUCE_SUM_DATA_TEARDOWN_CUDA;
-
-  } else {
-     getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
-  }
-}
-
-void REDUCE_SUM::runCudaVariant(VariantID vid, size_t tune_idx)
+void REDUCE_SUM::runCudaVariantCub(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -128,23 +93,64 @@ void REDUCE_SUM::runCudaVariant(VariantID vid, size_t tune_idx)
 
     REDUCE_SUM_DATA_TEARDOWN_CUDA;
 
-  } else if ( vid == RAJA_CUDA ) {
+  } else {
+     getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
 
+template < size_t block_size >
+void REDUCE_SUM::runCudaVariantBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  REDUCE_SUM_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    REDUCE_SUM_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> sum(m_sum_init);
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          REDUCE_SUM_BODY;
+      });
+
+      m_sum = sum.get();
+
+    }
+    stopTimer();
+
+    REDUCE_SUM_DATA_TEARDOWN_CUDA;
+
+  } else {
+     getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+void REDUCE_SUM::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  if ( vid == Base_CUDA ) {
+    runCudaVariantCub(vid);
+  } else if ( vid == RAJA_CUDA ) {
     size_t t = 0;
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
         if (tune_idx == t) {
-          runCudaVariantImpl<block_size>(vid);
+          runCudaVariantBlock<block_size>(vid);
         }
         t += 1;
       }
     });
-
   } else {
      getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
   }
-
 }
 
 void REDUCE_SUM::setCudaTuningDefinitions(VariantID vid)

--- a/src/algorithm/REDUCE_SUM-Cuda.cpp
+++ b/src/algorithm/REDUCE_SUM-Cuda.cpp
@@ -127,8 +127,11 @@ void REDUCE_SUM::runCudaVariantCub(VariantID vid)
     REDUCE_SUM_DATA_TEARDOWN_CUDA;
 
   } else {
-     getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+
+    getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+
   }
+
 }
 
 template < size_t block_size >
@@ -194,60 +197,103 @@ void REDUCE_SUM::runCudaVariantBlock(VariantID vid)
     REDUCE_SUM_DATA_TEARDOWN_CUDA;
 
   } else {
-     getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+
+    getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+
   }
+
 }
 
 void REDUCE_SUM::runCudaVariant(VariantID vid, size_t tune_idx)
 {
   if ( vid == Base_CUDA ) {
+
     size_t t = 0;
+
     if (tune_idx == t) {
+
       runCudaVariantCub(vid);
+
     }
+
     t += 1;
+
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
+
         if (tune_idx == t) {
+
           runCudaVariantBlock<block_size>(vid);
+
         }
+
         t += 1;
+
       }
+
     });
+
   } else if ( vid == RAJA_CUDA ) {
+
     size_t t = 0;
+
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
+
         if (tune_idx == t) {
+
           runCudaVariantBlock<block_size>(vid);
+
         }
+
         t += 1;
+
       }
+
     });
+
   } else {
-     getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+
+    getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+
   }
+
 }
 
 void REDUCE_SUM::setCudaTuningDefinitions(VariantID vid)
 {
   if ( vid == Base_CUDA ) {
+
     addVariantTuningName(vid, "cub");
+
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
+
         addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
       }
+
     });
+
   } else if ( vid == RAJA_CUDA ) {
+
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
+
         addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
       }
+
     });
+
   }
 }
 

--- a/src/algorithm/REDUCE_SUM-Cuda.cpp
+++ b/src/algorithm/REDUCE_SUM-Cuda.cpp
@@ -1,0 +1,167 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "REDUCE_SUM.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include "cub/device/device_reduce.cuh"
+#include "cub/util_allocator.cuh"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+#define REDUCE_SUM_DATA_SETUP_CUDA \
+  allocAndInitCudaDeviceData(x, m_x, iend);
+
+#define REDUCE_SUM_DATA_TEARDOWN_CUDA \
+  deallocCudaDeviceData(x);
+
+
+template < size_t block_size >
+void REDUCE_SUM::runCudaVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  REDUCE_SUM_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    REDUCE_SUM_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> sum(m_sum_init);
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          REDUCE_SUM_BODY;
+      });
+
+      m_sum = sum.get();
+
+    }
+    stopTimer();
+
+    REDUCE_SUM_DATA_TEARDOWN_CUDA;
+
+  } else {
+     getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+void REDUCE_SUM::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  REDUCE_SUM_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    REDUCE_SUM_DATA_SETUP_CUDA;
+
+    cudaStream_t stream = 0;
+
+    int len = iend - ibegin;
+
+    Real_type* sum_storage;
+    allocCudaPinnedData(sum_storage, 1);
+
+    // Determine temporary device storage requirements
+    void* d_temp_storage = nullptr;
+    size_t temp_storage_bytes = 0;
+    cudaErrchk(::cub::DeviceReduce::Reduce(d_temp_storage,
+                                           temp_storage_bytes,
+                                           x+ibegin,
+                                           sum_storage,
+                                           len,
+                                           ::cub::Sum(),
+                                           m_sum_init,
+                                           stream));
+
+    // Allocate temporary storage
+    unsigned char* temp_storage;
+    allocCudaDeviceData(temp_storage, temp_storage_bytes);
+    d_temp_storage = temp_storage;
+
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      // Run
+      cudaErrchk(::cub::DeviceReduce::Reduce(d_temp_storage,
+                                             temp_storage_bytes,
+                                             x+ibegin,
+                                             sum_storage,
+                                             len,
+                                             ::cub::Sum(),
+                                             m_sum_init,
+                                             stream));
+
+      cudaErrchk(cudaStreamSynchronize(stream));
+      m_sum = *sum_storage;
+
+    }
+    stopTimer();
+
+    // Free temporary storage
+    deallocCudaDeviceData(temp_storage);
+    deallocCudaPinnedData(sum_storage);
+
+    REDUCE_SUM_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    size_t t = 0;
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+        if (tune_idx == t) {
+          runCudaVariantImpl<block_size>(vid);
+        }
+        t += 1;
+      }
+    });
+
+  } else {
+     getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+  }
+
+}
+
+void REDUCE_SUM::setCudaTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_CUDA ) {
+    addVariantTuningName(vid, "cub");
+  } else if ( vid == RAJA_CUDA ) {
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+      }
+    });
+  }
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/algorithm/REDUCE_SUM-Hip.cpp
+++ b/src/algorithm/REDUCE_SUM-Hip.cpp
@@ -36,42 +36,7 @@ namespace algorithm
   deallocHipDeviceData(x);
 
 
-template < size_t block_size >
-void REDUCE_SUM::runHipVariantImpl(VariantID vid)
-{
-  const Index_type run_reps = getRunReps();
-  const Index_type ibegin = 0;
-  const Index_type iend = getActualProblemSize();
-
-  REDUCE_SUM_DATA_SETUP;
-
-  if ( vid == RAJA_HIP ) {
-
-    REDUCE_SUM_DATA_SETUP_HIP;
-
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-      RAJA::ReduceSum<RAJA::hip_reduce, Real_type> sum(m_sum_init);
-
-      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
-        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-          REDUCE_SUM_BODY;
-      });
-
-      m_sum = sum.get();
-
-    }
-    stopTimer();
-
-    REDUCE_SUM_DATA_TEARDOWN_HIP;
-
-  } else {
-     getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
-  }
-}
-
-void REDUCE_SUM::runHipVariant(VariantID vid, size_t tune_idx)
+void REDUCE_SUM::runHipVariantRocprim(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -155,24 +120,64 @@ void REDUCE_SUM::runHipVariant(VariantID vid, size_t tune_idx)
 
     REDUCE_SUM_DATA_TEARDOWN_HIP;
 
+  } else {
+     getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
 
+template < size_t block_size >
+void REDUCE_SUM::runHipVariantBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  REDUCE_SUM_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    REDUCE_SUM_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::hip_reduce, Real_type> sum(m_sum_init);
+
+      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          REDUCE_SUM_BODY;
+      });
+
+      m_sum = sum.get();
+
+    }
+    stopTimer();
+
+    REDUCE_SUM_DATA_TEARDOWN_HIP;
+
+  } else {
+     getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+void REDUCE_SUM::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  if ( vid == Base_HIP ) {
+    runHipVariantRocprim(vid);
   } else if ( vid == RAJA_HIP ) {
-
     size_t t = 0;
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
         if (tune_idx == t) {
-          runHipVariantImpl<block_size>(vid);
+          runHipVariantBlock<block_size>(vid);
         }
         t += 1;
       }
     });
-
   } else {
      getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
   }
-
 }
 
 void REDUCE_SUM::setHipTuningDefinitions(VariantID vid)

--- a/src/algorithm/REDUCE_SUM-Hip.cpp
+++ b/src/algorithm/REDUCE_SUM-Hip.cpp
@@ -1,0 +1,199 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "REDUCE_SUM.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+#if defined(__HIPCC__)
+#define ROCPRIM_HIP_API 1
+#include "rocprim/device/device_reduce.hpp"
+#elif defined(__CUDACC__)
+#include "cub/device/device_reduce.cuh"
+#include "cub/util_allocator.cuh"
+#endif
+
+#include "common/HipDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+#define REDUCE_SUM_DATA_SETUP_HIP \
+  allocAndInitHipDeviceData(x, m_x, iend);
+
+#define REDUCE_SUM_DATA_TEARDOWN_HIP \
+  deallocHipDeviceData(x);
+
+
+template < size_t block_size >
+void REDUCE_SUM::runHipVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  REDUCE_SUM_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    REDUCE_SUM_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::hip_reduce, Real_type> sum(m_sum_init);
+
+      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          REDUCE_SUM_BODY;
+      });
+
+      m_sum = sum.get();
+
+    }
+    stopTimer();
+
+    REDUCE_SUM_DATA_TEARDOWN_HIP;
+
+  } else {
+     getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+void REDUCE_SUM::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  REDUCE_SUM_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    REDUCE_SUM_DATA_SETUP_HIP;
+
+    hipStream_t stream = 0;
+
+    int len = iend - ibegin;
+
+    Real_type* sum_storage;
+    allocHipPinnedData(sum_storage, 1);
+
+    // Determine temporary device storage requirements
+    void* d_temp_storage = nullptr;
+    size_t temp_storage_bytes = 0;
+#if defined(__HIPCC__)
+    hipErrchk(::rocprim::reduce(d_temp_storage,
+                                temp_storage_bytes,
+                                x+ibegin,
+                                sum_storage,
+                                m_sum_init,
+                                len,
+                                rocprim::plus<Real_type>(),
+                                stream));
+#elif defined(__CUDACC__)
+    hipErrchk(::cub::DeviceReduce::Reduce(d_temp_storage,
+                                          temp_storage_bytes,
+                                          x+ibegin,
+                                          sum_storage,
+                                          len,
+                                          ::cub::Sum(),
+                                          m_sum_init,
+                                          stream));
+#endif
+
+    // Allocate temporary storage
+    unsigned char* temp_storage;
+    allocHipDeviceData(temp_storage, temp_storage_bytes);
+    d_temp_storage = temp_storage;
+
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      // Run
+#if defined(__HIPCC__)
+      hipErrchk(::rocprim::reduce(d_temp_storage,
+                                  temp_storage_bytes,
+                                  x+ibegin,
+                                  sum_storage,
+                                  m_sum_init,
+                                  len,
+                                  rocprim::plus<Real_type>(),
+                                  stream));
+#elif defined(__CUDACC__)
+      hipErrchk(::cub::DeviceReduce::Reduce(d_temp_storage,
+                                            temp_storage_bytes,
+                                            x+ibegin,
+                                            sum_storage,
+                                            len,
+                                            ::cub::Sum(),
+                                            m_sum_init,
+                                            stream));
+#endif
+
+      hipErrchk(hipStreamSynchronize(stream));
+      m_sum = *sum_storage;
+
+    }
+    stopTimer();
+
+    // Free temporary storage
+    deallocHipDeviceData(temp_storage);
+    deallocHipPinnedData(sum_storage);
+
+    REDUCE_SUM_DATA_TEARDOWN_HIP;
+
+
+  } else if ( vid == RAJA_HIP ) {
+
+    size_t t = 0;
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+        if (tune_idx == t) {
+          runHipVariantImpl<block_size>(vid);
+        }
+        t += 1;
+      }
+    });
+
+  } else {
+     getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+  }
+
+}
+
+void REDUCE_SUM::setHipTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_HIP ) {
+#if defined(__HIPCC__)
+    addVariantTuningName(vid, "rocprim");
+#elif defined(__CUDACC__)
+    addVariantTuningName(vid, "cub");
+#endif
+  } else if ( vid == RAJA_HIP ) {
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+      }
+    });
+  }
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_HIP

--- a/src/algorithm/REDUCE_SUM-Hip.cpp
+++ b/src/algorithm/REDUCE_SUM-Hip.cpp
@@ -154,8 +154,11 @@ void REDUCE_SUM::runHipVariantRocprim(VariantID vid)
     REDUCE_SUM_DATA_TEARDOWN_HIP;
 
   } else {
-     getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+
+    getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+
   }
+
 }
 
 template < size_t block_size >
@@ -220,65 +223,109 @@ void REDUCE_SUM::runHipVariantBlock(VariantID vid)
     REDUCE_SUM_DATA_TEARDOWN_HIP;
 
   } else {
-     getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+
+    getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+
   }
+
 }
 
 void REDUCE_SUM::runHipVariant(VariantID vid, size_t tune_idx)
 {
   if ( vid == Base_HIP ) {
+
     size_t t = 0;
+
     if (tune_idx == t) {
+
       runHipVariantRocprim(vid);
+
     }
+
     t += 1;
+
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
+
         if (tune_idx == t) {
+
           runHipVariantBlock<block_size>(vid);
+
         }
+
         t += 1;
+
       }
+
     });
+
   } else if ( vid == RAJA_HIP ) {
+
     size_t t = 0;
+
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
+
         if (tune_idx == t) {
+
           runHipVariantBlock<block_size>(vid);
+
         }
+
         t += 1;
+
       }
+
     });
+
   } else {
-     getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+
+    getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+
   }
+
 }
 
 void REDUCE_SUM::setHipTuningDefinitions(VariantID vid)
 {
   if ( vid == Base_HIP ) {
+
 #if defined(__HIPCC__)
     addVariantTuningName(vid, "rocprim");
 #elif defined(__CUDACC__)
     addVariantTuningName(vid, "cub");
 #endif
+
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
+
         addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
       }
+
     });
+
   } else if ( vid == RAJA_HIP ) {
+
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
+
         addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
       }
+
     });
+
   }
+
 }
 
 } // end namespace algorithm

--- a/src/algorithm/REDUCE_SUM-OMP.cpp
+++ b/src/algorithm/REDUCE_SUM-OMP.cpp
@@ -1,0 +1,110 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "REDUCE_SUM.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+void REDUCE_SUM::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  REDUCE_SUM_DATA_SETUP;
+
+  switch ( vid ) {
+
+    case Base_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        Real_type sum = m_sum_init;
+
+        #pragma omp parallel for reduction(+:sum)
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          REDUCE_SUM_BODY;
+        }
+
+        m_sum = sum;
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case Lambda_OpenMP : {
+
+      auto sumreduce_base_lam = [=](Index_type i) {
+                                 return x[i];
+                               };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        Real_type sum = m_sum_init;
+
+        #pragma omp parallel for reduction(+:sum)
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          sum += sumreduce_base_lam(i);
+        }
+
+        m_sum = sum;
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::ReduceSum<RAJA::omp_reduce, Real_type> sum(m_sum_init);
+
+        RAJA::forall<RAJA::omp_parallel_for_exec>(
+          RAJA::RangeSegment(ibegin, iend),
+          [=](Index_type i) {
+            REDUCE_SUM_BODY;
+        });
+
+        m_sum = sum.get();
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    default : {
+      getCout() << "\n  REDUCE_SUM : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/REDUCE_SUM-OMPTarget.cpp
+++ b/src/algorithm/REDUCE_SUM-OMPTarget.cpp
@@ -1,0 +1,101 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "REDUCE_SUM.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+  //
+  // Define threads per team for target execution
+  //
+  const size_t threads_per_team = 256;
+
+#define REDUCE_SUM_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  allocAndInitOpenMPDeviceData(x, m_x, iend, did, hid);
+
+#define REDUCE_SUM_DATA_TEARDOWN_OMP_TARGET \
+  deallocOpenMPDeviceData(x, did); \
+
+
+void REDUCE_SUM::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  REDUCE_SUM_DATA_SETUP;
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    REDUCE_SUM_DATA_SETUP_OMP_TARGET
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type sum = m_sum_init;
+
+      #pragma omp target is_device_ptr(x) device( did ) map(tofrom:sum)
+      #pragma omp teams distribute parallel for reduction(+:sum) \
+              thread_limit(threads_per_team) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        REDUCE_SUM_BODY;
+      }
+
+      m_sum = sum;
+
+    }
+    stopTimer();
+
+    REDUCE_SUM_DATA_TEARDOWN_OMP_TARGET
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    REDUCE_SUM_DATA_SETUP_OMP_TARGET
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> sum(m_sum_init);
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+        RAJA::RangeSegment(ibegin, iend),
+        [=](Index_type i) {
+          REDUCE_SUM_BODY;
+      });
+
+      m_sum = sum.get();
+
+    }
+    stopTimer();
+
+    REDUCE_SUM_DATA_TEARDOWN_OMP_TARGET
+
+  } else {
+    getCout() << "\n  REDUCE_SUM : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/algorithm/REDUCE_SUM-Seq.cpp
+++ b/src/algorithm/REDUCE_SUM-Seq.cpp
@@ -1,0 +1,104 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "REDUCE_SUM.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+void REDUCE_SUM::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  REDUCE_SUM_DATA_SETUP;
+
+  switch ( vid ) {
+
+    case Base_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        Real_type sum = m_sum_init;
+
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          REDUCE_SUM_BODY;
+        }
+
+        m_sum = sum;
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+#if defined(RUN_RAJA_SEQ)
+    case Lambda_Seq : {
+
+      auto reduce_sum_base_lam = [=](Index_type i) {
+                                 return x[i];
+                               };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        Real_type sum = m_sum_init;
+
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          sum += reduce_sum_base_lam(i);
+        }
+
+        m_sum = sum;
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::ReduceSum<RAJA::seq_reduce, Real_type> sum(m_sum_init);
+
+        RAJA::forall<RAJA::loop_exec>( RAJA::RangeSegment(ibegin, iend),
+          [=](Index_type i) {
+            REDUCE_SUM_BODY;
+        });
+
+        m_sum = sum.get();
+
+      }
+      stopTimer();
+
+      break;
+    }
+#endif
+
+    default : {
+      getCout() << "\n  REDUCE_SUM : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/REDUCE_SUM.cpp
+++ b/src/algorithm/REDUCE_SUM.cpp
@@ -1,0 +1,79 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "REDUCE_SUM.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+REDUCE_SUM::REDUCE_SUM(const RunParams& params)
+  : KernelBase(rajaperf::Algorithm_REDUCE_SUM, params)
+{
+  setDefaultProblemSize(1000000);
+  setDefaultReps(50);
+
+  setActualProblemSize( getTargetProblemSize() );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) +
+                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(getActualProblemSize());
+
+  setUsesFeature(Forall);
+  setUsesFeature(Reduction);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
+}
+
+REDUCE_SUM::~REDUCE_SUM()
+{
+}
+
+void REDUCE_SUM::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  allocAndInitData(m_x, getActualProblemSize(), vid);
+  m_sum_init = 0.0;
+  m_sum = 0.0;
+}
+
+void REDUCE_SUM::updateChecksum(VariantID vid, size_t tune_idx)
+{
+  checksum[vid].at(tune_idx) += calcChecksum(&m_sum, 1);
+}
+
+void REDUCE_SUM::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  (void) vid;
+  deallocData(m_x);
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/REDUCE_SUM.hpp
+++ b/src/algorithm/REDUCE_SUM.hpp
@@ -61,10 +61,12 @@ public:
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void runCudaVariantCub(VariantID vid);
+  void runHipVariantRocprim(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantImpl(VariantID vid);
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantImpl(VariantID vid);
+  void runHipVariantBlock(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/algorithm/REDUCE_SUM.hpp
+++ b/src/algorithm/REDUCE_SUM.hpp
@@ -1,0 +1,81 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// REDUCE_SUM kernel reference implementation:
+///
+/// Real_type sum = std::reduce(x+ibegin, x+iend);
+/// // or
+/// Real_type sum = std::accumulate(x+ibegin, x+iend, 0.0);
+/// // or
+/// Real_type sum = 0.0;
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   sum += x[i] ;
+/// }
+///
+
+#ifndef RAJAPerf_Algorithm_REDUCE_SUM_HPP
+#define RAJAPerf_Algorithm_REDUCE_SUM_HPP
+
+#define REDUCE_SUM_DATA_SETUP \
+  Real_ptr x = m_x;
+
+#define REDUCE_SUM_STD_ARGS  \
+  x + ibegin, x + iend
+
+#define REDUCE_SUM_BODY \
+  sum += x[i];
+
+
+#include "common/KernelBase.hpp"
+
+namespace rajaperf
+{
+class RunParams;
+
+namespace algorithm
+{
+
+class REDUCE_SUM : public KernelBase
+{
+public:
+
+  REDUCE_SUM(const RunParams& params);
+
+  ~REDUCE_SUM();
+
+  void setUp(VariantID vid, size_t tune_idx);
+  void updateChecksum(VariantID vid, size_t tune_idx);
+  void tearDown(VariantID vid, size_t tune_idx);
+
+  void runSeqVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPVariant(VariantID vid, size_t tune_idx);
+  void runCudaVariant(VariantID vid, size_t tune_idx);
+  void runHipVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+
+  void setCudaTuningDefinitions(VariantID vid);
+  void setHipTuningDefinitions(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantImpl(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantImpl(VariantID vid);
+
+private:
+  static const size_t default_gpu_block_size = 256;
+  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+
+  Real_ptr m_x;
+  Real_type m_sum_init;
+  Real_type m_sum;
+};
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/basic/INDEXLIST-OMP.cpp
+++ b/src/basic/INDEXLIST-OMP.cpp
@@ -198,6 +198,8 @@ void INDEXLIST::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
 
   }
 
+#else
+  RAJA_UNUSED_VAR(vid);
 #endif
 }
 

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -94,6 +94,7 @@
 //
 #include "algorithm/SORT.hpp"
 #include "algorithm/SORTPAIRS.hpp"
+#include "algorithm/REDUCE_SUM.hpp"
 
 
 #include <iostream>
@@ -222,6 +223,7 @@ static const std::string KernelNames [] =
 //
   std::string("Algorithm_SORT"),
   std::string("Algorithm_SORTPAIRS"),
+  std::string("Algorithm_REDUCE_SUM"),
 
   std::string("Unknown Kernel")  // Keep this at the end and DO NOT remove....
 
@@ -739,6 +741,10 @@ KernelBase* getKernelObject(KernelID kid,
     }
     case Algorithm_SORTPAIRS: {
        kernel = new algorithm::SORTPAIRS(run_params);
+       break;
+    }
+    case Algorithm_REDUCE_SUM: {
+       kernel = new algorithm::REDUCE_SUM(run_params);
        break;
     }
 

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -147,6 +147,7 @@ enum KernelID {
 //
   Algorithm_SORT,
   Algorithm_SORTPAIRS,
+  Algorithm_REDUCE_SUM,
 
   NumKernels // Keep this one last and NEVER comment out (!!)
 


### PR DESCRIPTION
# Add an algorithm reduce sum kernel.

Add an algorithm reduce sum kernel so we can more easily compare reduction implementations. This has gpu tunings for a native library like cub/rocprim as well as the normal perf suite base implementation and raja reducer implemention.
This also serves as an example of how to implement multiple tunings for kernels.

- This PR is a (refactoring, bugfix, feature, something else)
- It does the following (modify list as needed):
  - Modifies/refactors (class or method) (how?)
  - Fixes (issue number(s))
  - Adds (specific feature) at the request of (project or person)
