### PR TITLE
Fix bugs in MPI usage

### DIFF
--- a/src/algorithm/SCAN-Cuda.cpp
+++ b/src/algorithm/SCAN-Cuda.cpp
@@ -106,7 +106,7 @@ void SCAN::runCudaVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
     SCAN_DATA_TEARDOWN_CUDA;
 
   } else {
-     std::cout << "\n  SCAN : Unknown Cuda variant id = " << vid << std::endl;
+     getCout() << "\n  SCAN : Unknown Cuda variant id = " << vid << std::endl;
   }
 }
 

--- a/src/algorithm/SCAN-Hip.cpp
+++ b/src/algorithm/SCAN-Hip.cpp
@@ -133,7 +133,7 @@ void SCAN::runHipVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
     SCAN_DATA_TEARDOWN_HIP;
 
   } else {
-     std::cout << "\n  SCAN : Unknown Hip variant id = " << vid << std::endl;
+     getCout() << "\n  SCAN : Unknown Hip variant id = " << vid << std::endl;
   }
 }
 

--- a/src/algorithm/SCAN-OMP.cpp
+++ b/src/algorithm/SCAN-OMP.cpp
@@ -175,7 +175,7 @@ void SCAN::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
     }
 
     default : {
-      std::cout << "\n  SCAN : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  SCAN : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/algorithm/SCAN-Seq.cpp
+++ b/src/algorithm/SCAN-Seq.cpp
@@ -79,7 +79,7 @@ void SCAN::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 #endif
 
     default : {
-      std::cout << "\n  SCAN : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  SCAN : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/apps/NODAL_ACCUMULATION_3D-Cuda.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D-Cuda.cpp
@@ -109,7 +109,7 @@ void NODAL_ACCUMULATION_3D::runCudaVariantImpl(VariantID vid)
     NODAL_ACCUMULATION_3D_DATA_TEARDOWN_CUDA;
 
   } else {
-     std::cout << "\n  NODAL_ACCUMULATION_3D : Unknown Cuda variant id = " << vid << std::endl;
+     getCout() << "\n  NODAL_ACCUMULATION_3D : Unknown Cuda variant id = " << vid << std::endl;
   }
 }
 

--- a/src/apps/NODAL_ACCUMULATION_3D-Hip.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D-Hip.cpp
@@ -109,7 +109,7 @@ void NODAL_ACCUMULATION_3D::runHipVariantImpl(VariantID vid)
     NODAL_ACCUMULATION_3D_DATA_TEARDOWN_HIP;
 
   } else {
-     std::cout << "\n  NODAL_ACCUMULATION_3D : Unknown Hip variant id = " << vid << std::endl;
+     getCout() << "\n  NODAL_ACCUMULATION_3D : Unknown Hip variant id = " << vid << std::endl;
   }
 }
 

--- a/src/apps/NODAL_ACCUMULATION_3D-OMP.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D-OMP.cpp
@@ -133,7 +133,7 @@ void NODAL_ACCUMULATION_3D::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUS
     }
 
     default : {
-      std::cout << "\n  NODAL_ACCUMULATION_3D : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  NODAL_ACCUMULATION_3D : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/apps/NODAL_ACCUMULATION_3D-OMPTarget.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D-OMPTarget.cpp
@@ -116,7 +116,7 @@ void NODAL_ACCUMULATION_3D::runOpenMPTargetVariant(VariantID vid, size_t RAJAPER
     NODAL_ACCUMULATION_3D_DATA_TEARDOWN_OMP_TARGET;
 
   } else {
-    std::cout << "\n  NODAL_ACCUMULATION_3D : Unknown OMP Target variant id = " << vid << std::endl;
+    getCout() << "\n  NODAL_ACCUMULATION_3D : Unknown OMP Target variant id = " << vid << std::endl;
   }
 }
 

--- a/src/apps/NODAL_ACCUMULATION_3D-Seq.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D-Seq.cpp
@@ -93,7 +93,7 @@ void NODAL_ACCUMULATION_3D::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_
 #endif // RUN_RAJA_SEQ
 
     default : {
-      std::cout << "\n  NODAL_ACCUMULATION_3D : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  NODAL_ACCUMULATION_3D : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/basic/INDEXLIST-Cuda.cpp
+++ b/src/basic/INDEXLIST-Cuda.cpp
@@ -306,7 +306,7 @@ void INDEXLIST::runCudaVariantImpl(VariantID vid)
     INDEXLIST_DATA_TEARDOWN_CUDA;
 
   } else {
-    std::cout << "\n  INDEXLIST : Unknown variant id = " << vid << std::endl;
+    getCout() << "\n  INDEXLIST : Unknown variant id = " << vid << std::endl;
   }
 }
 

--- a/src/basic/INDEXLIST-Hip.cpp
+++ b/src/basic/INDEXLIST-Hip.cpp
@@ -306,7 +306,7 @@ void INDEXLIST::runHipVariantImpl(VariantID vid)
     INDEXLIST_DATA_TEARDOWN_HIP;
 
   } else {
-    std::cout << "\n  INDEXLIST : Unknown variant id = " << vid << std::endl;
+    getCout() << "\n  INDEXLIST : Unknown variant id = " << vid << std::endl;
   }
 }
 

--- a/src/basic/INDEXLIST-OMP.cpp
+++ b/src/basic/INDEXLIST-OMP.cpp
@@ -193,7 +193,7 @@ void INDEXLIST::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
 
     default : {
       ignore_unused(run_reps, ibegin, iend, x, list);
-      std::cout << "\n  INDEXLIST : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  INDEXLIST : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/basic/INDEXLIST-OMPTarget.cpp
+++ b/src/basic/INDEXLIST-OMPTarget.cpp
@@ -86,7 +86,7 @@ void INDEXLIST::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG
 
     default : {
       ignore_unused(run_reps, ibegin, iend, x, list);
-      std::cout << "\n  INDEXLIST : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  INDEXLIST : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/basic/INDEXLIST-Seq.cpp
+++ b/src/basic/INDEXLIST-Seq.cpp
@@ -73,7 +73,7 @@ void INDEXLIST::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
 #endif
 
     default : {
-      std::cout << "\n  INDEXLIST : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  INDEXLIST : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/basic/INDEXLIST_3LOOP-Cuda.cpp
+++ b/src/basic/INDEXLIST_3LOOP-Cuda.cpp
@@ -166,7 +166,7 @@ void INDEXLIST_3LOOP::runCudaVariantImpl(VariantID vid)
     INDEXLIST_3LOOP_DATA_TEARDOWN_CUDA;
 
   } else {
-    std::cout << "\n  INDEXLIST_3LOOP : Unknown variant id = " << vid << std::endl;
+    getCout() << "\n  INDEXLIST_3LOOP : Unknown variant id = " << vid << std::endl;
   }
 }
 

--- a/src/basic/INDEXLIST_3LOOP-Hip.cpp
+++ b/src/basic/INDEXLIST_3LOOP-Hip.cpp
@@ -188,7 +188,7 @@ void INDEXLIST_3LOOP::runHipVariantImpl(VariantID vid)
     INDEXLIST_3LOOP_DATA_TEARDOWN_HIP;
 
   } else {
-    std::cout << "\n  INDEXLIST_3LOOP : Unknown variant id = " << vid << std::endl;
+    getCout() << "\n  INDEXLIST_3LOOP : Unknown variant id = " << vid << std::endl;
   }
 }
 

--- a/src/basic/INDEXLIST_3LOOP-OMP.cpp
+++ b/src/basic/INDEXLIST_3LOOP-OMP.cpp
@@ -234,7 +234,7 @@ void INDEXLIST_3LOOP::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG
     }
 
     default : {
-      std::cout << "\n  INDEXLIST_3LOOP : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  INDEXLIST_3LOOP : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/basic/INDEXLIST_3LOOP-OMPTarget.cpp
+++ b/src/basic/INDEXLIST_3LOOP-OMPTarget.cpp
@@ -99,7 +99,7 @@ void INDEXLIST_3LOOP::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUS
     }
 
     default : {
-      std::cout << "\n  INDEXLIST_3LOOP : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  INDEXLIST_3LOOP : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/basic/INDEXLIST_3LOOP-Seq.cpp
+++ b/src/basic/INDEXLIST_3LOOP-Seq.cpp
@@ -149,7 +149,7 @@ void INDEXLIST_3LOOP::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
 #endif
 
     default : {
-      std::cout << "\n  INDEXLIST_3LOOP : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  INDEXLIST_3LOOP : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/basic/REDUCE_STRUCT-OMP.cpp
+++ b/src/basic/REDUCE_STRUCT-OMP.cpp
@@ -140,7 +140,7 @@ void REDUCE_STRUCT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
     }
 
     default : {
-      std::cout << "\n  REDUCE_STRUCT : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  REDUCE_STRUCT : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/basic/REDUCE_STRUCT-OMPTarget.cpp
+++ b/src/basic/REDUCE_STRUCT-OMPTarget.cpp
@@ -115,7 +115,7 @@ void REDUCE_STRUCT::runOpenMPTargetVariant(VariantID vid)
     REDUCE_STRUCT_DATA_TEARDOWN_OMP_TARGET;
 
   } else {
-     std::cout << "\n  REDUCE_STRUCT : Unknown OMP Target variant id = " << vid << std::endl;
+     getCout() << "\n  REDUCE_STRUCT : Unknown OMP Target variant id = " << vid << std::endl;
   }
 
 }

--- a/src/basic/REDUCE_STRUCT-Seq.cpp
+++ b/src/basic/REDUCE_STRUCT-Seq.cpp
@@ -128,7 +128,7 @@ void REDUCE_STRUCT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
 #endif // RUN_RAJA_SEQ
 
     default : {
-      std::cout << "\n  REDUCE_STRUCT : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  REDUCE_STRUCT : Unknown variant id = " << vid << std::endl;
     }
 
   }

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -1616,7 +1616,7 @@ string Executor::getReportTitle(CSVRepMode mode, RunParams::CombinerOpt combiner
       title = string("Max ");
     }
     break;
-    default : { cout << "\n Unknown CSV combiner mode = " << combiner << endl; }
+    default : { getCout() << "\n Unknown CSV combiner mode = " << combiner << endl; }
   }
   switch ( mode ) {
     case CSVRepMode::Timing : {
@@ -1658,7 +1658,7 @@ long double Executor::getReportDataEntry(CSVRepMode mode,
           retval = kern->getMaxTime(vid, tune_idx);
         }
         break;
-        default : { cout << "\n Unknown CSV combiner mode = " << combiner << endl; }
+        default : { getCout() << "\n Unknown CSV combiner mode = " << combiner << endl; }
       }
       break;
     }
@@ -1682,7 +1682,7 @@ long double Executor::getReportDataEntry(CSVRepMode mode,
                        kern->getMaxTime(vid, tune_idx);
             }
             break;
-            default : { cout << "\n Unknown CSV combiner mode = " << combiner << endl; }
+            default : { getCout() << "\n Unknown CSV combiner mode = " << combiner << endl; }
           }
         } else {
           retval = 0.0;

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -44,6 +44,8 @@ using namespace std;
 
 namespace {
 
+#ifdef RAJA_PERFSUITE_ENABLE_MPI
+
 void Allreduce(const Checksum_type* send, Checksum_type* recv, int count,
                MPI_Op op, MPI_Comm comm)
 {
@@ -93,6 +95,8 @@ void Allreduce(const Checksum_type* send, Checksum_type* recv, int count,
   }
 
 }
+
+#endif
 
 }
 

--- a/src/common/OutputUtils.cpp
+++ b/src/common/OutputUtils.cpp
@@ -31,15 +31,6 @@ namespace rajaperf
  */
 std::string recursiveMkdir(const std::string& in_path)
 {
-#ifdef RAJA_PERFSUITE_ENABLE_MPI
-  int rank = 0;
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
-  // Processes wait for rank 0 to make the directories before proceeding
-  if (rank != 0) {
-    MPI_Barrier(MPI_COMM_WORLD);
-  }
-#endif
 
   std::string dir;
 
@@ -56,6 +47,15 @@ std::string recursiveMkdir(const std::string& in_path)
 
   if ( path.empty() ) return std::string();
 
+#ifdef RAJA_PERFSUITE_ENABLE_MPI
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  // Processes wait for rank 0 to make the directories before proceeding
+  if (rank != 0) {
+    MPI_Barrier(MPI_COMM_WORLD);
+  }
+#endif
 // ----------------------------------------
   std::string outpath = path;
 

--- a/src/common/OutputUtils.cpp
+++ b/src/common/OutputUtils.cpp
@@ -31,10 +31,9 @@ namespace rajaperf
  */
 std::string recursiveMkdir(const std::string& in_path)
 {
-
-  std::string dir;
-
   std::string path = in_path;
+
+  // remove leading "." or "./"
   if ( !path.empty() ) {
     if ( path.at(0) == '.' ) {
       if ( path.length() > 2 && path.at(1) == '/' ) {
@@ -56,6 +55,7 @@ std::string recursiveMkdir(const std::string& in_path)
     MPI_Barrier(MPI_COMM_WORLD);
   }
 #endif
+
 // ----------------------------------------
   std::string outpath = path;
 

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -330,7 +330,7 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
           got_someting = true;
           int gpu_block_size = ::atoi( opt.c_str() );
           if ( gpu_block_size <= 0 ) {
-            std::cout << "\nBad input:"
+            getCout() << "\nBad input:"
                       << " must give --gpu_block_size POSITIVE values (int)"
                       << std::endl;
             input_state = BadInput;
@@ -341,7 +341,7 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
         }
       }
       if (!got_someting) {
-        std::cout << "\nBad input:"
+        getCout() << "\nBad input:"
                   << " must give --gpu_block_size one or more values (int)"
                   << std::endl;
         input_state = BadInput;


### PR DESCRIPTION
# Fix bugs in MPI usage

Fix hang where rank 0 did not enter a barrier if no path was given when creating directories.
Support long double with all reduce even if the MPI implementation lackes support for long double.
Fix prints to be rank 0 only.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes various things
