### PR TITLE
Omptarget fixes

### DIFF
--- a/src/algorithm/REDUCE_SUM-OMPTarget.cpp
+++ b/src/algorithm/REDUCE_SUM-OMPTarget.cpp
@@ -76,12 +76,14 @@ void REDUCE_SUM::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_AR
 
       RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> sum(m_sum_init);
 
+      #pragma omp target data map(tofrom : sum)
+      {
       RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-        RAJA::RangeSegment(ibegin, iend),
-        [=](Index_type i) {
+          RAJA::RangeSegment(ibegin, iend),
+        [=,&sum](Index_type i) {
           REDUCE_SUM_BODY;
       });
-
+      }
       m_sum = sum.get();
 
     }

--- a/src/algorithm/SCAN.cpp
+++ b/src/algorithm/SCAN.cpp
@@ -48,6 +48,7 @@ SCAN::SCAN(const RunParams& params)
 
 #if _OPENMP >= 201811 && defined(RAJA_PERFSUITE_ENABLE_OPENMP5_SCAN)
   setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
 #endif
 
   setVariantDefined( Base_CUDA );

--- a/src/basic/PI_REDUCE-OMPTarget.cpp
+++ b/src/basic/PI_REDUCE-OMPTarget.cpp
@@ -63,12 +63,14 @@ void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG
 
       RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> pi(m_pi_init);
 
+      #pragma omp target data map(tofrom : pi) 
+      {
       RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
         RAJA::RangeSegment(ibegin, iend),
-        [=](Index_type i) {
+        [=,&pi](Index_type i) {
           PI_REDUCE_BODY;
       });
-
+      }
       m_pi = 4.0 * pi.get();
 
     }

--- a/src/basic/REDUCE3_INT-OMPTarget.cpp
+++ b/src/basic/REDUCE3_INT-OMPTarget.cpp
@@ -84,12 +84,14 @@ void REDUCE3_INT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_A
       RAJA::ReduceMin<RAJA::omp_target_reduce, Int_type> vmin(m_vmin_init);
       RAJA::ReduceMax<RAJA::omp_target_reduce, Int_type> vmax(m_vmax_init);
 
+      #pragma omp target data map(tofrom : vsum, vmin, vmax) map(to: vec) 
+      {
       RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
         RAJA::RangeSegment(ibegin, iend),
-        [=](Index_type i) {
+        [=,&vsum, &vmin,&vmax](Index_type i) {
         REDUCE3_INT_BODY_RAJA;
       });
-
+      }
       m_vsum += static_cast<Real_type>(vsum.get());
       m_vmin = RAJA_MIN(m_vmin, static_cast<Real_type>(vmin.get()));
       m_vmax = RAJA_MAX(m_vmax, static_cast<Real_type>(vmax.get()));

--- a/src/basic/REDUCE_STRUCT-OMPTarget.cpp
+++ b/src/basic/REDUCE_STRUCT-OMPTarget.cpp
@@ -105,12 +105,14 @@ void REDUCE_STRUCT::runOpenMPTargetVariant(VariantID vid,
       RAJA::ReduceMax<RAJA::omp_target_reduce, Real_type> xmax(m_init_max);
       RAJA::ReduceMax<RAJA::omp_target_reduce, Real_type> ymax(m_init_max);
 
+      #pragma omp target data map(tofrom : xsum, ysum, xmin, ymin, xmax, ymax)
+      {
       RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
         RAJA::RangeSegment(ibegin, iend),
-        [=](Index_type i) {
+        [=, &xsum, &ysum, &xmin, &ymin, &xmax, &ymax](Index_type i) {
         REDUCE_STRUCT_BODY_RAJA;
       });
-
+      }
       points.SetCenter(xsum.get()/(points.N),
                        ysum.get()/(points.N));
       points.SetXMin(xmin.get());

--- a/src/basic/TRAP_INT-OMPTarget.cpp
+++ b/src/basic/TRAP_INT-OMPTarget.cpp
@@ -88,11 +88,13 @@ void TRAP_INT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(
 
       RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> sumx(m_sumx_init);
 
+      #pragma omp target data map(tofrom : sumx) 
+      {
       RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        RAJA::RangeSegment(ibegin, iend), [=,&sumx](Index_type i) {
         TRAP_INT_BODY;
       });
-
+      }
       m_sumx += static_cast<Real_type>(sumx.get()) * h;
 
     }

--- a/src/lcals/FIRST_MIN-OMPTarget.cpp
+++ b/src/lcals/FIRST_MIN-OMPTarget.cpp
@@ -80,11 +80,13 @@ void FIRST_MIN::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG
       RAJA::ReduceMinLoc<RAJA::omp_target_reduce, Real_type, Index_type> loc(
                                                   m_xmin_init, m_initloc);
 
+      #pragma omp target data map(tofrom : loc)
+      {
       RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        RAJA::RangeSegment(ibegin, iend), [=,&loc](Index_type i) {
         FIRST_MIN_BODY_RAJA;
       });
-
+      }
       m_minloc = loc.getLoc();
 
     }

--- a/src/stream/DOT-OMPTarget.cpp
+++ b/src/stream/DOT-OMPTarget.cpp
@@ -77,11 +77,13 @@ void DOT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
 
       RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> dot(m_dot_init);
 
+      #pragma omp target data map(tofrom : dot)
+      {
       RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+          RAJA::RangeSegment(ibegin, iend), [=,&dot](Index_type i) {
         DOT_BODY;
       });
-
+      }
       m_dot += static_cast<Real_type>(dot.get());
 
     }


### PR DESCRIPTION
Variables that are modified within a lambda expression are now captured by reference instead of value.

The lambda expressions used in the OMPTarget tests capture variables by value. Assignments to variables within a lambda expression are not visible outside. After the execution of the lambda expression these variables still contain their init value. Only tests that do not copy their data into the target environment beforehand via initOpenMPDeviceData() resp. getOpenMPDeviceData() are affected.

The RAJA::forall calls are enclosed within "omp target data" pragmas as I didn't find any implicit copy operations of the data into the target environment. 

However, the tests still fail. There seem to be other issues. 

Even though there is no RAJA OpenMP target test implemented for SCAN yet, I added the line 'setVariantDefined( RAJA_OpenMPTarget )' to SCAN.cpp. This was not supposed to be part of this PR. 🙄