### PR TITLE
stream-kokkos: Kokkos variants of the RAJAPerf Suite Stream kernels

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_subdirectory(lcals)
 add_subdirectory(lcals-kokkos)
 add_subdirectory(polybench)
 add_subdirectory(stream)
+add_subdirectory(stream-kokkos)
 add_subdirectory(algorithm)
 
 set(RAJA_PERFSUITE_EXECUTABLE_DEPENDS
@@ -27,6 +28,7 @@ set(RAJA_PERFSUITE_EXECUTABLE_DEPENDS
     lcals-kokkos
     polybench
     stream
+    stream-kokkos
     algorithm)
 list(APPEND RAJA_PERFSUITE_EXECUTABLE_DEPENDS ${RAJA_PERFSUITE_DEPENDS})
 

--- a/src/stream-kokkos/ADD-Kokkos.cpp
+++ b/src/stream-kokkos/ADD-Kokkos.cpp
@@ -1,5 +1,5 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
-// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
 // and RAJA Performance Suite project contributors.
 // See the RAJAPerf/COPYRIGHT file for details.
 //
@@ -27,8 +27,6 @@ void ADD::runKokkosVariant(VariantID vid,
   auto a_view = getViewFromPointer(a, iend);
   auto b_view = getViewFromPointer(b, iend);
   auto c_view = getViewFromPointer(c, iend);
-
-  auto add_lam = [=](Index_type i) { ADD_BODY; };
 
   switch (vid) {
 

--- a/src/stream-kokkos/ADD-Kokkos.cpp
+++ b/src/stream-kokkos/ADD-Kokkos.cpp
@@ -1,0 +1,65 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ADD.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace stream {
+
+void ADD::runKokkosVariant(VariantID vid,
+                           size_t RAJAPERF_UNUSED_ARG(tune_idx)) {
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  ADD_DATA_SETUP;
+
+  // Instiating views using getViewFromPointer
+
+  auto a_view = getViewFromPointer(a, iend);
+  auto b_view = getViewFromPointer(b, iend);
+  auto c_view = getViewFromPointer(c, iend);
+
+  auto add_lam = [=](Index_type i) { ADD_BODY; };
+
+  switch (vid) {
+
+  case Kokkos_Lambda: {
+
+    Kokkos::fence();
+    startTimer();
+
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      Kokkos::parallel_for(
+          "ADD_Kokkos Kokkos_Lambda",
+          Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(ibegin, iend),
+          KOKKOS_LAMBDA(Index_type i) { c_view[i] = a_view[i] + b_view[i]; });
+    }
+
+    Kokkos::fence();
+    stopTimer();
+
+    break;
+  }
+
+  default: {
+    std::cout << "\n  ADD : Unknown variant id = " << vid << std::endl;
+  }
+  }
+
+  moveDataToHostFromKokkosView(a, a_view, iend);
+  moveDataToHostFromKokkosView(b, b_view, iend);
+  moveDataToHostFromKokkosView(c, c_view, iend);
+}
+
+} // end namespace stream
+} // end namespace rajaperf
+#endif // (RUN_KOKKOS)

--- a/src/stream-kokkos/CMakeLists.txt
+++ b/src/stream-kokkos/CMakeLists.txt
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+# and RAJA Performance Suite project contributors.
+# See the RAJAPerf/COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+blt_add_library(
+  NAME stream-kokkos
+  SOURCES ADD-Kokkos.cpp 
+          COPY-Kokkos.cpp 
+          DOT-Kokkos.cpp 
+          MUL-Kokkos.cpp 
+          TRIAD-Kokkos.cpp
+  INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../stream
+  DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
+  )

--- a/src/stream-kokkos/COPY-Kokkos.cpp
+++ b/src/stream-kokkos/COPY-Kokkos.cpp
@@ -1,5 +1,5 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
-// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
 // and RAJA Performance Suite project contributors.
 // See the RAJAPerf/COPYRIGHT file for details.
 //
@@ -24,8 +24,6 @@ void COPY::runKokkosVariant(VariantID vid,
 
   auto a_view = getViewFromPointer(a, iend);
   auto c_view = getViewFromPointer(c, iend);
-
-  auto copy_lam = [=](Index_type i) { COPY_BODY; };
 
   switch (vid) {
 

--- a/src/stream-kokkos/COPY-Kokkos.cpp
+++ b/src/stream-kokkos/COPY-Kokkos.cpp
@@ -1,0 +1,60 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "COPY.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace stream {
+
+void COPY::runKokkosVariant(VariantID vid,
+                            size_t RAJAPERF_UNUSED_ARG(tune_idx)) {
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  COPY_DATA_SETUP;
+
+  auto a_view = getViewFromPointer(a, iend);
+  auto c_view = getViewFromPointer(c, iend);
+
+  auto copy_lam = [=](Index_type i) { COPY_BODY; };
+
+  switch (vid) {
+
+  case Kokkos_Lambda: {
+
+    Kokkos::fence();
+    startTimer();
+
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      Kokkos::parallel_for(
+          "COPY_Kokkos Kokkos_Lambda",
+          Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(ibegin, iend),
+          KOKKOS_LAMBDA(Index_type i) { c_view[i] = a_view[i]; });
+    }
+    Kokkos::fence();
+    stopTimer();
+
+    break;
+  }
+
+  default: {
+    std::cout << "\n  COPY : Unknown variant id = " << vid << std::endl;
+  }
+  }
+
+  moveDataToHostFromKokkosView(a, a_view, iend);
+  moveDataToHostFromKokkosView(c, c_view, iend);
+}
+
+} // end namespace stream
+} // end namespace rajaperf
+#endif // (RUN_KOKKOS)

--- a/src/stream-kokkos/DOT-Kokkos.cpp
+++ b/src/stream-kokkos/DOT-Kokkos.cpp
@@ -1,0 +1,67 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DOT.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace stream {
+
+void DOT::runKokkosVariant(VariantID vid,
+                           size_t RAJAPERF_UNUSED_ARG(tune_idx)) {
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  DOT_DATA_SETUP;
+
+  // Instantiation of pointer - wrapped Kokkos views:
+  auto a_view = getViewFromPointer(a, iend);
+  auto b_view = getViewFromPointer(b, iend);
+
+  switch (vid) {
+
+  case Kokkos_Lambda: {
+    Kokkos::fence();
+    startTimer();
+
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type dot = m_dot_init;
+
+      parallel_reduce(
+          "DOT-Kokkos Kokkos_Lambda",
+          Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(ibegin, iend),
+          KOKKOS_LAMBDA(Index_type i, Real_type & dot_res) {
+            dot_res += a_view[i] * b_view[i];
+          },
+          dot);
+      m_dot += static_cast<Real_type>(dot);
+    }
+
+    Kokkos::fence();
+    stopTimer();
+
+    break;
+  }
+
+  default: {
+    std::cout << "\n  DOT : Unknown variant id = " << vid << std::endl;
+  }
+  }
+
+  moveDataToHostFromKokkosView(a, a_view, iend);
+  moveDataToHostFromKokkosView(b, b_view, iend);
+}
+
+} // end namespace stream
+} // end namespace rajaperf
+#endif // (RUN_KOKKOS)

--- a/src/stream-kokkos/DOT-Kokkos.cpp
+++ b/src/stream-kokkos/DOT-Kokkos.cpp
@@ -1,5 +1,5 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
-// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
 // and RAJA Performance Suite project contributors.
 // See the RAJAPerf/COPYRIGHT file for details.
 //

--- a/src/stream-kokkos/MUL-Kokkos.cpp
+++ b/src/stream-kokkos/MUL-Kokkos.cpp
@@ -1,5 +1,5 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
-// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
 // and RAJA Performance Suite project contributors.
 // See the RAJAPerf/COPYRIGHT file for details.
 //
@@ -24,8 +24,6 @@ void MUL::runKokkosVariant(VariantID vid,
 
   auto b_view = getViewFromPointer(b, iend);
   auto c_view = getViewFromPointer(c, iend);
-
-  auto mul_lam = [=](Index_type i) { MUL_BODY; };
 
   switch (vid) {
 

--- a/src/stream-kokkos/MUL-Kokkos.cpp
+++ b/src/stream-kokkos/MUL-Kokkos.cpp
@@ -1,0 +1,61 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MUL.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace stream {
+
+void MUL::runKokkosVariant(VariantID vid,
+                           size_t RAJAPERF_UNUSED_ARG(tune_idx)) {
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  MUL_DATA_SETUP;
+
+  auto b_view = getViewFromPointer(b, iend);
+  auto c_view = getViewFromPointer(c, iend);
+
+  auto mul_lam = [=](Index_type i) { MUL_BODY; };
+
+  switch (vid) {
+
+  case Kokkos_Lambda: {
+
+    Kokkos::fence();
+    startTimer();
+
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Kokkos::parallel_for(
+          "MUL_Kokkos Kokkos_Lambda",
+          Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(ibegin, iend),
+          KOKKOS_LAMBDA(Index_type i) { b_view[i] = alpha * c_view[i]; });
+    }
+    Kokkos::fence();
+    stopTimer();
+
+    break;
+  }
+
+  default: {
+    std::cout << "\n  MUL : Unknown variant id = " << vid << std::endl;
+  }
+  }
+
+  moveDataToHostFromKokkosView(b, b_view, iend);
+  moveDataToHostFromKokkosView(c, c_view, iend);
+}
+
+} // end namespace stream
+} // end namespace rajaperf
+#endif // (RUN_KOKKOS)

--- a/src/stream-kokkos/TRIAD-Kokkos.cpp
+++ b/src/stream-kokkos/TRIAD-Kokkos.cpp
@@ -1,5 +1,5 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
-// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
 // and RAJA Performance Suite project contributors.
 // See the RAJAPerf/COPYRIGHT file for details.
 //
@@ -25,8 +25,6 @@ void TRIAD::runKokkosVariant(VariantID vid,
   auto a_view = getViewFromPointer(a, iend);
   auto b_view = getViewFromPointer(b, iend);
   auto c_view = getViewFromPointer(c, iend);
-
-  auto triad_lam = [=](Index_type i) { TRIAD_BODY; };
 
   switch (vid) {
 

--- a/src/stream-kokkos/TRIAD-Kokkos.cpp
+++ b/src/stream-kokkos/TRIAD-Kokkos.cpp
@@ -1,0 +1,64 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-20, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "TRIAD.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace stream {
+
+void TRIAD::runKokkosVariant(VariantID vid,
+                             size_t RAJAPERF_UNUSED_ARG(tune_idx)) {
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  TRIAD_DATA_SETUP;
+
+  auto a_view = getViewFromPointer(a, iend);
+  auto b_view = getViewFromPointer(b, iend);
+  auto c_view = getViewFromPointer(c, iend);
+
+  auto triad_lam = [=](Index_type i) { TRIAD_BODY; };
+
+  switch (vid) {
+
+  case Kokkos_Lambda: {
+    Kokkos::fence();
+    startTimer();
+
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      Kokkos::parallel_for(
+          "TRIAD_Kokkos, Kokkos_Lambda",
+          Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(ibegin, iend),
+          KOKKOS_LAMBDA(Index_type i) {
+            a_view[i] = b_view[i] + alpha * c_view[i];
+          });
+    }
+
+    Kokkos::fence();
+    stopTimer();
+
+    break;
+  }
+
+  default: {
+    std::cout << "\n  TRIAD : Unknown variant id = " << vid << std::endl;
+  }
+  }
+
+  moveDataToHostFromKokkosView(a, a_view, iend);
+  moveDataToHostFromKokkosView(b, b_view, iend);
+  moveDataToHostFromKokkosView(c, c_view, iend);
+}
+
+} // end namespace stream
+} // end namespace rajaperf
+#endif // (RUN_KOKKOS)

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -52,6 +52,8 @@ ADD::ADD(const RunParams& params)
   setVariantDefined( Base_HIP );
   setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
+
+  setVariantDefined( Kokkos_Lambda );
 }
 
 ADD::~ADD()

--- a/src/stream/ADD.hpp
+++ b/src/stream/ADD.hpp
@@ -52,6 +52,7 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -52,6 +52,8 @@ COPY::COPY(const RunParams& params)
   setVariantDefined( Base_HIP );
   setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
+
+  setVariantDefined( Kokkos_Lambda );
 }
 
 COPY::~COPY()

--- a/src/stream/COPY.hpp
+++ b/src/stream/COPY.hpp
@@ -51,6 +51,7 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);

--- a/src/stream/DOT.cpp
+++ b/src/stream/DOT.cpp
@@ -52,6 +52,8 @@ DOT::DOT(const RunParams& params)
 
   setVariantDefined( Base_HIP );
   setVariantDefined( RAJA_HIP );
+
+  setVariantDefined( Kokkos_Lambda );
 }
 
 DOT::~DOT()

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -51,6 +51,7 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -52,6 +52,8 @@ MUL::MUL(const RunParams& params)
   setVariantDefined( Base_HIP );
   setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
+
+  setVariantDefined( Kokkos_Lambda );
 }
 
 MUL::~MUL()

--- a/src/stream/MUL.hpp
+++ b/src/stream/MUL.hpp
@@ -52,6 +52,7 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -56,6 +56,8 @@ TRIAD::TRIAD(const RunParams& params)
   setVariantDefined( Base_HIP );
   setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
+
+  setVariantDefined( Kokkos_Lambda );
 }
 
 TRIAD::~TRIAD()

--- a/src/stream/TRIAD.hpp
+++ b/src/stream/TRIAD.hpp
@@ -53,6 +53,7 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);


### PR DESCRIPTION
# Summary: This PR proposes Kokkos implementation of the RAJAPerf Suite stream kernels.

The corresponding PR that will be merged is here: https://github.com/LLNL/RAJAPerf/pull/269. Please review and approve that one.

- This PR is:
enhances / extends RAJAPerf Suite datasets

- To configure, build and run:

```
git clone --recursive git@github.com:LLNL/RAJAPerf.git

# Nota bene:  Kokkos in tpls/kokkos 

mkdir build

cd build

# Kokkos Cuda build:
cmake \
-DENABLE_KOKKOS=ON \
-DRAJA_PERFSUITE_ENABLE_TESTS=OFF \
-DCUDA_ARCH=sm_70 \
-DENABLE_CUDA=ON \
-DKokkos_ARCH_VOLTA70=ON \
-DCMAKE_CUDA_ARCHITECTURES=70 \
-DCMAKE_BUILD_TYPE=Release .. \

or

# Kokkos OpenMP build:
#cmake \
#-DENABLE_KOKKOS=ON \
#-DENABLE_OPENMP=ON \
#-DCMAKE_BUILD_TYPE=Release .. \

pwd

build

ls

bin  CMakeCache.txt    CMakeDoxygenDefaults.cmake  cmake_install.cmake    CTestTestfile.cmake    include  Makefile  Testing  tpl
blt  CMakeDoxyfile.in  CMakeFiles                  compile_commands.json  DartConfiguration.tcl  lib      src       tests

cd bin

./raja-perf.exe

See results in csv files
```