### PR TITLE
Fix lambda var names in MEMCPY

### DIFF
--- a/src/algorithm/MEMCPY-OMP.cpp
+++ b/src/algorithm/MEMCPY-OMP.cpp
@@ -48,7 +48,7 @@ void MEMCPY::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
 
     case Lambda_OpenMP : {
 
-      auto memset_lambda = [=](Index_type i) {
+      auto memcpy_lambda = [=](Index_type i) {
                              MEMCPY_BODY;
                            };
 
@@ -57,7 +57,7 @@ void MEMCPY::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
 
         #pragma omp parallel for
         for (Index_type i = ibegin; i < iend; ++i ) {
-          memset_lambda(i);
+          memcpy_lambda(i);
         }
 
       }

--- a/src/algorithm/MEMCPY-Seq.cpp
+++ b/src/algorithm/MEMCPY-Seq.cpp
@@ -94,7 +94,7 @@ void MEMCPY::runSeqVariantDefault(VariantID vid)
 #if defined(RUN_RAJA_SEQ)
     case Lambda_Seq : {
 
-      auto memset_lambda = [=](Index_type i) {
+      auto memcpy_lambda = [=](Index_type i) {
                              MEMCPY_BODY;
                            };
 
@@ -102,7 +102,7 @@ void MEMCPY::runSeqVariantDefault(VariantID vid)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         for (Index_type i = ibegin; i < iend; ++i ) {
-          memset_lambda(i);
+          memcpy_lambda(i);
         }
 
       }


### PR DESCRIPTION
# Fix lambda var naming in MEMCPY

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes #252 
