### PR TITLE
Use explicit compiler version in CI jobs

### DIFF
--- a/.gitlab/corona-jobs.yml
+++ b/.gitlab/corona-jobs.yml
@@ -5,12 +5,12 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 #############################################################################
 
-hip_5.1.1_clang_13_0_0 (build and test on corona):
+hip_5_1_1_clang_13_0_0 (build and test on corona):
   variables:
     SPEC: "+rocm~openmp amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@5.1.1"
   extends: .build_and_test_on_corona
 
-#hip_5.1.1_clang_13_0_0_desul_atomics (build and test on corona):
+#hip_5_1_1_clang_13_0_0_desul_atomics (build and test on corona):
 #  variables:
 #    SPEC: "+rocm~openmp +desul amdgpu_target=gfx906 %clang@13.0.0 ^blt@develop ^hip@5.1.1"
 #  extends: .build_and_test_on_corona

--- a/.gitlab/lassen-jobs.yml
+++ b/.gitlab/lassen-jobs.yml
@@ -19,7 +19,7 @@ clang_11_0_0:
     SPEC: "+openmp %clang@11.0.0"
   extends: .build_and_test_on_lassen
 
-#ibm_clang_9_gcc_8:
+#ibm_clang_9_0_0_gcc_8_3_1:
 #  variables:
 #    SPEC: "%clang@ibm.9.0.0 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
 #  extends: .build_and_test_on_lassen
@@ -45,33 +45,33 @@ xl_16_1_1_12_gcc_8_3_1:
 # CUDA
 ##########
 
-#ibm_clang_9_cuda:
+#ibm_clang_9_0_0_cuda_10_1_168:
 #  variables:
 #    SPEC: "+cuda cuda_arch=70 %clang@ibm.9.0.0 ^cuda@10.1.168"
 #  extends: .build_and_test_on_lassen
 
-clang_11_cuda:
+clang_11_0_0_cuda_11_5_0:
   variables:
     SPEC: "+openmp +cuda cuda_arch=70 %clang@11.0.0 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 ^cuda@11.5.0"
   extends: .build_and_test_on_lassen
 
-gcc_8_3_1_cuda:
+gcc_8_3_1_cuda_10_1_168:
   variables:
     SPEC: "+openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
   extends: .build_and_test_on_lassen
 
-gcc_8_3_1_cuda_ats_disabled:
+gcc_8_3_1_cuda_10_1_168_ats_disabled:
   variables:
     SPEC: "+openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
   extends: .build_and_test_on_lassen_ats_disabled
 
-xl_16_1_1_12_cuda:
+xl_16_1_1_12_cuda_10_1_168:
   variables:
     SPEC: "+openmp +cuda %xl@16.1.1.12 cxxflags='-qthreaded -std=c++14 -O2 -qstrict -qxlcompatmacros -qalias=noansi -qsmp=omp -qhot -qnoeh -qsuppress=1500-029 -qsuppress=1500-036' cuda_arch=70 ^cuda@10.1.168 ^cmake@3.14.5"
     DEFAULT_TIME: 60
   extends: .build_and_test_on_lassen
 
-xl_16_1_1_12_gcc_8_3_1_cuda_11:
+xl_16_1_1_12_gcc_8_3_1_cuda_11_0_2:
   variables:
     SPEC: "+openmp +cuda %xl@16.1.1.12 cuda_arch=70 cxxflags'=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -qthreaded -std=c++14 -O2 -qstrict -qxlcompatmacros -qalias=noansi -qsmp=omp -qhot -qnoeh -qsuppress=1500-029 -qsuppress=1500-036' cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 ^cuda@11.0.2 ^cmake@3.14.5"
     DEFAULT_TIME: 60
@@ -92,7 +92,7 @@ clang_9_0_0_memleak (build and test on lassen):
     ASAN_OPTIONS: "detect_leaks=1"
   extends: .build_and_test_on_lassen
 
-#gcc_8_3_1_cuda_desul_atomics:
+#gcc_8_3_1_cuda_10_1_168_desul_atomics:
 #  variables:
 #    SPEC: "+cuda +desul %gcc@8.3.1 cuda_arch=70 ^cuda@10.1.168"
 #  extends: .build_and_test_on_lassen

--- a/.gitlab/ruby-jobs.yml
+++ b/.gitlab/ruby-jobs.yml
@@ -5,12 +5,12 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ##############################################################################
 
-clang_10:
+clang_10_0_1:
   variables:
     SPEC: "+openmp %clang@10.0.1"
   extends: .build_and_test_on_ruby
 
-clang_9:
+clang_9_0_0:
   variables:
     SPEC: "+openmp %clang@9.0.0"
   extends: .build_and_test_on_ruby
@@ -21,18 +21,6 @@ gcc_8_1_0:
     DEFAULT_TIME: 60
   extends: .build_and_test_on_ruby
 
-#icpc_17_0_2:
-#  variables:
-#    SPEC: "%intel@17.0.2"
-#    DEFAULT_TIME: 40
-#  extends: .build_and_test_on_ruby
-
-#icpc_18_0_2:
-#  variables:
-#    SPEC: " tests=none %intel@18.0.2"
-#    DEFAULT_TIME: 40
-#  extends: .build_and_test_on_ruby
-
 icpc_19_1_0:
   variables:
     SPEC: "+openmp %intel@19.1.0"
@@ -41,13 +29,7 @@ icpc_19_1_0:
 
 # EXTRAS
 
-#gcc_4_9_3:
-#  variables:
-#    SPEC: "%gcc@4.9.3"
-#    DEFAULT_TIME: 60
-#  extends: .build_and_test_on_ruby
-
-#clang_10_desul_atomics:
+#clang_10_0_1_desul_atomics:
 #  variables:
 #    SPEC: "+openmp +desul %clang@10.0.1 cxxflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 cflags=--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1"
 #  extends: .build_and_test_on_ruby


### PR DESCRIPTION
# Summary 
- This PR contains updates to compiler version names to be explicit and consistent.