### PR TITLE
Try new spack version, incrementally update package

### DIFF
--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -1,7 +1,7 @@
 {
 "package_name" : "raja_perf",
 "package_version" : "develop",
-"package_final_phase" : "hostconfig",
+"package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
 "spack_branch": "v0.19.0",

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "hostconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "v0.18.1",
+"spack_branch": "v0.19.0",
 "spack_activate" : {},
 "spack_configs_path": "tpl/RAJA/scripts/radiuss-spack-configs",
 "spack_packages_path": "scripts/spack_packages",

--- a/scripts/spack_packages/camp/package.py
+++ b/scripts/spack_packages/camp/package.py
@@ -58,9 +58,12 @@ def hip_for_radiuss_projects(options, spec, spec_compiler):
     # adrienbernede-22-11:
     #   Specific to Umpire, attempt port to RAJA and CHAI
     hip_link_flags = ""
-    if "%gcc" in spec:
-        gcc_bin = os.path.dirname(spec_compiler.cxx)
-        gcc_prefix = join_path(gcc_bin, "..")
+    if "%gcc" in spec or spec_uses_toolchain(spec):
+        if "%gcc" in spec:
+            gcc_bin = os.path.dirname(spec_compiler.cxx)
+            gcc_prefix = join_path(gcc_bin, "..")
+        else:
+            gcc_prefix = spec_uses_toolchain(spec)[0]
         options.append(cmake_cache_string("HIP_CLANG_FLAGS", "--gcc-toolchain={0}".format(gcc_prefix)))
         options.append(cmake_cache_string("CMAKE_EXE_LINKER_FLAGS", hip_link_flags + " -Wl,-rpath {}/lib64".format(gcc_prefix)))
     else:

--- a/scripts/spack_packages/raja_perf/package.py
+++ b/scripts/spack_packages/raja_perf/package.py
@@ -3,17 +3,15 @@
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-
-from spack import *
-from spack.pkg.builtin.camp import hip_repair_cache
-
-import socket
 import os
+import socket
+import re
 
 from os import environ as env
 from os.path import join as pjoin
 
-import re
+from spack import *
+from spack.pkg.builtin.camp import hip_repair_cache
 
 def cmake_cache_entry(name, value, comment=""):
     """Generate a string for a cmake cache variable"""
@@ -34,32 +32,15 @@ def cmake_cache_option(name, boolean_value, comment=""):
     return 'set(%s %s CACHE BOOL "%s")\n\n' % (name,value,comment)
 
 
-def get_spec_path(spec, package_name, path_replacements = {}, use_bin = False) :
-    """Extracts the prefix path for the given spack package
-       path_replacements is a dictionary with string replacements for the path.
-    """
-
-    if not use_bin:
-        path = spec[package_name].prefix
-    else:
-        path = spec[package_name].prefix.bin
-
-    path = os.path.realpath(path)
-
-    for key in path_replacements:
-        path = path.replace(key, path_replacements[key])
-
-    return path
-
-
 class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
-    """RAJAPerf Suite Framework."""
+    """RAJA Performance Suite."""
 
     homepage = "http://software.llnl.gov/RAJAPerf/"
     git      = "https://github.com/LLNL/RAJAPerf.git"
 
     version('develop', branch='develop', submodules='True')
     version('main',  branch='main',  submodules='True')
+    version('2022.10.0', tag='v2022.10.0', submodules="True")
     version('0.12.0', tag='v0.12.0', submodules="True")
     version('0.11.0', tag='v0.11.0', submodules="True")
     version('0.10.0', tag='v0.10.0', submodules="True")
@@ -80,6 +61,7 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
             multi=False, description='Tests to run')
 
     depends_on("blt")
+    depends_on("blt@0.5.2:", type="build", when="@2022.10.0:")
     depends_on("blt@0.5.0:", type="build", when="@0.12.0:")
     depends_on("blt@0.4.1:", type="build", when="@0.11.0:")
     depends_on("blt@0.4.0:", type="build", when="@0.8.0:")
@@ -93,7 +75,6 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("rocprim", when="+rocm")
 
-    conflicts('+openmp', when='+rocm')
     conflicts('~openmp', when='+openmp_target', msg='OpenMP target requires OpenMP')
 
     phases = ['hostconfig', 'cmake', 'build', 'install']
@@ -124,7 +105,7 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
     def hostconfig(self, spec, prefix, py_site_pkgs_dir=None):
         """
         This method creates a 'host-config' file that specifies
-        all of the options used to configure and build Umpire.
+        all of the options used to configure and build RAJAPerf.
 
         For more details about 'host-config' files see:
             http://software.llnl.gov/conduit/building.html

--- a/scripts/spack_packages/raja_perf/package.py
+++ b/scripts/spack_packages/raja_perf/package.py
@@ -11,25 +11,9 @@ from os import environ as env
 from os.path import join as pjoin
 
 from spack import *
-from spack.pkg.builtin.camp import hip_repair_cache
-
-def cmake_cache_entry(name, value, comment=""):
-    """Generate a string for a cmake cache variable"""
-
-    return 'set(%s "%s" CACHE PATH "%s")\n\n' % (name,value,comment)
-
-
-def cmake_cache_string(name, string, comment=""):
-    """Generate a string for a cmake cache variable"""
-
-    return 'set(%s "%s" CACHE STRING "%s")\n\n' % (name,string,comment)
-
-
-def cmake_cache_option(name, boolean_value, comment=""):
-    """Generate a string for a cmake configuration option"""
-
-    value = "ON" if boolean_value else "OFF"
-    return 'set(%s %s CACHE BOOL "%s")\n\n' % (name,value,comment)
+from spack.pkg.builtin.camp import hip_for_radiuss_projects
+from spack.pkg.builtin.camp import cuda_for_radiuss_projects
+from spack.pkg.builtin.camp import blt_link_helpers
 
 
 class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
@@ -38,27 +22,27 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
     homepage = "http://software.llnl.gov/RAJAPerf/"
     git      = "https://github.com/LLNL/RAJAPerf.git"
 
-    version('develop', branch='develop', submodules='True')
-    version('main',  branch='main',  submodules='True')
-    version('2022.10.0', tag='v2022.10.0', submodules="True")
-    version('0.12.0', tag='v0.12.0', submodules="True")
-    version('0.11.0', tag='v0.11.0', submodules="True")
-    version('0.10.0', tag='v0.10.0', submodules="True")
-    version('0.9.0', tag='v0.9.0', submodules="True")
-    version('0.8.0', tag='v0.8.0', submodules="True")
-    version('0.7.0', tag='v0.7.0', submodules="True")
-    version('0.6.0', tag='v0.6.0', submodules="True")
-    version('0.5.2', tag='v0.5.2', submodules="True")
-    version('0.5.1', tag='v0.5.1', submodules="True")
-    version('0.5.0', tag='v0.5.0', submodules="True")
-    version('0.4.0', tag='v0.4.0', submodules="True")
+    version("develop", branch="develop", submodules="True")
+    version("main",  branch="main",  submodules="True")
+    version("2022.10.0", tag="v2022.10.0", submodules="True")
+    version("0.12.0", tag="v0.12.0", submodules="True")
+    version("0.11.0", tag="v0.11.0", submodules="True")
+    version("0.10.0", tag="v0.10.0", submodules="True")
+    version("0.9.0", tag="v0.9.0", submodules="True")
+    version("0.8.0", tag="v0.8.0", submodules="True")
+    version("0.7.0", tag="v0.7.0", submodules="True")
+    version("0.6.0", tag="v0.6.0", submodules="True")
+    version("0.5.2", tag="v0.5.2", submodules="True")
+    version("0.5.1", tag="v0.5.1", submodules="True")
+    version("0.5.0", tag="v0.5.0", submodules="True")
+    version("0.4.0", tag="v0.4.0", submodules="True")
 
-    variant('openmp', default=True, description='Build OpenMP backend')
-    variant('openmp_target', default=False, description='Build with OpenMP target support')
-    variant('shared', default=False, description='Build Shared Libs')
-    variant('libcpp', default=False, description='Uses libc++ instead of libstdc++')
-    variant('tests', default='basic', values=('none', 'basic', 'benchmarks'),
-            multi=False, description='Tests to run')
+    variant("openmp", default=True, description="Build OpenMP backend")
+    variant("openmp_target", default=False, description="Build with OpenMP target support")
+    variant("shared", default=False, description="Build Shared Libs")
+    variant("libcpp", default=False, description="Uses libc++ instead of libstdc++")
+    variant("tests", default="basic", values=("none", "basic", "benchmarks"),
+            multi=False, description="Tests to run")
 
     depends_on("blt")
     depends_on("blt@0.5.2:", type="build", when="@2022.10.0:")
@@ -75,9 +59,9 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("rocprim", when="+rocm")
 
-    conflicts('~openmp', when='+openmp_target', msg='OpenMP target requires OpenMP')
+    conflicts("~openmp", when="+openmp_target", msg="OpenMP target requires OpenMP")
 
-    phases = ['hostconfig', 'cmake', 'build', 'install']
+    phases = ["hostconfig", "cmake", "build", "install"]
 
     def _get_sys_type(self, spec):
         sys_type = str(spec.architecture)
@@ -87,13 +71,13 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
         return sys_type
 
     def _get_host_config_path(self, spec):
-        var=''
-        if '+cuda' in spec:
-            var= '-'.join([var,'cuda'])
-        if '+libcpp' in spec:
-            var='-'.join([var,'libcpp'])
+        var=""
+        if "+cuda" in spec:
+            var= "-".join([var,"cuda"])
+        if "+libcpp" in spec:
+            var="-".join([var,"libcpp"])
 
-        host_config_path = "hc-%s-%s-%s%s-%s.cmake" % (socket.gethostname().rstrip('1234567890'),
+        host_config_path = "hc-%s-%s-%s%s-%s.cmake" % (socket.gethostname().rstrip("1234567890"),
                                                self._get_sys_type(spec),
                                                spec.compiler,
                                                var,
@@ -148,7 +132,7 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
         # Find and record what CMake is used
         ##############################################
 
-        cmake_exe = spec['cmake'].command.path
+        cmake_exe = spec["cmake"].command.path
         cmake_exe = os.path.realpath(cmake_exe)
 
         host_config_path = self._get_host_config_path(spec)
@@ -169,7 +153,7 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
         cfg.write("# CMake executable path: %s\n" % cmake_exe)
         cfg.write("#------------------\n\n".format("-" * 60))
 
-        cfg.write(cmake_cache_string("CMAKE_BUILD_TYPE", spec.variants['build_type'].value))
+        cfg.write(cmake_cache_string("CMAKE_BUILD_TYPE", spec.variants["build_type"].value))
 
         #######################
         # Compiler Settings
@@ -182,15 +166,15 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
         cfg.write(cmake_cache_entry("CMAKE_CXX_COMPILER", cpp_compiler))
 
         # use global spack compiler flags
-        cflags = ' '.join(spec.compiler_flags['cflags'])
+        cflags = " ".join(spec.compiler_flags["cflags"])
         if "+libcpp" in spec:
-            cflags += ' '.join([cflags,"-DGTEST_HAS_CXXABI_H_=0"])
+            cflags += " ".join([cflags,"-DGTEST_HAS_CXXABI_H_=0"])
         if cflags:
             cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
 
-        cxxflags = ' '.join(spec.compiler_flags['cxxflags'])
+        cxxflags = " ".join(spec.compiler_flags["cxxflags"])
         if "+libcpp" in spec:
-            cxxflags += ' '.join([cxxflags,"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0"])
+            cxxflags += " ".join([cxxflags,"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0"])
         if cxxflags:
             cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
 
@@ -254,7 +238,7 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
                 cuda_release_flags = "-O3 -Xcompiler -Ofast -Xcompiler -finline-functions -Xcompiler -finline-limit=20000"
                 cuda_reldebinf_flags = "-O3 -g -Xcompiler -Ofast -Xcompiler -finline-functions -Xcompiler -finline-limit=20000"
                 cuda_debug_flags = "-O0 -g -Xcompiler -O0 -Xcompiler -finline-functions -Xcompiler -finline-limit=20000"
-            
+
             else:
                 cuda_release_flags = "-O3 -Xcompiler -Ofast -Xcompiler -finline-functions"
                 cuda_reldebinf_flags = "-O3 -g -Xcompiler -Ofast -Xcompiler -finline-functions"
@@ -265,15 +249,15 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
                 cuda_release_flags += " -Xcompiler --gcc-toolchain={0}".format(gcc_prefix)
                 cuda_reldebinf_flags += " -Xcompiler --gcc-toolchain={0}".format(gcc_prefix)
                 cuda_debug_flags += " -Xcompiler --gcc-toolchain={0}".format(gcc_prefix)
-                
+
             cfg.write(cmake_cache_string("CMAKE_CUDA_FLAGS_RELEASE", cuda_release_flags))
             cfg.write(cmake_cache_string("CMAKE_CUDA_FLAGS_RELWITHDEBINFO", cuda_reldebinf_flags))
             cfg.write(cmake_cache_string("CMAKE_CUDA_FLAGS_DEBUG", cuda_debug_flags))
 
-            if not spec.satisfies('cuda_arch=none'):
-                cuda_arch = spec.variants['cuda_arch'].value
-                cfg.write(cmake_cache_string("CUDA_ARCH", 'sm_{0}'.format(cuda_arch[0])))
-                cfg.write(cmake_cache_string("CMAKE_CUDA_ARCHITECTURES", '{0}'.format(cuda_arch[0])))
+            if not spec.satisfies("cuda_arch=none"):
+                cuda_arch = spec.variants["cuda_arch"].value
+                cfg.write(cmake_cache_string("CUDA_ARCH", "sm_{0}".format(cuda_arch[0])))
+                cfg.write(cmake_cache_string("CMAKE_CUDA_ARCHITECTURES", "{0}".format(cuda_arch[0])))
 
         else:
             cfg.write(cmake_cache_option("ENABLE_CUDA", False))
@@ -285,27 +269,27 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
 
             cfg.write(cmake_cache_option("ENABLE_HIP", True))
 
-            hip_root = spec['hip'].prefix
+            hip_root = spec["hip"].prefix
             rocm_root = hip_root + "/.."
             cfg.write(cmake_cache_entry("HIP_ROOT_DIR",
                                         hip_root))
             cfg.write(cmake_cache_entry("ROCM_ROOT_DIR",
                                         rocm_root))
             cfg.write(cmake_cache_entry("HIP_PATH",
-                                        rocm_root + '/llvm/bin'))
-            cfg.write(cmake_cache_entry("CMAKE_HIP_ARCHITECTURES", 'gfx906'))
+                                        rocm_root + "/llvm/bin"))
+            cfg.write(cmake_cache_entry("CMAKE_HIP_ARCHITECTURES", "gfx906"))
 
-            hipcc_flags = ['--amdgpu-target=gfx906']
+            hipcc_flags = ["--amdgpu-target=gfx906"]
 
-            cfg.write(cmake_cache_entry("HIP_HIPCC_FLAGS", ';'.join(hipcc_flags)))
+            cfg.write(cmake_cache_entry("HIP_HIPCC_FLAGS", ";".join(hipcc_flags)))
 
             #cfg.write(cmake_cache_entry("HIP_RUNTIME_INCLUDE_DIRS",
             #                            "{0}/include;{0}/../hsa/include".format(hip_root)))
             #hip_link_flags = "-Wl,--disable-new-dtags -L{0}/lib -L{0}/../lib64 -L{0}/../lib -Wl,-rpath,{0}/lib:{0}/../lib:{0}/../lib64 -lamdhip64 -lhsakmt -lhsa-runtime64".format(hip_root)
-            if ('%gcc' in spec) or (using_toolchain):
-                if ('%gcc' in spec):
+            if ("%gcc" in spec) or (using_toolchain):
+                if ("%gcc" in spec):
                     gcc_bin = os.path.dirname(self.compiler.cxx)
-                    gcc_prefix = join_path(gcc_bin, '..')
+                    gcc_prefix = join_path(gcc_bin, "..")
                 else:
                     gcc_prefix = gcc_toolchain_path.group(1)
                 cfg.write(cmake_cache_entry("HIP_CLANG_FLAGS",
@@ -320,10 +304,10 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
 
         cfg.write(cmake_cache_option("ENABLE_OPENMP_TARGET", "+openmp_target" in spec))
         if "+openmp_target" in spec:
-            if ('%xl' in spec):
+            if ("%xl" in spec):
                 cfg.write(cmake_cache_string("BLT_OPENMP_COMPILE_FLAGS", "-qoffload;-qsmp=omp;-qnoeh;-qalias=noansi"))
                 cfg.write(cmake_cache_string("BLT_OPENMP_LINK_FLAGS", "-qoffload;-qsmp=omp;-qnoeh;-qalias=noansi"))
-            if ('%clang' in spec):
+            if ("%clang" in spec):
                 cfg.write(cmake_cache_string("BLT_OPENMP_COMPILE_FLAGS", "-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda"))
                 cfg.write(cmake_cache_string("BLT_OPENMP_LINK_FLAGS", "-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda"))
                 cfg.write(cmake_cache_option("ENABLE_CUDA", False))
@@ -343,8 +327,8 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
         cfg.write(cmake_cache_option("BUILD_SHARED_LIBS","+shared" in spec))
         cfg.write(cmake_cache_option("ENABLE_OPENMP","+openmp" in spec))
 
-        cfg.write(cmake_cache_option("ENABLE_BENCHMARKS", 'tests=benchmarks' in spec))
-        cfg.write(cmake_cache_option("ENABLE_TESTS", not 'tests=none' in spec or self.run_tests))
+        cfg.write(cmake_cache_option("ENABLE_BENCHMARKS", "tests=benchmarks" in spec))
+        cfg.write(cmake_cache_option("ENABLE_TESTS", not "tests=none" in spec or self.run_tests))
 
         #######################
         # Close and save
@@ -359,6 +343,6 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
         host_config_path = self._get_host_config_path(spec)
 
         options = []
-        options.extend(['-C', host_config_path])
+        options.extend(["-C", host_config_path])
 
         return options

--- a/scripts/spack_packages/raja_perf/package.py
+++ b/scripts/spack_packages/raja_perf/package.py
@@ -62,8 +62,6 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
     conflicts("~openmp", when="+openmp_target", msg="OpenMP target requires OpenMP")
     conflicts("+cuda", when="+openmp_target", msg="Cuda may not be activated when openmp_target is ON")
 
-    phases = ["hostconfig", "cmake", "build", "install"]
-
     def _get_sys_type(self, spec):
         sys_type = str(spec.architecture)
         # if on llnl systems, we can use the SYS_TYPE
@@ -96,7 +94,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         spec = self.spec
         compiler = self.compiler
         # Default entries are already defined in CachedCMakePackage, inherit them:
-        entries = super(Raja, self).initconfig_compiler_entries()
+        entries = super(RajaPerf, self).initconfig_compiler_entries()
 
         # Switch to hip as a CPP compiler.
         # adrienbernede-22-11:
@@ -140,7 +138,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
     def initconfig_hardware_entries(self):
         spec = self.spec
         compiler = self.compiler
-        entries = super(Raja, self).initconfig_hardware_entries()
+        entries = super(RajaPerf, self).initconfig_hardware_entries()
 
         entries.append(cmake_cache_option("ENABLE_OPENMP", "+openmp" in spec))
 

--- a/scripts/spack_packages/raja_perf/package.py
+++ b/scripts/spack_packages/raja_perf/package.py
@@ -16,7 +16,7 @@ from spack.pkg.builtin.camp import cuda_for_radiuss_projects
 from spack.pkg.builtin.camp import blt_link_helpers
 
 
-class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
+class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
     """RAJA Performance Suite."""
 
     homepage = "http://software.llnl.gov/RAJAPerf/"
@@ -60,6 +60,7 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("rocprim", when="+rocm")
 
     conflicts("~openmp", when="+openmp_target", msg="OpenMP target requires OpenMP")
+    conflicts("+cuda", when="+openmp_target", msg="Cuda may not be activated when openmp_target is ON")
 
     phases = ["hostconfig", "cmake", "build", "install"]
 
@@ -70,279 +71,172 @@ class RajaPerf(CMakePackage, CudaPackage, ROCmPackage):
             sys_type = env["SYS_TYPE"]
         return sys_type
 
-    def _get_host_config_path(self, spec):
+    @property
+    # TODO: name cache file conditionally to cuda and libcpp variants
+    def cache_name(self):
+        hostname = socket.gethostname()
+        if "SYS_TYPE" in env:
+            hostname = hostname.rstrip("1234567890")
         var=""
         if "+cuda" in spec:
             var= "-".join([var,"cuda"])
         if "+libcpp" in spec:
             var="-".join([var,"libcpp"])
 
-        host_config_path = "hc-%s-%s-%s%s-%s.cmake" % (socket.gethostname().rstrip("1234567890"),
-                                               self._get_sys_type(spec),
-                                               spec.compiler,
-                                               var,
-                                               spec.dag_hash())
-        dest_dir = self.stage.source_path
-        host_config_path = os.path.abspath(pjoin(dest_dir, host_config_path))
-        return host_config_path
+        return "{0}-{1}{2}-{3}@{4}-{5}.cmake".format(
+            hostname,
+            self._get_sys_type(self.spec),
+            var,
+            self.spec.compiler.name,
+            self.spec.compiler.version,
+            self.spec.dag_hash(8)
+        )
 
-    def hostconfig(self, spec, prefix, py_site_pkgs_dir=None):
-        """
-        This method creates a 'host-config' file that specifies
-        all of the options used to configure and build RAJAPerf.
+    def initconfig_compiler_entries(self):
+        spec = self.spec
+        compiler = self.compiler
+        # Default entries are already defined in CachedCMakePackage, inherit them:
+        entries = super(Raja, self).initconfig_compiler_entries()
 
-        For more details about 'host-config' files see:
-            http://software.llnl.gov/conduit/building.html
+        # Switch to hip as a CPP compiler.
+        # adrienbernede-22-11:
+        #   This was only done in upstream Spack raja package.
+        #   I could not find the equivalent logic in Spack source, so keeping it.
+        #if "+rocm" in spec:
+        #    entries.insert(0, cmake_cache_path("CMAKE_CXX_COMPILER", spec["hip"].hipcc))
 
-        Note:
-          The `py_site_pkgs_dir` arg exists to allow a package that
-          subclasses this package provide a specific site packages
-          dir when calling this function. `py_site_pkgs_dir` should
-          be an absolute path or `None`.
-
-          This is necessary because the spack `site_packages_dir`
-          var will not exist in the base class. For more details
-          on this issue see: https://github.com/spack/spack/issues/6261
-        """
-
-        #######################
-        # Compiler Info
-        #######################
-        c_compiler = env["SPACK_CC"]
-        cpp_compiler = env["SPACK_CXX"]
-
-        # Even though we don't have fortran code in our project we sometimes
-        # use the Fortran compiler to determine which libstdc++ to use
-        f_compiler = ""
-        if "SPACK_FC" in env.keys():
-            # even if this is set, it may not exist
-            # do one more sanity check
-            if os.path.isfile(env["SPACK_FC"]):
-                f_compiler = env["SPACK_FC"]
-
-        #######################################################################
-        # By directly fetching the names of the actual compilers we appear
-        # to doing something evil here, but this is necessary to create a
-        # 'host config' file that works outside of the spack install env.
-        #######################################################################
-
-        sys_type = self._get_sys_type(spec)
-
-        ##############################################
-        # Find and record what CMake is used
-        ##############################################
-
-        cmake_exe = spec["cmake"].command.path
-        cmake_exe = os.path.realpath(cmake_exe)
-
-        host_config_path = self._get_host_config_path(spec)
-        cfg = open(host_config_path, "w")
-        cfg.write("###################\n".format("#" * 60))
-        cfg.write("# Generated host-config - Edit at own risk!\n")
-        cfg.write("###################\n".format("#" * 60))
-        cfg.write("# Copyright (c) 2017-22, Lawrence Livermore National Security, LLC and\n")
-        cfg.write("# other RAJAPerf contributors. See the top-level LICENSE file for\n")
-        cfg.write("# details.\n")
-        cfg.write("#\n")
-        cfg.write("# SPDX-License-Identifier: (BSD-3-Clause) \n")
-        cfg.write("###################\n\n".format("#" * 60))
-
-        cfg.write("#------------------\n".format("-" * 60))
-        cfg.write("# SYS_TYPE: {0}\n".format(sys_type))
-        cfg.write("# Compiler Spec: {0}\n".format(spec.compiler))
-        cfg.write("# CMake executable path: %s\n" % cmake_exe)
-        cfg.write("#------------------\n\n".format("-" * 60))
-
-        cfg.write(cmake_cache_string("CMAKE_BUILD_TYPE", spec.variants["build_type"].value))
-
-        #######################
-        # Compiler Settings
-        #######################
-
-        cfg.write("#------------------\n".format("-" * 60))
-        cfg.write("# Compilers\n")
-        cfg.write("#------------------\n\n".format("-" * 60))
-        cfg.write(cmake_cache_entry("CMAKE_C_COMPILER", c_compiler))
-        cfg.write(cmake_cache_entry("CMAKE_CXX_COMPILER", cpp_compiler))
+        # Override CachedCMakePackage CMAKE_C_FLAGS and CMAKE_CXX_FLAGS add
+        # +libcpp specific flags
+        flags = spec.compiler_flags
 
         # use global spack compiler flags
-        cflags = " ".join(spec.compiler_flags["cflags"])
+        cppflags = " ".join(flags["cppflags"])
+        if cppflags:
+            # avoid always ending up with " " with no flags defined
+            cppflags += " "
+
+        cflags = cppflags + " ".join(flags["cflags"])
         if "+libcpp" in spec:
             cflags += " ".join([cflags,"-DGTEST_HAS_CXXABI_H_=0"])
         if cflags:
-            cfg.write(cmake_cache_entry("CMAKE_C_FLAGS", cflags))
+            entries.append(cmake_cache_string("CMAKE_C_FLAGS", cflags))
 
-        cxxflags = " ".join(spec.compiler_flags["cxxflags"])
+        cxxflags = cppflags + " ".join(flags["cxxflags"])
         if "+libcpp" in spec:
             cxxflags += " ".join([cxxflags,"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0"])
         if cxxflags:
-            cfg.write(cmake_cache_entry("CMAKE_CXX_FLAGS", cxxflags))
+            entries.append(cmake_cache_string("CMAKE_CXX_FLAGS", cxxflags))
 
-        if ("gfortran" in f_compiler) and ("clang" in cpp_compiler):
-            libdir = pjoin(os.path.dirname(
-                           os.path.dirname(f_compiler)), "lib")
-            flags = ""
-            for _libpath in [libdir, libdir + "64"]:
-                if os.path.exists(_libpath):
-                    flags += " -Wl,-rpath,{0}".format(_libpath)
-            description = ("Adds a missing libstdc++ rpath")
-            #if flags:
-            #    cfg.write(cmake_cache_string("BLT_EXE_LINKER_FLAGS", flags,
-            #                                description))
+        blt_link_helpers(entries, spec, compiler)
 
-        gcc_toolchain_regex = re.compile("--gcc-toolchain=(.*)")
-        gcc_name_regex = re.compile(".*gcc-name.*")
-
-        using_toolchain = list(filter(gcc_toolchain_regex.match, spec.compiler_flags['cxxflags']))
-
-        if(using_toolchain):
-          gcc_toolchain_path = gcc_toolchain_regex.match(using_toolchain[0])
-        using_gcc_name = list(filter(gcc_name_regex.match, spec.compiler_flags['cxxflags']))
-        compilers_using_toolchain = ["pgi", "xl", "icpc", "clang"]
-        if any(compiler in cpp_compiler for compiler in compilers_using_toolchain):
-            if using_toolchain or using_gcc_name:
-                cfg.write(cmake_cache_entry("BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE",
-                "/usr/tce/packages/gcc/gcc-4.9.3/lib64;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64/gcc/powerpc64le-unknown-linux-gnu/4.9.3;/usr/tce/packages/gcc/gcc-4.9.3/gnu/lib64;/usr/tce/packages/gcc/gcc-4.9.3/lib64/gcc/x86_64-unknown-linux-gnu/4.9.3"))
-
+        # adrienbernede-23-01
+        # Maybe we want to share this in the above blt_link_helpers function.
         compilers_using_cxx14 = ["intel-17", "intel-18", "xl"]
         if any(compiler in cpp_compiler for compiler in compilers_using_cxx14):
-            cfg.write(cmake_cache_entry("BLT_CXX_STD", "c++14"))
+            entries.append(cmake_cache_string("BLT_CXX_STD", "c++14"))
 
+        return entries
+
+    def initconfig_hardware_entries(self):
+        spec = self.spec
+        compiler = self.compiler
+        entries = super(Raja, self).initconfig_hardware_entries()
+
+        entries.append(cmake_cache_option("ENABLE_OPENMP", "+openmp" in spec))
+
+        # T benefit from the shared function "cuda_for_radiuss_projects",
+        # we do not modify CMAKE_CUDA_FLAGS: it is already appended by the
+        # shared function.
         if "+cuda" in spec:
-            cfg.write("#------------------{0}\n".format("-" * 60))
-            cfg.write("# Cuda\n")
-            cfg.write("#------------------{0}\n\n".format("-" * 60))
+            entries.append(cmake_cache_option("ENABLE_CUDA", True))
+            # Shared handling of cuda.
+            cuda_for_radiuss_projects(entries, spec)
 
-            cfg.write(cmake_cache_option("ENABLE_CUDA", True))
-
-            cudatoolkitdir = spec['cuda'].prefix
-            cfg.write(cmake_cache_entry("CUDA_TOOLKIT_ROOT_DIR",
-                                        cudatoolkitdir))
-            cudacompiler = "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc"
-            cfg.write(cmake_cache_entry("CMAKE_CUDA_COMPILER",
-                                        cudacompiler))
-
-            cfg.write(cmake_cache_string("BLT_CXX_STD", "c++14"))
-            cfg.write(cmake_cache_option("ENABLE_TESTS", not 'tests=none' in spec or self.run_tests))
-
+            # Custom options. We place everything in CMAKE_CUDA_FLAGS_(RELEASE|RELWITHDEBINFO|DEBUG) which are not set by cuda_for_radiuss_projects
             if ("xl" in cpp_compiler):
-                cfg.write(cmake_cache_entry("CMAKE_CUDA_FLAGS", "-Xcompiler -O2 -Xcompiler -qstrict " +
-                                            "-Xcompiler -qxlcompatmacros -Xcompiler -qalias=noansi " + 
-                                            "-Xcompiler -qsmp=omp -Xcompiler -qhot -Xcompiler -qnoeh -Xcompiler -qsuppress=1500-029 " +
-                                            "-Xcompiler -qsuppress=1500-036 -Xcompiler -qsuppress=1500-030"))
-                cuda_release_flags = "-O3"
-                cuda_reldebinf_flags = "-O3 -g"
-                cuda_debug_flags = "-O0 -g"
+                all_targets_flags = "-Xcompiler -qstrict -Xcompiler -qxlcompatmacros -Xcompiler -qalias=noansi"
+                                  + "-Xcompiler -qsmp=omp -Xcompiler -qhot -Xcompiler -qnoeh"
+                                  + "-Xcompiler -qsuppress=1500-029 -Xcompiler -qsuppress=1500-036"
+                                  + "-Xcompiler -qsuppress=1500-030"
+
+                cuda_release_flags = "-O3 -Xcompiler -O2 " + all_targets_flags
+                cuda_reldebinf_flags = "-O3 -g -Xcompiler -O2 " + all_targets_flags
+                cuda_debug_flags = "-O0 -g -Xcompiler -O2 " + all_targets_flags
 
             elif ("gcc" in cpp_compiler):
-                cuda_release_flags = "-O3 -Xcompiler -Ofast -Xcompiler -finline-functions -Xcompiler -finline-limit=20000"
-                cuda_reldebinf_flags = "-O3 -g -Xcompiler -Ofast -Xcompiler -finline-functions -Xcompiler -finline-limit=20000"
-                cuda_debug_flags = "-O0 -g -Xcompiler -O0 -Xcompiler -finline-functions -Xcompiler -finline-limit=20000"
+                all_targets_flags = "-Xcompiler -finline-functions -Xcompiler -finline-limit=20000"
+
+                cuda_release_flags = "-O3 -Xcompiler -Ofast " + all_targets_flags
+                cuda_reldebinf_flags = "-O3 -g -Xcompiler -Ofast " + all_targets_flags
+                cuda_debug_flags = "-O0 -g -Xcompiler -O0 " + all_targets_flags
 
             else:
-                cuda_release_flags = "-O3 -Xcompiler -Ofast -Xcompiler -finline-functions"
-                cuda_reldebinf_flags = "-O3 -g -Xcompiler -Ofast -Xcompiler -finline-functions"
-                cuda_debug_flags = "-O0 -g -Xcompiler -O0 -Xcompiler -finline-functions"
+                all_targets_flags = "-Xcompiler -finline-functions"
 
-            if (using_toolchain):
-                gcc_prefix = gcc_toolchain_path.group(1)
-                cuda_release_flags += " -Xcompiler --gcc-toolchain={0}".format(gcc_prefix)
-                cuda_reldebinf_flags += " -Xcompiler --gcc-toolchain={0}".format(gcc_prefix)
-                cuda_debug_flags += " -Xcompiler --gcc-toolchain={0}".format(gcc_prefix)
+                cuda_release_flags = "-O3 -Xcompiler -Ofast " + all_targets_flags
+                cuda_reldebinf_flags = "-O3 -g -Xcompiler -Ofast " + all_targets_flags
+                cuda_debug_flags = "-O0 -g -Xcompiler -O0 " + all_targets_flags
 
-            cfg.write(cmake_cache_string("CMAKE_CUDA_FLAGS_RELEASE", cuda_release_flags))
-            cfg.write(cmake_cache_string("CMAKE_CUDA_FLAGS_RELWITHDEBINFO", cuda_reldebinf_flags))
-            cfg.write(cmake_cache_string("CMAKE_CUDA_FLAGS_DEBUG", cuda_debug_flags))
-
-            if not spec.satisfies("cuda_arch=none"):
-                cuda_arch = spec.variants["cuda_arch"].value
-                cfg.write(cmake_cache_string("CUDA_ARCH", "sm_{0}".format(cuda_arch[0])))
-                cfg.write(cmake_cache_string("CMAKE_CUDA_ARCHITECTURES", "{0}".format(cuda_arch[0])))
+            entries.append(cmake_cache_string("CMAKE_CUDA_FLAGS_RELEASE", cuda_release_flags))
+            entries.append(cmake_cache_string("CMAKE_CUDA_FLAGS_RELWITHDEBINFO", cuda_reldebinf_flags))
+            entries.append(cmake_cache_string("CMAKE_CUDA_FLAGS_DEBUG", cuda_debug_flags))
 
         else:
-            cfg.write(cmake_cache_option("ENABLE_CUDA", False))
+            entries.append(cmake_cache_option("ENABLE_CUDA", False))
 
         if "+rocm" in spec:
-            cfg.write("#------------------{0}\n".format("-" * 60))
-            cfg.write("# HIP\n")
-            cfg.write("#------------------{0}\n\n".format("-" * 60))
-
-            cfg.write(cmake_cache_option("ENABLE_HIP", True))
-
-            hip_root = spec["hip"].prefix
-            rocm_root = hip_root + "/.."
-            cfg.write(cmake_cache_entry("HIP_ROOT_DIR",
-                                        hip_root))
-            cfg.write(cmake_cache_entry("ROCM_ROOT_DIR",
-                                        rocm_root))
-            cfg.write(cmake_cache_entry("HIP_PATH",
-                                        rocm_root + "/llvm/bin"))
-            cfg.write(cmake_cache_entry("CMAKE_HIP_ARCHITECTURES", "gfx906"))
-
-            hipcc_flags = ["--amdgpu-target=gfx906"]
-
-            cfg.write(cmake_cache_entry("HIP_HIPCC_FLAGS", ";".join(hipcc_flags)))
-
-            #cfg.write(cmake_cache_entry("HIP_RUNTIME_INCLUDE_DIRS",
-            #                            "{0}/include;{0}/../hsa/include".format(hip_root)))
-            #hip_link_flags = "-Wl,--disable-new-dtags -L{0}/lib -L{0}/../lib64 -L{0}/../lib -Wl,-rpath,{0}/lib:{0}/../lib:{0}/../lib64 -lamdhip64 -lhsakmt -lhsa-runtime64".format(hip_root)
-            if ("%gcc" in spec) or (using_toolchain):
-                if ("%gcc" in spec):
-                    gcc_bin = os.path.dirname(self.compiler.cxx)
-                    gcc_prefix = join_path(gcc_bin, "..")
-                else:
-                    gcc_prefix = gcc_toolchain_path.group(1)
-                cfg.write(cmake_cache_entry("HIP_CLANG_FLAGS",
-                "--gcc-toolchain={0}".format(gcc_prefix))) 
-                cfg.write(cmake_cache_entry("CMAKE_EXE_LINKER_FLAGS",
-                " -Wl,-rpath {}/lib64".format(gcc_prefix)))
-            #else:
-            #    cfg.write(cmake_cache_entry("CMAKE_EXE_LINKER_FLAGS", hip_link_flags))
-
+            entries.append(cmake_cache_option("ENABLE_HIP", True))
+            hip_for_radiuss_projects(entries, spec, compiler)
         else:
-            cfg.write(cmake_cache_option("ENABLE_HIP", False))
+            entries.append(cmake_cache_option("ENABLE_HIP", False))
 
         cfg.write(cmake_cache_option("ENABLE_OPENMP_TARGET", "+openmp_target" in spec))
         if "+openmp_target" in spec:
             if ("%xl" in spec):
-                cfg.write(cmake_cache_string("BLT_OPENMP_COMPILE_FLAGS", "-qoffload;-qsmp=omp;-qnoeh;-qalias=noansi"))
-                cfg.write(cmake_cache_string("BLT_OPENMP_LINK_FLAGS", "-qoffload;-qsmp=omp;-qnoeh;-qalias=noansi"))
+                entries.append(cmake_cache_string("BLT_OPENMP_COMPILE_FLAGS", "-qoffload;-qsmp=omp;-qnoeh;-qalias=noansi"))
+                entries.append(cmake_cache_string("BLT_OPENMP_LINK_FLAGS", "-qoffload;-qsmp=omp;-qnoeh;-qalias=noansi"))
             if ("%clang" in spec):
-                cfg.write(cmake_cache_string("BLT_OPENMP_COMPILE_FLAGS", "-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda"))
-                cfg.write(cmake_cache_string("BLT_OPENMP_LINK_FLAGS", "-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda"))
-                cfg.write(cmake_cache_option("ENABLE_CUDA", False))
+                entries.append(cmake_cache_string("BLT_OPENMP_COMPILE_FLAGS", "-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda"))
+                entries.append(cmake_cache_string("BLT_OPENMP_LINK_FLAGS", "-fopenmp;-fopenmp-targets=nvptx64-nvidia-cuda"))
 
+        return entries
 
-        cfg.write("#------------------{0}\n".format("-" * 60))
-        cfg.write("# Other\n")
-        cfg.write("#------------------{0}\n\n".format("-" * 60))
+    def initconfig_package_entries(self):
+        spec = self.spec
+        entries = []
 
-        cfg.write(cmake_cache_string("RAJA_RANGE_ALIGN", "4"))
-        cfg.write(cmake_cache_string("RAJA_RANGE_MIN_LENGTH", "32"))
-        cfg.write(cmake_cache_string("RAJA_DATA_ALIGN", "64"))
+        option_prefix = "RAJA_" if spec.satisfies("@0.14.0:") else ""
 
-        cfg.write(cmake_cache_option("RAJA_HOST_CONFIG_LOADED", True))
+        # TPL locations
+        entries.append("#------------------{0}".format("-" * 60))
+        entries.append("# TPLs")
+        entries.append("#------------------{0}\n".format("-" * 60))
 
-        # shared vs static libs
-        cfg.write(cmake_cache_option("BUILD_SHARED_LIBS","+shared" in spec))
-        cfg.write(cmake_cache_option("ENABLE_OPENMP","+openmp" in spec))
+        entries.append(cmake_cache_path("BLT_SOURCE_DIR", spec["blt"].prefix))
 
-        cfg.write(cmake_cache_option("ENABLE_BENCHMARKS", "tests=benchmarks" in spec))
-        cfg.write(cmake_cache_option("ENABLE_TESTS", not "tests=none" in spec or self.run_tests))
+        # Build options
+        entries.append("#------------------{0}".format("-" * 60))
+        entries.append("# Build Options")
+        entries.append("#------------------{0}\n".format("-" * 60))
 
-        #######################
-        # Close and save
-        #######################
-        cfg.write("\n")
-        cfg.close()
+        entries.append(cmake_cache_string(
+            "CMAKE_BUILD_TYPE", spec.variants["build_type"].value))
 
-        print("OUT: host-config file {0}".format(host_config_path))
+        entries.append(cmake_cache_string("RAJA_RANGE_ALIGN", "4"))
+        entries.append(cmake_cache_string("RAJA_RANGE_MIN_LENGTH", "32"))
+        entries.append(cmake_cache_string("RAJA_DATA_ALIGN", "64"))
+
+        entries.append(cmake_cache_option("RAJA_HOST_CONFIG_LOADED", True))
+
+        entries.append(cmake_cache_option("BUILD_SHARED_LIBS","+shared" in spec))
+        entries.append(cmake_cache_option("ENABLE_OPENMP","+openmp" in spec))
+
+        entries.append(cmake_cache_option("ENABLE_BENCHMARKS", "tests=benchmarks" in spec))
+        entries.append(cmake_cache_option("ENABLE_TESTS", not "tests=none" in spec or self.run_tests))
+
+        return entries
 
     def cmake_args(self):
-        spec = self.spec
-        host_config_path = self._get_host_config_path(spec)
-
         options = []
-        options.extend(["-C", host_config_path])
-
         return options
+

--- a/scripts/spack_packages/raja_perf/package.py
+++ b/scripts/spack_packages/raja_perf/package.py
@@ -76,9 +76,9 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         if "SYS_TYPE" in env:
             hostname = hostname.rstrip("1234567890")
         var=""
-        if "+cuda" in spec:
+        if "+cuda" in self.spec:
             var= "-".join([var,"cuda"])
-        if "+libcpp" in spec:
+        if "+libcpp" in self.spec:
             var="-".join([var,"libcpp"])
 
         return "{0}-{1}{2}-{3}@{4}-{5}.cmake".format(

--- a/scripts/spack_packages/raja_perf/package.py
+++ b/scripts/spack_packages/raja_perf/package.py
@@ -188,7 +188,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         else:
             entries.append(cmake_cache_option("ENABLE_HIP", False))
 
-        cfg.write(cmake_cache_option("ENABLE_OPENMP_TARGET", "+openmp_target" in spec))
+        entries.append(cmake_cache_option("ENABLE_OPENMP_TARGET", "+openmp_target" in spec))
         if "+openmp_target" in spec:
             if ("%xl" in spec):
                 entries.append(cmake_cache_string("BLT_OPENMP_COMPILE_FLAGS", "-qoffload;-qsmp=omp;-qnoeh;-qalias=noansi"))

--- a/scripts/spack_packages/raja_perf/package.py
+++ b/scripts/spack_packages/raja_perf/package.py
@@ -130,7 +130,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
         # adrienbernede-23-01
         # Maybe we want to share this in the above blt_link_helpers function.
         compilers_using_cxx14 = ["intel-17", "intel-18", "xl"]
-        if any(compiler in cpp_compiler for compiler in compilers_using_cxx14):
+        if any(compiler in self.compiler.cxx for compiler in compilers_using_cxx14):
             entries.append(cmake_cache_string("BLT_CXX_STD", "c++14"))
 
         return entries
@@ -151,7 +151,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
             cuda_for_radiuss_projects(entries, spec)
 
             # Custom options. We place everything in CMAKE_CUDA_FLAGS_(RELEASE|RELWITHDEBINFO|DEBUG) which are not set by cuda_for_radiuss_projects
-            if ("xl" in cpp_compiler):
+            if ("xl" in self.compiler.cxx):
                 all_targets_flags = "-Xcompiler -qstrict -Xcompiler -qxlcompatmacros -Xcompiler -qalias=noansi" \
                                   + "-Xcompiler -qsmp=omp -Xcompiler -qhot -Xcompiler -qnoeh" \
                                   + "-Xcompiler -qsuppress=1500-029 -Xcompiler -qsuppress=1500-036" \
@@ -161,7 +161,7 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
                 cuda_reldebinf_flags = "-O3 -g -Xcompiler -O2 " + all_targets_flags
                 cuda_debug_flags = "-O0 -g -Xcompiler -O2 " + all_targets_flags
 
-            elif ("gcc" in cpp_compiler):
+            elif ("gcc" in self.compiler.cxx):
                 all_targets_flags = "-Xcompiler -finline-functions -Xcompiler -finline-limit=20000"
 
                 cuda_release_flags = "-O3 -Xcompiler -Ofast " + all_targets_flags

--- a/scripts/spack_packages/raja_perf/package.py
+++ b/scripts/spack_packages/raja_perf/package.py
@@ -154,10 +154,10 @@ class RajaPerf(CachedCMakePackage, CudaPackage, ROCmPackage):
 
             # Custom options. We place everything in CMAKE_CUDA_FLAGS_(RELEASE|RELWITHDEBINFO|DEBUG) which are not set by cuda_for_radiuss_projects
             if ("xl" in cpp_compiler):
-                all_targets_flags = "-Xcompiler -qstrict -Xcompiler -qxlcompatmacros -Xcompiler -qalias=noansi"
-                                  + "-Xcompiler -qsmp=omp -Xcompiler -qhot -Xcompiler -qnoeh"
-                                  + "-Xcompiler -qsuppress=1500-029 -Xcompiler -qsuppress=1500-036"
-                                  + "-Xcompiler -qsuppress=1500-030"
+                all_targets_flags = "-Xcompiler -qstrict -Xcompiler -qxlcompatmacros -Xcompiler -qalias=noansi" \
+                                  + "-Xcompiler -qsmp=omp -Xcompiler -qhot -Xcompiler -qnoeh" \
+                                  + "-Xcompiler -qsuppress=1500-029 -Xcompiler -qsuppress=1500-036" \
+                                  + "-Xcompiler -qsuppress=1500-030" \
 
                 cuda_release_flags = "-O3 -Xcompiler -O2 " + all_targets_flags
                 cuda_reldebinf_flags = "-O3 -g -Xcompiler -O2 " + all_targets_flags

--- a/test/test-raja-perf-suite.cpp
+++ b/test/test-raja-perf-suite.cpp
@@ -35,7 +35,7 @@ TEST(ShortSuiteTest, Basic)
   std::vector< std::string > sargv(argc);
   sargv[0] = std::string("dummy ");  // for executable name
   sargv[1] = std::string("--checkrun");
-  sargv[2] = std::string("5");
+  sargv[2] = std::string("3");
   sargv[3] = std::string("--show-progress");
 
 #if defined(RAJA_ENABLE_HIP) && \


### PR DESCRIPTION
# Summary 

- This PR is an attempt to use latest spack release and update spack package for GitLab CI

## Choices made:

- with HIP support, the arch used to be `gfx906`. I changed it for the more general `spec.variants["amdgpu_target"].value`

- Some comments in the hip support section have been removed, they looked like early hacks.

- In the Cuda support section, we have a shared routine cuda_for_radiuss_projects(entries, spec) gathering standard settings. In particular it sets `CMAKE_CUDA_FLAGS` with the gxx toolchain flags when needed. I find that the new implementation is cleaner.

- I added a conflict between openmp_target and cuda when using clang: it’s implied by the implementation of openmp_target support.