### PR TITLE
Add Host Memory Alignment Option

### DIFF
--- a/src/algorithm/MEMCPY.cpp
+++ b/src/algorithm/MEMCPY.cpp
@@ -71,8 +71,8 @@ void MEMCPY::updateChecksum(VariantID vid, size_t tune_idx)
 void MEMCPY::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_y);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
 }
 
 } // end namespace algorithm

--- a/src/algorithm/MEMSET.cpp
+++ b/src/algorithm/MEMSET.cpp
@@ -72,7 +72,7 @@ void MEMSET::updateChecksum(VariantID vid, size_t tune_idx)
 void MEMSET::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
+  deallocData(m_x, vid);
 }
 
 } // end namespace algorithm

--- a/src/algorithm/REDUCE_SUM.cpp
+++ b/src/algorithm/REDUCE_SUM.cpp
@@ -72,7 +72,7 @@ void REDUCE_SUM::updateChecksum(VariantID vid, size_t tune_idx)
 void REDUCE_SUM::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
+  deallocData(m_x, vid);
 }
 
 } // end namespace algorithm

--- a/src/algorithm/SCAN.cpp
+++ b/src/algorithm/SCAN.cpp
@@ -75,8 +75,8 @@ void SCAN::updateChecksum(VariantID vid, size_t tune_idx)
 void SCAN::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_y);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
 }
 
 } // end namespace algorithm

--- a/src/algorithm/SORT.cpp
+++ b/src/algorithm/SORT.cpp
@@ -60,7 +60,7 @@ void SORT::updateChecksum(VariantID vid, size_t tune_idx)
 void SORT::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
+  deallocData(m_x, vid);
 }
 
 } // end namespace algorithm

--- a/src/algorithm/SORTPAIRS.cpp
+++ b/src/algorithm/SORTPAIRS.cpp
@@ -62,8 +62,8 @@ void SORTPAIRS::updateChecksum(VariantID vid, size_t tune_idx)
 void SORTPAIRS::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_i);
+  deallocData(m_x, vid);
+  deallocData(m_i, vid);
 }
 
 } // end namespace algorithm

--- a/src/apps/CONVECTION3DPA.cpp
+++ b/src/apps/CONVECTION3DPA.cpp
@@ -90,12 +90,12 @@ void CONVECTION3DPA::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
 {
   (void) vid;
 
-  deallocData(m_B);
-  deallocData(m_Bt);
-  deallocData(m_G);
-  deallocData(m_D);
-  deallocData(m_X);
-  deallocData(m_Y);
+  deallocData(m_B, vid);
+  deallocData(m_Bt, vid);
+  deallocData(m_G, vid);
+  deallocData(m_D, vid);
+  deallocData(m_X, vid);
+  deallocData(m_Y, vid);
 }
 
 } // end namespace apps

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -96,11 +96,11 @@ void DEL_DOT_VEC_2D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
 {
   (void) vid;
 
-  deallocData(m_x);
-  deallocData(m_y);
-  deallocData(m_xdot);
-  deallocData(m_ydot);
-  deallocData(m_div);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
+  deallocData(m_xdot, vid);
+  deallocData(m_ydot, vid);
+  deallocData(m_div, vid);
 }
 
 } // end namespace apps

--- a/src/apps/DIFFUSION3DPA.cpp
+++ b/src/apps/DIFFUSION3DPA.cpp
@@ -90,11 +90,11 @@ void DIFFUSION3DPA::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx)
 {
   (void) vid;
 
-  deallocData(m_B);
-  deallocData(m_G);
-  deallocData(m_D);
-  deallocData(m_X);
-  deallocData(m_Y);
+  deallocData(m_B, vid);
+  deallocData(m_G, vid);
+  deallocData(m_D, vid);
+  deallocData(m_X, vid);
+  deallocData(m_Y, vid);
 }
 
 } // end namespace apps

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -86,10 +86,10 @@ void ENERGY::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
   allocAndInitData(m_qq_old, getActualProblemSize(), vid);
   allocAndInitData(m_vnewc, getActualProblemSize(), vid);
 
-  initData(m_rho0);
-  initData(m_e_cut);
-  initData(m_emin);
-  initData(m_q_cut);
+  initData(m_rho0, vid);
+  initData(m_e_cut, vid);
+  initData(m_emin, vid);
+  initData(m_q_cut, vid);
 }
 
 void ENERGY::updateChecksum(VariantID vid, size_t tune_idx)
@@ -102,21 +102,21 @@ void ENERGY::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
 
-  deallocData(m_e_new);
-  deallocData(m_e_old);
-  deallocData(m_delvc);
-  deallocData(m_p_new);
-  deallocData(m_p_old);
-  deallocData(m_q_new);
-  deallocData(m_q_old);
-  deallocData(m_work);
-  deallocData(m_compHalfStep);
-  deallocData(m_pHalfStep);
-  deallocData(m_bvc);
-  deallocData(m_pbvc);
-  deallocData(m_ql_old);
-  deallocData(m_qq_old);
-  deallocData(m_vnewc);
+  deallocData(m_e_new, vid);
+  deallocData(m_e_old, vid);
+  deallocData(m_delvc, vid);
+  deallocData(m_p_new, vid);
+  deallocData(m_p_old, vid);
+  deallocData(m_q_new, vid);
+  deallocData(m_q_old, vid);
+  deallocData(m_work, vid);
+  deallocData(m_compHalfStep, vid);
+  deallocData(m_pHalfStep, vid);
+  deallocData(m_bvc, vid);
+  deallocData(m_pbvc, vid);
+  deallocData(m_ql_old, vid);
+  deallocData(m_qq_old, vid);
+  deallocData(m_vnewc, vid);
 }
 
 } // end namespace apps

--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -77,8 +77,8 @@ void FIR::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
 
-  deallocData(m_in);
-  deallocData(m_out);
+  deallocData(m_in, vid);
+  deallocData(m_out, vid);
 }
 
 } // end namespace apps

--- a/src/apps/HALOEXCHANGE.cpp
+++ b/src/apps/HALOEXCHANGE.cpp
@@ -120,7 +120,7 @@ void HALOEXCHANGE::updateChecksum(VariantID vid, size_t tune_idx)
 void HALOEXCHANGE::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   for (int l = 0; l < s_num_neighbors; ++l) {
-    deallocData(m_buffers[l]);
+    deallocData(m_buffers[l], vid);
   }
   m_buffers.clear();
 
@@ -133,7 +133,7 @@ void HALOEXCHANGE::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
   m_pack_index_lists.clear();
 
   for (int v = 0; v < m_num_vars; ++v) {
-    deallocData(m_vars[v]);
+    deallocData(m_vars[v], vid);
   }
   m_vars.clear();
 }
@@ -293,7 +293,7 @@ void HALOEXCHANGE::destroy_pack_lists(
   (void) vid;
 
   for (Index_type l = 0; l < num_neighbors; ++l) {
-    deallocData(pack_index_lists[l]);
+    deallocData(pack_index_lists[l], vid);
   }
 }
 
@@ -438,7 +438,7 @@ void HALOEXCHANGE::destroy_unpack_lists(
   (void) vid;
 
   for (Index_type l = 0; l < num_neighbors; ++l) {
-    deallocData(unpack_index_lists[l]);
+    deallocData(unpack_index_lists[l], vid);
   }
 }
 

--- a/src/apps/HALOEXCHANGE.cpp
+++ b/src/apps/HALOEXCHANGE.cpp
@@ -19,28 +19,6 @@ namespace rajaperf
 namespace apps
 {
 
-namespace {
-
-void create_pack_lists(std::vector<Int_ptr>& pack_index_lists,
-                       std::vector<Index_type >& pack_index_list_lengths,
-                       const Index_type halo_width, const Index_type* grid_dims,
-                       const Index_type num_neighbors,
-                       VariantID vid);
-void create_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
-                         std::vector<Index_type >& unpack_index_list_lengths,
-                         const Index_type halo_width, const Index_type* grid_dims,
-                         const Index_type num_neighbors,
-                         VariantID vid);
-void destroy_pack_lists(std::vector<Int_ptr>& pack_index_lists,
-                        const Index_type num_neighbors,
-                        VariantID vid);
-void destroy_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
-                          const Index_type num_neighbors,
-                          VariantID vid);
-
-}
-
-
 HALOEXCHANGE::HALOEXCHANGE(const RunParams& params)
   : KernelBase(rajaperf::Apps_HALOEXCHANGE, params)
 {
@@ -172,14 +150,17 @@ struct Extent
   Index_type k_max;
 };
 
+}
+
 //
 // Function to generate index lists for packing.
 //
-void create_pack_lists(std::vector<Int_ptr>& pack_index_lists,
-                       std::vector<Index_type >& pack_index_list_lengths,
-                       const Index_type halo_width, const Index_type* grid_dims,
-                       const Index_type num_neighbors,
-                       VariantID vid)
+void HALOEXCHANGE::create_pack_lists(
+    std::vector<Int_ptr>& pack_index_lists,
+    std::vector<Index_type >& pack_index_list_lengths,
+    const Index_type halo_width, const Index_type* grid_dims,
+    const Index_type num_neighbors,
+    VariantID vid)
 {
   std::vector<Extent> pack_index_list_extents(num_neighbors);
 
@@ -304,9 +285,10 @@ void create_pack_lists(std::vector<Int_ptr>& pack_index_lists,
 //
 // Function to destroy packing index lists.
 //
-void destroy_pack_lists(std::vector<Int_ptr>& pack_index_lists,
-                       const Index_type num_neighbors,
-                       VariantID vid)
+void HALOEXCHANGE::destroy_pack_lists(
+    std::vector<Int_ptr>& pack_index_lists,
+    const Index_type num_neighbors,
+    VariantID vid)
 {
   (void) vid;
 
@@ -318,11 +300,12 @@ void destroy_pack_lists(std::vector<Int_ptr>& pack_index_lists,
 //
 // Function to generate index lists for unpacking.
 //
-void create_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
-                         std::vector<Index_type >& unpack_index_list_lengths,
-                         const Index_type halo_width, const Index_type* grid_dims,
-                         const Index_type num_neighbors,
-                         VariantID vid)
+void HALOEXCHANGE::create_unpack_lists(
+    std::vector<Int_ptr>& unpack_index_lists,
+    std::vector<Index_type >& unpack_index_list_lengths,
+    const Index_type halo_width, const Index_type* grid_dims,
+    const Index_type num_neighbors,
+    VariantID vid)
 {
   std::vector<Extent> unpack_index_list_extents(num_neighbors);
 
@@ -447,9 +430,10 @@ void create_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
 //
 // Function to destroy unpacking index lists.
 //
-void destroy_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
-                          const Index_type num_neighbors,
-                          VariantID vid)
+void HALOEXCHANGE::destroy_unpack_lists(
+    std::vector<Int_ptr>& unpack_index_lists,
+    const Index_type num_neighbors,
+    VariantID vid)
 {
   (void) vid;
 
@@ -457,8 +441,6 @@ void destroy_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
     deallocData(unpack_index_lists[l]);
   }
 }
-
-} // end namespace
 
 } // end namespace apps
 } // end namespace rajaperf

--- a/src/apps/HALOEXCHANGE.hpp
+++ b/src/apps/HALOEXCHANGE.hpp
@@ -126,6 +126,23 @@ private:
   std::vector<Index_type > m_pack_index_list_lengths;
   std::vector<Int_ptr> m_unpack_index_lists;
   std::vector<Index_type > m_unpack_index_list_lengths;
+
+  void create_pack_lists(std::vector<Int_ptr>& pack_index_lists,
+                         std::vector<Index_type >& pack_index_list_lengths,
+                         const Index_type halo_width, const Index_type* grid_dims,
+                         const Index_type num_neighbors,
+                         VariantID vid);
+  void destroy_pack_lists(std::vector<Int_ptr>& pack_index_lists,
+                          const Index_type num_neighbors,
+                          VariantID vid);
+  void create_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
+                           std::vector<Index_type >& unpack_index_list_lengths,
+                           const Index_type halo_width, const Index_type* grid_dims,
+                           const Index_type num_neighbors,
+                           VariantID vid);
+  void destroy_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
+                            const Index_type num_neighbors,
+                            VariantID vid);
 };
 
 } // end namespace apps

--- a/src/apps/HALOEXCHANGE_FUSED.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED.cpp
@@ -19,28 +19,6 @@ namespace rajaperf
 namespace apps
 {
 
-namespace {
-
-void create_pack_lists(std::vector<Int_ptr>& pack_index_lists,
-                       std::vector<Index_type >& pack_index_list_lengths,
-                       const Index_type halo_width, const Index_type* grid_dims,
-                       const Index_type num_neighbors,
-                       VariantID vid);
-void create_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
-                         std::vector<Index_type >& unpack_index_list_lengths,
-                         const Index_type halo_width, const Index_type* grid_dims,
-                         const Index_type num_neighbors,
-                         VariantID vid);
-void destroy_pack_lists(std::vector<Int_ptr>& pack_index_lists,
-                        const Index_type num_neighbors,
-                        VariantID vid);
-void destroy_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
-                          const Index_type num_neighbors,
-                          VariantID vid);
-
-}
-
-
 HALOEXCHANGE_FUSED::HALOEXCHANGE_FUSED(const RunParams& params)
   : KernelBase(rajaperf::Apps_HALOEXCHANGE_FUSED, params)
 {
@@ -172,14 +150,17 @@ struct Extent
   Index_type k_max;
 };
 
+}
+
 //
 // Function to generate index lists for packing.
 //
-void create_pack_lists(std::vector<Int_ptr>& pack_index_lists,
-                       std::vector<Index_type >& pack_index_list_lengths,
-                       const Index_type halo_width, const Index_type* grid_dims,
-                       const Index_type num_neighbors,
-                       VariantID vid)
+void HALOEXCHANGE_FUSED::create_pack_lists(
+    std::vector<Int_ptr>& pack_index_lists,
+    std::vector<Index_type >& pack_index_list_lengths,
+    const Index_type halo_width, const Index_type* grid_dims,
+    const Index_type num_neighbors,
+    VariantID vid)
 {
   std::vector<Extent> pack_index_list_extents(num_neighbors);
 
@@ -304,9 +285,10 @@ void create_pack_lists(std::vector<Int_ptr>& pack_index_lists,
 //
 // Function to destroy packing index lists.
 //
-void destroy_pack_lists(std::vector<Int_ptr>& pack_index_lists,
-                       const Index_type num_neighbors,
-                       VariantID vid)
+void HALOEXCHANGE_FUSED::destroy_pack_lists(
+    std::vector<Int_ptr>& pack_index_lists,
+    const Index_type num_neighbors,
+    VariantID vid)
 {
   (void) vid;
 
@@ -318,11 +300,12 @@ void destroy_pack_lists(std::vector<Int_ptr>& pack_index_lists,
 //
 // Function to generate index lists for unpacking.
 //
-void create_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
-                         std::vector<Index_type >& unpack_index_list_lengths,
-                         const Index_type halo_width, const Index_type* grid_dims,
-                         const Index_type num_neighbors,
-                         VariantID vid)
+void HALOEXCHANGE_FUSED::create_unpack_lists(
+    std::vector<Int_ptr>& unpack_index_lists,
+    std::vector<Index_type >& unpack_index_list_lengths,
+    const Index_type halo_width, const Index_type* grid_dims,
+    const Index_type num_neighbors,
+    VariantID vid)
 {
   std::vector<Extent> unpack_index_list_extents(num_neighbors);
 
@@ -447,9 +430,10 @@ void create_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
 //
 // Function to destroy unpacking index lists.
 //
-void destroy_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
-                          const Index_type num_neighbors,
-                          VariantID vid)
+void HALOEXCHANGE_FUSED::destroy_unpack_lists(
+    std::vector<Int_ptr>& unpack_index_lists,
+    const Index_type num_neighbors,
+    VariantID vid)
 {
   (void) vid;
 
@@ -457,8 +441,6 @@ void destroy_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
     deallocData(unpack_index_lists[l]);
   }
 }
-
-} // end namespace
 
 } // end namespace apps
 } // end namespace rajaperf

--- a/src/apps/HALOEXCHANGE_FUSED.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED.cpp
@@ -120,7 +120,7 @@ void HALOEXCHANGE_FUSED::updateChecksum(VariantID vid, size_t tune_idx)
 void HALOEXCHANGE_FUSED::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   for (int l = 0; l < s_num_neighbors; ++l) {
-    deallocData(m_buffers[l]);
+    deallocData(m_buffers[l], vid);
   }
   m_buffers.clear();
 
@@ -133,7 +133,7 @@ void HALOEXCHANGE_FUSED::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
   m_pack_index_lists.clear();
 
   for (int v = 0; v < m_num_vars; ++v) {
-    deallocData(m_vars[v]);
+    deallocData(m_vars[v], vid);
   }
   m_vars.clear();
 }
@@ -293,7 +293,7 @@ void HALOEXCHANGE_FUSED::destroy_pack_lists(
   (void) vid;
 
   for (Index_type l = 0; l < num_neighbors; ++l) {
-    deallocData(pack_index_lists[l]);
+    deallocData(pack_index_lists[l], vid);
   }
 }
 
@@ -438,7 +438,7 @@ void HALOEXCHANGE_FUSED::destroy_unpack_lists(
   (void) vid;
 
   for (Index_type l = 0; l < num_neighbors; ++l) {
-    deallocData(unpack_index_lists[l]);
+    deallocData(unpack_index_lists[l], vid);
   }
 }
 

--- a/src/apps/HALOEXCHANGE_FUSED.hpp
+++ b/src/apps/HALOEXCHANGE_FUSED.hpp
@@ -170,6 +170,23 @@ private:
   std::vector<Index_type > m_pack_index_list_lengths;
   std::vector<Int_ptr> m_unpack_index_lists;
   std::vector<Index_type > m_unpack_index_list_lengths;
+
+  void create_pack_lists(std::vector<Int_ptr>& pack_index_lists,
+                         std::vector<Index_type >& pack_index_list_lengths,
+                         const Index_type halo_width, const Index_type* grid_dims,
+                         const Index_type num_neighbors,
+                         VariantID vid);
+  void destroy_pack_lists(std::vector<Int_ptr>& pack_index_lists,
+                          const Index_type num_neighbors,
+                          VariantID vid);
+  void create_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
+                           std::vector<Index_type >& unpack_index_list_lengths,
+                           const Index_type halo_width, const Index_type* grid_dims,
+                           const Index_type num_neighbors,
+                           VariantID vid);
+  void destroy_unpack_lists(std::vector<Int_ptr>& unpack_index_lists,
+                            const Index_type num_neighbors,
+                            VariantID vid);
 };
 
 } // end namespace apps

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -99,9 +99,9 @@ void LTIMES::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
 
-  deallocData(m_phidat);
-  deallocData(m_elldat);
-  deallocData(m_psidat);
+  deallocData(m_phidat, vid);
+  deallocData(m_elldat, vid);
+  deallocData(m_psidat, vid);
 }
 
 } // end namespace apps

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -98,9 +98,9 @@ void LTIMES_NOVIEW::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx)
 {
   (void) vid;
 
-  deallocData(m_phidat);
-  deallocData(m_elldat);
-  deallocData(m_psidat);
+  deallocData(m_phidat, vid);
+  deallocData(m_elldat, vid);
+  deallocData(m_psidat, vid);
 }
 
 } // end namespace apps

--- a/src/apps/MASS3DPA.cpp
+++ b/src/apps/MASS3DPA.cpp
@@ -86,11 +86,11 @@ void MASS3DPA::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
 
-  deallocData(m_B);
-  deallocData(m_Bt);
-  deallocData(m_D);
-  deallocData(m_X);
-  deallocData(m_Y);
+  deallocData(m_B, vid);
+  deallocData(m_Bt, vid);
+  deallocData(m_D, vid);
+  deallocData(m_X, vid);
+  deallocData(m_Y, vid);
 }
 
 } // end namespace apps

--- a/src/apps/NODAL_ACCUMULATION_3D.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D.cpp
@@ -89,8 +89,8 @@ void NODAL_ACCUMULATION_3D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
 {
   (void) vid;
 
-  deallocData(m_x);
-  deallocData(m_vol);
+  deallocData(m_x, vid);
+  deallocData(m_vol, vid);
 }
 
 } // end namespace apps

--- a/src/apps/PRESSURE.cpp
+++ b/src/apps/PRESSURE.cpp
@@ -66,10 +66,10 @@ void PRESSURE::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
   allocAndInitData(m_e_old, getActualProblemSize(), vid);
   allocAndInitData(m_vnewc, getActualProblemSize(), vid);
 
-  initData(m_cls);
-  initData(m_p_cut);
-  initData(m_pmin);
-  initData(m_eosvmax);
+  initData(m_cls, vid);
+  initData(m_p_cut, vid);
+  initData(m_pmin, vid);
+  initData(m_eosvmax, vid);
 }
 
 void PRESSURE::updateChecksum(VariantID vid, size_t tune_idx)
@@ -81,11 +81,11 @@ void PRESSURE::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
 
-  deallocData(m_compression);
-  deallocData(m_bvc);
-  deallocData(m_p_new);
-  deallocData(m_e_old);
-  deallocData(m_vnewc);
+  deallocData(m_compression, vid);
+  deallocData(m_bvc, vid);
+  deallocData(m_p_new, vid);
+  deallocData(m_e_old, vid);
+  deallocData(m_vnewc, vid);
 }
 
 } // end namespace apps

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -96,10 +96,10 @@ void VOL3D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
 
-  deallocData(m_x);
-  deallocData(m_y);
-  deallocData(m_z);
-  deallocData(m_vol);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
+  deallocData(m_z, vid);
+  deallocData(m_vol, vid);
 }
 
 } // end namespace apps

--- a/src/apps/WIP-COUPLE.cpp
+++ b/src/apps/WIP-COUPLE.cpp
@@ -193,11 +193,11 @@ void COUPLE::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
 
-  deallocData(m_t0);
-  deallocData(m_t1);
-  deallocData(m_t2);
-  deallocData(m_denac);
-  deallocData(m_denlw);
+  deallocData(m_t0, vid);
+  deallocData(m_t1, vid);
+  deallocData(m_t2, vid);
+  deallocData(m_denac, vid);
+  deallocData(m_denlw, vid);
 }
 
 } // end namespace apps

--- a/src/basic/DAXPY.cpp
+++ b/src/basic/DAXPY.cpp
@@ -63,7 +63,7 @@ void DAXPY::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   allocAndInitDataConst(m_y, getActualProblemSize(), 0.0, vid);
   allocAndInitData(m_x, getActualProblemSize(), vid);
-  initData(m_a);
+  initData(m_a, vid);
 }
 
 void DAXPY::updateChecksum(VariantID vid, size_t tune_idx)
@@ -74,8 +74,8 @@ void DAXPY::updateChecksum(VariantID vid, size_t tune_idx)
 void DAXPY::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_y);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
 }
 
 } // end namespace basic

--- a/src/basic/DAXPY_ATOMIC.cpp
+++ b/src/basic/DAXPY_ATOMIC.cpp
@@ -63,7 +63,7 @@ void DAXPY_ATOMIC::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   allocAndInitDataConst(m_y, getActualProblemSize(), 0.0, vid);
   allocAndInitData(m_x, getActualProblemSize(), vid);
-  initData(m_a);
+  initData(m_a, vid);
 }
 
 void DAXPY_ATOMIC::updateChecksum(VariantID vid, size_t tune_idx)
@@ -74,8 +74,8 @@ void DAXPY_ATOMIC::updateChecksum(VariantID vid, size_t tune_idx)
 void DAXPY_ATOMIC::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_y);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
 }
 
 } // end namespace basic

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -81,11 +81,11 @@ void IF_QUAD::updateChecksum(VariantID vid, size_t tune_idx)
 void IF_QUAD::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_a);
-  deallocData(m_b);
-  deallocData(m_c);
-  deallocData(m_x1);
-  deallocData(m_x2);
+  deallocData(m_a, vid);
+  deallocData(m_b, vid);
+  deallocData(m_c, vid);
+  deallocData(m_x1, vid);
+  deallocData(m_x2, vid);
 }
 
 } // end namespace basic

--- a/src/basic/INDEXLIST.cpp
+++ b/src/basic/INDEXLIST.cpp
@@ -71,8 +71,8 @@ void INDEXLIST::updateChecksum(VariantID vid, size_t tune_idx)
 void INDEXLIST::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_list);
+  deallocData(m_x, vid);
+  deallocData(m_list, vid);
 }
 
 } // end namespace basic

--- a/src/basic/INDEXLIST_3LOOP.cpp
+++ b/src/basic/INDEXLIST_3LOOP.cpp
@@ -80,8 +80,8 @@ void INDEXLIST_3LOOP::updateChecksum(VariantID vid, size_t tune_idx)
 void INDEXLIST_3LOOP::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_list);
+  deallocData(m_x, vid);
+  deallocData(m_list, vid);
 }
 
 } // end namespace basic

--- a/src/basic/INIT3.cpp
+++ b/src/basic/INIT3.cpp
@@ -78,11 +78,11 @@ void INIT3::updateChecksum(VariantID vid, size_t tune_idx)
 void INIT3::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_out1);
-  deallocData(m_out2);
-  deallocData(m_out3);
-  deallocData(m_in1);
-  deallocData(m_in2);
+  deallocData(m_out1, vid);
+  deallocData(m_out2, vid);
+  deallocData(m_out3, vid);
+  deallocData(m_in1, vid);
+  deallocData(m_in2, vid);
 }
 
 } // end namespace basic

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -74,7 +74,7 @@ void INIT_VIEW1D::updateChecksum(VariantID vid, size_t tune_idx)
 void INIT_VIEW1D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_a);
+  deallocData(m_a, vid);
 }
 
 } // end namespace basic

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -74,7 +74,7 @@ void INIT_VIEW1D_OFFSET::updateChecksum(VariantID vid, size_t tune_idx)
 void INIT_VIEW1D_OFFSET::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_a);
+  deallocData(m_a, vid);
 }
 
 } // end namespace basic

--- a/src/basic/MAT_MAT_SHARED.cpp
+++ b/src/basic/MAT_MAT_SHARED.cpp
@@ -78,9 +78,9 @@ void MAT_MAT_SHARED::updateChecksum(VariantID vid, size_t tune_idx) {
 
 void MAT_MAT_SHARED::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx)) {
   (void)vid;
-  deallocData(m_A);
-  deallocData(m_B);
-  deallocData(m_C);
+  deallocData(m_A, vid);
+  deallocData(m_B, vid);
+  deallocData(m_C, vid);
 }
 
 } // end namespace basic

--- a/src/basic/MULADDSUB.cpp
+++ b/src/basic/MULADDSUB.cpp
@@ -78,11 +78,11 @@ void MULADDSUB::updateChecksum(VariantID vid, size_t tune_idx)
 void MULADDSUB::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_out1);
-  deallocData(m_out2);
-  deallocData(m_out3);
-  deallocData(m_in1);
-  deallocData(m_in2);
+  deallocData(m_out1, vid);
+  deallocData(m_out2, vid);
+  deallocData(m_out3, vid);
+  deallocData(m_in1, vid);
+  deallocData(m_in2, vid);
 }
 
 } // end namespace basic

--- a/src/basic/PI_ATOMIC.cpp
+++ b/src/basic/PI_ATOMIC.cpp
@@ -76,7 +76,7 @@ void PI_ATOMIC::updateChecksum(VariantID vid, size_t tune_idx)
 void PI_ATOMIC::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_pi);
+  deallocData(m_pi, vid);
 }
 
 } // end namespace basic

--- a/src/basic/REDUCE3_INT.cpp
+++ b/src/basic/REDUCE3_INT.cpp
@@ -86,7 +86,7 @@ void REDUCE3_INT::updateChecksum(VariantID vid, size_t tune_idx)
 void REDUCE3_INT::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_vec);
+  deallocData(m_vec, vid);
 }
 
 } // end namespace basic

--- a/src/basic/REDUCE_STRUCT.cpp
+++ b/src/basic/REDUCE_STRUCT.cpp
@@ -92,8 +92,8 @@ void REDUCE_STRUCT::updateChecksum(VariantID vid, size_t tune_idx)
 void REDUCE_STRUCT::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_y);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
 }
 
 } // end namespace basic

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -122,7 +122,7 @@ void initCudaDeviceData(T& dptr, const T hptr, int len)
                           len * sizeof(typename std::remove_pointer<T>::type),
                           cudaMemcpyHostToDevice ) );
 
-  incDataInitCount();
+  detail::incDataInitCount();
 }
 
 /*!

--- a/src/common/DataUtils.cpp
+++ b/src/common/DataUtils.cpp
@@ -43,38 +43,38 @@ void incDataInitCount()
  */
 void allocAndInitData(Int_ptr& ptr, int len, int align, VariantID vid)
 {
-  allocData(ptr, len, align);
+  allocData(ptr, len, align, vid);
   initData(ptr, len, vid);
 }
 
 void allocAndInitData(Real_ptr& ptr, int len, int align, VariantID vid )
 {
-  allocData(ptr, len, align);
+  allocData(ptr, len, align, vid);
   initData(ptr, len, vid);
 }
 
 void allocAndInitDataConst(Real_ptr& ptr, int len, int align, Real_type val,
                            VariantID vid)
 {
-  allocData(ptr, len, align);
+  allocData(ptr, len, align, vid);
   initDataConst(ptr, len, val, vid);
 }
 
 void allocAndInitDataRandSign(Real_ptr& ptr, int len, int align, VariantID vid)
 {
-  allocData(ptr, len, align);
+  allocData(ptr, len, align, vid);
   initDataRandSign(ptr, len, vid);
 }
 
 void allocAndInitDataRandValue(Real_ptr& ptr, int len, int align, VariantID vid)
 {
-  allocData(ptr, len, align);
+  allocData(ptr, len, align, vid);
   initDataRandValue(ptr, len, vid);
 }
 
 void allocAndInitData(Complex_ptr& ptr, int len, int align, VariantID vid)
 {
-  allocData(ptr, len, align);
+  allocData(ptr, len, align, vid);
   initData(ptr, len, vid);
 }
 
@@ -82,20 +82,26 @@ void allocAndInitData(Complex_ptr& ptr, int len, int align, VariantID vid)
 /*
  * Allocate data arrays of given type.
  */
-void allocData(Int_ptr& ptr, int len, int align)
+void allocData(Int_ptr& ptr, int len, int align,
+               VariantID vid)
 {
+  (void)vid;
   ptr = RAJA::allocate_aligned_type<Int_type>(
       align, len*sizeof(Int_type));
 }
 
-void allocData(Real_ptr& ptr, int len, int align)
+void allocData(Real_ptr& ptr, int len, int align,
+               VariantID vid)
 {
+  (void)vid;
   ptr = RAJA::allocate_aligned_type<Real_type>(
       align, len*sizeof(Real_type));
 }
 
-void allocData(Complex_ptr& ptr, int len, int align)
+void allocData(Complex_ptr& ptr, int len, int align,
+               VariantID vid)
 {
+  (void)vid;
   ptr = RAJA::allocate_aligned_type<Complex_type>(
       align, len*sizeof(Complex_type));
 }
@@ -104,24 +110,30 @@ void allocData(Complex_ptr& ptr, int len, int align)
 /*
  * Free data arrays of given type.
  */
-void deallocData(Int_ptr& ptr)
+void deallocData(Int_ptr& ptr,
+                 VariantID vid)
 {
+  (void)vid;
   if (ptr) {
     RAJA::free_aligned(ptr);
     ptr = nullptr;
   }
 }
 
-void deallocData(Real_ptr& ptr)
+void deallocData(Real_ptr& ptr,
+                 VariantID vid)
 {
+  (void)vid;
   if (ptr) {
     RAJA::free_aligned(ptr);
     ptr = nullptr;
   }
 }
 
-void deallocData(Complex_ptr& ptr)
+void deallocData(Complex_ptr& ptr,
+                 VariantID vid)
 {
+  (void)vid;
   if (ptr) {
     RAJA::free_aligned(ptr);
     ptr = nullptr;

--- a/src/common/DataUtils.cpp
+++ b/src/common/DataUtils.cpp
@@ -16,6 +16,9 @@
 namespace rajaperf
 {
 
+namespace detail
+{
+
 static int data_init_count = 0;
 
 /*
@@ -36,45 +39,42 @@ void incDataInitCount()
 
 
 /*
- * Allocate and initialize aligned integer data arrays.
- */
-void allocAndInitData(Int_ptr& ptr, int len, VariantID vid)
-{
-  allocData(ptr, len);
-  initData(ptr, len, vid);
-}
-
-/*
  * Allocate and initialize aligned data arrays.
  */
-void allocAndInitData(Real_ptr& ptr, int len, VariantID vid )
+void allocAndInitData(Int_ptr& ptr, int len, int align, VariantID vid)
 {
-  allocData(ptr, len);
+  allocData(ptr, len, align);
   initData(ptr, len, vid);
 }
 
-void allocAndInitDataConst(Real_ptr& ptr, int len, Real_type val,
+void allocAndInitData(Real_ptr& ptr, int len, int align, VariantID vid )
+{
+  allocData(ptr, len, align);
+  initData(ptr, len, vid);
+}
+
+void allocAndInitDataConst(Real_ptr& ptr, int len, int align, Real_type val,
                            VariantID vid)
 {
-  allocData(ptr, len);
+  allocData(ptr, len, align);
   initDataConst(ptr, len, val, vid);
 }
 
-void allocAndInitDataRandSign(Real_ptr& ptr, int len, VariantID vid)
+void allocAndInitDataRandSign(Real_ptr& ptr, int len, int align, VariantID vid)
 {
-  allocData(ptr, len);
+  allocData(ptr, len, align);
   initDataRandSign(ptr, len, vid);
 }
 
-void allocAndInitDataRandValue(Real_ptr& ptr, int len, VariantID vid)
+void allocAndInitDataRandValue(Real_ptr& ptr, int len, int align, VariantID vid)
 {
-  allocData(ptr, len);
+  allocData(ptr, len, align);
   initDataRandValue(ptr, len, vid);
 }
 
-void allocAndInitData(Complex_ptr& ptr, int len, VariantID vid)
+void allocAndInitData(Complex_ptr& ptr, int len, int align, VariantID vid)
 {
-  allocData(ptr, len);
+  allocData(ptr, len, align);
   initData(ptr, len, vid);
 }
 
@@ -82,22 +82,22 @@ void allocAndInitData(Complex_ptr& ptr, int len, VariantID vid)
 /*
  * Allocate data arrays of given type.
  */
-void allocData(Int_ptr& ptr, int len)
+void allocData(Int_ptr& ptr, int len, int align)
 {
-  ptr = RAJA::allocate_aligned_type<Int_type>(RAJA::DATA_ALIGN,
-                                              len*sizeof(Int_type));
+  ptr = RAJA::allocate_aligned_type<Int_type>(
+      align, len*sizeof(Int_type));
 }
 
-void allocData(Real_ptr& ptr, int len)
+void allocData(Real_ptr& ptr, int len, int align)
 {
-  ptr = RAJA::allocate_aligned_type<Real_type>(RAJA::DATA_ALIGN,
-                                               len*sizeof(Real_type));
+  ptr = RAJA::allocate_aligned_type<Real_type>(
+      align, len*sizeof(Real_type));
 }
 
-void allocData(Complex_ptr& ptr, int len)
+void allocData(Complex_ptr& ptr, int len, int align)
 {
-  ptr = RAJA::allocate_aligned_type<Complex_type>(RAJA::DATA_ALIGN,
-                                                  len*sizeof(Complex_type));
+  ptr = RAJA::allocate_aligned_type<Complex_type>(
+      align, len*sizeof(Complex_type));
 }
 
 
@@ -328,6 +328,7 @@ void initData(Real_type& d, VariantID vid)
   incDataInitCount();
 }
 
+}  // closing brace for detail namespace
 
 /*
  * Calculate and return checksum for data arrays.

--- a/src/common/DataUtils.cpp
+++ b/src/common/DataUtils.cpp
@@ -84,21 +84,20 @@ void allocAndInitData(Complex_ptr& ptr, int len, VariantID vid)
  */
 void allocData(Int_ptr& ptr, int len)
 {
-  // Should we do this differently for alignment?? If so, change dealloc()
-  ptr = new Int_type[len];
+  ptr = RAJA::allocate_aligned_type<Int_type>(RAJA::DATA_ALIGN,
+                                              len*sizeof(Int_type));
 }
 
 void allocData(Real_ptr& ptr, int len)
 {
-  ptr =
-    RAJA::allocate_aligned_type<Real_type>(RAJA::DATA_ALIGN,
-                                           len*sizeof(Real_type));
+  ptr = RAJA::allocate_aligned_type<Real_type>(RAJA::DATA_ALIGN,
+                                               len*sizeof(Real_type));
 }
 
 void allocData(Complex_ptr& ptr, int len)
 {
-  // Should we do this differently for alignment?? If so, change dealloc()
-  ptr = new Complex_type[len];
+  ptr = RAJA::allocate_aligned_type<Complex_type>(RAJA::DATA_ALIGN,
+                                                  len*sizeof(Complex_type));
 }
 
 
@@ -108,8 +107,8 @@ void allocData(Complex_ptr& ptr, int len)
 void deallocData(Int_ptr& ptr)
 {
   if (ptr) {
-    delete [] ptr;
-    ptr = 0;
+    RAJA::free_aligned(ptr);
+    ptr = nullptr;
   }
 }
 
@@ -117,15 +116,15 @@ void deallocData(Real_ptr& ptr)
 {
   if (ptr) {
     RAJA::free_aligned(ptr);
-    ptr = 0;
+    ptr = nullptr;
   }
 }
 
 void deallocData(Complex_ptr& ptr)
 {
   if (ptr) {
-    delete [] ptr;
-    ptr = 0;
+    RAJA::free_aligned(ptr);
+    ptr = nullptr;
   }
 }
 

--- a/src/common/DataUtils.hpp
+++ b/src/common/DataUtils.hpp
@@ -96,20 +96,26 @@ void allocAndInitData(Complex_ptr& ptr, int len, int align,
 /*!
  * \brief Allocate data arrays.
  */
-void allocData(Int_ptr& ptr, int len, int align);
+void allocData(Int_ptr& ptr, int len, int align,
+               VariantID vid);
 ///
-void allocData(Real_ptr& ptr, int len, int align);
+void allocData(Real_ptr& ptr, int len, int align,
+               VariantID vid);
 ///
-void allocData(Complex_ptr& ptr, int len, int align);
+void allocData(Complex_ptr& ptr, int len, int align,
+               VariantID vid);
 
 /*!
  * \brief Free data arrays.
  */
-void deallocData(Int_ptr& ptr);
+void deallocData(Int_ptr& ptr,
+                 VariantID vid);
 ///
-void deallocData(Real_ptr& ptr);
+void deallocData(Real_ptr& ptr,
+                 VariantID vid);
 ///
-void deallocData(Complex_ptr& ptr);
+void deallocData(Complex_ptr& ptr,
+                 VariantID vid);
 
 
 /*!

--- a/src/common/DataUtils.hpp
+++ b/src/common/DataUtils.hpp
@@ -31,6 +31,8 @@
 namespace rajaperf
 {
 
+namespace detail
+{
 
 /*!
  * Reset counter for data initialization.
@@ -48,16 +50,16 @@ void incDataInitCount();
  *
  * Array is initialized using method initData(Int_ptr& ptr...) below.
  */
-void allocAndInitData(Int_ptr& ptr, int len,
-                      VariantID vid = NumVariants);
+void allocAndInitData(Int_ptr& ptr, int len, int align,
+                      VariantID vid);
 
 /*!
  * \brief Allocate and initialize aligned Real_type data array.
  *
  * Array is initialized using method initData(Real_ptr& ptr...) below.
  */
-void allocAndInitData(Real_ptr& ptr, int len,
-                      VariantID vid = NumVariants);
+void allocAndInitData(Real_ptr& ptr, int len, int align,
+                      VariantID vid);
 
 /*!
  * \brief Allocate and initialize aligned Real_type data array.
@@ -65,16 +67,16 @@ void allocAndInitData(Real_ptr& ptr, int len,
  * Array entries are initialized using the method
  * initDataConst(Real_ptr& ptr...) below.
  */
-void allocAndInitDataConst(Real_ptr& ptr, int len, Real_type val,
-                           VariantID vid = NumVariants);
+void allocAndInitDataConst(Real_ptr& ptr, int len, int align, Real_type val,
+                           VariantID vid);
 
 /*!
  * \brief Allocate and initialize aligned Real_type data array with random sign.
  *
  * Array is initialized using method initDataRandSign(Real_ptr& ptr...) below.
  */
-void allocAndInitDataRandSign(Real_ptr& ptr, int len,
-                              VariantID vid = NumVariants);
+void allocAndInitDataRandSign(Real_ptr& ptr, int len, int align,
+                              VariantID vid);
 
 /*!
  * \brief Allocate and initialize aligned Real_type data array with random
@@ -82,23 +84,23 @@ void allocAndInitDataRandSign(Real_ptr& ptr, int len,
  *
  * Array is initialized using method initDataRandValue(Real_ptr& ptr...) below.
  */
-void allocAndInitDataRandValue(Real_ptr& ptr, int len,
-                               VariantID vid = NumVariants);
+void allocAndInitDataRandValue(Real_ptr& ptr, int len, int align,
+                               VariantID vid);
 
 /*!
  * \brief Allocate and initialize aligned Complex_type data array.
  */
-void allocAndInitData(Complex_ptr& ptr, int len,
-                      VariantID vid = NumVariants);
+void allocAndInitData(Complex_ptr& ptr, int len, int align,
+                      VariantID vid);
 
 /*!
  * \brief Allocate data arrays.
  */
-void allocData(Int_ptr& ptr, int len);
+void allocData(Int_ptr& ptr, int len, int align);
 ///
-void allocData(Real_ptr& ptr, int len);
+void allocData(Real_ptr& ptr, int len, int align);
 ///
-void allocData(Complex_ptr& ptr, int len);
+void allocData(Complex_ptr& ptr, int len, int align);
 
 /*!
  * \brief Free data arrays.
@@ -118,7 +120,7 @@ void deallocData(Complex_ptr& ptr);
  * a value > 1, one to a value < -1.
  */
 void initData(Int_ptr& ptr, int len,
-              VariantID vid = NumVariants);
+              VariantID vid);
 
 /*!
  * \brief Initialize Real_type data array.
@@ -128,7 +130,7 @@ void initData(Int_ptr& ptr, int len,
  * and the order in which this method is called.
  */
 void initData(Real_ptr& ptr, int len,
-              VariantID vid = NumVariants);
+              VariantID vid);
 
 /*!
  * \brief Initialize Real_type data array.
@@ -136,7 +138,7 @@ void initData(Real_ptr& ptr, int len,
  * Array entries are set to given constant value.
  */
 void initDataConst(Real_ptr& ptr, int len, Real_type val,
-                   VariantID vid = NumVariants);
+                   VariantID vid);
 
 /*!
  * \brief Initialize Real_type data array with random sign.
@@ -145,7 +147,7 @@ void initDataConst(Real_ptr& ptr, int len, Real_type val,
  * initData(Real_ptr& ptr...) above, but with random sign.
  */
 void initDataRandSign(Real_ptr& ptr, int len,
-                      VariantID vid = NumVariants);
+                      VariantID vid);
 
 /*!
  * \brief Initialize Real_type data array with random values.
@@ -153,7 +155,7 @@ void initDataRandSign(Real_ptr& ptr, int len,
  * Array entries are initialized with random values in the interval [0.0, 1.0].
  */
 void initDataRandValue(Real_ptr& ptr, int len,
-                       VariantID vid = NumVariants);
+                       VariantID vid);
 
 /*!
  * \brief Initialize Complex_type data array.
@@ -162,7 +164,7 @@ void initDataRandValue(Real_ptr& ptr, int len,
  * method allocAndInitData(Real_ptr& ptr...) above.
  */
 void initData(Complex_ptr& ptr, int len,
-              VariantID vid = NumVariants);
+              VariantID vid);
 
 /*!
  * \brief Initialize Real_type scalar data.
@@ -171,7 +173,9 @@ void initData(Complex_ptr& ptr, int len,
  * initData(Real_ptr& ptr...) above.
  */
 void initData(Real_type& d,
-              VariantID vid = NumVariants);
+              VariantID vid);
+
+}  // closing brace for detail namespace
 
 /*!
  * \brief Calculate and return checksum for data arrays.

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -109,7 +109,7 @@ void initHipDeviceData(T& dptr, const T hptr, int len)
                           len * sizeof(typename std::remove_pointer<T>::type),
                           hipMemcpyHostToDevice ) );
 
-  incDataInitCount();
+  detail::incDataInitCount();
 }
 
 /*!

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -160,7 +160,7 @@ void KernelBase::execute(VariantID vid, size_t tune_idx)
 
   resetTimer();
 
-  resetDataInitCount();
+  detail::resetDataInitCount();
   this->setUp(vid, tune_idx);
 
   this->runKernel(vid, tune_idx);

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -188,7 +188,7 @@ public:
 #endif
   }
 
-  int getDataAlignment() const { return run_params.getMemoryAlignment(); }
+  int getDataAlignment() const { return run_params.getDataAlignment(); }
   template <typename T>
   void allocData(T*& ptr, int len,
                  VariantID vid)

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -188,6 +188,73 @@ public:
 #endif
   }
 
+  // run_params.getMemoryAlignment(); }
+  int getDataAlignment() const { return RAJA::DATA_ALIGN; }
+  template <typename T>
+  void allocData(T*& ptr, int len)
+  {
+    rajaperf::detail::allocData(ptr, len, getDataAlignment());
+  }
+  template <typename T>
+  void allocAndInitData(T*& ptr, int len,
+                        VariantID vid = NumVariants)
+  {
+    rajaperf::detail::allocAndInitData(ptr, len, getDataAlignment(), vid);
+  }
+  template <typename T>
+  void allocAndInitDataConst(T*& ptr, int len, T val,
+                             VariantID vid = NumVariants)
+  {
+    rajaperf::detail::allocAndInitDataConst(ptr, len, getDataAlignment(), val, vid);
+  }
+  template <typename T>
+  void allocAndInitDataRandSign(T*& ptr, int len,
+                                VariantID vid = NumVariants)
+  {
+    rajaperf::detail::allocAndInitDataRandSign(ptr, len, getDataAlignment(), vid);
+  }
+  template <typename T>
+  void allocAndInitDataRandValue(T*& ptr, int len,
+                                 VariantID vid = NumVariants)
+  {
+    rajaperf::detail::allocAndInitDataRandValue(ptr, len, getDataAlignment(), vid);
+  }
+  template <typename T>
+  void deallocData(T*& ptr)
+  {
+    rajaperf::detail::deallocData(ptr);
+  }
+  template <typename T>
+  void initData(T*& ptr, int len,
+                VariantID vid = NumVariants)
+  {
+    rajaperf::detail::initData(ptr, len, vid);
+  }
+  template <typename T>
+  void initDataConst(T*& ptr, int len, T val,
+                     VariantID vid = NumVariants)
+  {
+    rajaperf::detail::initDataConst(ptr, len, val, vid);
+  }
+  template <typename T>
+  void initDataRandSign(T*& ptr, int len,
+                        VariantID vid = NumVariants)
+  {
+    rajaperf::detail::initDataRandSign(ptr, len, vid);
+  }
+  template <typename T>
+  void initDataRandValue(T*& ptr, int len,
+                         VariantID vid = NumVariants)
+  {
+    rajaperf::detail::initDataRandValue(ptr, len, vid);
+  }
+  template <typename T>
+  void initData(T& d,
+                VariantID vid = NumVariants)
+  {
+    rajaperf::detail::initData(d, vid);
+  }
+
   void startTimer()
   {
     synchronize();

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -188,8 +188,7 @@ public:
 #endif
   }
 
-  // run_params.getMemoryAlignment(); }
-  int getDataAlignment() const { return RAJA::DATA_ALIGN; }
+  int getDataAlignment() const { return run_params.getMemoryAlignment(); }
   template <typename T>
   void allocData(T*& ptr, int len,
                  VariantID vid)

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -191,66 +191,68 @@ public:
   // run_params.getMemoryAlignment(); }
   int getDataAlignment() const { return RAJA::DATA_ALIGN; }
   template <typename T>
-  void allocData(T*& ptr, int len)
+  void allocData(T*& ptr, int len,
+                 VariantID vid)
   {
-    rajaperf::detail::allocData(ptr, len, getDataAlignment());
+    rajaperf::detail::allocData(ptr, len, getDataAlignment(), vid);
   }
   template <typename T>
   void allocAndInitData(T*& ptr, int len,
-                        VariantID vid = NumVariants)
+                        VariantID vid)
   {
     rajaperf::detail::allocAndInitData(ptr, len, getDataAlignment(), vid);
   }
   template <typename T>
   void allocAndInitDataConst(T*& ptr, int len, T val,
-                             VariantID vid = NumVariants)
+                             VariantID vid)
   {
     rajaperf::detail::allocAndInitDataConst(ptr, len, getDataAlignment(), val, vid);
   }
   template <typename T>
   void allocAndInitDataRandSign(T*& ptr, int len,
-                                VariantID vid = NumVariants)
+                                VariantID vid)
   {
     rajaperf::detail::allocAndInitDataRandSign(ptr, len, getDataAlignment(), vid);
   }
   template <typename T>
   void allocAndInitDataRandValue(T*& ptr, int len,
-                                 VariantID vid = NumVariants)
+                                 VariantID vid)
   {
     rajaperf::detail::allocAndInitDataRandValue(ptr, len, getDataAlignment(), vid);
   }
   template <typename T>
-  void deallocData(T*& ptr)
+  void deallocData(T*& ptr,
+                   VariantID vid)
   {
-    rajaperf::detail::deallocData(ptr);
+    rajaperf::detail::deallocData(ptr, vid);
   }
   template <typename T>
   void initData(T*& ptr, int len,
-                VariantID vid = NumVariants)
+                VariantID vid)
   {
     rajaperf::detail::initData(ptr, len, vid);
   }
   template <typename T>
   void initDataConst(T*& ptr, int len, T val,
-                     VariantID vid = NumVariants)
+                     VariantID vid)
   {
     rajaperf::detail::initDataConst(ptr, len, val, vid);
   }
   template <typename T>
   void initDataRandSign(T*& ptr, int len,
-                        VariantID vid = NumVariants)
+                        VariantID vid)
   {
     rajaperf::detail::initDataRandSign(ptr, len, vid);
   }
   template <typename T>
   void initDataRandValue(T*& ptr, int len,
-                         VariantID vid = NumVariants)
+                         VariantID vid)
   {
     rajaperf::detail::initDataRandValue(ptr, len, vid);
   }
   template <typename T>
   void initData(T& d,
-                VariantID vid = NumVariants)
+                VariantID vid)
   {
     rajaperf::detail::initData(d, vid);
   }

--- a/src/common/OpenMPTargetDataUtils.hpp
+++ b/src/common/OpenMPTargetDataUtils.hpp
@@ -49,7 +49,7 @@ void initOpenMPDeviceData(T& dptr, const T hptr, int len,
                           int did, int hid)
 {
   copyOpenMPDeviceData(dptr, hptr, len, did, hid);
-  incDataInitCount();
+  detail::incDataInitCount();
 }
 
 /*!

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -34,6 +34,7 @@ RunParams::RunParams(int argc, char** argv)
    size_meaning(SizeMeaning::Unset),
    size(0.0),
    size_factor(0.0),
+   memory_alignment(RAJA::DATA_ALIGN),
    gpu_block_sizes(),
    pf_tol(0.1),
    checkrun_reps(1),

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -34,7 +34,7 @@ RunParams::RunParams(int argc, char** argv)
    size_meaning(SizeMeaning::Unset),
    size(0.0),
    size_factor(0.0),
-   memory_alignment(RAJA::DATA_ALIGN),
+   data_alignment(RAJA::DATA_ALIGN),
    gpu_block_sizes(),
    pf_tol(0.1),
    checkrun_reps(1),
@@ -99,7 +99,7 @@ void RunParams::print(std::ostream& str) const
   str << "\n size_meaning = " << SizeMeaningToStr(getSizeMeaning());
   str << "\n size = " << size;
   str << "\n size_factor = " << size_factor;
-  str << "\n memory_alignment = " << memory_alignment;
+  str << "\n data_alignment = " << data_alignment;
   str << "\n gpu_block_sizes = ";
   for (size_t j = 0; j < gpu_block_sizes.size(); ++j) {
     str << "\n\t" << gpu_block_sizes[j];
@@ -318,8 +318,8 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
         input_state = BadInput;
       }
 
-    } else if ( opt == std::string("--align") ||
-                opt == std::string("--memory_alignment") ) {
+    } else if ( opt == std::string("-align") ||
+                opt == std::string("--data_alignment") ) {
 
       i++;
       if ( i < argc ) {
@@ -336,7 +336,7 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
                 << std::endl;
           input_state = BadInput;
         } else {
-          memory_alignment = align;
+          data_alignment = align;
         }
       } else {
         getCout() << "\nBad input:"
@@ -619,11 +619,11 @@ void RunParams::printHelpMessage(std::ostream& str) const
   str << "\t\t Example...\n"
       << "\t\t --size 1000000 (runs kernels with size ~1,000,000)\n\n";
 
-  str << "\t --memory_alignment, --align <int> [default is RAJA::DATA_ALIGN]\n"
+  str << "\t --data_alignment, -align <int> [default is RAJA::DATA_ALIGN]\n"
       << "\t      (minimum memory alignment for host allocations)\n"
       << "\t      (must be a power of 2 at least as large as the default alignment)\n";
   str << "\t\t Example...\n"
-      << "\t\t --align 4096 (allocates memory aligned to 4KiB boundaries)\n\n";
+      << "\t\t -align 4096 (allocates memory aligned to 4KiB boundaries)\n\n";
 
   str << "\t --gpu_block_size <space-separated ints> [no default]\n"
       << "\t      (block sizes to run for all GPU kernels)\n"

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -125,7 +125,7 @@ public:
 
   double getSizeFactor() const { return size_factor; }
 
-  size_t getMemoryAlignment() const { return memory_alignment; }
+  size_t getDataAlignment() const { return data_alignment; }
 
   size_t numValidGPUBlockSize() const { return gpu_block_sizes.size(); }
   bool validGPUBlockSize(size_t block_size) const
@@ -234,7 +234,7 @@ private:
   SizeMeaning size_meaning; /*!< meaning of size value */
   double size;           /*!< kernel size to run (input option) */
   double size_factor;    /*!< default kernel size multipier (input option) */
-  size_t memory_alignment;
+  size_t data_alignment;
   std::vector<size_t> gpu_block_sizes; /*!< Block sizes for gpu tunings to run (input option) */
 
   double pf_tol;         /*!< pct RAJA variant run time can exceed base for

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -125,7 +125,7 @@ public:
 
   double getSizeFactor() const { return size_factor; }
 
-  int getMemoryAlignment() const { return memory_alignment; }
+  size_t getMemoryAlignment() const { return memory_alignment; }
 
   size_t numValidGPUBlockSize() const { return gpu_block_sizes.size(); }
   bool validGPUBlockSize(size_t block_size) const
@@ -234,7 +234,7 @@ private:
   SizeMeaning size_meaning; /*!< meaning of size value */
   double size;           /*!< kernel size to run (input option) */
   double size_factor;    /*!< default kernel size multipier (input option) */
-  int memory_alignment;
+  size_t memory_alignment;
   std::vector<size_t> gpu_block_sizes; /*!< Block sizes for gpu tunings to run (input option) */
 
   double pf_tol;         /*!< pct RAJA variant run time can exceed base for

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -125,6 +125,8 @@ public:
 
   double getSizeFactor() const { return size_factor; }
 
+  int getMemoryAlignment() const { return memory_alignment; }
+
   size_t numValidGPUBlockSize() const { return gpu_block_sizes.size(); }
   bool validGPUBlockSize(size_t block_size) const
   {
@@ -232,6 +234,7 @@ private:
   SizeMeaning size_meaning; /*!< meaning of size value */
   double size;           /*!< kernel size to run (input option) */
   double size_factor;    /*!< default kernel size multipier (input option) */
+  int memory_alignment;
   std::vector<size_t> gpu_block_sizes; /*!< Block sizes for gpu tunings to run (input option) */
 
   double pf_tol;         /*!< pct RAJA variant run time can exceed base for

--- a/src/lcals/DIFF_PREDICT.cpp
+++ b/src/lcals/DIFF_PREDICT.cpp
@@ -74,8 +74,8 @@ void DIFF_PREDICT::updateChecksum(VariantID vid, size_t tune_idx)
 void DIFF_PREDICT::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_px);
-  deallocData(m_cx);
+  deallocData(m_px, vid);
+  deallocData(m_cx, vid);
 }
 
 } // end namespace lcals

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -85,10 +85,10 @@ void EOS::updateChecksum(VariantID vid, size_t tune_idx)
 void EOS::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_y);
-  deallocData(m_z);
-  deallocData(m_u);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
+  deallocData(m_z, vid);
+  deallocData(m_u, vid);
 }
 
 } // end namespace lcals

--- a/src/lcals/FIRST_DIFF.cpp
+++ b/src/lcals/FIRST_DIFF.cpp
@@ -75,8 +75,8 @@ void FIRST_DIFF::updateChecksum(VariantID vid, size_t tune_idx)
 void FIRST_DIFF::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_y);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
 }
 
 } // end namespace lcals

--- a/src/lcals/FIRST_MIN.cpp
+++ b/src/lcals/FIRST_MIN.cpp
@@ -82,7 +82,7 @@ void FIRST_MIN::updateChecksum(VariantID vid, size_t tune_idx)
 void FIRST_MIN::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
+  deallocData(m_x, vid);
 }
 
 } // end namespace lcals

--- a/src/lcals/FIRST_SUM.cpp
+++ b/src/lcals/FIRST_SUM.cpp
@@ -74,8 +74,8 @@ void FIRST_SUM::updateChecksum(VariantID vid, size_t tune_idx)
 void FIRST_SUM::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_y);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
 }
 
 } // end namespace lcals

--- a/src/lcals/GEN_LIN_RECUR.cpp
+++ b/src/lcals/GEN_LIN_RECUR.cpp
@@ -83,10 +83,10 @@ void GEN_LIN_RECUR::updateChecksum(VariantID vid, size_t tune_idx)
 void GEN_LIN_RECUR::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_b5);
-  deallocData(m_stb5);
-  deallocData(m_sa);
-  deallocData(m_sb);
+  deallocData(m_b5, vid);
+  deallocData(m_stb5, vid);
+  deallocData(m_sa, vid);
+  deallocData(m_sb, vid);
 }
 
 } // end namespace lcals

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -83,9 +83,9 @@ void HYDRO_1D::updateChecksum(VariantID vid, size_t tune_idx)
 void HYDRO_1D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_y);
-  deallocData(m_z);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
+  deallocData(m_z, vid);
 }
 
 } // end namespace lcals

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -103,17 +103,17 @@ void HYDRO_2D::updateChecksum(VariantID vid, size_t tune_idx)
 void HYDRO_2D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_zrout);
-  deallocData(m_zzout);
-  deallocData(m_za);
-  deallocData(m_zb);
-  deallocData(m_zm);
-  deallocData(m_zp);
-  deallocData(m_zq);
-  deallocData(m_zr);
-  deallocData(m_zu);
-  deallocData(m_zv);
-  deallocData(m_zz);
+  deallocData(m_zrout, vid);
+  deallocData(m_zzout, vid);
+  deallocData(m_za, vid);
+  deallocData(m_zb, vid);
+  deallocData(m_zm, vid);
+  deallocData(m_zp, vid);
+  deallocData(m_zq, vid);
+  deallocData(m_zr, vid);
+  deallocData(m_zu, vid);
+  deallocData(m_zv, vid);
+  deallocData(m_zz, vid);
 }
 
 } // end namespace lcals

--- a/src/lcals/INT_PREDICT.cpp
+++ b/src/lcals/INT_PREDICT.cpp
@@ -65,14 +65,14 @@ void INT_PREDICT::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
   m_px_initval = 1.0;
   allocAndInitDataConst(m_px, m_array_length, m_px_initval, vid);
 
-  initData(m_dm22);
-  initData(m_dm23);
-  initData(m_dm24);
-  initData(m_dm25);
-  initData(m_dm26);
-  initData(m_dm27);
-  initData(m_dm28);
-  initData(m_c0);
+  initData(m_dm22, vid);
+  initData(m_dm23, vid);
+  initData(m_dm24, vid);
+  initData(m_dm25, vid);
+  initData(m_dm26, vid);
+  initData(m_dm27, vid);
+  initData(m_dm28, vid);
+  initData(m_c0, vid);
 }
 
 void INT_PREDICT::updateChecksum(VariantID vid, size_t tune_idx)
@@ -87,7 +87,7 @@ void INT_PREDICT::updateChecksum(VariantID vid, size_t tune_idx)
 void INT_PREDICT::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_px);
+  deallocData(m_px, vid);
 }
 
 } // end namespace lcals

--- a/src/lcals/PLANCKIAN.cpp
+++ b/src/lcals/PLANCKIAN.cpp
@@ -74,11 +74,11 @@ void PLANCKIAN::updateChecksum(VariantID vid, size_t tune_idx)
 void PLANCKIAN::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_y);
-  deallocData(m_u);
-  deallocData(m_v);
-  deallocData(m_w);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
+  deallocData(m_u, vid);
+  deallocData(m_v, vid);
+  deallocData(m_w, vid);
 }
 
 } // end namespace lcals

--- a/src/lcals/TRIDIAG_ELIM.cpp
+++ b/src/lcals/TRIDIAG_ELIM.cpp
@@ -75,10 +75,10 @@ void TRIDIAG_ELIM::updateChecksum(VariantID vid, size_t tune_idx)
 void TRIDIAG_ELIM::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_xout);
-  deallocData(m_xin);
-  deallocData(m_y);
-  deallocData(m_z);
+  deallocData(m_xout, vid);
+  deallocData(m_xin, vid);
+  deallocData(m_y, vid);
+  deallocData(m_z, vid);
 }
 
 } // end namespace lcals

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -102,11 +102,11 @@ void POLYBENCH_2MM::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_2MM::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_tmp);
-  deallocData(m_A);
-  deallocData(m_B);
-  deallocData(m_C);
-  deallocData(m_D);
+  deallocData(m_tmp, vid);
+  deallocData(m_A, vid);
+  deallocData(m_B, vid);
+  deallocData(m_C, vid);
+  deallocData(m_D, vid);
 }
 
 } // end namespace polybench

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -112,13 +112,13 @@ void POLYBENCH_3MM::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_3MM::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_A);
-  deallocData(m_B);
-  deallocData(m_C);
-  deallocData(m_D);
-  deallocData(m_E);
-  deallocData(m_F);
-  deallocData(m_G);
+  deallocData(m_A, vid);
+  deallocData(m_B, vid);
+  deallocData(m_C, vid);
+  deallocData(m_D, vid);
+  deallocData(m_E, vid);
+  deallocData(m_F, vid);
+  deallocData(m_G, vid);
 }
 
 } // end namespace basic

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -85,10 +85,10 @@ void POLYBENCH_ADI::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_ADI::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_U);
-  deallocData(m_V);
-  deallocData(m_P);
-  deallocData(m_Q);
+  deallocData(m_U, vid);
+  deallocData(m_V, vid);
+  deallocData(m_P, vid);
+  deallocData(m_Q, vid);
 }
 
 } // end namespace polybench

--- a/src/polybench/POLYBENCH_ATAX.cpp
+++ b/src/polybench/POLYBENCH_ATAX.cpp
@@ -88,10 +88,10 @@ void POLYBENCH_ATAX::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_ATAX::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_tmp);
-  deallocData(m_x);
-  deallocData(m_y);
-  deallocData(m_A);
+  deallocData(m_tmp, vid);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
+  deallocData(m_A, vid);
 }
 
 } // end namespace polybench

--- a/src/polybench/POLYBENCH_FDTD_2D.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.cpp
@@ -106,10 +106,10 @@ void POLYBENCH_FDTD_2D::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_FDTD_2D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_fict);
-  deallocData(m_ex);
-  deallocData(m_ey);
-  deallocData(m_hz);
+  deallocData(m_fict, vid);
+  deallocData(m_ex, vid);
+  deallocData(m_ey, vid);
+  deallocData(m_hz, vid);
 }
 
 } // end namespace polybench

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
@@ -81,8 +81,8 @@ void POLYBENCH_FLOYD_WARSHALL::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_FLOYD_WARSHALL::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_pin);
-  deallocData(m_pout);
+  deallocData(m_pin, vid);
+  deallocData(m_pout, vid);
 }
 
 } // end namespace polybench

--- a/src/polybench/POLYBENCH_GEMM.cpp
+++ b/src/polybench/POLYBENCH_GEMM.cpp
@@ -92,9 +92,9 @@ void POLYBENCH_GEMM::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_GEMM::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_A);
-  deallocData(m_B);
-  deallocData(m_C);
+  deallocData(m_A, vid);
+  deallocData(m_B, vid);
+  deallocData(m_C, vid);
 }
 
 } // end namespace polybench

--- a/src/polybench/POLYBENCH_GEMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMVER.cpp
@@ -108,15 +108,15 @@ void POLYBENCH_GEMVER::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_GEMVER::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_A);
-  deallocData(m_u1);
-  deallocData(m_v1);
-  deallocData(m_u2);
-  deallocData(m_v2);
-  deallocData(m_w);
-  deallocData(m_x);
-  deallocData(m_y);
-  deallocData(m_z);
+  deallocData(m_A, vid);
+  deallocData(m_u1, vid);
+  deallocData(m_v1, vid);
+  deallocData(m_u2, vid);
+  deallocData(m_v2, vid);
+  deallocData(m_w, vid);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
+  deallocData(m_z, vid);
 }
 
 } // end namespace basic

--- a/src/polybench/POLYBENCH_GESUMMV.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV.cpp
@@ -82,10 +82,10 @@ void POLYBENCH_GESUMMV::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_GESUMMV::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x);
-  deallocData(m_y);
-  deallocData(m_A);
-  deallocData(m_B);
+  deallocData(m_x, vid);
+  deallocData(m_y, vid);
+  deallocData(m_A, vid);
+  deallocData(m_B, vid);
 }
 
 } // end namespace polybench

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -94,10 +94,10 @@ void POLYBENCH_HEAT_3D::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_HEAT_3D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_A);
-  deallocData(m_B);
-  deallocData(m_Ainit);
-  deallocData(m_Binit);
+  deallocData(m_A, vid);
+  deallocData(m_B, vid);
+  deallocData(m_Ainit, vid);
+  deallocData(m_Binit, vid);
 }
 
 } // end namespace polybench

--- a/src/polybench/POLYBENCH_JACOBI_1D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.cpp
@@ -91,10 +91,10 @@ void POLYBENCH_JACOBI_1D::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_JACOBI_1D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_A);
-  deallocData(m_B);
-  deallocData(m_Ainit);
-  deallocData(m_Binit);
+  deallocData(m_A, vid);
+  deallocData(m_B, vid);
+  deallocData(m_Ainit, vid);
+  deallocData(m_Binit, vid);
 }
 
 } // end namespace polybench

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -93,10 +93,10 @@ void POLYBENCH_JACOBI_2D::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_JACOBI_2D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_A);
-  deallocData(m_B);
-  deallocData(m_Ainit);
-  deallocData(m_Binit);
+  deallocData(m_A, vid);
+  deallocData(m_B, vid);
+  deallocData(m_Ainit, vid);
+  deallocData(m_Binit, vid);
 }
 
 } // end namespace polybench

--- a/src/polybench/POLYBENCH_MVT.cpp
+++ b/src/polybench/POLYBENCH_MVT.cpp
@@ -87,11 +87,11 @@ void POLYBENCH_MVT::updateChecksum(VariantID vid, size_t tune_idx)
 void POLYBENCH_MVT::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_x1);
-  deallocData(m_x2);
-  deallocData(m_y1);
-  deallocData(m_y2);
-  deallocData(m_A);
+  deallocData(m_x1, vid);
+  deallocData(m_x2, vid);
+  deallocData(m_y1, vid);
+  deallocData(m_y2, vid);
+  deallocData(m_A, vid);
 }
 
 } // end namespace polybench

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -75,9 +75,9 @@ void ADD::updateChecksum(VariantID vid, size_t tune_idx)
 void ADD::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_a);
-  deallocData(m_b);
-  deallocData(m_c);
+  deallocData(m_a, vid);
+  deallocData(m_b, vid);
+  deallocData(m_c, vid);
 }
 
 } // end namespace stream

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -74,8 +74,8 @@ void COPY::updateChecksum(VariantID vid, size_t tune_idx)
 void COPY::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_a);
-  deallocData(m_c);
+  deallocData(m_a, vid);
+  deallocData(m_c, vid);
 }
 
 } // end namespace stream

--- a/src/stream/DOT.cpp
+++ b/src/stream/DOT.cpp
@@ -77,8 +77,8 @@ void DOT::updateChecksum(VariantID vid, size_t tune_idx)
 void DOT::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_a);
-  deallocData(m_b);
+  deallocData(m_a, vid);
+  deallocData(m_b, vid);
 }
 
 } // end namespace stream

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -75,8 +75,8 @@ void MUL::updateChecksum(VariantID vid, size_t tune_idx)
 void MUL::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_b);
-  deallocData(m_c);
+  deallocData(m_b, vid);
+  deallocData(m_c, vid);
 }
 
 } // end namespace stream

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -80,9 +80,9 @@ void TRIAD::updateChecksum(VariantID vid, size_t tune_idx)
 void TRIAD::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   (void) vid;
-  deallocData(m_a);
-  deallocData(m_b);
-  deallocData(m_c);
+  deallocData(m_a, vid);
+  deallocData(m_b, vid);
+  deallocData(m_c, vid);
 }
 
 } // end namespace stream


### PR DESCRIPTION
# Add Host Memory Alignment Option

This adds a command line option --align that lets you change the alignment of host memory allocations.

- This PR is a feature
- It does the following (modify list as needed):
  - Adds user settable memory alignment at the request of Corbin and me