### PR TITLE
Add basic Memory algorithms

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -227,6 +227,9 @@ blt_add_executable(
   algorithm/REDUCE_SUM.cpp
   algorithm/REDUCE_SUM-Seq.cpp
   algorithm/REDUCE_SUM-OMPTarget.cpp
+  algorithm/MEMSET.cpp
+  algorithm/MEMSET-Seq.cpp
+  algorithm/MEMSET-OMPTarget.cpp
   DEPENDS_ON ${RAJA_PERFSUITE_DEPENDS}
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -230,6 +230,9 @@ blt_add_executable(
   algorithm/MEMSET.cpp
   algorithm/MEMSET-Seq.cpp
   algorithm/MEMSET-OMPTarget.cpp
+  algorithm/MEMCPY.cpp
+  algorithm/MEMCPY-Seq.cpp
+  algorithm/MEMCPY-OMPTarget.cpp
   DEPENDS_ON ${RAJA_PERFSUITE_DEPENDS}
 )
 

--- a/src/algorithm/CMakeLists.txt
+++ b/src/algorithm/CMakeLists.txt
@@ -29,5 +29,11 @@ blt_add_library(
           REDUCE_SUM-Cuda.cpp
           REDUCE_SUM-OMP.cpp
           REDUCE_SUM-OMPTarget.cpp
+          MEMSET.cpp
+          MEMSET-Seq.cpp
+          MEMSET-Hip.cpp
+          MEMSET-Cuda.cpp
+          MEMSET-OMP.cpp
+          MEMSET-OMPTarget.cpp
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/algorithm/CMakeLists.txt
+++ b/src/algorithm/CMakeLists.txt
@@ -35,5 +35,11 @@ blt_add_library(
           MEMSET-Cuda.cpp
           MEMSET-OMP.cpp
           MEMSET-OMPTarget.cpp
+          MEMCPY.cpp
+          MEMCPY-Seq.cpp
+          MEMCPY-Hip.cpp
+          MEMCPY-Cuda.cpp
+          MEMCPY-OMP.cpp
+          MEMCPY-OMPTarget.cpp
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/algorithm/MEMCPY-Cuda.cpp
+++ b/src/algorithm/MEMCPY-Cuda.cpp
@@ -42,7 +42,7 @@ __global__ void memcpy(Real_ptr x, Real_ptr y,
 }
 
 
-void MEMCPY::runCudaVariantMemcpy(VariantID vid)
+void MEMCPY::runCudaVariantLibrary(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -168,7 +168,7 @@ void MEMCPY::runCudaVariant(VariantID vid, size_t tune_idx)
 
     if (tune_idx == t) {
 
-      runCudaVariantMemcpy(vid);
+      runCudaVariantLibrary(vid);
 
     }
 
@@ -197,7 +197,7 @@ void MEMCPY::runCudaVariant(VariantID vid, size_t tune_idx)
 void MEMCPY::setCudaTuningDefinitions(VariantID vid)
 {
   if (vid == Base_CUDA || vid == RAJA_CUDA) {
-    addVariantTuningName(vid, "memcpy");
+    addVariantTuningName(vid, "library");
   }
 
   seq_for(gpu_block_sizes_type{}, [&](auto block_size) {

--- a/src/algorithm/MEMCPY-Cuda.cpp
+++ b/src/algorithm/MEMCPY-Cuda.cpp
@@ -1,0 +1,156 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMCPY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+#define MEMCPY_DATA_SETUP_CUDA \
+  allocAndInitCudaDeviceData(x, m_x, iend); \
+  allocAndInitCudaDeviceData(y, m_y, iend);
+
+#define MEMCPY_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_y, y, iend); \
+  deallocCudaDeviceData(x); \
+  deallocCudaDeviceData(y);
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void memcpy(Real_ptr x, Real_ptr y,
+                       Index_type iend)
+{
+  Index_type i = blockIdx.x * block_size + threadIdx.x;
+  if ( i < iend ) {
+    MEMCPY_BODY;
+  }
+}
+
+
+template < size_t block_size >
+void MEMCPY::runCudaVariantBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  MEMCPY_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    MEMCPY_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      memcpy<block_size><<<grid_size, block_size>>>(
+          x, y, iend );
+      cudaErrchk( cudaGetLastError() );
+
+    }
+    stopTimer();
+
+    MEMCPY_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    MEMCPY_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto memcpy_lambda = [=] __device__ (Index_type i) {
+        MEMCPY_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      lambda_cuda_forall<block_size><<<grid_size, block_size>>>(
+          ibegin, iend, memcpy_lambda );
+      cudaErrchk( cudaGetLastError() );
+
+    }
+    stopTimer();
+
+    MEMCPY_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    MEMCPY_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          MEMCPY_BODY;
+      });
+
+    }
+    stopTimer();
+
+    MEMCPY_DATA_TEARDOWN_CUDA;
+
+  } else {
+
+    getCout() << "\n  MEMCPY : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void MEMCPY::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (tune_idx == t) {
+
+        runCudaVariantBlock<block_size>(vid);
+
+      }
+
+      t += 1;
+
+    }
+
+  });
+}
+
+void MEMCPY::setCudaTuningDefinitions(VariantID vid)
+{
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+    }
+
+  });
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/algorithm/MEMCPY-Hip.cpp
+++ b/src/algorithm/MEMCPY-Hip.cpp
@@ -42,7 +42,7 @@ __global__ void memcpy(Real_ptr x, Real_ptr y,
 }
 
 
-void MEMCPY::runHipVariantMemcpy(VariantID vid)
+void MEMCPY::runHipVariantLibrary(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -170,7 +170,7 @@ void MEMCPY::runHipVariant(VariantID vid, size_t tune_idx)
 
     if (tune_idx == t) {
 
-      runHipVariantMemcpy(vid);
+      runHipVariantLibrary(vid);
 
     }
 
@@ -200,7 +200,7 @@ void MEMCPY::runHipVariant(VariantID vid, size_t tune_idx)
 void MEMCPY::setHipTuningDefinitions(VariantID vid)
 {
   if (vid == Base_HIP || vid == RAJA_HIP) {
-    addVariantTuningName(vid, "memcpy");
+    addVariantTuningName(vid, "library");
   }
 
   seq_for(gpu_block_sizes_type{}, [&](auto block_size) {

--- a/src/algorithm/MEMCPY-Hip.cpp
+++ b/src/algorithm/MEMCPY-Hip.cpp
@@ -1,0 +1,160 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMCPY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+#include "common/HipDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+#define MEMCPY_DATA_SETUP_HIP \
+  allocAndInitHipDeviceData(x, m_x, iend); \
+  allocAndInitHipDeviceData(y, m_y, iend);
+
+#define MEMCPY_DATA_TEARDOWN_HIP \
+  getHipDeviceData(m_y, y, iend); \
+  deallocHipDeviceData(x); \
+  deallocHipDeviceData(y);
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void memcpy(Real_ptr x, Real_ptr y,
+                       Index_type iend)
+{
+  Index_type i = blockIdx.x * block_size + threadIdx.x;
+  if ( i < iend ) {
+    MEMCPY_BODY;
+  }
+}
+
+template < size_t block_size >
+void MEMCPY::runHipVariantBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  MEMCPY_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    MEMCPY_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      hipLaunchKernelGGL( (memcpy<block_size>),
+          dim3(grid_size), dim3(block_size), 0, 0,
+          x, y, iend );
+      hipErrchk( hipGetLastError() );
+
+    }
+    stopTimer();
+
+    MEMCPY_DATA_TEARDOWN_HIP;
+
+  } else if ( vid == Lambda_HIP ) {
+
+    MEMCPY_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto memcpy_lambda = [=] __device__ (Index_type i) {
+        MEMCPY_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(memcpy_lambda)>),
+          grid_size, block_size, 0, 0,
+          ibegin, iend, memcpy_lambda);
+      hipErrchk( hipGetLastError() );
+
+    }
+    stopTimer();
+
+    MEMCPY_DATA_TEARDOWN_HIP;
+
+  } else if ( vid == RAJA_HIP ) {
+
+    MEMCPY_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          MEMCPY_BODY;
+      });
+
+    }
+    stopTimer();
+
+    MEMCPY_DATA_TEARDOWN_HIP;
+
+  } else {
+
+    getCout() << "\n  MEMCPY : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void MEMCPY::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (tune_idx == t) {
+
+        runHipVariantBlock<block_size>(vid);
+
+      }
+
+      t += 1;
+
+    }
+
+  });
+
+}
+
+void MEMCPY::setHipTuningDefinitions(VariantID vid)
+{
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+    }
+
+  });
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_HIP

--- a/src/algorithm/MEMCPY-OMP.cpp
+++ b/src/algorithm/MEMCPY-OMP.cpp
@@ -1,0 +1,98 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMCPY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+void MEMCPY::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  MEMCPY_DATA_SETUP;
+
+  switch ( vid ) {
+
+    case Base_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          MEMCPY_BODY;
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case Lambda_OpenMP : {
+
+      auto memset_lambda = [=](Index_type i) {
+                             MEMCPY_BODY;
+                           };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          memset_lambda(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::forall<RAJA::omp_parallel_for_exec>(
+          RAJA::RangeSegment(ibegin, iend),
+          [=](Index_type i) {
+            MEMCPY_BODY;
+        });
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    default : {
+      getCout() << "\n  MEMCPY : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/MEMCPY-OMPTarget.cpp
+++ b/src/algorithm/MEMCPY-OMPTarget.cpp
@@ -1,0 +1,93 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMCPY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+  //
+  // Define threads per team for target execution
+  //
+  const size_t threads_per_team = 256;
+
+#define MEMCPY_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  allocAndInitOpenMPDeviceData(x, m_x, iend, did, hid);
+
+#define MEMCPY_DATA_TEARDOWN_OMP_TARGET \
+  deallocOpenMPDeviceData(x, did); \
+
+
+void MEMCPY::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  MEMCPY_DATA_SETUP;
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    MEMCPY_DATA_SETUP_OMP_TARGET
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(x, y) device( did )
+      #pragma omp teams distribute parallel for \
+              thread_limit(threads_per_team) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        MEMCPY_BODY;
+      }
+
+    }
+    stopTimer();
+
+    MEMCPY_DATA_TEARDOWN_OMP_TARGET
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    MEMCPY_DATA_SETUP_OMP_TARGET
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+        RAJA::RangeSegment(ibegin, iend),
+        [=](Index_type i) {
+          MEMCPY_BODY;
+      });
+
+    }
+    stopTimer();
+
+    MEMCPY_DATA_TEARDOWN_OMP_TARGET
+
+  } else {
+    getCout() << "\n  MEMCPY : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/algorithm/MEMCPY-Seq.cpp
+++ b/src/algorithm/MEMCPY-Seq.cpp
@@ -18,7 +18,7 @@ namespace algorithm
 {
 
 
-void MEMCPY::runSeqVariantMemcpy(VariantID vid)
+void MEMCPY::runSeqVariantLibrary(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -144,7 +144,7 @@ void MEMCPY::runSeqVariant(VariantID vid, size_t tune_idx)
 
     if (tune_idx == t) {
 
-      runSeqVariantMemcpy(vid);
+      runSeqVariantLibrary(vid);
 
     }
 
@@ -164,7 +164,7 @@ void MEMCPY::runSeqVariant(VariantID vid, size_t tune_idx)
 void MEMCPY::setSeqTuningDefinitions(VariantID vid)
 {
   if (vid == Base_Seq || vid == RAJA_Seq) {
-    addVariantTuningName(vid, "memcpy");
+    addVariantTuningName(vid, "library");
   }
 
   addVariantTuningName(vid, "default");

--- a/src/algorithm/MEMCPY-Seq.cpp
+++ b/src/algorithm/MEMCPY-Seq.cpp
@@ -1,0 +1,92 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMCPY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+void MEMCPY::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  MEMCPY_DATA_SETUP;
+
+  switch ( vid ) {
+
+    case Base_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          MEMCPY_BODY;
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+#if defined(RUN_RAJA_SEQ)
+    case Lambda_Seq : {
+
+      auto memset_lambda = [=](Index_type i) {
+                             MEMCPY_BODY;
+                           };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          memset_lambda(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::forall<RAJA::loop_exec>( RAJA::RangeSegment(ibegin, iend),
+          [=](Index_type i) {
+            MEMCPY_BODY;
+        });
+
+      }
+      stopTimer();
+
+      break;
+    }
+#endif
+
+    default : {
+      getCout() << "\n  MEMCPY : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/MEMCPY.cpp
+++ b/src/algorithm/MEMCPY.cpp
@@ -1,0 +1,79 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMCPY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+MEMCPY::MEMCPY(const RunParams& params)
+  : KernelBase(rajaperf::Algorithm_MEMCPY, params)
+{
+  setDefaultProblemSize(1000000);
+  setDefaultReps(100);
+
+  setActualProblemSize( getTargetProblemSize() );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(0);
+
+  setUsesFeature(Forall);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
+  setVariantDefined( RAJA_HIP );
+}
+
+MEMCPY::~MEMCPY()
+{
+}
+
+void MEMCPY::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  allocAndInitDataConst(m_x, getActualProblemSize(), 0.0, vid);
+  allocAndInitDataConst(m_y, getActualProblemSize(), -1.234567e89, vid);
+}
+
+void MEMCPY::updateChecksum(VariantID vid, size_t tune_idx)
+{
+  checksum[vid].at(tune_idx) += calcChecksum(m_y, getActualProblemSize());
+}
+
+void MEMCPY::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  (void) vid;
+  deallocData(m_x);
+  deallocData(m_y);
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/MEMCPY.hpp
+++ b/src/algorithm/MEMCPY.hpp
@@ -59,15 +59,15 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   void runSeqVariantDefault(VariantID vid);
-  void runSeqVariantMemcpy(VariantID vid);
+  void runSeqVariantLibrary(VariantID vid);
 
   template < size_t block_size >
   void runCudaVariantBlock(VariantID vid);
-  void runCudaVariantMemcpy(VariantID vid);
+  void runCudaVariantLibrary(VariantID vid);
 
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
-  void runHipVariantMemcpy(VariantID vid);
+  void runHipVariantLibrary(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/algorithm/MEMCPY.hpp
+++ b/src/algorithm/MEMCPY.hpp
@@ -64,6 +64,7 @@ public:
   template < size_t block_size >
   void runCudaVariantBlock(VariantID vid);
   void runCudaVariantMemcpy(VariantID vid);
+
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
   void runHipVariantMemcpy(VariantID vid);

--- a/src/algorithm/MEMCPY.hpp
+++ b/src/algorithm/MEMCPY.hpp
@@ -60,6 +60,7 @@ public:
   void setHipTuningDefinitions(VariantID vid);
   void runSeqVariantDefault(VariantID vid);
   void runSeqVariantMemcpy(VariantID vid);
+
   template < size_t block_size >
   void runCudaVariantBlock(VariantID vid);
   void runCudaVariantMemcpy(VariantID vid);

--- a/src/algorithm/MEMCPY.hpp
+++ b/src/algorithm/MEMCPY.hpp
@@ -55,12 +55,17 @@ public:
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
 
+  void setSeqTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void runSeqVariantDefault(VariantID vid);
+  void runSeqVariantMemcpy(VariantID vid);
   template < size_t block_size >
   void runCudaVariantBlock(VariantID vid);
+  void runCudaVariantMemcpy(VariantID vid);
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
+  void runHipVariantMemcpy(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/algorithm/MEMCPY.hpp
+++ b/src/algorithm/MEMCPY.hpp
@@ -1,0 +1,76 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// MEMCPY kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   x[i] = val ;
+/// }
+///
+
+#ifndef RAJAPerf_Algorithm_MEMCPY_HPP
+#define RAJAPerf_Algorithm_MEMCPY_HPP
+
+#define MEMCPY_DATA_SETUP \
+  Real_ptr x = m_x; \
+  Real_ptr y = m_y; \
+
+#define MEMCPY_STD_ARGS  \
+  y + ibegin, x + ibegin, (iend-ibegin)*sizeof(Real_type)
+
+#define MEMCPY_BODY \
+  y[i] = x[i];
+
+
+#include "common/KernelBase.hpp"
+
+namespace rajaperf
+{
+class RunParams;
+
+namespace algorithm
+{
+
+class MEMCPY : public KernelBase
+{
+public:
+
+  MEMCPY(const RunParams& params);
+
+  ~MEMCPY();
+
+  void setUp(VariantID vid, size_t tune_idx);
+  void updateChecksum(VariantID vid, size_t tune_idx);
+  void tearDown(VariantID vid, size_t tune_idx);
+
+  void runSeqVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPVariant(VariantID vid, size_t tune_idx);
+  void runCudaVariant(VariantID vid, size_t tune_idx);
+  void runHipVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+
+  void setCudaTuningDefinitions(VariantID vid);
+  void setHipTuningDefinitions(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlock(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlock(VariantID vid);
+
+private:
+  static const size_t default_gpu_block_size = 256;
+  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+
+  Real_ptr m_x;
+  Real_ptr m_y;
+};
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/algorithm/MEMSET-Cuda.cpp
+++ b/src/algorithm/MEMSET-Cuda.cpp
@@ -40,7 +40,7 @@ __global__ void memset(Real_ptr x, Real_type val,
 }
 
 
-void MEMSET::runCudaVariantMemset(VariantID vid)
+void MEMSET::runCudaVariantLibrary(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -168,7 +168,7 @@ void MEMSET::runCudaVariant(VariantID vid, size_t tune_idx)
 
     if (tune_idx == t) {
 
-      runCudaVariantMemset(vid);
+      runCudaVariantLibrary(vid);
 
     }
 
@@ -197,7 +197,7 @@ void MEMSET::runCudaVariant(VariantID vid, size_t tune_idx)
 void MEMSET::setCudaTuningDefinitions(VariantID vid)
 {
   if (vid == Base_CUDA || vid == RAJA_CUDA) {
-    addVariantTuningName(vid, "memset");
+    addVariantTuningName(vid, "library");
   }
 
   seq_for(gpu_block_sizes_type{}, [&](auto block_size) {

--- a/src/algorithm/MEMSET-Cuda.cpp
+++ b/src/algorithm/MEMSET-Cuda.cpp
@@ -1,0 +1,156 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMSET.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+#define MEMSET_DATA_SETUP_CUDA \
+  allocAndInitCudaDeviceData(x, m_x, iend);
+
+#define MEMSET_DATA_TEARDOWN_CUDA \
+  getCudaDeviceData(m_x, x, iend); \
+  deallocCudaDeviceData(x);
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void memset(Real_ptr x, Real_type val,
+                       Index_type iend)
+{
+  Index_type i = blockIdx.x * block_size + threadIdx.x;
+  if ( i < iend ) {
+    MEMSET_BODY;
+  }
+}
+
+
+template < size_t block_size >
+void MEMSET::runCudaVariantBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  MEMSET_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    MEMSET_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      memset<block_size><<<grid_size, block_size,
+                  sizeof(Real_type)*block_size>>>( x,
+                                                   val,
+                                                   iend );
+      cudaErrchk( cudaGetLastError() );
+
+    }
+    stopTimer();
+
+    MEMSET_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    MEMSET_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto memset_lambda = [=] __device__ (Index_type i) {
+        MEMSET_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      lambda_cuda_forall<block_size><<<grid_size, block_size>>>(
+          ibegin, iend, memset_lambda );
+      cudaErrchk( cudaGetLastError() );
+
+    }
+    stopTimer();
+
+    MEMSET_DATA_TEARDOWN_CUDA;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    MEMSET_DATA_SETUP_CUDA;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          MEMSET_BODY;
+      });
+
+    }
+    stopTimer();
+
+    MEMSET_DATA_TEARDOWN_CUDA;
+
+  } else {
+
+    getCout() << "\n  MEMSET : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void MEMSET::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (tune_idx == t) {
+
+        runCudaVariantBlock<block_size>(vid);
+
+      }
+
+      t += 1;
+
+    }
+
+  });
+}
+
+void MEMSET::setCudaTuningDefinitions(VariantID vid)
+{
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+    }
+
+  });
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/algorithm/MEMSET-Hip.cpp
+++ b/src/algorithm/MEMSET-Hip.cpp
@@ -1,0 +1,158 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMSET.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+#include "common/HipDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+#define MEMSET_DATA_SETUP_HIP \
+  allocAndInitHipDeviceData(x, m_x, iend);
+
+#define MEMSET_DATA_TEARDOWN_HIP \
+  getHipDeviceData(m_x, x, iend); \
+  deallocHipDeviceData(x);
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void memset(Real_ptr x, Real_type val,
+                       Index_type iend)
+{
+  Index_type i = blockIdx.x * block_size + threadIdx.x;
+  if ( i < iend ) {
+    MEMSET_BODY;
+  }
+}
+
+template < size_t block_size >
+void MEMSET::runHipVariantBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  MEMSET_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    MEMSET_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      hipLaunchKernelGGL( (memset<block_size>),
+          dim3(grid_size), dim3(block_size), 0, 0,
+          x, val, iend );
+      hipErrchk( hipGetLastError() );
+
+    }
+    stopTimer();
+
+    MEMSET_DATA_TEARDOWN_HIP;
+
+  } else if ( vid == Lambda_HIP ) {
+
+    MEMSET_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto memset_lambda = [=] __device__ (Index_type i) {
+        MEMSET_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(memset_lambda)>),
+          grid_size, block_size, 0, 0,
+          ibegin, iend, memset_lambda);
+      hipErrchk( hipGetLastError() );
+
+    }
+    stopTimer();
+
+    MEMSET_DATA_TEARDOWN_HIP;
+
+  } else if ( vid == RAJA_HIP ) {
+
+    MEMSET_DATA_SETUP_HIP;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          MEMSET_BODY;
+      });
+
+    }
+    stopTimer();
+
+    MEMSET_DATA_TEARDOWN_HIP;
+
+  } else {
+
+    getCout() << "\n  MEMSET : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void MEMSET::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (tune_idx == t) {
+
+        runHipVariantBlock<block_size>(vid);
+
+      }
+
+      t += 1;
+
+    }
+
+  });
+
+}
+
+void MEMSET::setHipTuningDefinitions(VariantID vid)
+{
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+    }
+
+  });
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_HIP

--- a/src/algorithm/MEMSET-Hip.cpp
+++ b/src/algorithm/MEMSET-Hip.cpp
@@ -40,7 +40,7 @@ __global__ void memset(Real_ptr x, Real_type val,
 }
 
 
-void MEMSET::runHipVariantMemset(VariantID vid)
+void MEMSET::runHipVariantLibrary(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -168,7 +168,7 @@ void MEMSET::runHipVariant(VariantID vid, size_t tune_idx)
 
     if (tune_idx == t) {
 
-      runHipVariantMemset(vid);
+      runHipVariantLibrary(vid);
 
     }
 
@@ -198,7 +198,7 @@ void MEMSET::runHipVariant(VariantID vid, size_t tune_idx)
 void MEMSET::setHipTuningDefinitions(VariantID vid)
 {
   if (vid == Base_HIP || vid == RAJA_HIP) {
-    addVariantTuningName(vid, "memset");
+    addVariantTuningName(vid, "library");
   }
 
   seq_for(gpu_block_sizes_type{}, [&](auto block_size) {

--- a/src/algorithm/MEMSET-OMP.cpp
+++ b/src/algorithm/MEMSET-OMP.cpp
@@ -1,0 +1,98 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMSET.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+void MEMSET::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  MEMSET_DATA_SETUP;
+
+  switch ( vid ) {
+
+    case Base_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          MEMSET_BODY;
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case Lambda_OpenMP : {
+
+      auto memset_lambda = [=](Index_type i) {
+                             MEMSET_BODY;
+                           };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          memset_lambda(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::forall<RAJA::omp_parallel_for_exec>(
+          RAJA::RangeSegment(ibegin, iend),
+          [=](Index_type i) {
+            MEMSET_BODY;
+        });
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    default : {
+      getCout() << "\n  MEMSET : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/MEMSET-OMPTarget.cpp
+++ b/src/algorithm/MEMSET-OMPTarget.cpp
@@ -1,0 +1,93 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMSET.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+  //
+  // Define threads per team for target execution
+  //
+  const size_t threads_per_team = 256;
+
+#define MEMSET_DATA_SETUP_OMP_TARGET \
+  int hid = omp_get_initial_device(); \
+  int did = omp_get_default_device(); \
+\
+  allocAndInitOpenMPDeviceData(x, m_x, iend, did, hid);
+
+#define MEMSET_DATA_TEARDOWN_OMP_TARGET \
+  deallocOpenMPDeviceData(x, did); \
+
+
+void MEMSET::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  MEMSET_DATA_SETUP;
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    MEMSET_DATA_SETUP_OMP_TARGET
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(x) device( did )
+      #pragma omp teams distribute parallel for \
+              thread_limit(threads_per_team) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        MEMSET_BODY;
+      }
+
+    }
+    stopTimer();
+
+    MEMSET_DATA_TEARDOWN_OMP_TARGET
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    MEMSET_DATA_SETUP_OMP_TARGET
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+        RAJA::RangeSegment(ibegin, iend),
+        [=](Index_type i) {
+          MEMSET_BODY;
+      });
+
+    }
+    stopTimer();
+
+    MEMSET_DATA_TEARDOWN_OMP_TARGET
+
+  } else {
+    getCout() << "\n  MEMSET : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/algorithm/MEMSET-Seq.cpp
+++ b/src/algorithm/MEMSET-Seq.cpp
@@ -1,0 +1,92 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMSET.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+void MEMSET::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  MEMSET_DATA_SETUP;
+
+  switch ( vid ) {
+
+    case Base_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          MEMSET_BODY;
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+#if defined(RUN_RAJA_SEQ)
+    case Lambda_Seq : {
+
+      auto memset_lambda = [=](Index_type i) {
+                             MEMSET_BODY;
+                           };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          memset_lambda(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::forall<RAJA::loop_exec>( RAJA::RangeSegment(ibegin, iend),
+          [=](Index_type i) {
+            MEMSET_BODY;
+        });
+
+      }
+      stopTimer();
+
+      break;
+    }
+#endif
+
+    default : {
+      getCout() << "\n  MEMSET : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/MEMSET-Seq.cpp
+++ b/src/algorithm/MEMSET-Seq.cpp
@@ -19,7 +19,7 @@ namespace algorithm
 {
 
 
-void MEMSET::runSeqVariantMemset(VariantID vid)
+void MEMSET::runSeqVariantLibrary(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -145,7 +145,7 @@ void MEMSET::runSeqVariant(VariantID vid, size_t tune_idx)
 
     if (tune_idx == t) {
 
-      runSeqVariantMemset(vid);
+      runSeqVariantLibrary(vid);
 
     }
 
@@ -165,7 +165,7 @@ void MEMSET::runSeqVariant(VariantID vid, size_t tune_idx)
 void MEMSET::setSeqTuningDefinitions(VariantID vid)
 {
   if (vid == Base_Seq || vid == RAJA_Seq) {
-    addVariantTuningName(vid, "memset");
+    addVariantTuningName(vid, "library");
   }
 
   addVariantTuningName(vid, "default");

--- a/src/algorithm/MEMSET.cpp
+++ b/src/algorithm/MEMSET.cpp
@@ -1,0 +1,79 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MEMSET.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+MEMSET::MEMSET(const RunParams& params)
+  : KernelBase(rajaperf::Algorithm_MEMSET, params)
+{
+  setDefaultProblemSize(1000000);
+  setDefaultReps(100);
+
+  setActualProblemSize( getTargetProblemSize() );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesPerRep( (0*sizeof(Real_type) + 1*sizeof(Real_type)) +
+                  (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(0);
+
+  setUsesFeature(Forall);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
+  setVariantDefined( RAJA_HIP );
+}
+
+MEMSET::~MEMSET()
+{
+}
+
+void MEMSET::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  allocAndInitDataConst(m_x, getActualProblemSize(), -1.234567e89, vid);
+  m_val = 0.0;
+}
+
+void MEMSET::updateChecksum(VariantID vid, size_t tune_idx)
+{
+  checksum[vid].at(tune_idx) += calcChecksum(m_x, getActualProblemSize());
+}
+
+void MEMSET::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  (void) vid;
+  deallocData(m_x);
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/MEMSET.hpp
+++ b/src/algorithm/MEMSET.hpp
@@ -22,7 +22,7 @@
   Real_type val = m_val;
 
 #define MEMSET_STD_ARGS  \
-  x + ibegin, val, (iend-ibegin)*sizeof(Real_type)
+  x + ibegin, (int)val, (iend-ibegin)*sizeof(Real_type)
 
 #define MEMSET_BODY \
   x[i] = val;
@@ -55,12 +55,17 @@ public:
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
 
+  void setSeqTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void runSeqVariantDefault(VariantID vid);
+  void runSeqVariantMemset(VariantID vid);
   template < size_t block_size >
   void runCudaVariantBlock(VariantID vid);
+  void runCudaVariantMemset(VariantID vid);
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
+  void runHipVariantMemset(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/algorithm/MEMSET.hpp
+++ b/src/algorithm/MEMSET.hpp
@@ -1,0 +1,76 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// MEMSET kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   x[i] = val ;
+/// }
+///
+
+#ifndef RAJAPerf_Algorithm_MEMSET_HPP
+#define RAJAPerf_Algorithm_MEMSET_HPP
+
+#define MEMSET_DATA_SETUP \
+  Real_ptr x = m_x; \
+  Real_type val = m_val;
+
+#define MEMSET_STD_ARGS  \
+  x + ibegin, val, (iend-ibegin)*sizeof(Real_type)
+
+#define MEMSET_BODY \
+  x[i] = val;
+
+
+#include "common/KernelBase.hpp"
+
+namespace rajaperf
+{
+class RunParams;
+
+namespace algorithm
+{
+
+class MEMSET : public KernelBase
+{
+public:
+
+  MEMSET(const RunParams& params);
+
+  ~MEMSET();
+
+  void setUp(VariantID vid, size_t tune_idx);
+  void updateChecksum(VariantID vid, size_t tune_idx);
+  void tearDown(VariantID vid, size_t tune_idx);
+
+  void runSeqVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPVariant(VariantID vid, size_t tune_idx);
+  void runCudaVariant(VariantID vid, size_t tune_idx);
+  void runHipVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+
+  void setCudaTuningDefinitions(VariantID vid);
+  void setHipTuningDefinitions(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlock(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlock(VariantID vid);
+
+private:
+  static const size_t default_gpu_block_size = 256;
+  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+
+  Real_ptr m_x;
+  Real_type m_val;
+};
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/algorithm/MEMSET.hpp
+++ b/src/algorithm/MEMSET.hpp
@@ -60,6 +60,7 @@ public:
   void setHipTuningDefinitions(VariantID vid);
   void runSeqVariantDefault(VariantID vid);
   void runSeqVariantMemset(VariantID vid);
+
   template < size_t block_size >
   void runCudaVariantBlock(VariantID vid);
   void runCudaVariantMemset(VariantID vid);

--- a/src/algorithm/MEMSET.hpp
+++ b/src/algorithm/MEMSET.hpp
@@ -59,15 +59,15 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   void runSeqVariantDefault(VariantID vid);
-  void runSeqVariantMemset(VariantID vid);
+  void runSeqVariantLibrary(VariantID vid);
 
   template < size_t block_size >
   void runCudaVariantBlock(VariantID vid);
-  void runCudaVariantMemset(VariantID vid);
+  void runCudaVariantLibrary(VariantID vid);
 
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
-  void runHipVariantMemset(VariantID vid);
+  void runHipVariantLibrary(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/algorithm/MEMSET.hpp
+++ b/src/algorithm/MEMSET.hpp
@@ -64,6 +64,7 @@ public:
   template < size_t block_size >
   void runCudaVariantBlock(VariantID vid);
   void runCudaVariantMemset(VariantID vid);
+
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
   void runHipVariantMemset(VariantID vid);

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -100,6 +100,7 @@
 #include "algorithm/SORT.hpp"
 #include "algorithm/SORTPAIRS.hpp"
 #include "algorithm/REDUCE_SUM.hpp"
+#include "algorithm/MEMSET.hpp"
 
 
 #include <iostream>
@@ -234,6 +235,7 @@ static const std::string KernelNames [] =
   std::string("Algorithm_SORT"),
   std::string("Algorithm_SORTPAIRS"),
   std::string("Algorithm_REDUCE_SUM"),
+  std::string("Algorithm_MEMSET"),
 
   std::string("Unknown Kernel")  // Keep this at the end and DO NOT remove....
 
@@ -789,6 +791,10 @@ KernelBase* getKernelObject(KernelID kid,
     }
     case Algorithm_REDUCE_SUM: {
        kernel = new algorithm::REDUCE_SUM(run_params);
+       break;
+    }
+    case Algorithm_MEMSET: {
+       kernel = new algorithm::MEMSET(run_params);
        break;
     }
 

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -101,6 +101,7 @@
 #include "algorithm/SORTPAIRS.hpp"
 #include "algorithm/REDUCE_SUM.hpp"
 #include "algorithm/MEMSET.hpp"
+#include "algorithm/MEMCPY.hpp"
 
 
 #include <iostream>
@@ -236,6 +237,7 @@ static const std::string KernelNames [] =
   std::string("Algorithm_SORTPAIRS"),
   std::string("Algorithm_REDUCE_SUM"),
   std::string("Algorithm_MEMSET"),
+  std::string("Algorithm_MEMCPY"),
 
   std::string("Unknown Kernel")  // Keep this at the end and DO NOT remove....
 
@@ -795,6 +797,10 @@ KernelBase* getKernelObject(KernelID kid,
     }
     case Algorithm_MEMSET: {
        kernel = new algorithm::MEMSET(run_params);
+       break;
+    }
+    case Algorithm_MEMCPY: {
+       kernel = new algorithm::MEMCPY(run_params);
        break;
     }
 

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -154,6 +154,7 @@ enum KernelID {
   Algorithm_SORTPAIRS,
   Algorithm_REDUCE_SUM,
   Algorithm_MEMSET,
+  Algorithm_MEMCPY,
 
   NumKernels // Keep this one last and NEVER comment out (!!)
 

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -153,6 +153,7 @@ enum KernelID {
   Algorithm_SORT,
   Algorithm_SORTPAIRS,
   Algorithm_REDUCE_SUM,
+  Algorithm_MEMSET,
 
   NumKernels // Keep this one last and NEVER comment out (!!)
 


### PR DESCRIPTION
# Add Memset and Memcpy kernels

Add basic memory operation kernels so we can compare native memset and memcpy library calls to tunings using loops and raja.
I also plan to add support for different memory spaces and this will also give us the ability to test the performance of basic memory operations with those memory spaces.

Does anyone have a preference for the naming of the tunings?
I'm currently calling the native tunings "memset" and "memcpy", but does it make more sense to call these tunings "native"? These tunings use functions like std::memset/cudaMemset/camp::resource::Host::memset/etc.
I'm calling the tunings that use loops and RAJA forall "default".

- This PR is a feature
- It does the following:
  - Adds basic mem algorithms at the request of myself
