### PR TITLE
Fix RTD build issue

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 ##
 ## Code for debugging directory structure in readthedocs 
 ## to fix broken links, etc.
@@ -27,8 +33,7 @@ sphinx:
 # Optionally build docs in add'l formats such as PDF and ePub
 #formats: all
 
-# Optionally set the version of Python and requirements to build the docs
+# Set requirements needed to build the docs
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,23 +22,23 @@ import subprocess
 #sys.path.insert(0, os.path.abspath('_exts'))
 
 # Call doxygen in ReadtheDocs
-#read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
-#if read_the_docs_build:
-#    # Generate an RST file for Doxygen index, this is replaced by the real
-#    # index.html by hooking into the Sphinx build-finished event at the bottom of
-#    # this file
-#    cwd=os.getcwd()
-#    fpath=os.path.join(cwd,"doxygen/html")
-#    if (os.path.isdir(fpath) == 0):
-#        os.makedirs(fpath)
-#    with open(os.path.join(fpath,"index.rst"), 'w') as f:
-#        print("Writing file {}", f)
-#        f.write(".. _doxygen:\n")
-#        f.write("\n")
-#        f.write("*******\n")
-#        f.write("Doxygen\n")
-#        f.write("*******\n")
-#
+read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
+if read_the_docs_build:
+    # Generate an RST file for Doxygen index, this is replaced by the real
+    # index.html by hooking into the Sphinx build-finished event at the bottom of
+    # this file
+    cwd=os.getcwd()
+    fpath=os.path.join(cwd,"doxygen/html")
+    if (os.path.isdir(fpath) == 0):
+        os.makedirs(fpath)
+    with open(os.path.join(fpath,"index.rst"), 'w') as f:
+        print("Writing file {}", f)
+        f.write(".. _doxygen:\n")
+        f.write("\n")
+        f.write("*******\n")
+        f.write("Doxygen\n")
+        f.write("*******\n")
+
 # Get current directory
 conf_directory = os.path.dirname(os.path.realpath(__file__))
 
@@ -332,20 +332,20 @@ texinfo_documents = [
 
 # Generate Doxygen, and overwrite the index.rst in doxygen/html
 # Only do this on readthedocs
-#def gendoxy(app, exception):
-#    if read_the_docs_build:
-#        buildpath=os.path.join(conf_directory,"_build/html/doxygen/html")
-#        if (os.path.isdir(buildpath) == 0):
-#            os.makedirs(buildpath)
-#
-#        if (os.path.exists(os.path.join(buildpath, 'index.html"'))):
-#            print("Removing existing index.html")
-#            os.remove(os.path.join(buildpath, "index.html"))
-#
-#        # Call doxygen
-#        from subprocess import call
-#        call(['doxygen', "./doxygen/Doxyfile"])
-#
-#
-#def setup(app):
-#    app.connect('build-finished', gendoxy)
+def gendoxy(app, exception):
+    if read_the_docs_build:
+        buildpath=os.path.join(conf_directory,"_build/html/doxygen/html")
+        if (os.path.isdir(buildpath) == 0):
+            os.makedirs(buildpath)
+
+        if (os.path.exists(os.path.join(buildpath, 'index.html"'))):
+            print("Removing existing index.html")
+            os.remove(os.path.join(buildpath, "index.html"))
+
+        # Call doxygen
+        from subprocess import call
+        call(['doxygen', "./doxygen/Doxyfile"])
+
+
+def setup(app):
+    app.connect('build-finished', gendoxy)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-docutils<0.18
+docutils<0.20


### PR DESCRIPTION
# Summary 

- This PR fixes the RTD build failing [urllib3 error](https://readthedocs.org/projects/axom/builds/20566025/)

    Relevant stackoverflow: [link](https://stackoverflow.com/questions/76185542/trying-to-run-jupyter-notebook-on-macos-13-3-1-a-with-python-3-9-importerror)

Passing build here: https://rajaperf.readthedocs.io/en/bugfix-rtd_urllib/