### PR TITLE
Fixes: Cmake fails in container as BLT component is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-11.2.0 AS gcc11
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
+RUN git submodule update --init --recursive
 RUN cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_COMPILER=g++ -DRAJA_ENABLE_WARNINGS=On -DENABLE_OPENMP=On .. && \
     make -j 6 &&\
     ctest -T test --output-on-failure


### PR DESCRIPTION
# Summary (Write a short headline summary of PR)
Issue: While building a stage gcc-11 using the Dockerfile, ends in failure since Cmake is not able to find
BLT components.
- This PR is a bugfix
- It does the following (modify list as needed):
   - Fixes the Issue listed above only for gcc-11 stage. If it seems to be the right solution then similar change can be included for other stages as well.