### PR TITLE
Minimal changes to get corona CI to run (leave RAJA submodule as is)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ stages:
 
 .build_toss_4_x86_64_ib_corona_script:
   script:
-    - srun -p pbatch -t 30 -N 1 scripts/gitlab/build_and_test.sh
+    - flux mini run --time-limit=30m --nodes=1 scripts/gitlab/build_and_test.sh
 
 # Lassen and Butte use a different job scheduler (spectrum lsf) that does not
 # allow pre-allocation the same way slurm does.

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,9 @@ FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-11.0.0 AS clang11
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN . /opt/spack/share/spack/setup-env.sh && spack load llvm && \
-    cmake -DCMAKE_CXX_COMPILER=clang++ -DENABLE_OPENMP=On .. && \
+RUN . /opt/spack/share/spack/setup-env.sh && \
+    export LD_LIBRARY_PATH=/opt/view/lib:$LD_LIBRARY_PATH && \
+    cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=On .. && \
     make -j 6 &&\
     ctest -T test --output-on-failure
 
@@ -50,7 +51,9 @@ FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-11.0.0 AS clang11-debug
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug .. && \
+RUN . /opt/spack/share/spack/setup-env.sh && \
+    export LD_LIBRARY_PATH=/opt/view/lib:$LD_LIBRARY_PATH && \
+    cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug .. && \
     make -j 6 &&\
     ctest -T test --output-on-failure
 
@@ -58,7 +61,8 @@ FROM ghcr.io/rse-ops/clang-ubuntu-22.04:llvm-13.0.0 AS clang13
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN . /opt/spack/share/spack/setup-env.sh && spack load llvm && \
+RUN . /opt/spack/share/spack/setup-env.sh && \
+    export LD_LIBRARY_PATH=/opt/view/lib:$LD_LIBRARY_PATH && \
     cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=On .. && \
     make -j 6 &&\
     ctest -T test --output-on-failure


### PR DESCRIPTION
# Summary 

- This PR attempts to restart GItlab CI on corona after slurm to flux change.
