### PR TITLE
Remove unnecessary const qualifier that causes many compiler warnings.

### DIFF
--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -196,7 +196,7 @@ public:
   const std::string& getOutputDirName() const { return outdir; }
   const std::string& getOutputFilePrefix() const { return outfile_prefix; }
 
-  const bool getDisableWarmup() const { return disable_warmup; }
+  bool getDisableWarmup() const { return disable_warmup; }
 
 //@}
 


### PR DESCRIPTION
# The title says it all.