### PR TITLE
Update checksum weighing

### DIFF
--- a/src/algorithm/SCAN.cpp
+++ b/src/algorithm/SCAN.cpp
@@ -31,11 +31,10 @@ SCAN::SCAN(const RunParams& params)
   setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() );
   setFLOPsPerRep(1 * getActualProblemSize());
 
-  Checksum_type actualProblemSize = getActualProblemSize();
   checksum_scale_factor = 1e-2 *
                  ( static_cast<Checksum_type>(getDefaultProblemSize()) /
                                               getActualProblemSize() ) /
-                 ( actualProblemSize * (actualProblemSize + 1) / 2 );
+                 getActualProblemSize();
 
   setUsesFeature(Scan);
 

--- a/src/common/DataUtils.cpp
+++ b/src/common/DataUtils.cpp
@@ -337,14 +337,21 @@ long double calcChecksum(const Int_ptr ptr, int len,
                          Real_type scale_factor)
 {
   long double tchk = 0.0;
+  long double ckahan = 0.0;
   for (Index_type j = 0; j < len; ++j) {
-    tchk += (j+1)*ptr[j]*scale_factor;
+    long double x = (std::abs(std::sin(j+1.0))+0.5) * ptr[j];
+    long double y = x - ckahan;
+    volatile long double t = tchk + y;
+    volatile long double z = t - tchk;
+    ckahan = z - y;
+    tchk = t;
 #if 0 // RDH DEBUG
     if ( (j % 100) == 0 ) {
       getCout() << "j : tchk = " << j << " : " << tchk << std::endl;
     }
 #endif
   }
+  tchk *= scale_factor;
   return tchk;
 }
 
@@ -352,14 +359,21 @@ long double calcChecksum(const Real_ptr ptr, int len,
                          Real_type scale_factor)
 {
   long double tchk = 0.0;
+  long double ckahan = 0.0;
   for (Index_type j = 0; j < len; ++j) {
-    tchk += (j+1)*ptr[j]*scale_factor;
+    long double x = (std::abs(std::sin(j+1.0))+0.5) * ptr[j];
+    long double y = x - ckahan;
+    volatile long double t = tchk + y;
+    volatile long double z = t - tchk;
+    ckahan = z - y;
+    tchk = t;
 #if 0 // RDH DEBUG
     if ( (j % 100) == 0 ) {
       getCout() << "j : tchk = " << j << " : " << tchk << std::endl;
     }
 #endif
   }
+  tchk *= scale_factor;
   return tchk;
 }
 
@@ -367,14 +381,21 @@ long double calcChecksum(const Complex_ptr ptr, int len,
                          Real_type scale_factor)
 {
   long double tchk = 0.0;
+  long double ckahan = 0.0;
   for (Index_type j = 0; j < len; ++j) {
-    tchk += (j+1)*(real(ptr[j])+imag(ptr[j]))*scale_factor;
+    long double x = (std::abs(std::sin(j+1.0))+0.5) * (real(ptr[j])+imag(ptr[j]));
+    long double y = x - ckahan;
+    volatile long double t = tchk + y;
+    volatile long double z = t - tchk;
+    ckahan = z - y;
+    tchk = t;
 #if 0 // RDH DEBUG
     if ( (j % 100) == 0 ) {
       getCout() << "j : tchk = " << j << " : " << tchk << std::endl;
     }
 #endif
   }
+  tchk *= scale_factor;
   return tchk;
 }
 


### PR DESCRIPTION
# Update checksum weighing

Use more uniform weighing when calculating checksums to avoid weighing early or late elements more heavily.
Use kahan sum to reduce error when calculating the checksum.

- This PR is a feature
- It does the following (modify list as needed):
  - Fixes #237 
  - Adds better checksums at the request of me and Rich
