### PR TITLE
Rename feature teams to launch

### DIFF
--- a/src/apps/CONVECTION3DPA.cpp
+++ b/src/apps/CONVECTION3DPA.cpp
@@ -50,7 +50,7 @@ CONVECTION3DPA::CONVECTION3DPA(const RunParams& params)
                          (1 + 2*CPA_Q1D) * CPA_D1D * CPA_D1D * CPA_D1D // 8
                          ));
 
-  setUsesFeature(Teams);
+  setUsesFeature(Launch);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( RAJA_Seq );

--- a/src/apps/DIFFUSION3DPA.cpp
+++ b/src/apps/DIFFUSION3DPA.cpp
@@ -51,7 +51,7 @@ DIFFUSION3DPA::DIFFUSION3DPA(const RunParams& params)
                          7 * DPA_D1D * DPA_Q1D * DPA_D1D * DPA_D1D +
                          3 * DPA_D1D * DPA_D1D * DPA_D1D));
 
-  setUsesFeature(Teams);
+  setUsesFeature(Launch);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( RAJA_Seq );

--- a/src/apps/MASS3DPA.cpp
+++ b/src/apps/MASS3DPA.cpp
@@ -47,7 +47,7 @@ MASS3DPA::MASS3DPA(const RunParams& params)
                          2 * MPA_Q1D * MPA_Q1D * MPA_Q1D * MPA_D1D +
                          2 * MPA_Q1D * MPA_Q1D * MPA_D1D * MPA_D1D +
                          2 * MPA_Q1D * MPA_D1D * MPA_D1D * MPA_D1D + MPA_D1D * MPA_D1D * MPA_D1D));
-  setUsesFeature(Teams);
+  setUsesFeature(Launch);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( RAJA_Seq );

--- a/src/basic/MAT_MAT_SHARED.cpp
+++ b/src/basic/MAT_MAT_SHARED.cpp
@@ -43,7 +43,7 @@ MAT_MAT_SHARED::MAT_MAT_SHARED(const RunParams &params)
                                            getActualProblemSize() );
 
 
-  setUsesFeature(Teams);
+  setUsesFeature(Launch);
 
   setVariantDefined(Base_Seq);
   setVariantDefined(Lambda_Seq);

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -302,7 +302,7 @@ static const std::string FeatureNames [] =
 
   std::string("Forall"),
   std::string("Kernel"),
-  std::string("Teams"),
+  std::string("Launch"),
 
   std::string("Sort"),
   std::string("Scan"),

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -217,7 +217,7 @@ enum FeatureID {
 
   Forall = 0,
   Kernel,
-  Teams,
+  Launch,
 
   Sort,
   Scan,


### PR DESCRIPTION
The API formally known as teams is now called launch. 