### PR TITLE
Add SW4CK kernels

### DIFF
--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -80,7 +80,9 @@ blt_add_library(
           PRESSURE-Hip.cpp 
           PRESSURE-Cuda.cpp 
           PRESSURE-OMP.cpp 
-          PRESSURE-OMPTarget.cpp 
+          PRESSURE-OMPTarget.cpp
+          SW4CK_KERNEL_2.cpp
+          SW4CK_KERNEL_2-Seq.cpp
           VOL3D.cpp
           VOL3D-Seq.cpp
           VOL3D-Hip.cpp 

--- a/src/apps/SW4CK_KERNEL_2-Seq.cpp
+++ b/src/apps/SW4CK_KERNEL_2-Seq.cpp
@@ -1,0 +1,81 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "SW4CK_KERNEL_2.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "AppsData.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace apps
+{
+
+
+void SW4CK_KERNEL_2::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  const Index_type run_reps = getRunReps();
+
+  SW4CK_KERNEL_2_DATA_SETUP;
+
+  switch ( vid ) {
+
+    case Base_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        //Reference impl
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+#if defined(RUN_RAJA_SEQ)
+    case Lambda_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        //Lambda impl
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_Seq : {
+
+      startTimer();      
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        //RAJA impl
+        
+      }
+      stopTimer();
+
+      break;
+    }
+#endif // RUN_RAJA_SEQ
+
+    default : {
+      getCout() << "\n  SW4CK_KERNEL_2 : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+}
+
+} // end namespace apps
+} // end namespace rajaperf

--- a/src/apps/SW4CK_KERNEL_2.cpp
+++ b/src/apps/SW4CK_KERNEL_2.cpp
@@ -1,0 +1,95 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "SW4CK_KERNEL_2.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "AppsData.hpp"
+#include "common/DataUtils.hpp"
+
+#include <cmath>
+
+
+namespace rajaperf
+{
+namespace apps
+{
+
+
+SW4CK_KERNEL_2::SW4CK_KERNEL_2(const RunParams& params)
+  : KernelBase(rajaperf::Apps_SW4CK_KERNEL_2, params)
+{
+  setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
+  setDefaultReps(100);
+
+  Index_type rzmax = std::cbrt(getTargetProblemSize())+1;
+  //m_domain = new ADomain(rzmax, /* ndims = */ 3);
+
+  //m_array_length = m_domain->nnalls;
+
+  //setActualProblemSize( m_domain->lpz+1 - m_domain->fpz );
+
+  //setItsPerRep( m_domain->lpz+1 - m_domain->fpz );
+  setKernelsPerRep(1);
+  // touched data size, not actual number of stores and loads
+  //  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getItsPerRep() +
+  //(0*sizeof(Real_type) + 3*sizeof(Real_type)) * (getItsPerRep() + 1+m_domain->jp+m_domain->kp) );
+  
+  //setFLOPsPerRep(72 * (m_domain->lpz+1 - m_domain->fpz));
+
+  checksum_scale_factor = 0.001 *
+              ( static_cast<Checksum_type>(getDefaultProblemSize()) /
+                                           getActualProblemSize() );
+
+  setUsesFeature(Teams);
+
+  //Goal is to get the following three variants right first
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  /*
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( RAJA_HIP );
+  */
+}
+
+SW4CK_KERNEL_2::~SW4CK_KERNEL_2()
+{
+  //  delete m_domain;
+}
+
+void SW4CK_KERNEL_2::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+
+}
+
+void SW4CK_KERNEL_2::updateChecksum(VariantID vid, size_t tune_idx)
+{
+  //checksum[vid][tune_idx] += calcChecksum(m_vol, m_array_length, checksum_scale_factor );
+}
+
+void SW4CK_KERNEL_2::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  (void) vid;
+
+}
+
+} // end namespace apps
+} // end namespace rajaperf

--- a/src/apps/SW4CK_KERNEL_2.hpp
+++ b/src/apps/SW4CK_KERNEL_2.hpp
@@ -1,3 +1,4 @@
+
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 // Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
 // and RAJA Performance Suite project contributors.
@@ -8,484 +9,433 @@
 
 ///
 /// SW4CK_KERNEL_2 kernel reference implementation:
+/// https://github.com/LLNL/SW4CK
 ///
+///   for (int k = kstart; k <= klast - 2; k++)
+///     for (int j = jfirst + 2; j <= jlast - 2; j++)
+///       for (int i = ifirst + 2; i <= ilast - 2; i++) {
 ///
+///         // 5 ops
+///         float_sw4 ijac = strx(i) * stry(j) / jac(i, j, k);
+///         float_sw4 istry = 1 / (stry(j));
+///         float_sw4 istrx = 1 / (strx(i));
+///         float_sw4 istrxy = istry * istrx;
 ///
-int main()
-{
-  for( int k= kstart; k <= klast-2 ; k++ )
-    for( int j=jfirst+2; j <= jlast-2 ; j++ )
-      for( int i=ifirst+2; i <= ilast-2 ; i++ )
-        {
-
-          // 5 ops
-          float_sw4 ijac = strx(i) * stry(j) / jac(i, j, k);
-          float_sw4 istry = 1 / (stry(j));
-          float_sw4 istrx = 1 / (strx(i));
-          float_sw4 istrxy = istry * istrx;
-
-          float_sw4 r1 = 0;
-          
-          // pp derivative (u)
-          // 53 ops, tot=58
-          float_sw4 cof1 = (2 * mu(i - 2, j, k) + la(i - 2, j, k)) *
-                           met(1, i - 2, j, k) * met(1, i - 2, j, k) *
-                           strx(i - 2);
-          float_sw4 cof2 = (2 * mu(i - 1, j, k) + la(i - 1, j, k)) *
-                           met(1, i - 1, j, k) * met(1, i - 1, j, k) *
-                           strx(i - 1);
-          float_sw4 cof3 = (2 * mu(i, j, k) + la(i, j, k)) * met(1, i, j, k) *
-                           met(1, i, j, k) * strx(i);
-          float_sw4 cof4 = (2 * mu(i + 1, j, k) + la(i + 1, j, k)) *
-                           met(1, i + 1, j, k) * met(1, i + 1, j, k) *
-                           strx(i + 1);
-          float_sw4 cof5 = (2 * mu(i + 2, j, k) + la(i + 2, j, k)) *
-                           met(1, i + 2, j, k) * met(1, i + 2, j, k) *
-                           strx(i + 2);
-          float_sw4 mux1 = cof2 - tf * (cof3 + cof1);
-          float_sw4 mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
-          float_sw4 mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
-          float_sw4 mux4 = cof4 - tf * (cof3 + cof5);
-
-          r1 += i6 *
-                (mux1 * (u(1, i - 2, j, k) - u(1, i, j, k)) +
-                 mux2 * (u(1, i - 1, j, k) - u(1, i, j, k)) +
-                 mux3 * (u(1, i + 1, j, k) - u(1, i, j, k)) +
-                 mux4 * (u(1, i + 2, j, k) - u(1, i, j, k))) *
-                istry;
-          // qq derivative (u)
-          // 43 ops, tot=101
-          {
-            float_sw4 cof1 = (mu(i, j - 2, k)) * met(1, i, j - 2, k) *
-                             met(1, i, j - 2, k) * stry(j - 2);
-            float_sw4 cof2 = (mu(i, j - 1, k)) * met(1, i, j - 1, k) *
-                             met(1, i, j - 1, k) * stry(j - 1);
-            float_sw4 cof3 =
-                (mu(i, j, k)) * met(1, i, j, k) * met(1, i, j, k) * stry(j);
-            float_sw4 cof4 = (mu(i, j + 1, k)) * met(1, i, j + 1, k) *
-                             met(1, i, j + 1, k) * stry(j + 1);
-            float_sw4 cof5 = (mu(i, j + 2, k)) * met(1, i, j + 2, k) *
-                             met(1, i, j + 2, k) * stry(j + 2);
-            float_sw4 mux1 = cof2 - tf * (cof3 + cof1);
-            float_sw4 mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
-            float_sw4 mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
-            float_sw4 mux4 = cof4 - tf * (cof3 + cof5);
-
-            r1 += i6 *
-                  (mux1 * (u(1, i, j - 2, k) - u(1, i, j, k)) +
-                   mux2 * (u(1, i, j - 1, k) - u(1, i, j, k)) +
-                   mux3 * (u(1, i, j + 1, k) - u(1, i, j, k)) +
-                   mux4 * (u(1, i, j + 2, k) - u(1, i, j, k))) *
-                  istrx;
-          }
-#ifdef MAGIC_SYNC
-	__syncthreads();
-#endif
-          // rr derivative (u)
-          // 5*11+14+14=83 ops, tot=184
-          {
-            float_sw4 cof1 =
-                (2 * mu(i, j, k - 2) + la(i, j, k - 2)) * met(2, i, j, k - 2) *
-                    strx(i) * met(2, i, j, k - 2) * strx(i) +
-                mu(i, j, k - 2) * (met(3, i, j, k - 2) * stry(j) *
-                                       met(3, i, j, k - 2) * stry(j) +
-                                   met(4, i, j, k - 2) * met(4, i, j, k - 2));
-            float_sw4 cof2 =
-                (2 * mu(i, j, k - 1) + la(i, j, k - 1)) * met(2, i, j, k - 1) *
-                    strx(i) * met(2, i, j, k - 1) * strx(i) +
-                mu(i, j, k - 1) * (met(3, i, j, k - 1) * stry(j) *
-                                       met(3, i, j, k - 1) * stry(j) +
-                                   met(4, i, j, k - 1) * met(4, i, j, k - 1));
-            float_sw4 cof3 = (2 * mu(i, j, k) + la(i, j, k)) * met(2, i, j, k) *
-                                 strx(i) * met(2, i, j, k) * strx(i) +
-                             mu(i, j, k) * (met(3, i, j, k) * stry(j) *
-                                                met(3, i, j, k) * stry(j) +
-                                            met(4, i, j, k) * met(4, i, j, k));
-            float_sw4 cof4 =
-                (2 * mu(i, j, k + 1) + la(i, j, k + 1)) * met(2, i, j, k + 1) *
-                    strx(i) * met(2, i, j, k + 1) * strx(i) +
-                mu(i, j, k + 1) * (met(3, i, j, k + 1) * stry(j) *
-                                       met(3, i, j, k + 1) * stry(j) +
-                                   met(4, i, j, k + 1) * met(4, i, j, k + 1));
-            float_sw4 cof5 =
-                (2 * mu(i, j, k + 2) + la(i, j, k + 2)) * met(2, i, j, k + 2) *
-                    strx(i) * met(2, i, j, k + 2) * strx(i) +
-                mu(i, j, k + 2) * (met(3, i, j, k + 2) * stry(j) *
-                                       met(3, i, j, k + 2) * stry(j) +
-                                   met(4, i, j, k + 2) * met(4, i, j, k + 2));
-
-            float_sw4 mux1 = cof2 - tf * (cof3 + cof1);
-            float_sw4 mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
-            float_sw4 mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
-            float_sw4 mux4 = cof4 - tf * (cof3 + cof5);
-
-            r1 += i6 *
-                  (mux1 * (u(1, i, j, k - 2) - u(1, i, j, k)) +
-                   mux2 * (u(1, i, j, k - 1) - u(1, i, j, k)) +
-                   mux3 * (u(1, i, j, k + 1) - u(1, i, j, k)) +
-                   mux4 * (u(1, i, j, k + 2) - u(1, i, j, k))) *
-                  istrxy;
-          }
-          // rr derivative (v)
-          // 42 ops, tot=226
-          cof1 = (mu(i, j, k - 2) + la(i, j, k - 2)) * met(2, i, j, k - 2) *
-                 met(3, i, j, k - 2);
-          cof2 = (mu(i, j, k - 1) + la(i, j, k - 1)) * met(2, i, j, k - 1) *
-                 met(3, i, j, k - 1);
-          cof3 =
-              (mu(i, j, k) + la(i, j, k)) * met(2, i, j, k) * met(3, i, j, k);
-          cof4 = (mu(i, j, k + 1) + la(i, j, k + 1)) * met(2, i, j, k + 1) *
-                 met(3, i, j, k + 1);
-          cof5 = (mu(i, j, k + 2) + la(i, j, k + 2)) * met(2, i, j, k + 2) *
-                 met(3, i, j, k + 2);
-          mux1 = cof2 - tf * (cof3 + cof1);
-          mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
-          mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
-          mux4 = cof4 - tf * (cof3 + cof5);
-
-          r1 += i6 * (mux1 * (u(2, i, j, k - 2) - u(2, i, j, k)) +
-                      mux2 * (u(2, i, j, k - 1) - u(2, i, j, k)) +
-                      mux3 * (u(2, i, j, k + 1) - u(2, i, j, k)) +
-                      mux4 * (u(2, i, j, k + 2) - u(2, i, j, k)));
-
-          // rr derivative (w)
-          // 43 ops, tot=269
-          cof1 = (mu(i, j, k - 2) + la(i, j, k - 2)) * met(2, i, j, k - 2) *
-                 met(4, i, j, k - 2);
-          cof2 = (mu(i, j, k - 1) + la(i, j, k - 1)) * met(2, i, j, k - 1) *
-                 met(4, i, j, k - 1);
-          cof3 =
-              (mu(i, j, k) + la(i, j, k)) * met(2, i, j, k) * met(4, i, j, k);
-          cof4 = (mu(i, j, k + 1) + la(i, j, k + 1)) * met(2, i, j, k + 1) *
-                 met(4, i, j, k + 1);
-          cof5 = (mu(i, j, k + 2) + la(i, j, k + 2)) * met(2, i, j, k + 2) *
-                 met(4, i, j, k + 2);
-          mux1 = cof2 - tf * (cof3 + cof1);
-          mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
-          mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
-          mux4 = cof4 - tf * (cof3 + cof5);
-
-          r1 += i6 *
-                (mux1 * (u(3, i, j, k - 2) - u(3, i, j, k)) +
-                 mux2 * (u(3, i, j, k - 1) - u(3, i, j, k)) +
-                 mux3 * (u(3, i, j, k + 1) - u(3, i, j, k)) +
-                 mux4 * (u(3, i, j, k + 2) - u(3, i, j, k))) *
-                istry;
-
-          // pq-derivatives
-          // 38 ops, tot=307
-          r1 +=
-              c2 *
-                  (mu(i, j + 2, k) * met(1, i, j + 2, k) * met(1, i, j + 2, k) *
-                       (c2 * (u(2, i + 2, j + 2, k) - u(2, i - 2, j + 2, k)) +
-                        c1 * (u(2, i + 1, j + 2, k) - u(2, i - 1, j + 2, k))) -
-                   mu(i, j - 2, k) * met(1, i, j - 2, k) * met(1, i, j - 2, k) *
-                       (c2 * (u(2, i + 2, j - 2, k) - u(2, i - 2, j - 2, k)) +
-                        c1 * (u(2, i + 1, j - 2, k) - u(2, i - 1, j - 2, k)))) +
-              c1 *
-                  (mu(i, j + 1, k) * met(1, i, j + 1, k) * met(1, i, j + 1, k) *
-                       (c2 * (u(2, i + 2, j + 1, k) - u(2, i - 2, j + 1, k)) +
-                        c1 * (u(2, i + 1, j + 1, k) - u(2, i - 1, j + 1, k))) -
-                   mu(i, j - 1, k) * met(1, i, j - 1, k) * met(1, i, j - 1, k) *
-                       (c2 * (u(2, i + 2, j - 1, k) - u(2, i - 2, j - 1, k)) +
-                        c1 * (u(2, i + 1, j - 1, k) - u(2, i - 1, j - 1, k))));
-
-          // qp-derivatives
-          // 38 ops, tot=345
-          r1 +=
-              c2 *
-                  (la(i + 2, j, k) * met(1, i + 2, j, k) * met(1, i + 2, j, k) *
-                       (c2 * (u(2, i + 2, j + 2, k) - u(2, i + 2, j - 2, k)) +
-                        c1 * (u(2, i + 2, j + 1, k) - u(2, i + 2, j - 1, k))) -
-                   la(i - 2, j, k) * met(1, i - 2, j, k) * met(1, i - 2, j, k) *
-                       (c2 * (u(2, i - 2, j + 2, k) - u(2, i - 2, j - 2, k)) +
-                        c1 * (u(2, i - 2, j + 1, k) - u(2, i - 2, j - 1, k)))) +
-              c1 *
-                  (la(i + 1, j, k) * met(1, i + 1, j, k) * met(1, i + 1, j, k) *
-                       (c2 * (u(2, i + 1, j + 2, k) - u(2, i + 1, j - 2, k)) +
-                        c1 * (u(2, i + 1, j + 1, k) - u(2, i + 1, j - 1, k))) -
-                   la(i - 1, j, k) * met(1, i - 1, j, k) * met(1, i - 1, j, k) *
-                       (c2 * (u(2, i - 1, j + 2, k) - u(2, i - 1, j - 2, k)) +
-                        c1 * (u(2, i - 1, j + 1, k) - u(2, i - 1, j - 1, k))));
-
-          // pr-derivatives
-          // 130 ops., tot=475
-          r1 +=
-              c2 *
-                  ((2 * mu(i, j, k + 2) + la(i, j, k + 2)) *
-                       met(2, i, j, k + 2) * met(1, i, j, k + 2) *
-                       (c2 * (u(1, i + 2, j, k + 2) - u(1, i - 2, j, k + 2)) +
-                        c1 * (u(1, i + 1, j, k + 2) - u(1, i - 1, j, k + 2))) *
-                       strx(i) * istry +
-                   mu(i, j, k + 2) * met(3, i, j, k + 2) * met(1, i, j, k + 2) *
-                       (c2 * (u(2, i + 2, j, k + 2) - u(2, i - 2, j, k + 2)) +
-                        c1 * (u(2, i + 1, j, k + 2) - u(2, i - 1, j, k + 2))) +
-                   mu(i, j, k + 2) * met(4, i, j, k + 2) * met(1, i, j, k + 2) *
-                       (c2 * (u(3, i + 2, j, k + 2) - u(3, i - 2, j, k + 2)) +
-                        c1 * (u(3, i + 1, j, k + 2) - u(3, i - 1, j, k + 2))) *
-                       istry -
-                   ((2 * mu(i, j, k - 2) + la(i, j, k - 2)) *
-                        met(2, i, j, k - 2) * met(1, i, j, k - 2) *
-                        (c2 * (u(1, i + 2, j, k - 2) - u(1, i - 2, j, k - 2)) +
-                         c1 * (u(1, i + 1, j, k - 2) - u(1, i - 1, j, k - 2))) *
-                        strx(i) * istry +
-                    mu(i, j, k - 2) * met(3, i, j, k - 2) *
-                        met(1, i, j, k - 2) *
-                        (c2 * (u(2, i + 2, j, k - 2) - u(2, i - 2, j, k - 2)) +
-                         c1 * (u(2, i + 1, j, k - 2) - u(2, i - 1, j, k - 2))) +
-                    mu(i, j, k - 2) * met(4, i, j, k - 2) *
-                        met(1, i, j, k - 2) *
-                        (c2 * (u(3, i + 2, j, k - 2) - u(3, i - 2, j, k - 2)) +
-                         c1 * (u(3, i + 1, j, k - 2) - u(3, i - 1, j, k - 2))) *
-                        istry)) +
-              c1 *
-                  ((2 * mu(i, j, k + 1) + la(i, j, k + 1)) *
-                       met(2, i, j, k + 1) * met(1, i, j, k + 1) *
-                       (c2 * (u(1, i + 2, j, k + 1) - u(1, i - 2, j, k + 1)) +
-                        c1 * (u(1, i + 1, j, k + 1) - u(1, i - 1, j, k + 1))) *
-                       strx(i) * istry +
-                   mu(i, j, k + 1) * met(3, i, j, k + 1) * met(1, i, j, k + 1) *
-                       (c2 * (u(2, i + 2, j, k + 1) - u(2, i - 2, j, k + 1)) +
-                        c1 * (u(2, i + 1, j, k + 1) - u(2, i - 1, j, k + 1))) +
-                   mu(i, j, k + 1) * met(4, i, j, k + 1) * met(1, i, j, k + 1) *
-                       (c2 * (u(3, i + 2, j, k + 1) - u(3, i - 2, j, k + 1)) +
-                        c1 * (u(3, i + 1, j, k + 1) - u(3, i - 1, j, k + 1))) *
-                       istry -
-                   ((2 * mu(i, j, k - 1) + la(i, j, k - 1)) *
-                        met(2, i, j, k - 1) * met(1, i, j, k - 1) *
-                        (c2 * (u(1, i + 2, j, k - 1) - u(1, i - 2, j, k - 1)) +
-                         c1 * (u(1, i + 1, j, k - 1) - u(1, i - 1, j, k - 1))) *
-                        strx(i) * istry +
-                    mu(i, j, k - 1) * met(3, i, j, k - 1) *
-                        met(1, i, j, k - 1) *
-                        (c2 * (u(2, i + 2, j, k - 1) - u(2, i - 2, j, k - 1)) +
-                         c1 * (u(2, i + 1, j, k - 1) - u(2, i - 1, j, k - 1))) +
-                    mu(i, j, k - 1) * met(4, i, j, k - 1) *
-                        met(1, i, j, k - 1) *
-                        (c2 * (u(3, i + 2, j, k - 1) - u(3, i - 2, j, k - 1)) +
-                         c1 * (u(3, i + 1, j, k - 1) - u(3, i - 1, j, k - 1))) *
-                        istry));
-
-          // rp derivatives
-          // 130 ops, tot=605
-          r1 +=
-              (c2 *
-                   ((2 * mu(i + 2, j, k) + la(i + 2, j, k)) *
-                        met(2, i + 2, j, k) * met(1, i + 2, j, k) *
-                        (c2 * (u(1, i + 2, j, k + 2) - u(1, i + 2, j, k - 2)) +
-                         c1 * (u(1, i + 2, j, k + 1) - u(1, i + 2, j, k - 1))) *
-                        strx(i + 2) +
-                    la(i + 2, j, k) * met(3, i + 2, j, k) *
-                        met(1, i + 2, j, k) *
-                        (c2 * (u(2, i + 2, j, k + 2) - u(2, i + 2, j, k - 2)) +
-                         c1 * (u(2, i + 2, j, k + 1) - u(2, i + 2, j, k - 1))) *
-                        stry(j) +
-                    la(i + 2, j, k) * met(4, i + 2, j, k) *
-                        met(1, i + 2, j, k) *
-                        (c2 * (u(3, i + 2, j, k + 2) - u(3, i + 2, j, k - 2)) +
-                         c1 * (u(3, i + 2, j, k + 1) - u(3, i + 2, j, k - 1))) -
-                    ((2 * mu(i - 2, j, k) + la(i - 2, j, k)) *
-                         met(2, i - 2, j, k) * met(1, i - 2, j, k) *
-                         (c2 * (u(1, i - 2, j, k + 2) - u(1, i - 2, j, k - 2)) +
-                          c1 *
-                              (u(1, i - 2, j, k + 1) - u(1, i - 2, j, k - 1))) *
-                         strx(i - 2) +
-                     la(i - 2, j, k) * met(3, i - 2, j, k) *
-                         met(1, i - 2, j, k) *
-                         (c2 * (u(2, i - 2, j, k + 2) - u(2, i - 2, j, k - 2)) +
-                          c1 *
-                              (u(2, i - 2, j, k + 1) - u(2, i - 2, j, k - 1))) *
-                         stry(j) +
-                     la(i - 2, j, k) * met(4, i - 2, j, k) *
-                         met(1, i - 2, j, k) *
-                         (c2 * (u(3, i - 2, j, k + 2) - u(3, i - 2, j, k - 2)) +
-                          c1 * (u(3, i - 2, j, k + 1) -
-                                u(3, i - 2, j, k - 1))))) +
-               c1 *
-                   ((2 * mu(i + 1, j, k) + la(i + 1, j, k)) *
-                        met(2, i + 1, j, k) * met(1, i + 1, j, k) *
-                        (c2 * (u(1, i + 1, j, k + 2) - u(1, i + 1, j, k - 2)) +
-                         c1 * (u(1, i + 1, j, k + 1) - u(1, i + 1, j, k - 1))) *
-                        strx(i + 1) +
-                    la(i + 1, j, k) * met(3, i + 1, j, k) *
-                        met(1, i + 1, j, k) *
-                        (c2 * (u(2, i + 1, j, k + 2) - u(2, i + 1, j, k - 2)) +
-                         c1 * (u(2, i + 1, j, k + 1) - u(2, i + 1, j, k - 1))) *
-                        stry(j) +
-                    la(i + 1, j, k) * met(4, i + 1, j, k) *
-                        met(1, i + 1, j, k) *
-                        (c2 * (u(3, i + 1, j, k + 2) - u(3, i + 1, j, k - 2)) +
-                         c1 * (u(3, i + 1, j, k + 1) - u(3, i + 1, j, k - 1))) -
-                    ((2 * mu(i - 1, j, k) + la(i - 1, j, k)) *
-                         met(2, i - 1, j, k) * met(1, i - 1, j, k) *
-                         (c2 * (u(1, i - 1, j, k + 2) - u(1, i - 1, j, k - 2)) +
-                          c1 *
-                              (u(1, i - 1, j, k + 1) - u(1, i - 1, j, k - 1))) *
-                         strx(i - 1) +
-                     la(i - 1, j, k) * met(3, i - 1, j, k) *
-                         met(1, i - 1, j, k) *
-                         (c2 * (u(2, i - 1, j, k + 2) - u(2, i - 1, j, k - 2)) +
-                          c1 *
-                              (u(2, i - 1, j, k + 1) - u(2, i - 1, j, k - 1))) *
-                         stry(j) +
-                     la(i - 1, j, k) * met(4, i - 1, j, k) *
-                         met(1, i - 1, j, k) *
-                         (c2 * (u(3, i - 1, j, k + 2) - u(3, i - 1, j, k - 2)) +
-                          c1 * (u(3, i - 1, j, k + 1) -
-                                u(3, i - 1, j, k - 1)))))) *
-              istry;
-
-          // qr derivatives
-          // 82 ops, tot=687
-          r1 +=
-              c2 *
-                  (mu(i, j, k + 2) * met(3, i, j, k + 2) * met(1, i, j, k + 2) *
-                       (c2 * (u(1, i, j + 2, k + 2) - u(1, i, j - 2, k + 2)) +
-                        c1 * (u(1, i, j + 1, k + 2) - u(1, i, j - 1, k + 2))) *
-                       stry(j) * istrx +
-                   la(i, j, k + 2) * met(2, i, j, k + 2) * met(1, i, j, k + 2) *
-                       (c2 * (u(2, i, j + 2, k + 2) - u(2, i, j - 2, k + 2)) +
-                        c1 * (u(2, i, j + 1, k + 2) - u(2, i, j - 1, k + 2))) -
-                   (mu(i, j, k - 2) * met(3, i, j, k - 2) *
-                        met(1, i, j, k - 2) *
-                        (c2 * (u(1, i, j + 2, k - 2) - u(1, i, j - 2, k - 2)) +
-                         c1 * (u(1, i, j + 1, k - 2) - u(1, i, j - 1, k - 2))) *
-                        stry(j) * istrx +
-                    la(i, j, k - 2) * met(2, i, j, k - 2) *
-                        met(1, i, j, k - 2) *
-                        (c2 * (u(2, i, j + 2, k - 2) - u(2, i, j - 2, k - 2)) +
-                         c1 * (u(2, i, j + 1, k - 2) -
-                               u(2, i, j - 1, k - 2))))) +
-              c1 *
-                  (mu(i, j, k + 1) * met(3, i, j, k + 1) * met(1, i, j, k + 1) *
-                       (c2 * (u(1, i, j + 2, k + 1) - u(1, i, j - 2, k + 1)) +
-                        c1 * (u(1, i, j + 1, k + 1) - u(1, i, j - 1, k + 1))) *
-                       stry(j) * istrx +
-                   la(i, j, k + 1) * met(2, i, j, k + 1) * met(1, i, j, k + 1) *
-                       (c2 * (u(2, i, j + 2, k + 1) - u(2, i, j - 2, k + 1)) +
-                        c1 * (u(2, i, j + 1, k + 1) - u(2, i, j - 1, k + 1))) -
-                   (mu(i, j, k - 1) * met(3, i, j, k - 1) *
-                        met(1, i, j, k - 1) *
-                        (c2 * (u(1, i, j + 2, k - 1) - u(1, i, j - 2, k - 1)) +
-                         c1 * (u(1, i, j + 1, k - 1) - u(1, i, j - 1, k - 1))) *
-                        stry(j) * istrx +
-                    la(i, j, k - 1) * met(2, i, j, k - 1) *
-                        met(1, i, j, k - 1) *
-                        (c2 * (u(2, i, j + 2, k - 1) - u(2, i, j - 2, k - 1)) +
-                         c1 *
-                             (u(2, i, j + 1, k - 1) - u(2, i, j - 1, k - 1)))));
-
-          // rq derivatives
-          // 82 ops, tot=769
-          r1 +=
-              c2 *
-                  (mu(i, j + 2, k) * met(3, i, j + 2, k) * met(1, i, j + 2, k) *
-                       (c2 * (u(1, i, j + 2, k + 2) - u(1, i, j + 2, k - 2)) +
-                        c1 * (u(1, i, j + 2, k + 1) - u(1, i, j + 2, k - 1))) *
-                       stry(j + 2) * istrx +
-                   mu(i, j + 2, k) * met(2, i, j + 2, k) * met(1, i, j + 2, k) *
-                       (c2 * (u(2, i, j + 2, k + 2) - u(2, i, j + 2, k - 2)) +
-                        c1 * (u(2, i, j + 2, k + 1) - u(2, i, j + 2, k - 1))) -
-                   (mu(i, j - 2, k) * met(3, i, j - 2, k) *
-                        met(1, i, j - 2, k) *
-                        (c2 * (u(1, i, j - 2, k + 2) - u(1, i, j - 2, k - 2)) +
-                         c1 * (u(1, i, j - 2, k + 1) - u(1, i, j - 2, k - 1))) *
-                        stry(j - 2) * istrx +
-                    mu(i, j - 2, k) * met(2, i, j - 2, k) *
-                        met(1, i, j - 2, k) *
-                        (c2 * (u(2, i, j - 2, k + 2) - u(2, i, j - 2, k - 2)) +
-                         c1 * (u(2, i, j - 2, k + 1) -
-                               u(2, i, j - 2, k - 1))))) +
-              c1 *
-                  (mu(i, j + 1, k) * met(3, i, j + 1, k) * met(1, i, j + 1, k) *
-                       (c2 * (u(1, i, j + 1, k + 2) - u(1, i, j + 1, k - 2)) +
-                        c1 * (u(1, i, j + 1, k + 1) - u(1, i, j + 1, k - 1))) *
-                       stry(j + 1) * istrx +
-                   mu(i, j + 1, k) * met(2, i, j + 1, k) * met(1, i, j + 1, k) *
-                       (c2 * (u(2, i, j + 1, k + 2) - u(2, i, j + 1, k - 2)) +
-                        c1 * (u(2, i, j + 1, k + 1) - u(2, i, j + 1, k - 1))) -
-                   (mu(i, j - 1, k) * met(3, i, j - 1, k) *
-                        met(1, i, j - 1, k) *
-                        (c2 * (u(1, i, j - 1, k + 2) - u(1, i, j - 1, k - 2)) +
-                         c1 * (u(1, i, j - 1, k + 1) - u(1, i, j - 1, k - 1))) *
-                        stry(j - 1) * istrx +
-                    mu(i, j - 1, k) * met(2, i, j - 1, k) *
-                        met(1, i, j - 1, k) *
-                        (c2 * (u(2, i, j - 1, k + 2) - u(2, i, j - 1, k - 2)) +
-                         c1 *
-                             (u(2, i, j - 1, k + 1) - u(2, i, j - 1, k - 1)))));
-
-          // 4 ops, tot=773
-          lu(1, i, j, k) = a1 * lu(1, i, j, k) + sgn * r1 * ijac;
-
-
-
-
-
-        }
-
+///         float_sw4 r1 = 0;
 ///
+///         // pp derivative (u)
+///         // 53 ops, tot=58
+///         float_sw4 cof1 = (2 * mu(i - 2, j, k) + la(i - 2, j, k)) *
+///                          met(1, i - 2, j, k) * met(1, i - 2, j, k) *
+///                          strx(i - 2);
+///         float_sw4 cof2 = (2 * mu(i - 1, j, k) + la(i - 1, j, k)) *
+///                          met(1, i - 1, j, k) * met(1, i - 1, j, k) *
+///                          strx(i - 1);
+///         float_sw4 cof3 = (2 * mu(i, j, k) + la(i, j, k)) * met(1, i, j, k) *
+///                          met(1, i, j, k) * strx(i);
+///         float_sw4 cof4 = (2 * mu(i + 1, j, k) + la(i + 1, j, k)) *
+///                          met(1, i + 1, j, k) * met(1, i + 1, j, k) *
+///                          strx(i + 1);
+///         float_sw4 cof5 = (2 * mu(i + 2, j, k) + la(i + 2, j, k)) *
+///                          met(1, i + 2, j, k) * met(1, i + 2, j, k) *
+///                          strx(i + 2);
+///         float_sw4 mux1 = cof2 - tf * (cof3 + cof1);
+///         float_sw4 mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
+///         float_sw4 mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
+///         float_sw4 mux4 = cof4 - tf * (cof3 + cof5);
+///
+///         r1 += i6 *
+///               (mux1 * (u(1, i - 2, j, k) - u(1, i, j, k)) +
+///                mux2 * (u(1, i - 1, j, k) - u(1, i, j, k)) +
+///                mux3 * (u(1, i + 1, j, k) - u(1, i, j, k)) +
+///                mux4 * (u(1, i + 2, j, k) - u(1, i, j, k))) *
+///               istry;
+///         // qq derivative (u)
+///         // 43 ops, tot=101
+///         {
+///           float_sw4 cof1 = (mu(i, j - 2, k)) * met(1, i, j - 2, k) *
+///                            met(1, i, j - 2, k) * stry(j - 2);
+///           float_sw4 cof2 = (mu(i, j - 1, k)) * met(1, i, j - 1, k) *
+///                            met(1, i, j - 1, k) * stry(j - 1);
+///           float_sw4 cof3 =
+///               (mu(i, j, k)) * met(1, i, j, k) * met(1, i, j, k) * stry(j);
+///           float_sw4 cof4 = (mu(i, j + 1, k)) * met(1, i, j + 1, k) *
+///                            met(1, i, j + 1, k) * stry(j + 1);
+///           float_sw4 cof5 = (mu(i, j + 2, k)) * met(1, i, j + 2, k) *
+///                            met(1, i, j + 2, k) * stry(j + 2);
+///           float_sw4 mux1 = cof2 - tf * (cof3 + cof1);
+///           float_sw4 mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
+///           float_sw4 mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
+///           float_sw4 mux4 = cof4 - tf * (cof3 + cof5);
+///
+///           r1 += i6 *
+///                 (mux1 * (u(1, i, j - 2, k) - u(1, i, j, k)) +
+///                  mux2 * (u(1, i, j - 1, k) - u(1, i, j, k)) +
+///                  mux3 * (u(1, i, j + 1, k) - u(1, i, j, k)) +
+///                  mux4 * (u(1, i, j + 2, k) - u(1, i, j, k))) *
+///                 istrx;
+///         }
+/// #ifdef MAGIC_SYNC
+///         __syncthreads();
+/// #endif
+///         // rr derivative (u)
+///         // 5*11+14+14=83 ops, tot=184
+///         {
+///           float_sw4 cof1 =
+///               (2 * mu(i, j, k - 2) + la(i, j, k - 2)) * met(2, i, j, k - 2) *
+///                   strx(i) * met(2, i, j, k - 2) * strx(i) +
+///               mu(i, j, k - 2) * (met(3, i, j, k - 2) * stry(j) *
+///                                      met(3, i, j, k - 2) * stry(j) +
+///                                  met(4, i, j, k - 2) * met(4, i, j, k - 2));
+///           float_sw4 cof2 =
+///               (2 * mu(i, j, k - 1) + la(i, j, k - 1)) * met(2, i, j, k - 1) *
+///                   strx(i) * met(2, i, j, k - 1) * strx(i) +
+///               mu(i, j, k - 1) * (met(3, i, j, k - 1) * stry(j) *
+///                                      met(3, i, j, k - 1) * stry(j) +
+///                                  met(4, i, j, k - 1) * met(4, i, j, k - 1));
+///           float_sw4 cof3 = (2 * mu(i, j, k) + la(i, j, k)) * met(2, i, j, k) *
+///                                strx(i) * met(2, i, j, k) * strx(i) +
+///                            mu(i, j, k) * (met(3, i, j, k) * stry(j) *
+///                                               met(3, i, j, k) * stry(j) +
+///                                           met(4, i, j, k) * met(4, i, j, k));
+///           float_sw4 cof4 =
+///               (2 * mu(i, j, k + 1) + la(i, j, k + 1)) * met(2, i, j, k + 1) *
+///                   strx(i) * met(2, i, j, k + 1) * strx(i) +
+///               mu(i, j, k + 1) * (met(3, i, j, k + 1) * stry(j) *
+///                                      met(3, i, j, k + 1) * stry(j) +
+///                                  met(4, i, j, k + 1) * met(4, i, j, k + 1));
+///           float_sw4 cof5 =
+///               (2 * mu(i, j, k + 2) + la(i, j, k + 2)) * met(2, i, j, k + 2) *
+///                   strx(i) * met(2, i, j, k + 2) * strx(i) +
+///               mu(i, j, k + 2) * (met(3, i, j, k + 2) * stry(j) *
+///                                      met(3, i, j, k + 2) * stry(j) +
+///                                  met(4, i, j, k + 2) * met(4, i, j, k + 2));
+///
+///           float_sw4 mux1 = cof2 - tf * (cof3 + cof1);
+///           float_sw4 mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
+///           float_sw4 mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
+///           float_sw4 mux4 = cof4 - tf * (cof3 + cof5);
+///
+///           r1 += i6 *
+///                 (mux1 * (u(1, i, j, k - 2) - u(1, i, j, k)) +
+///                  mux2 * (u(1, i, j, k - 1) - u(1, i, j, k)) +
+///                  mux3 * (u(1, i, j, k + 1) - u(1, i, j, k)) +
+///                  mux4 * (u(1, i, j, k + 2) - u(1, i, j, k))) *
+///                 istrxy;
+///         }
+///         // rr derivative (v)
+///         // 42 ops, tot=226
+///         cof1 = (mu(i, j, k - 2) + la(i, j, k - 2)) * met(2, i, j, k - 2) *
+///                met(3, i, j, k - 2);
+///         cof2 = (mu(i, j, k - 1) + la(i, j, k - 1)) * met(2, i, j, k - 1) *
+///                met(3, i, j, k - 1);
+///         cof3 = (mu(i, j, k) + la(i, j, k)) * met(2, i, j, k) * met(3, i, j, k);
+///         cof4 = (mu(i, j, k + 1) + la(i, j, k + 1)) * met(2, i, j, k + 1) *
+///                met(3, i, j, k + 1);
+///         cof5 = (mu(i, j, k + 2) + la(i, j, k + 2)) * met(2, i, j, k + 2) *
+///                met(3, i, j, k + 2);
+///         mux1 = cof2 - tf * (cof3 + cof1);
+///         mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
+///         mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
+///         mux4 = cof4 - tf * (cof3 + cof5);
+///
+///         r1 += i6 * (mux1 * (u(2, i, j, k - 2) - u(2, i, j, k)) +
+///                     mux2 * (u(2, i, j, k - 1) - u(2, i, j, k)) +
+///                     mux3 * (u(2, i, j, k + 1) - u(2, i, j, k)) +
+///                     mux4 * (u(2, i, j, k + 2) - u(2, i, j, k)));
+///
+///         // rr derivative (w)
+///         // 43 ops, tot=269
+///         cof1 = (mu(i, j, k - 2) + la(i, j, k - 2)) * met(2, i, j, k - 2) *
+///                met(4, i, j, k - 2);
+///         cof2 = (mu(i, j, k - 1) + la(i, j, k - 1)) * met(2, i, j, k - 1) *
+///                met(4, i, j, k - 1);
+///         cof3 = (mu(i, j, k) + la(i, j, k)) * met(2, i, j, k) * met(4, i, j, k);
+///         cof4 = (mu(i, j, k + 1) + la(i, j, k + 1)) * met(2, i, j, k + 1) *
+///                met(4, i, j, k + 1);
+///         cof5 = (mu(i, j, k + 2) + la(i, j, k + 2)) * met(2, i, j, k + 2) *
+///                met(4, i, j, k + 2);
+///         mux1 = cof2 - tf * (cof3 + cof1);
+///         mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
+///         mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
+///         mux4 = cof4 - tf * (cof3 + cof5);
+///
+///         r1 += i6 *
+///               (mux1 * (u(3, i, j, k - 2) - u(3, i, j, k)) +
+///                mux2 * (u(3, i, j, k - 1) - u(3, i, j, k)) +
+///                mux3 * (u(3, i, j, k + 1) - u(3, i, j, k)) +
+///                mux4 * (u(3, i, j, k + 2) - u(3, i, j, k))) *
+///               istry;
+///
+///         // pq-derivatives
+///         // 38 ops, tot=307
+///         r1 +=
+///             c2 * (mu(i, j + 2, k) * met(1, i, j + 2, k) * met(1, i, j + 2, k) *
+///                       (c2 * (u(2, i + 2, j + 2, k) - u(2, i - 2, j + 2, k)) +
+///                        c1 * (u(2, i + 1, j + 2, k) - u(2, i - 1, j + 2, k))) -
+///                   mu(i, j - 2, k) * met(1, i, j - 2, k) * met(1, i, j - 2, k) *
+///                       (c2 * (u(2, i + 2, j - 2, k) - u(2, i - 2, j - 2, k)) +
+///                        c1 * (u(2, i + 1, j - 2, k) - u(2, i - 1, j - 2, k)))) +
+///             c1 * (mu(i, j + 1, k) * met(1, i, j + 1, k) * met(1, i, j + 1, k) *
+///                       (c2 * (u(2, i + 2, j + 1, k) - u(2, i - 2, j + 1, k)) +
+///                        c1 * (u(2, i + 1, j + 1, k) - u(2, i - 1, j + 1, k))) -
+///                   mu(i, j - 1, k) * met(1, i, j - 1, k) * met(1, i, j - 1, k) *
+///                       (c2 * (u(2, i + 2, j - 1, k) - u(2, i - 2, j - 1, k)) +
+///                        c1 * (u(2, i + 1, j - 1, k) - u(2, i - 1, j - 1, k))));
+///
+///         // qp-derivatives
+///         // 38 ops, tot=345
+///         r1 +=
+///             c2 * (la(i + 2, j, k) * met(1, i + 2, j, k) * met(1, i + 2, j, k) *
+///                       (c2 * (u(2, i + 2, j + 2, k) - u(2, i + 2, j - 2, k)) +
+///                        c1 * (u(2, i + 2, j + 1, k) - u(2, i + 2, j - 1, k))) -
+///                   la(i - 2, j, k) * met(1, i - 2, j, k) * met(1, i - 2, j, k) *
+///                       (c2 * (u(2, i - 2, j + 2, k) - u(2, i - 2, j - 2, k)) +
+///                        c1 * (u(2, i - 2, j + 1, k) - u(2, i - 2, j - 1, k)))) +
+///             c1 * (la(i + 1, j, k) * met(1, i + 1, j, k) * met(1, i + 1, j, k) *
+///                       (c2 * (u(2, i + 1, j + 2, k) - u(2, i + 1, j - 2, k)) +
+///                        c1 * (u(2, i + 1, j + 1, k) - u(2, i + 1, j - 1, k))) -
+///                   la(i - 1, j, k) * met(1, i - 1, j, k) * met(1, i - 1, j, k) *
+///                       (c2 * (u(2, i - 1, j + 2, k) - u(2, i - 1, j - 2, k)) +
+///                        c1 * (u(2, i - 1, j + 1, k) - u(2, i - 1, j - 1, k))));
+///
+///         // pr-derivatives
+///         // 130 ops., tot=475
+///         r1 +=
+///             c2 * ((2 * mu(i, j, k + 2) + la(i, j, k + 2)) *
+///                       met(2, i, j, k + 2) * met(1, i, j, k + 2) *
+///                       (c2 * (u(1, i + 2, j, k + 2) - u(1, i - 2, j, k + 2)) +
+///                        c1 * (u(1, i + 1, j, k + 2) - u(1, i - 1, j, k + 2))) *
+///                       strx(i) * istry +
+///                   mu(i, j, k + 2) * met(3, i, j, k + 2) * met(1, i, j, k + 2) *
+///                       (c2 * (u(2, i + 2, j, k + 2) - u(2, i - 2, j, k + 2)) +
+///                        c1 * (u(2, i + 1, j, k + 2) - u(2, i - 1, j, k + 2))) +
+///                   mu(i, j, k + 2) * met(4, i, j, k + 2) * met(1, i, j, k + 2) *
+///                       (c2 * (u(3, i + 2, j, k + 2) - u(3, i - 2, j, k + 2)) +
+///                        c1 * (u(3, i + 1, j, k + 2) - u(3, i - 1, j, k + 2))) *
+///                       istry -
+///                   ((2 * mu(i, j, k - 2) + la(i, j, k - 2)) *
+///                        met(2, i, j, k - 2) * met(1, i, j, k - 2) *
+///                        (c2 * (u(1, i + 2, j, k - 2) - u(1, i - 2, j, k - 2)) +
+///                         c1 * (u(1, i + 1, j, k - 2) - u(1, i - 1, j, k - 2))) *
+///                        strx(i) * istry +
+///                    mu(i, j, k - 2) * met(3, i, j, k - 2) * met(1, i, j, k - 2) *
+///                        (c2 * (u(2, i + 2, j, k - 2) - u(2, i - 2, j, k - 2)) +
+///                         c1 * (u(2, i + 1, j, k - 2) - u(2, i - 1, j, k - 2))) +
+///                    mu(i, j, k - 2) * met(4, i, j, k - 2) * met(1, i, j, k - 2) *
+///                        (c2 * (u(3, i + 2, j, k - 2) - u(3, i - 2, j, k - 2)) +
+///                         c1 * (u(3, i + 1, j, k - 2) - u(3, i - 1, j, k - 2))) *
+///                        istry)) +
+///             c1 * ((2 * mu(i, j, k + 1) + la(i, j, k + 1)) *
+///                       met(2, i, j, k + 1) * met(1, i, j, k + 1) *
+///                       (c2 * (u(1, i + 2, j, k + 1) - u(1, i - 2, j, k + 1)) +
+///                        c1 * (u(1, i + 1, j, k + 1) - u(1, i - 1, j, k + 1))) *
+///                       strx(i) * istry +
+///                   mu(i, j, k + 1) * met(3, i, j, k + 1) * met(1, i, j, k + 1) *
+///                       (c2 * (u(2, i + 2, j, k + 1) - u(2, i - 2, j, k + 1)) +
+///                        c1 * (u(2, i + 1, j, k + 1) - u(2, i - 1, j, k + 1))) +
+///                   mu(i, j, k + 1) * met(4, i, j, k + 1) * met(1, i, j, k + 1) *
+///                       (c2 * (u(3, i + 2, j, k + 1) - u(3, i - 2, j, k + 1)) +
+///                        c1 * (u(3, i + 1, j, k + 1) - u(3, i - 1, j, k + 1))) *
+///                       istry -
+///                   ((2 * mu(i, j, k - 1) + la(i, j, k - 1)) *
+///                        met(2, i, j, k - 1) * met(1, i, j, k - 1) *
+///                        (c2 * (u(1, i + 2, j, k - 1) - u(1, i - 2, j, k - 1)) +
+///                         c1 * (u(1, i + 1, j, k - 1) - u(1, i - 1, j, k - 1))) *
+///                        strx(i) * istry +
+///                    mu(i, j, k - 1) * met(3, i, j, k - 1) * met(1, i, j, k - 1) *
+///                        (c2 * (u(2, i + 2, j, k - 1) - u(2, i - 2, j, k - 1)) +
+///                         c1 * (u(2, i + 1, j, k - 1) - u(2, i - 1, j, k - 1))) +
+///                    mu(i, j, k - 1) * met(4, i, j, k - 1) * met(1, i, j, k - 1) *
+///                        (c2 * (u(3, i + 2, j, k - 1) - u(3, i - 2, j, k - 1)) +
+///                         c1 * (u(3, i + 1, j, k - 1) - u(3, i - 1, j, k - 1))) *
+///                        istry));
+///
+///         // rp derivatives
+///         // 130 ops, tot=605
+///         r1 +=
+///             (c2 *
+///                  ((2 * mu(i + 2, j, k) + la(i + 2, j, k)) *
+///                       met(2, i + 2, j, k) * met(1, i + 2, j, k) *
+///                       (c2 * (u(1, i + 2, j, k + 2) - u(1, i + 2, j, k - 2)) +
+///                        c1 * (u(1, i + 2, j, k + 1) - u(1, i + 2, j, k - 1))) *
+///                       strx(i + 2) +
+///                   la(i + 2, j, k) * met(3, i + 2, j, k) * met(1, i + 2, j, k) *
+///                       (c2 * (u(2, i + 2, j, k + 2) - u(2, i + 2, j, k - 2)) +
+///                        c1 * (u(2, i + 2, j, k + 1) - u(2, i + 2, j, k - 1))) *
+///                       stry(j) +
+///                   la(i + 2, j, k) * met(4, i + 2, j, k) * met(1, i + 2, j, k) *
+///                       (c2 * (u(3, i + 2, j, k + 2) - u(3, i + 2, j, k - 2)) +
+///                        c1 * (u(3, i + 2, j, k + 1) - u(3, i + 2, j, k - 1))) -
+///                   ((2 * mu(i - 2, j, k) + la(i - 2, j, k)) *
+///                        met(2, i - 2, j, k) * met(1, i - 2, j, k) *
+///                        (c2 * (u(1, i - 2, j, k + 2) - u(1, i - 2, j, k - 2)) +
+///                         c1 * (u(1, i - 2, j, k + 1) - u(1, i - 2, j, k - 1))) *
+///                        strx(i - 2) +
+///                    la(i - 2, j, k) * met(3, i - 2, j, k) * met(1, i - 2, j, k) *
+///                        (c2 * (u(2, i - 2, j, k + 2) - u(2, i - 2, j, k - 2)) +
+///                         c1 * (u(2, i - 2, j, k + 1) - u(2, i - 2, j, k - 1))) *
+///                        stry(j) +
+///                    la(i - 2, j, k) * met(4, i - 2, j, k) * met(1, i - 2, j, k) *
+///                        (c2 * (u(3, i - 2, j, k + 2) - u(3, i - 2, j, k - 2)) +
+///                         c1 *
+///                             (u(3, i - 2, j, k + 1) - u(3, i - 2, j, k - 1))))) +
+///              c1 *
+///                  ((2 * mu(i + 1, j, k) + la(i + 1, j, k)) *
+///                       met(2, i + 1, j, k) * met(1, i + 1, j, k) *
+///                       (c2 * (u(1, i + 1, j, k + 2) - u(1, i + 1, j, k - 2)) +
+///                        c1 * (u(1, i + 1, j, k + 1) - u(1, i + 1, j, k - 1))) *
+///                       strx(i + 1) +
+///                   la(i + 1, j, k) * met(3, i + 1, j, k) * met(1, i + 1, j, k) *
+///                       (c2 * (u(2, i + 1, j, k + 2) - u(2, i + 1, j, k - 2)) +
+///                        c1 * (u(2, i + 1, j, k + 1) - u(2, i + 1, j, k - 1))) *
+///                       stry(j) +
+///                   la(i + 1, j, k) * met(4, i + 1, j, k) * met(1, i + 1, j, k) *
+///                       (c2 * (u(3, i + 1, j, k + 2) - u(3, i + 1, j, k - 2)) +
+///                        c1 * (u(3, i + 1, j, k + 1) - u(3, i + 1, j, k - 1))) -
+///                   ((2 * mu(i - 1, j, k) + la(i - 1, j, k)) *
+///                        met(2, i - 1, j, k) * met(1, i - 1, j, k) *
+///                        (c2 * (u(1, i - 1, j, k + 2) - u(1, i - 1, j, k - 2)) +
+///                         c1 * (u(1, i - 1, j, k + 1) - u(1, i - 1, j, k - 1))) *
+///                        strx(i - 1) +
+///                    la(i - 1, j, k) * met(3, i - 1, j, k) * met(1, i - 1, j, k) *
+///                        (c2 * (u(2, i - 1, j, k + 2) - u(2, i - 1, j, k - 2)) +
+///                         c1 * (u(2, i - 1, j, k + 1) - u(2, i - 1, j, k - 1))) *
+///                        stry(j) +
+///                    la(i - 1, j, k) * met(4, i - 1, j, k) * met(1, i - 1, j, k) *
+///                        (c2 * (u(3, i - 1, j, k + 2) - u(3, i - 1, j, k - 2)) +
+///                         c1 * (u(3, i - 1, j, k + 1) -
+///                               u(3, i - 1, j, k - 1)))))) *
+///             istry;
+///
+///         // qr derivatives
+///         // 82 ops, tot=687
+///         r1 +=
+///             c2 *
+///                 (mu(i, j, k + 2) * met(3, i, j, k + 2) * met(1, i, j, k + 2) *
+///                      (c2 * (u(1, i, j + 2, k + 2) - u(1, i, j - 2, k + 2)) +
+///                       c1 * (u(1, i, j + 1, k + 2) - u(1, i, j - 1, k + 2))) *
+///                      stry(j) * istrx +
+///                  la(i, j, k + 2) * met(2, i, j, k + 2) * met(1, i, j, k + 2) *
+///                      (c2 * (u(2, i, j + 2, k + 2) - u(2, i, j - 2, k + 2)) +
+///                       c1 * (u(2, i, j + 1, k + 2) - u(2, i, j - 1, k + 2))) -
+///                  (mu(i, j, k - 2) * met(3, i, j, k - 2) * met(1, i, j, k - 2) *
+///                       (c2 * (u(1, i, j + 2, k - 2) - u(1, i, j - 2, k - 2)) +
+///                        c1 * (u(1, i, j + 1, k - 2) - u(1, i, j - 1, k - 2))) *
+///                       stry(j) * istrx +
+///                   la(i, j, k - 2) * met(2, i, j, k - 2) * met(1, i, j, k - 2) *
+///                       (c2 * (u(2, i, j + 2, k - 2) - u(2, i, j - 2, k - 2)) +
+///                        c1 * (u(2, i, j + 1, k - 2) - u(2, i, j - 1, k - 2))))) +
+///             c1 * (mu(i, j, k + 1) * met(3, i, j, k + 1) * met(1, i, j, k + 1) *
+///                       (c2 * (u(1, i, j + 2, k + 1) - u(1, i, j - 2, k + 1)) +
+///                        c1 * (u(1, i, j + 1, k + 1) - u(1, i, j - 1, k + 1))) *
+///                       stry(j) * istrx +
+///                   la(i, j, k + 1) * met(2, i, j, k + 1) * met(1, i, j, k + 1) *
+///                       (c2 * (u(2, i, j + 2, k + 1) - u(2, i, j - 2, k + 1)) +
+///                        c1 * (u(2, i, j + 1, k + 1) - u(2, i, j - 1, k + 1))) -
+///                   (mu(i, j, k - 1) * met(3, i, j, k - 1) * met(1, i, j, k - 1) *
+///                        (c2 * (u(1, i, j + 2, k - 1) - u(1, i, j - 2, k - 1)) +
+///                         c1 * (u(1, i, j + 1, k - 1) - u(1, i, j - 1, k - 1))) *
+///                        stry(j) * istrx +
+///                    la(i, j, k - 1) * met(2, i, j, k - 1) * met(1, i, j, k - 1) *
+///                        (c2 * (u(2, i, j + 2, k - 1) - u(2, i, j - 2, k - 1)) +
+///                         c1 * (u(2, i, j + 1, k - 1) - u(2, i, j - 1, k - 1)))));
+///
+///         // rq derivatives
+///         // 82 ops, tot=769
+///         r1 +=
+///             c2 *
+///                 (mu(i, j + 2, k) * met(3, i, j + 2, k) * met(1, i, j + 2, k) *
+///                      (c2 * (u(1, i, j + 2, k + 2) - u(1, i, j + 2, k - 2)) +
+///                       c1 * (u(1, i, j + 2, k + 1) - u(1, i, j + 2, k - 1))) *
+///                      stry(j + 2) * istrx +
+///                  mu(i, j + 2, k) * met(2, i, j + 2, k) * met(1, i, j + 2, k) *
+///                      (c2 * (u(2, i, j + 2, k + 2) - u(2, i, j + 2, k - 2)) +
+///                       c1 * (u(2, i, j + 2, k + 1) - u(2, i, j + 2, k - 1))) -
+///                  (mu(i, j - 2, k) * met(3, i, j - 2, k) * met(1, i, j - 2, k) *
+///                       (c2 * (u(1, i, j - 2, k + 2) - u(1, i, j - 2, k - 2)) +
+///                        c1 * (u(1, i, j - 2, k + 1) - u(1, i, j - 2, k - 1))) *
+///                       stry(j - 2) * istrx +
+///                   mu(i, j - 2, k) * met(2, i, j - 2, k) * met(1, i, j - 2, k) *
+///                       (c2 * (u(2, i, j - 2, k + 2) - u(2, i, j - 2, k - 2)) +
+///                        c1 * (u(2, i, j - 2, k + 1) - u(2, i, j - 2, k - 1))))) +
+///             c1 * (mu(i, j + 1, k) * met(3, i, j + 1, k) * met(1, i, j + 1, k) *
+///                       (c2 * (u(1, i, j + 1, k + 2) - u(1, i, j + 1, k - 2)) +
+///                        c1 * (u(1, i, j + 1, k + 1) - u(1, i, j + 1, k - 1))) *
+///                       stry(j + 1) * istrx +
+///                   mu(i, j + 1, k) * met(2, i, j + 1, k) * met(1, i, j + 1, k) *
+///                       (c2 * (u(2, i, j + 1, k + 2) - u(2, i, j + 1, k - 2)) +
+///                        c1 * (u(2, i, j + 1, k + 1) - u(2, i, j + 1, k - 1))) -
+///                   (mu(i, j - 1, k) * met(3, i, j - 1, k) * met(1, i, j - 1, k) *
+///                        (c2 * (u(1, i, j - 1, k + 2) - u(1, i, j - 1, k - 2)) +
+///                         c1 * (u(1, i, j - 1, k + 1) - u(1, i, j - 1, k - 1))) *
+///                        stry(j - 1) * istrx +
+///                    mu(i, j - 1, k) * met(2, i, j - 1, k) * met(1, i, j - 1, k) *
+///                        (c2 * (u(2, i, j - 1, k + 2) - u(2, i, j - 1, k - 2)) +
+///                         c1 * (u(2, i, j - 1, k + 1) - u(2, i, j - 1, k - 1)))));
+///
+///         // 4 ops, tot=773
+///         lu(1, i, j, k) = a1 * lu(1, i, j, k) + sgn * r1 * ijac;
+///       }
 
 #ifndef RAJAPerf_Apps_SW4CK_KERNEL_2_HPP
 #define RAJAPerf_Apps_SW4CK_KERNEL_2_HPP
 
-#define SW4CK_KERNEL_2_DATA_SETUP \
+#define SW4CK_KERNEL_2_DATA_SETUP
 
-#define SW4CK_KERNEL_2_BODY \
-
-
+#define SW4CK_KERNEL_2_BODY
 
 #include "common/KernelBase.hpp"
 
-namespace rajaperf
-{
-class RunParams;
+  namespace rajaperf {
+  class RunParams;
 
-namespace apps
-{
-class ADomain;
+  namespace apps {
+  class ADomain;
 
-class SW4CK_KERNEL_2 : public KernelBase
-{
-public:
+  class SW4CK_KERNEL_2 : public KernelBase {
+  public:
+    SW4CK_KERNEL_2(const RunParams &params);
 
-  SW4CK_KERNEL_2(const RunParams& params);
+    ~SW4CK_KERNEL_2();
 
-  ~SW4CK_KERNEL_2();
+    void setUp(VariantID vid, size_t tune_idx);
+    void updateChecksum(VariantID vid, size_t tune_idx);
+    void tearDown(VariantID vid, size_t tune_idx);
 
-  void setUp(VariantID vid, size_t tune_idx);
-  void updateChecksum(VariantID vid, size_t tune_idx);
-  void tearDown(VariantID vid, size_t tune_idx);
+    void runSeqVariant(VariantID vid, size_t tune_idx);
+    void runOpenMPVariant(VariantID vid, size_t tune_idx);
+    void runCudaVariant(VariantID vid, size_t tune_idx);
+    void runHipVariant(VariantID vid, size_t tune_idx);
+    void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
 
-  void runSeqVariant(VariantID vid, size_t tune_idx);
-  void runOpenMPVariant(VariantID vid, size_t tune_idx);
-  void runCudaVariant(VariantID vid, size_t tune_idx);
-  void runHipVariant(VariantID vid, size_t tune_idx);
-  void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+    void setCudaTuningDefinitions(VariantID vid);
+    void setHipTuningDefinitions(VariantID vid);
+    template <size_t block_size> void runCudaVariantImpl(VariantID vid);
+    template <size_t block_size> void runHipVariantImpl(VariantID vid);
 
-  void setCudaTuningDefinitions(VariantID vid);
-  void setHipTuningDefinitions(VariantID vid);
-  template < size_t block_size >
-  void runCudaVariantImpl(VariantID vid);
-  template < size_t block_size >
-  void runHipVariantImpl(VariantID vid);
+  private:
+    static const size_t default_gpu_block_size = 256;
+    using gpu_block_sizes_type =
+        gpu_block_size::make_list_type<default_gpu_block_size>;
 
-private:
-  static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+    Real_ptr m_a_mu;
+    Real_ptr m_a_lambda;
+    Real_ptr m_a_jac;
+    Real_ptr m_a_u;
+    Real_ptr a_lu;
+    Real_ptr a_met;
+    Real_ptr a_strx;
+    Real_ptr a_stry;
+    Real_ptr a_acof;
+    Real_ptr a_bope;
+    Real_ptr a_ghcof;
+    Real_ptr a_acof_no_gp;
+    Real_ptr a_ghcof_no_gp;
+    
+  };
 
-  Real_ptr m_x;
-  Real_ptr m_y;
-  Real_ptr m_z;
-  Real_ptr m_vol;
-
-  Real_type m_vnormq;
-
-  ADomain* m_domain;
-  Index_type m_array_length;
-};
-
-} // end namespace apps
-} // end namespace rajaperf
+  } // end namespace apps
+  } // end namespace rajaperf
 
 #endif // closing endif for header file include guard

--- a/src/apps/SW4CK_KERNEL_2.hpp
+++ b/src/apps/SW4CK_KERNEL_2.hpp
@@ -1,0 +1,491 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// SW4CK_KERNEL_2 kernel reference implementation:
+///
+///
+///
+int main()
+{
+  for( int k= kstart; k <= klast-2 ; k++ )
+    for( int j=jfirst+2; j <= jlast-2 ; j++ )
+      for( int i=ifirst+2; i <= ilast-2 ; i++ )
+        {
+
+          // 5 ops
+          float_sw4 ijac = strx(i) * stry(j) / jac(i, j, k);
+          float_sw4 istry = 1 / (stry(j));
+          float_sw4 istrx = 1 / (strx(i));
+          float_sw4 istrxy = istry * istrx;
+
+          float_sw4 r1 = 0;
+          
+          // pp derivative (u)
+          // 53 ops, tot=58
+          float_sw4 cof1 = (2 * mu(i - 2, j, k) + la(i - 2, j, k)) *
+                           met(1, i - 2, j, k) * met(1, i - 2, j, k) *
+                           strx(i - 2);
+          float_sw4 cof2 = (2 * mu(i - 1, j, k) + la(i - 1, j, k)) *
+                           met(1, i - 1, j, k) * met(1, i - 1, j, k) *
+                           strx(i - 1);
+          float_sw4 cof3 = (2 * mu(i, j, k) + la(i, j, k)) * met(1, i, j, k) *
+                           met(1, i, j, k) * strx(i);
+          float_sw4 cof4 = (2 * mu(i + 1, j, k) + la(i + 1, j, k)) *
+                           met(1, i + 1, j, k) * met(1, i + 1, j, k) *
+                           strx(i + 1);
+          float_sw4 cof5 = (2 * mu(i + 2, j, k) + la(i + 2, j, k)) *
+                           met(1, i + 2, j, k) * met(1, i + 2, j, k) *
+                           strx(i + 2);
+          float_sw4 mux1 = cof2 - tf * (cof3 + cof1);
+          float_sw4 mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
+          float_sw4 mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
+          float_sw4 mux4 = cof4 - tf * (cof3 + cof5);
+
+          r1 += i6 *
+                (mux1 * (u(1, i - 2, j, k) - u(1, i, j, k)) +
+                 mux2 * (u(1, i - 1, j, k) - u(1, i, j, k)) +
+                 mux3 * (u(1, i + 1, j, k) - u(1, i, j, k)) +
+                 mux4 * (u(1, i + 2, j, k) - u(1, i, j, k))) *
+                istry;
+          // qq derivative (u)
+          // 43 ops, tot=101
+          {
+            float_sw4 cof1 = (mu(i, j - 2, k)) * met(1, i, j - 2, k) *
+                             met(1, i, j - 2, k) * stry(j - 2);
+            float_sw4 cof2 = (mu(i, j - 1, k)) * met(1, i, j - 1, k) *
+                             met(1, i, j - 1, k) * stry(j - 1);
+            float_sw4 cof3 =
+                (mu(i, j, k)) * met(1, i, j, k) * met(1, i, j, k) * stry(j);
+            float_sw4 cof4 = (mu(i, j + 1, k)) * met(1, i, j + 1, k) *
+                             met(1, i, j + 1, k) * stry(j + 1);
+            float_sw4 cof5 = (mu(i, j + 2, k)) * met(1, i, j + 2, k) *
+                             met(1, i, j + 2, k) * stry(j + 2);
+            float_sw4 mux1 = cof2 - tf * (cof3 + cof1);
+            float_sw4 mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
+            float_sw4 mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
+            float_sw4 mux4 = cof4 - tf * (cof3 + cof5);
+
+            r1 += i6 *
+                  (mux1 * (u(1, i, j - 2, k) - u(1, i, j, k)) +
+                   mux2 * (u(1, i, j - 1, k) - u(1, i, j, k)) +
+                   mux3 * (u(1, i, j + 1, k) - u(1, i, j, k)) +
+                   mux4 * (u(1, i, j + 2, k) - u(1, i, j, k))) *
+                  istrx;
+          }
+#ifdef MAGIC_SYNC
+	__syncthreads();
+#endif
+          // rr derivative (u)
+          // 5*11+14+14=83 ops, tot=184
+          {
+            float_sw4 cof1 =
+                (2 * mu(i, j, k - 2) + la(i, j, k - 2)) * met(2, i, j, k - 2) *
+                    strx(i) * met(2, i, j, k - 2) * strx(i) +
+                mu(i, j, k - 2) * (met(3, i, j, k - 2) * stry(j) *
+                                       met(3, i, j, k - 2) * stry(j) +
+                                   met(4, i, j, k - 2) * met(4, i, j, k - 2));
+            float_sw4 cof2 =
+                (2 * mu(i, j, k - 1) + la(i, j, k - 1)) * met(2, i, j, k - 1) *
+                    strx(i) * met(2, i, j, k - 1) * strx(i) +
+                mu(i, j, k - 1) * (met(3, i, j, k - 1) * stry(j) *
+                                       met(3, i, j, k - 1) * stry(j) +
+                                   met(4, i, j, k - 1) * met(4, i, j, k - 1));
+            float_sw4 cof3 = (2 * mu(i, j, k) + la(i, j, k)) * met(2, i, j, k) *
+                                 strx(i) * met(2, i, j, k) * strx(i) +
+                             mu(i, j, k) * (met(3, i, j, k) * stry(j) *
+                                                met(3, i, j, k) * stry(j) +
+                                            met(4, i, j, k) * met(4, i, j, k));
+            float_sw4 cof4 =
+                (2 * mu(i, j, k + 1) + la(i, j, k + 1)) * met(2, i, j, k + 1) *
+                    strx(i) * met(2, i, j, k + 1) * strx(i) +
+                mu(i, j, k + 1) * (met(3, i, j, k + 1) * stry(j) *
+                                       met(3, i, j, k + 1) * stry(j) +
+                                   met(4, i, j, k + 1) * met(4, i, j, k + 1));
+            float_sw4 cof5 =
+                (2 * mu(i, j, k + 2) + la(i, j, k + 2)) * met(2, i, j, k + 2) *
+                    strx(i) * met(2, i, j, k + 2) * strx(i) +
+                mu(i, j, k + 2) * (met(3, i, j, k + 2) * stry(j) *
+                                       met(3, i, j, k + 2) * stry(j) +
+                                   met(4, i, j, k + 2) * met(4, i, j, k + 2));
+
+            float_sw4 mux1 = cof2 - tf * (cof3 + cof1);
+            float_sw4 mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
+            float_sw4 mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
+            float_sw4 mux4 = cof4 - tf * (cof3 + cof5);
+
+            r1 += i6 *
+                  (mux1 * (u(1, i, j, k - 2) - u(1, i, j, k)) +
+                   mux2 * (u(1, i, j, k - 1) - u(1, i, j, k)) +
+                   mux3 * (u(1, i, j, k + 1) - u(1, i, j, k)) +
+                   mux4 * (u(1, i, j, k + 2) - u(1, i, j, k))) *
+                  istrxy;
+          }
+          // rr derivative (v)
+          // 42 ops, tot=226
+          cof1 = (mu(i, j, k - 2) + la(i, j, k - 2)) * met(2, i, j, k - 2) *
+                 met(3, i, j, k - 2);
+          cof2 = (mu(i, j, k - 1) + la(i, j, k - 1)) * met(2, i, j, k - 1) *
+                 met(3, i, j, k - 1);
+          cof3 =
+              (mu(i, j, k) + la(i, j, k)) * met(2, i, j, k) * met(3, i, j, k);
+          cof4 = (mu(i, j, k + 1) + la(i, j, k + 1)) * met(2, i, j, k + 1) *
+                 met(3, i, j, k + 1);
+          cof5 = (mu(i, j, k + 2) + la(i, j, k + 2)) * met(2, i, j, k + 2) *
+                 met(3, i, j, k + 2);
+          mux1 = cof2 - tf * (cof3 + cof1);
+          mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
+          mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
+          mux4 = cof4 - tf * (cof3 + cof5);
+
+          r1 += i6 * (mux1 * (u(2, i, j, k - 2) - u(2, i, j, k)) +
+                      mux2 * (u(2, i, j, k - 1) - u(2, i, j, k)) +
+                      mux3 * (u(2, i, j, k + 1) - u(2, i, j, k)) +
+                      mux4 * (u(2, i, j, k + 2) - u(2, i, j, k)));
+
+          // rr derivative (w)
+          // 43 ops, tot=269
+          cof1 = (mu(i, j, k - 2) + la(i, j, k - 2)) * met(2, i, j, k - 2) *
+                 met(4, i, j, k - 2);
+          cof2 = (mu(i, j, k - 1) + la(i, j, k - 1)) * met(2, i, j, k - 1) *
+                 met(4, i, j, k - 1);
+          cof3 =
+              (mu(i, j, k) + la(i, j, k)) * met(2, i, j, k) * met(4, i, j, k);
+          cof4 = (mu(i, j, k + 1) + la(i, j, k + 1)) * met(2, i, j, k + 1) *
+                 met(4, i, j, k + 1);
+          cof5 = (mu(i, j, k + 2) + la(i, j, k + 2)) * met(2, i, j, k + 2) *
+                 met(4, i, j, k + 2);
+          mux1 = cof2 - tf * (cof3 + cof1);
+          mux2 = cof1 + cof4 + 3 * (cof3 + cof2);
+          mux3 = cof2 + cof5 + 3 * (cof4 + cof3);
+          mux4 = cof4 - tf * (cof3 + cof5);
+
+          r1 += i6 *
+                (mux1 * (u(3, i, j, k - 2) - u(3, i, j, k)) +
+                 mux2 * (u(3, i, j, k - 1) - u(3, i, j, k)) +
+                 mux3 * (u(3, i, j, k + 1) - u(3, i, j, k)) +
+                 mux4 * (u(3, i, j, k + 2) - u(3, i, j, k))) *
+                istry;
+
+          // pq-derivatives
+          // 38 ops, tot=307
+          r1 +=
+              c2 *
+                  (mu(i, j + 2, k) * met(1, i, j + 2, k) * met(1, i, j + 2, k) *
+                       (c2 * (u(2, i + 2, j + 2, k) - u(2, i - 2, j + 2, k)) +
+                        c1 * (u(2, i + 1, j + 2, k) - u(2, i - 1, j + 2, k))) -
+                   mu(i, j - 2, k) * met(1, i, j - 2, k) * met(1, i, j - 2, k) *
+                       (c2 * (u(2, i + 2, j - 2, k) - u(2, i - 2, j - 2, k)) +
+                        c1 * (u(2, i + 1, j - 2, k) - u(2, i - 1, j - 2, k)))) +
+              c1 *
+                  (mu(i, j + 1, k) * met(1, i, j + 1, k) * met(1, i, j + 1, k) *
+                       (c2 * (u(2, i + 2, j + 1, k) - u(2, i - 2, j + 1, k)) +
+                        c1 * (u(2, i + 1, j + 1, k) - u(2, i - 1, j + 1, k))) -
+                   mu(i, j - 1, k) * met(1, i, j - 1, k) * met(1, i, j - 1, k) *
+                       (c2 * (u(2, i + 2, j - 1, k) - u(2, i - 2, j - 1, k)) +
+                        c1 * (u(2, i + 1, j - 1, k) - u(2, i - 1, j - 1, k))));
+
+          // qp-derivatives
+          // 38 ops, tot=345
+          r1 +=
+              c2 *
+                  (la(i + 2, j, k) * met(1, i + 2, j, k) * met(1, i + 2, j, k) *
+                       (c2 * (u(2, i + 2, j + 2, k) - u(2, i + 2, j - 2, k)) +
+                        c1 * (u(2, i + 2, j + 1, k) - u(2, i + 2, j - 1, k))) -
+                   la(i - 2, j, k) * met(1, i - 2, j, k) * met(1, i - 2, j, k) *
+                       (c2 * (u(2, i - 2, j + 2, k) - u(2, i - 2, j - 2, k)) +
+                        c1 * (u(2, i - 2, j + 1, k) - u(2, i - 2, j - 1, k)))) +
+              c1 *
+                  (la(i + 1, j, k) * met(1, i + 1, j, k) * met(1, i + 1, j, k) *
+                       (c2 * (u(2, i + 1, j + 2, k) - u(2, i + 1, j - 2, k)) +
+                        c1 * (u(2, i + 1, j + 1, k) - u(2, i + 1, j - 1, k))) -
+                   la(i - 1, j, k) * met(1, i - 1, j, k) * met(1, i - 1, j, k) *
+                       (c2 * (u(2, i - 1, j + 2, k) - u(2, i - 1, j - 2, k)) +
+                        c1 * (u(2, i - 1, j + 1, k) - u(2, i - 1, j - 1, k))));
+
+          // pr-derivatives
+          // 130 ops., tot=475
+          r1 +=
+              c2 *
+                  ((2 * mu(i, j, k + 2) + la(i, j, k + 2)) *
+                       met(2, i, j, k + 2) * met(1, i, j, k + 2) *
+                       (c2 * (u(1, i + 2, j, k + 2) - u(1, i - 2, j, k + 2)) +
+                        c1 * (u(1, i + 1, j, k + 2) - u(1, i - 1, j, k + 2))) *
+                       strx(i) * istry +
+                   mu(i, j, k + 2) * met(3, i, j, k + 2) * met(1, i, j, k + 2) *
+                       (c2 * (u(2, i + 2, j, k + 2) - u(2, i - 2, j, k + 2)) +
+                        c1 * (u(2, i + 1, j, k + 2) - u(2, i - 1, j, k + 2))) +
+                   mu(i, j, k + 2) * met(4, i, j, k + 2) * met(1, i, j, k + 2) *
+                       (c2 * (u(3, i + 2, j, k + 2) - u(3, i - 2, j, k + 2)) +
+                        c1 * (u(3, i + 1, j, k + 2) - u(3, i - 1, j, k + 2))) *
+                       istry -
+                   ((2 * mu(i, j, k - 2) + la(i, j, k - 2)) *
+                        met(2, i, j, k - 2) * met(1, i, j, k - 2) *
+                        (c2 * (u(1, i + 2, j, k - 2) - u(1, i - 2, j, k - 2)) +
+                         c1 * (u(1, i + 1, j, k - 2) - u(1, i - 1, j, k - 2))) *
+                        strx(i) * istry +
+                    mu(i, j, k - 2) * met(3, i, j, k - 2) *
+                        met(1, i, j, k - 2) *
+                        (c2 * (u(2, i + 2, j, k - 2) - u(2, i - 2, j, k - 2)) +
+                         c1 * (u(2, i + 1, j, k - 2) - u(2, i - 1, j, k - 2))) +
+                    mu(i, j, k - 2) * met(4, i, j, k - 2) *
+                        met(1, i, j, k - 2) *
+                        (c2 * (u(3, i + 2, j, k - 2) - u(3, i - 2, j, k - 2)) +
+                         c1 * (u(3, i + 1, j, k - 2) - u(3, i - 1, j, k - 2))) *
+                        istry)) +
+              c1 *
+                  ((2 * mu(i, j, k + 1) + la(i, j, k + 1)) *
+                       met(2, i, j, k + 1) * met(1, i, j, k + 1) *
+                       (c2 * (u(1, i + 2, j, k + 1) - u(1, i - 2, j, k + 1)) +
+                        c1 * (u(1, i + 1, j, k + 1) - u(1, i - 1, j, k + 1))) *
+                       strx(i) * istry +
+                   mu(i, j, k + 1) * met(3, i, j, k + 1) * met(1, i, j, k + 1) *
+                       (c2 * (u(2, i + 2, j, k + 1) - u(2, i - 2, j, k + 1)) +
+                        c1 * (u(2, i + 1, j, k + 1) - u(2, i - 1, j, k + 1))) +
+                   mu(i, j, k + 1) * met(4, i, j, k + 1) * met(1, i, j, k + 1) *
+                       (c2 * (u(3, i + 2, j, k + 1) - u(3, i - 2, j, k + 1)) +
+                        c1 * (u(3, i + 1, j, k + 1) - u(3, i - 1, j, k + 1))) *
+                       istry -
+                   ((2 * mu(i, j, k - 1) + la(i, j, k - 1)) *
+                        met(2, i, j, k - 1) * met(1, i, j, k - 1) *
+                        (c2 * (u(1, i + 2, j, k - 1) - u(1, i - 2, j, k - 1)) +
+                         c1 * (u(1, i + 1, j, k - 1) - u(1, i - 1, j, k - 1))) *
+                        strx(i) * istry +
+                    mu(i, j, k - 1) * met(3, i, j, k - 1) *
+                        met(1, i, j, k - 1) *
+                        (c2 * (u(2, i + 2, j, k - 1) - u(2, i - 2, j, k - 1)) +
+                         c1 * (u(2, i + 1, j, k - 1) - u(2, i - 1, j, k - 1))) +
+                    mu(i, j, k - 1) * met(4, i, j, k - 1) *
+                        met(1, i, j, k - 1) *
+                        (c2 * (u(3, i + 2, j, k - 1) - u(3, i - 2, j, k - 1)) +
+                         c1 * (u(3, i + 1, j, k - 1) - u(3, i - 1, j, k - 1))) *
+                        istry));
+
+          // rp derivatives
+          // 130 ops, tot=605
+          r1 +=
+              (c2 *
+                   ((2 * mu(i + 2, j, k) + la(i + 2, j, k)) *
+                        met(2, i + 2, j, k) * met(1, i + 2, j, k) *
+                        (c2 * (u(1, i + 2, j, k + 2) - u(1, i + 2, j, k - 2)) +
+                         c1 * (u(1, i + 2, j, k + 1) - u(1, i + 2, j, k - 1))) *
+                        strx(i + 2) +
+                    la(i + 2, j, k) * met(3, i + 2, j, k) *
+                        met(1, i + 2, j, k) *
+                        (c2 * (u(2, i + 2, j, k + 2) - u(2, i + 2, j, k - 2)) +
+                         c1 * (u(2, i + 2, j, k + 1) - u(2, i + 2, j, k - 1))) *
+                        stry(j) +
+                    la(i + 2, j, k) * met(4, i + 2, j, k) *
+                        met(1, i + 2, j, k) *
+                        (c2 * (u(3, i + 2, j, k + 2) - u(3, i + 2, j, k - 2)) +
+                         c1 * (u(3, i + 2, j, k + 1) - u(3, i + 2, j, k - 1))) -
+                    ((2 * mu(i - 2, j, k) + la(i - 2, j, k)) *
+                         met(2, i - 2, j, k) * met(1, i - 2, j, k) *
+                         (c2 * (u(1, i - 2, j, k + 2) - u(1, i - 2, j, k - 2)) +
+                          c1 *
+                              (u(1, i - 2, j, k + 1) - u(1, i - 2, j, k - 1))) *
+                         strx(i - 2) +
+                     la(i - 2, j, k) * met(3, i - 2, j, k) *
+                         met(1, i - 2, j, k) *
+                         (c2 * (u(2, i - 2, j, k + 2) - u(2, i - 2, j, k - 2)) +
+                          c1 *
+                              (u(2, i - 2, j, k + 1) - u(2, i - 2, j, k - 1))) *
+                         stry(j) +
+                     la(i - 2, j, k) * met(4, i - 2, j, k) *
+                         met(1, i - 2, j, k) *
+                         (c2 * (u(3, i - 2, j, k + 2) - u(3, i - 2, j, k - 2)) +
+                          c1 * (u(3, i - 2, j, k + 1) -
+                                u(3, i - 2, j, k - 1))))) +
+               c1 *
+                   ((2 * mu(i + 1, j, k) + la(i + 1, j, k)) *
+                        met(2, i + 1, j, k) * met(1, i + 1, j, k) *
+                        (c2 * (u(1, i + 1, j, k + 2) - u(1, i + 1, j, k - 2)) +
+                         c1 * (u(1, i + 1, j, k + 1) - u(1, i + 1, j, k - 1))) *
+                        strx(i + 1) +
+                    la(i + 1, j, k) * met(3, i + 1, j, k) *
+                        met(1, i + 1, j, k) *
+                        (c2 * (u(2, i + 1, j, k + 2) - u(2, i + 1, j, k - 2)) +
+                         c1 * (u(2, i + 1, j, k + 1) - u(2, i + 1, j, k - 1))) *
+                        stry(j) +
+                    la(i + 1, j, k) * met(4, i + 1, j, k) *
+                        met(1, i + 1, j, k) *
+                        (c2 * (u(3, i + 1, j, k + 2) - u(3, i + 1, j, k - 2)) +
+                         c1 * (u(3, i + 1, j, k + 1) - u(3, i + 1, j, k - 1))) -
+                    ((2 * mu(i - 1, j, k) + la(i - 1, j, k)) *
+                         met(2, i - 1, j, k) * met(1, i - 1, j, k) *
+                         (c2 * (u(1, i - 1, j, k + 2) - u(1, i - 1, j, k - 2)) +
+                          c1 *
+                              (u(1, i - 1, j, k + 1) - u(1, i - 1, j, k - 1))) *
+                         strx(i - 1) +
+                     la(i - 1, j, k) * met(3, i - 1, j, k) *
+                         met(1, i - 1, j, k) *
+                         (c2 * (u(2, i - 1, j, k + 2) - u(2, i - 1, j, k - 2)) +
+                          c1 *
+                              (u(2, i - 1, j, k + 1) - u(2, i - 1, j, k - 1))) *
+                         stry(j) +
+                     la(i - 1, j, k) * met(4, i - 1, j, k) *
+                         met(1, i - 1, j, k) *
+                         (c2 * (u(3, i - 1, j, k + 2) - u(3, i - 1, j, k - 2)) +
+                          c1 * (u(3, i - 1, j, k + 1) -
+                                u(3, i - 1, j, k - 1)))))) *
+              istry;
+
+          // qr derivatives
+          // 82 ops, tot=687
+          r1 +=
+              c2 *
+                  (mu(i, j, k + 2) * met(3, i, j, k + 2) * met(1, i, j, k + 2) *
+                       (c2 * (u(1, i, j + 2, k + 2) - u(1, i, j - 2, k + 2)) +
+                        c1 * (u(1, i, j + 1, k + 2) - u(1, i, j - 1, k + 2))) *
+                       stry(j) * istrx +
+                   la(i, j, k + 2) * met(2, i, j, k + 2) * met(1, i, j, k + 2) *
+                       (c2 * (u(2, i, j + 2, k + 2) - u(2, i, j - 2, k + 2)) +
+                        c1 * (u(2, i, j + 1, k + 2) - u(2, i, j - 1, k + 2))) -
+                   (mu(i, j, k - 2) * met(3, i, j, k - 2) *
+                        met(1, i, j, k - 2) *
+                        (c2 * (u(1, i, j + 2, k - 2) - u(1, i, j - 2, k - 2)) +
+                         c1 * (u(1, i, j + 1, k - 2) - u(1, i, j - 1, k - 2))) *
+                        stry(j) * istrx +
+                    la(i, j, k - 2) * met(2, i, j, k - 2) *
+                        met(1, i, j, k - 2) *
+                        (c2 * (u(2, i, j + 2, k - 2) - u(2, i, j - 2, k - 2)) +
+                         c1 * (u(2, i, j + 1, k - 2) -
+                               u(2, i, j - 1, k - 2))))) +
+              c1 *
+                  (mu(i, j, k + 1) * met(3, i, j, k + 1) * met(1, i, j, k + 1) *
+                       (c2 * (u(1, i, j + 2, k + 1) - u(1, i, j - 2, k + 1)) +
+                        c1 * (u(1, i, j + 1, k + 1) - u(1, i, j - 1, k + 1))) *
+                       stry(j) * istrx +
+                   la(i, j, k + 1) * met(2, i, j, k + 1) * met(1, i, j, k + 1) *
+                       (c2 * (u(2, i, j + 2, k + 1) - u(2, i, j - 2, k + 1)) +
+                        c1 * (u(2, i, j + 1, k + 1) - u(2, i, j - 1, k + 1))) -
+                   (mu(i, j, k - 1) * met(3, i, j, k - 1) *
+                        met(1, i, j, k - 1) *
+                        (c2 * (u(1, i, j + 2, k - 1) - u(1, i, j - 2, k - 1)) +
+                         c1 * (u(1, i, j + 1, k - 1) - u(1, i, j - 1, k - 1))) *
+                        stry(j) * istrx +
+                    la(i, j, k - 1) * met(2, i, j, k - 1) *
+                        met(1, i, j, k - 1) *
+                        (c2 * (u(2, i, j + 2, k - 1) - u(2, i, j - 2, k - 1)) +
+                         c1 *
+                             (u(2, i, j + 1, k - 1) - u(2, i, j - 1, k - 1)))));
+
+          // rq derivatives
+          // 82 ops, tot=769
+          r1 +=
+              c2 *
+                  (mu(i, j + 2, k) * met(3, i, j + 2, k) * met(1, i, j + 2, k) *
+                       (c2 * (u(1, i, j + 2, k + 2) - u(1, i, j + 2, k - 2)) +
+                        c1 * (u(1, i, j + 2, k + 1) - u(1, i, j + 2, k - 1))) *
+                       stry(j + 2) * istrx +
+                   mu(i, j + 2, k) * met(2, i, j + 2, k) * met(1, i, j + 2, k) *
+                       (c2 * (u(2, i, j + 2, k + 2) - u(2, i, j + 2, k - 2)) +
+                        c1 * (u(2, i, j + 2, k + 1) - u(2, i, j + 2, k - 1))) -
+                   (mu(i, j - 2, k) * met(3, i, j - 2, k) *
+                        met(1, i, j - 2, k) *
+                        (c2 * (u(1, i, j - 2, k + 2) - u(1, i, j - 2, k - 2)) +
+                         c1 * (u(1, i, j - 2, k + 1) - u(1, i, j - 2, k - 1))) *
+                        stry(j - 2) * istrx +
+                    mu(i, j - 2, k) * met(2, i, j - 2, k) *
+                        met(1, i, j - 2, k) *
+                        (c2 * (u(2, i, j - 2, k + 2) - u(2, i, j - 2, k - 2)) +
+                         c1 * (u(2, i, j - 2, k + 1) -
+                               u(2, i, j - 2, k - 1))))) +
+              c1 *
+                  (mu(i, j + 1, k) * met(3, i, j + 1, k) * met(1, i, j + 1, k) *
+                       (c2 * (u(1, i, j + 1, k + 2) - u(1, i, j + 1, k - 2)) +
+                        c1 * (u(1, i, j + 1, k + 1) - u(1, i, j + 1, k - 1))) *
+                       stry(j + 1) * istrx +
+                   mu(i, j + 1, k) * met(2, i, j + 1, k) * met(1, i, j + 1, k) *
+                       (c2 * (u(2, i, j + 1, k + 2) - u(2, i, j + 1, k - 2)) +
+                        c1 * (u(2, i, j + 1, k + 1) - u(2, i, j + 1, k - 1))) -
+                   (mu(i, j - 1, k) * met(3, i, j - 1, k) *
+                        met(1, i, j - 1, k) *
+                        (c2 * (u(1, i, j - 1, k + 2) - u(1, i, j - 1, k - 2)) +
+                         c1 * (u(1, i, j - 1, k + 1) - u(1, i, j - 1, k - 1))) *
+                        stry(j - 1) * istrx +
+                    mu(i, j - 1, k) * met(2, i, j - 1, k) *
+                        met(1, i, j - 1, k) *
+                        (c2 * (u(2, i, j - 1, k + 2) - u(2, i, j - 1, k - 2)) +
+                         c1 *
+                             (u(2, i, j - 1, k + 1) - u(2, i, j - 1, k - 1)))));
+
+          // 4 ops, tot=773
+          lu(1, i, j, k) = a1 * lu(1, i, j, k) + sgn * r1 * ijac;
+
+
+
+
+
+        }
+
+///
+
+#ifndef RAJAPerf_Apps_SW4CK_KERNEL_2_HPP
+#define RAJAPerf_Apps_SW4CK_KERNEL_2_HPP
+
+#define SW4CK_KERNEL_2_DATA_SETUP \
+
+#define SW4CK_KERNEL_2_BODY \
+
+
+
+#include "common/KernelBase.hpp"
+
+namespace rajaperf
+{
+class RunParams;
+
+namespace apps
+{
+class ADomain;
+
+class SW4CK_KERNEL_2 : public KernelBase
+{
+public:
+
+  SW4CK_KERNEL_2(const RunParams& params);
+
+  ~SW4CK_KERNEL_2();
+
+  void setUp(VariantID vid, size_t tune_idx);
+  void updateChecksum(VariantID vid, size_t tune_idx);
+  void tearDown(VariantID vid, size_t tune_idx);
+
+  void runSeqVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPVariant(VariantID vid, size_t tune_idx);
+  void runCudaVariant(VariantID vid, size_t tune_idx);
+  void runHipVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+
+  void setCudaTuningDefinitions(VariantID vid);
+  void setHipTuningDefinitions(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantImpl(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantImpl(VariantID vid);
+
+private:
+  static const size_t default_gpu_block_size = 256;
+  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+
+  Real_ptr m_x;
+  Real_ptr m_y;
+  Real_ptr m_z;
+  Real_ptr m_vol;
+
+  Real_type m_vnormq;
+
+  ADomain* m_domain;
+  Index_type m_array_length;
+};
+
+} // end namespace apps
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -91,6 +91,7 @@
 #include "apps/MASS3DPA.hpp"
 #include "apps/NODAL_ACCUMULATION_3D.hpp"
 #include "apps/PRESSURE.hpp"
+#include "apps/SW4CK_KERNEL_2.hpp"
 #include "apps/VOL3D.hpp"
 
 //
@@ -227,6 +228,7 @@ static const std::string KernelNames [] =
   std::string("Apps_MASS3DPA"),
   std::string("Apps_NODAL_ACCUMULATION_3D"),
   std::string("Apps_PRESSURE"),
+  std::string("Apps_SW4CK_KERNEL_2"),
   std::string("Apps_VOL3D"),
 
 //
@@ -771,6 +773,10 @@ KernelBase* getKernelObject(KernelID kid,
        kernel = new apps::PRESSURE(run_params);
        break;
     }
+    case Apps_SW4CK_KERNEL_2 : {
+       kernel = new apps::SW4CK_KERNEL_2(run_params);
+       break;
+    }      
     case Apps_VOL3D : {
        kernel = new apps::VOL3D(run_params);
        break;

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -144,6 +144,7 @@ enum KernelID {
   Apps_MASS3DPA,
   Apps_NODAL_ACCUMULATION_3D,
   Apps_PRESSURE,
+  Apps_SW4CK_KERNEL_2,
   Apps_VOL3D,
 
 //


### PR DESCRIPTION
Adding SW4CK kernels 2 and 5 as they exhibit a performance gap between RAJA and "native variants".

Source https://github.com/LLNL/SW4CK.

