### PR TITLE
Fix uninitialized custom OpenMP reduction.

### DIFF
--- a/src/lcals/FIRST_MIN-OMP.cpp
+++ b/src/lcals/FIRST_MIN-OMP.cpp
@@ -36,7 +36,8 @@ void FIRST_MIN::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         #pragma omp declare reduction(minloc : MyMinLoc : \
-                                      omp_out = MinLoc_compare(omp_out, omp_in))
+                                      omp_out = MinLoc_compare(omp_out, omp_in)) \
+                                      initializer (omp_priv = omp_orig)
 
         FIRST_MIN_MINLOC_INIT;
 
@@ -63,7 +64,8 @@ void FIRST_MIN::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         #pragma omp declare reduction(minloc : MyMinLoc : \
-                                      omp_out = MinLoc_compare(omp_out, omp_in))
+                                      omp_out = MinLoc_compare(omp_out, omp_in)) \
+                                      initializer (omp_priv = omp_orig)
 
         FIRST_MIN_MINLOC_INIT;
 

--- a/src/lcals/FIRST_MIN-OMPTarget.cpp
+++ b/src/lcals/FIRST_MIN-OMPTarget.cpp
@@ -52,7 +52,8 @@ void FIRST_MIN::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       #pragma omp declare reduction(minloc : MyMinLoc : \
-                                    omp_out = MinLoc_compare(omp_out, omp_in))
+                                    omp_out = MinLoc_compare(omp_out, omp_in))\
+                                    initializer (omp_priv = omp_orig)
 
       FIRST_MIN_MINLOC_INIT;
 


### PR DESCRIPTION
# Summary 

- This PR is a a bugfix.
- It adds the OpenMP reduction initializer clause to fix uninitialized custom reduction variable. The issue only appears at large core counts.

This PR fixes https://github.com/LLNL/RAJAPerf/issues/293