### PR TITLE
Woptim/rhel 8 update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,7 @@ variables:
 
 # High level stages
 stages:
+  - machine-checks
   - build-and-test
 
 # Template for jobs triggering a build-and-test sub-pipelines:
@@ -58,7 +59,7 @@ stages:
     include:
       - local: '.gitlab/custom-jobs-and-variables.yml'
       - project: 'radiuss/radiuss-shared-ci'
-        ref: v2023.03.0rc
+        ref: v2023.03.1
         file: '${CI_MACHINE}-build-and-test.yml'
       - local: '.gitlab/${CI_MACHINE}-build-and-test-extra.yml'
     strategy: depend
@@ -68,7 +69,7 @@ stages:
 include:
   # checks preliminary to running the actual CI test (optional)
   #- project: 'radiuss/radiuss-shared-ci'
-  #  ref: v2023.03.0rc
+  #  ref: v2023.03.1
   #  file: 'preliminary-ignore-draft-pr.yml'
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'

--- a/.gitlab/corona-build-and-test-extra.yml
+++ b/.gitlab/corona-build-and-test-extra.yml
@@ -22,10 +22,6 @@
 # ${PROJECT_<MACHINE>_DEPS} in the extra jobs. There is no reason not to fully
 # describe the spec here.
 
-# With GitLab CI, included files cannot be empty.
-variables:
-  INCLUDED_FILE_CANNOT_BE_EMPTY: "True"
-
 # INFO: This job is activated in RAJA CI, but we don't use desul atomics here
 #rocmcc_5_1_1_hip_desul_atomics:
 #  variables:

--- a/.gitlab/corona-build-and-test-extra.yml
+++ b/.gitlab/corona-build-and-test-extra.yml
@@ -29,8 +29,8 @@
 #  extends: .build_and_test_on_corona
 
 # EXTRA
-rocmcc_5_1_1_hip_caliper:
+rocmcc_5_4_1_hip_caliper:
   variables:
-    SPEC: "~openmp +caliper +rocm amdgpu_target=gfx906 %rocmcc@5.1.1 ^hip@5.1.1 ^blt@develop"
+    SPEC: "~openmp +caliper +rocm amdgpu_target=gfx906 %rocmcc@5.4.1 ^hip@5.4.1 ^blt@develop"
   extends: .build_and_test_on_corona
 

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -19,7 +19,7 @@ variables:
 # Arguments for job level allocation
   RUBY_BUILD_AND_TEST_JOB_ALLOC: "--reservation=ci --qos=ci_ruby --time=30 --nodes=1"
 # Project specific variants for ruby
-  PROJECT_RUBY_VARIANTS: "+openmp "
+  PROJECT_RUBY_VARIANTS: "+tests +openmp "
 # Project specific deps for ruby
   PROJECT_RUBY_DEPS: ""
 
@@ -29,7 +29,7 @@ variables:
 # Arguments for job level allocation
   CORONA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=30m --nodes=1"
 # Project specific variants for corona
-  PROJECT_CORONA_VARIANTS: "~openmp "
+  PROJECT_CORONA_VARIANTS: "+tests ~openmp "
 # Project specific deps for corona
   PROJECT_CORONA_DEPS: "^blt@develop "
 
@@ -39,7 +39,7 @@ variables:
 # Arguments for job level allocation
   TIOGA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=45m --nodes=1"
 # Project specific variants for corona
-  PROJECT_TIOGA_VARIANTS: "~openmp"
+  PROJECT_TIOGA_VARIANTS: "+tests ~openmp"
 # Project specific deps for corona
   PROJECT_TIOGA_DEPS: "^blt@develop "
 
@@ -48,7 +48,7 @@ variables:
 # Arguments for job level allocation
   LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 30"
 # Project specific variants for lassen
-  PROJECT_LASSEN_VARIANTS: "+openmp "
+  PROJECT_LASSEN_VARIANTS: "+tests +openmp "
 # Project specific deps for lassen
   PROJECT_LASSEN_DEPS: ""
 

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -8,7 +8,6 @@
 
 # We define the following GitLab pipeline variables:
 variables:
-
 # On LLNL's ruby, this pipeline creates only one allocation shared among jobs
 # in order to save time and resources. This allocation has to be uniquely named
 # so that we are sure to retrieve it and avoid collisions.

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -19,7 +19,7 @@ variables:
 # Arguments for job level allocation
   RUBY_BUILD_AND_TEST_JOB_ALLOC: "--reservation=ci --qos=ci_ruby --time=30 --nodes=1"
 # Project specific variants for ruby
-  PROJECT_RUBY_VARIANTS: "~shared +openmp +tests"
+  PROJECT_RUBY_VARIANTS: "~shared +openmp"
 # Project specific deps for ruby
   PROJECT_RUBY_DEPS: ""
 
@@ -29,7 +29,7 @@ variables:
 # Arguments for job level allocation
   CORONA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=30m --nodes=1 --begin-time=+5s"
 # Project specific variants for corona
-  PROJECT_CORONA_VARIANTS: "~shared ~openmp +tests"
+  PROJECT_CORONA_VARIANTS: "~shared ~openmp"
 # Project specific deps for corona
   PROJECT_CORONA_DEPS: "^blt@develop "
 
@@ -39,7 +39,7 @@ variables:
 # Arguments for job level allocation
   TIOGA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=45m --nodes=1 --begin-time=+5s"
 # Project specific variants for corona
-  PROJECT_TIOGA_VARIANTS: "~shared ~openmp +tests"
+  PROJECT_TIOGA_VARIANTS: "~shared ~openmp"
 # Project specific deps for corona
   PROJECT_TIOGA_DEPS: "^blt@develop "
 
@@ -48,7 +48,7 @@ variables:
 # Arguments for job level allocation
   LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 30"
 # Project specific variants for lassen
-  PROJECT_LASSEN_VARIANTS: "~shared +openmp +tests cuda_arch=70"
+  PROJECT_LASSEN_VARIANTS: "~shared +openmp cuda_arch=70"
 # Project specific deps for lassen
   PROJECT_LASSEN_DEPS: ""
 

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -19,7 +19,7 @@ variables:
 # Arguments for job level allocation
   RUBY_BUILD_AND_TEST_JOB_ALLOC: "--reservation=ci --qos=ci_ruby --time=30 --nodes=1"
 # Project specific variants for ruby
-  PROJECT_RUBY_VARIANTS: "+tests +openmp "
+  PROJECT_RUBY_VARIANTS: " +openmp "
 # Project specific deps for ruby
   PROJECT_RUBY_DEPS: ""
 
@@ -29,7 +29,7 @@ variables:
 # Arguments for job level allocation
   CORONA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=30m --nodes=1"
 # Project specific variants for corona
-  PROJECT_CORONA_VARIANTS: "+tests ~openmp "
+  PROJECT_CORONA_VARIANTS: " ~openmp "
 # Project specific deps for corona
   PROJECT_CORONA_DEPS: "^blt@develop "
 
@@ -39,7 +39,7 @@ variables:
 # Arguments for job level allocation
   TIOGA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=45m --nodes=1"
 # Project specific variants for corona
-  PROJECT_TIOGA_VARIANTS: "+tests ~openmp"
+  PROJECT_TIOGA_VARIANTS: " ~openmp"
 # Project specific deps for corona
   PROJECT_TIOGA_DEPS: "^blt@develop "
 
@@ -48,7 +48,7 @@ variables:
 # Arguments for job level allocation
   LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 30"
 # Project specific variants for lassen
-  PROJECT_LASSEN_VARIANTS: "+tests +openmp "
+  PROJECT_LASSEN_VARIANTS: " +openmp "
 # Project specific deps for lassen
   PROJECT_LASSEN_DEPS: ""
 

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -19,7 +19,7 @@ variables:
 # Arguments for job level allocation
   RUBY_BUILD_AND_TEST_JOB_ALLOC: "--reservation=ci --qos=ci_ruby --time=30 --nodes=1"
 # Project specific variants for ruby
-  PROJECT_RUBY_VARIANTS: " +openmp "
+  PROJECT_RUBY_VARIANTS: "~shared +openmp +tests"
 # Project specific deps for ruby
   PROJECT_RUBY_DEPS: ""
 
@@ -27,9 +27,9 @@ variables:
 # Arguments for top level allocation
   CORONA_BUILD_AND_TEST_SHARED_ALLOC: "--exclusive --time-limit=60m --nodes=1"
 # Arguments for job level allocation
-  CORONA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=30m --nodes=1"
+  CORONA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=30m --nodes=1 --begin-time=+5s"
 # Project specific variants for corona
-  PROJECT_CORONA_VARIANTS: " ~openmp "
+  PROJECT_CORONA_VARIANTS: "~shared ~openmp +tests"
 # Project specific deps for corona
   PROJECT_CORONA_DEPS: "^blt@develop "
 
@@ -37,9 +37,9 @@ variables:
 # Arguments for top level allocation
   TIOGA_BUILD_AND_TEST_SHARED_ALLOC: "--exclusive --time-limit=60m --nodes=1"
 # Arguments for job level allocation
-  TIOGA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=45m --nodes=1"
+  TIOGA_BUILD_AND_TEST_JOB_ALLOC: "--time-limit=45m --nodes=1 --begin-time=+5s"
 # Project specific variants for corona
-  PROJECT_TIOGA_VARIANTS: " ~openmp"
+  PROJECT_TIOGA_VARIANTS: "~shared ~openmp +tests"
 # Project specific deps for corona
   PROJECT_TIOGA_DEPS: "^blt@develop "
 
@@ -48,7 +48,7 @@ variables:
 # Arguments for job level allocation
   LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 30"
 # Project specific variants for lassen
-  PROJECT_LASSEN_VARIANTS: " +openmp cuda_arch=70"
+  PROJECT_LASSEN_VARIANTS: "~shared +openmp +tests cuda_arch=70"
 # Project specific deps for lassen
   PROJECT_LASSEN_DEPS: ""
 

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -48,7 +48,7 @@ variables:
 # Arguments for job level allocation
   LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 30"
 # Project specific variants for lassen
-  PROJECT_LASSEN_VARIANTS: " +openmp "
+  PROJECT_LASSEN_VARIANTS: " +openmp cuda_arch=70"
 # Project specific deps for lassen
   PROJECT_LASSEN_DEPS: ""
 

--- a/.gitlab/lassen-build-and-test-extra.yml
+++ b/.gitlab/lassen-build-and-test-extra.yml
@@ -13,92 +13,21 @@
 # We keep ${PROJECT_<MACHINE>_VARIANTS} and ${PROJECT_<MACHINE>_DEPS} So that
 # the comparison with the original job is easier.
 
-# Overriding shared spec: Allow failures
-ibm_clang_9_0_0:
+# Overriding shared spec: Longer allocation + extra flags
+xl_2022_08_19_gcc_8_3_1_cuda_11_2_0:
   variables:
-    SPEC: " ${PROJECT_LASSEN_VARIANTS} %clang@ibm.9.0.0 ${PROJECT_LASSEN_DEPS}"
-  extends: .build_and_test_on_lassen
-  allow_failure: true
-
-# Overriding shared spec: Allow failures
-ibm_clang_9_0_0_gcc_8_3_1:
-  variables:
-    SPEC: " ${PROJECT_LASSEN_VARIANTS} %clang@ibm.9.0.0 cxxflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" cflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" ${PROJECT_LASSEN_DEPS}"
-  extends: .build_and_test_on_lassen
-  allow_failure: true
-
-# Overriding shared spec: Longer allocation + Allow failures
-ibm_clang_9_0_0_gcc_8_3_1_cuda_10_1_168:
-  variables:
-    SPEC: " ${PROJECT_LASSEN_VARIANTS} +cuda %clang@ibm.9.0.0 cxxflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" cflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" cuda_arch=70 ^cuda@10.1.168 ${PROJECT_LASSEN_DEPS}"
-    LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 60"
-  extends: .build_and_test_on_lassen
-  allow_failure: true
-
-# Overriding shared spec: Longer allocation + Allow failures
-ibm_clang_9_0_0_gcc_8_3_1_cuda_10_1_168:
-  variables:
-    SPEC: " ${PROJECT_LASSEN_VARIANTS} +cuda %clang@ibm.9.0.0 cxxflags=\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" cflags=\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" ^cuda@10.1.168 ${PROJECT_LASSEN_DEPS}"
-    LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 60"
-  extends: .build_and_test_on_lassen
-  allow_failure: true
-
-# Overriding shared spec: Extra flags
-gcc_8_3_1:
-  variables:
-    SPEC: " ${PROJECT_LASSEN_VARIANTS} %gcc@8.3.1 cxxflags==\"-finline-functions -finline-limit=20000\" cflags==\"-finline-functions -finline-limit=20000\" ${PROJECT_LASSEN_DEPS}"
+    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda cxxflags==\"-qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036\" %xl@16.1.1.12.gcc.8.3.1 ^cuda@11.2.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
+    MODULE_LIST: "cuda/11.2.0"
+    LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 120"
   extends: .build_and_test_on_lassen
 
-# Overriding shared spec: Longer allocation + Allow failures
-pgi_20_4_gcc_8_3_1:
+# Overriding shared spec: Longer allocation + extra flags
+xl_2022_08_19_gcc_8_3_1_cuda_11_7_0:
   variables:
-    SPEC: " ${PROJECT_LASSEN_VARIANTS} %pgi@20.4 cxxflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" cflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" ${PROJECT_LASSEN_DEPS}"
-    LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 60"
+    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda cxxflags==\"-qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036\" %xl@16.1.1.12.gcc.8.3.1 ^cuda@11.7.0+allow-unsupported-compilers ${PROJECT_LASSEN_DEPS}"
+    MODULE_LIST: "cuda/11.7.0"
+    LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 120"
   extends: .build_and_test_on_lassen
-  allow_failure: true
-
-# Overriding shared spec: Longer allocation + Extra flags
-xl_16_1_1_12:
-  variables:
-    SPEC: " ${PROJECT_LASSEN_VARIANTS} %xl@16.1.1.12 cxxflags==\"-qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qsmp=omp -qnoeh -qsuppress=1500-029 -qsuppress=1500-036 ${PROJECT_LASSEN_DEPS}\""
-    LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 50"
-  extends: .build_and_test_on_lassen
-
-# Overriding shared spec: Longer allocation + Extra flags
-xl_16_1_1_12_gcc_8_3_1:
-  variables:
-    SPEC: " ${PROJECT_LASSEN_VARIANTS} %xl@16.1.1.12 cxxflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qsmp=omp -qnoeh -qsuppress=1500-029 -qsuppress=1500-036\" cflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" ${PROJECT_LASSEN_DEPS}"
-    LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 50"
-  extends: .build_and_test_on_lassen
-
-# Overriding shared spec: Longer allocation + Extra flags
-xl_16_1_1_12_gcc_7_3_1_cuda_10_1_168:
-  variables:
-    SPEC: "${PROJECT_LASSEN_VARIANTS} +cuda %xl@16.1.1.12 cxxflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-7.3.1 -qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qsmp=omp -qnoeh -qsuppress=1500-029 -qsuppress=1500-036\" cflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-7.3.1\" cuda_arch=70 ^cuda@10.1.168 ${PROJECT_LASSEN_DEPS}"
-    LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 60"
-  extends: .build_and_test_on_lassen
-  script:
-    - |
-      echo -e "\e[31mDeactivated spec !\e[0m"
-      echo -e "\e[31m${SPEC}\e[0m"
-      echo -e "\e[31mRAJA won’t build with Cuda < 11.1.0 due to a known issue.\e[0m"
-    - exit 1
-  allow_failure: true
-
-# Overriding shared spec: Extra flags + Longer allocation + Allow failure
-xl_16_1_1_12_cuda_11_1_0:
-  variables:
-    SPEC: " ${PROJECT_LASSEN_VARIANTS} +cuda %xl@16.1.1.12 cxxflags==\"-qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036\" cuda_arch=70 ^cuda@11.1.0 ${PROJECT_LASSEN_DEPS}"
-    LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 60"
-  extends: .build_and_test_on_lassen
-
-# Overriding shared spec: Extra flags + Longer allocation + Allow failure
-xl_16_1_1_12_gcc_8_3_1_cuda_11_1_0:
-  variables:
-    SPEC: " ${PROJECT_LASSEN_VARIANTS} +cuda %xl@16.1.1.12 cxxflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1 -qthreaded -std=c++14 -O3 -qstrict -qxlcompatmacros -qlanglvl=extended0x -qalias=noansi -qhot -qpic -qsmp=omp -qsuppress=1500-029 -qsuppress=1500-036\" cflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" cuda_arch=70 ^cuda@11.1.0 ${PROJECT_LASSEN_DEPS}"
-    LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 60"
-  extends: .build_and_test_on_lassen
-
 
 ############
 # Extra jobs
@@ -119,16 +48,6 @@ clang_14_0_5:
 ##########
 # CUDA
 ##########
-
-clang_12_0_1_cuda_11_5_0:
-  variables:
-    SPEC: " +openmp +cuda cuda_arch=70 %clang@12.0.1 cxxflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" cflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" ^cuda@11.5.0"
-  extends: .build_and_test_on_lassen
-
-gcc_8_3_1_cuda_11_1_0:
-  variables:
-    SPEC: " +openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@11.1.0"
-  extends: .build_and_test_on_lassen
 
 gcc_8_3_1_cuda_11_5_0_ats_disabled:
   extends: .build_and_test_on_lassen

--- a/.gitlab/lassen-build-and-test-extra.yml
+++ b/.gitlab/lassen-build-and-test-extra.yml
@@ -49,19 +49,19 @@ clang_14_0_5:
 # CUDA
 ##########
 
-gcc_8_3_1_cuda_11_5_0_ats_disabled:
+gcc_8_3_1_cuda_11_7_0_ats_disabled:
   extends: .build_and_test_on_lassen
   variables:
-    SPEC: " +openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@11.5.0"
+    SPEC: " +openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@11.7.0"
     LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 --atsdisable -W 30"
 
 ##########
 # EXTRAS
 ##########
 
-clang_12_0_1_cuda_11_5_0_caliper:
+clang_12_0_1_gcc_8_3_1_cuda_11_7_0_caliper:
   variables:
-    SPEC: " +openmp +caliper +cuda cuda_arch=70 %clang@12.0.1 cxxflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" cflags==\"--gcc-toolchain=/usr/tce/packages/gcc/gcc-8.3.1\" ^cuda@11.5.0"
+    SPEC: " +openmp +caliper +cuda cuda_arch=70 %clang@12.0.1.gcc.8.3.1 ^cuda@11.7.0"
   extends: .build_and_test_on_lassen
 
 clang_13_0_1_libcpp:

--- a/.gitlab/lassen-build-and-test-extra.yml
+++ b/.gitlab/lassen-build-and-test-extra.yml
@@ -69,12 +69,12 @@ clang_12_0_1_gcc_8_3_1_cuda_11_2_0_caliper:
 
 clang_13_0_1_libcpp:
   variables:
-    SPEC: " ~shared +openmp +tests %clang@13.0.1 cflags==\"-DGTEST_HAS_CXXABI_H_=0\" cxxflags==\"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0\""
+    SPEC: " ~shared +openmp %clang@13.0.1 cflags==\"-DGTEST_HAS_CXXABI_H_=0\" cxxflags==\"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0\""
   extends: .build_and_test_on_lassen
 
 #clang_14_0_5_asan:
 #  variables:
-#    SPEC: " ~shared +openmp +tests %clang@14.0.5 cxxflags==\"-fsanitize=address\""
+#    SPEC: " ~shared +openmp %clang@14.0.5 cxxflags==\"-fsanitize=address\""
 #    ASAN_OPTIONS: "detect_leaks=1"
 #    LSAN_OPTIONS: "suppressions=${CI_PROJECT_DIR}/tpl/RAJA/suppressions.asan"
 #  extends: .build_and_test_on_lassen

--- a/.gitlab/lassen-build-and-test-extra.yml
+++ b/.gitlab/lassen-build-and-test-extra.yml
@@ -29,6 +29,7 @@ xl_2022_08_19_gcc_8_3_1_cuda_11_7_0:
     LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 -W 120"
   extends: .build_and_test_on_lassen
 
+
 ############
 # Extra jobs
 ############
@@ -42,38 +43,41 @@ xl_2022_08_19_gcc_8_3_1_cuda_11_7_0:
 
 clang_14_0_5:
   variables:
-    SPEC: " +openmp %clang@14.0.5"
+    SPEC: " ~shared +openmp %clang@14.0.5"
   extends: .build_and_test_on_lassen
 
 ##########
 # CUDA
 ##########
 
-gcc_8_3_1_cuda_11_7_0_ats_disabled:
+gcc_8_3_1_cuda_11_5_0_ats_disabled:
   extends: .build_and_test_on_lassen
   variables:
-    SPEC: " +openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@11.7.0+allow-unsupported-compilers"
+    SPEC: " +openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@11.5.0+allow-unsupported-compilers"
+    MODULE_LIST: "cuda/11.5.0"
     LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 --atsdisable -W 30"
 
 ##########
-# EXTRAS
+# OTHERS
 ##########
 
-clang_12_0_1_gcc_8_3_1_cuda_11_7_0_caliper:
+clang_12_0_1_gcc_8_3_1_cuda_11_2_0_caliper:
   variables:
-    SPEC: " +openmp +caliper +cuda cuda_arch=70 %clang@12.0.1.gcc.8.3.1 ^cuda@11.7.0+allow-unsupported-compilers"
+    SPEC: " ~shared +openmp +caliper +cuda cuda_arch=70 %clang@12.0.1.gcc.8.3.1 ^cuda@11.2.0+allow-unsupported-compilers"
+    MODULE_LIST: "cuda/11.2.0"
   extends: .build_and_test_on_lassen
 
 clang_13_0_1_libcpp:
   variables:
-    SPEC: " +openmp %clang@13.0.1+libcpp"
+    SPEC: " ~shared +openmp +tests %clang@13.0.1 cflags==\"-DGTEST_HAS_CXXABI_H_=0\" cxxflags==\"-stdlib=libc++ -DGTEST_HAS_CXXABI_H_=0\""
   extends: .build_and_test_on_lassen
 
-clang_14_0_5_asan:
-  variables:
-    SPEC: " +openmp %clang@14.0.5 cxxflags==\"-fsanitize=address\""
-    ASAN_OPTIONS: "detect_leaks=1"
-  extends: .build_and_test_on_lassen
+#clang_14_0_5_asan:
+#  variables:
+#    SPEC: " ~shared +openmp +tests %clang@14.0.5 cxxflags==\"-fsanitize=address\""
+#    ASAN_OPTIONS: "detect_leaks=1"
+#    LSAN_OPTIONS: "suppressions=${CI_PROJECT_DIR}/tpl/RAJA/suppressions.asan"
+#  extends: .build_and_test_on_lassen
 
 # Activated in RAJA, but we don't use desul atomics here
 #gcc_8_3_1_cuda_10_1_168_desul_atomics:

--- a/.gitlab/lassen-build-and-test-extra.yml
+++ b/.gitlab/lassen-build-and-test-extra.yml
@@ -52,7 +52,7 @@ clang_14_0_5:
 gcc_8_3_1_cuda_11_7_0_ats_disabled:
   extends: .build_and_test_on_lassen
   variables:
-    SPEC: " +openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@11.7.0"
+    SPEC: " +openmp +cuda %gcc@8.3.1 cuda_arch=70 ^cuda@11.7.0+allow-unsupported-compilers"
     LASSEN_BUILD_AND_TEST_JOB_ALLOC: "1 --atsdisable -W 30"
 
 ##########
@@ -61,7 +61,7 @@ gcc_8_3_1_cuda_11_7_0_ats_disabled:
 
 clang_12_0_1_gcc_8_3_1_cuda_11_7_0_caliper:
   variables:
-    SPEC: " +openmp +caliper +cuda cuda_arch=70 %clang@12.0.1.gcc.8.3.1 ^cuda@11.7.0"
+    SPEC: " +openmp +caliper +cuda cuda_arch=70 %clang@12.0.1.gcc.8.3.1 ^cuda@11.7.0+allow-unsupported-compilers"
   extends: .build_and_test_on_lassen
 
 clang_13_0_1_libcpp:

--- a/.gitlab/ruby-build-and-test-extra.yml
+++ b/.gitlab/ruby-build-and-test-extra.yml
@@ -14,19 +14,17 @@
 # the comparison with the original job is easier.
 
 # Overriding shared config for longer run
-gcc_8_1_0:
+gcc_8_5_0:
   variables:
-    SPEC: " ${PROJECT_RUBY_VARIANTS} %gcc@8.1.0 ${PROJECT_RUBY_DEPS}"
+    SPEC: " ${PROJECT_RUBY_VARIANTS} %gcc@8.5.0 ${PROJECT_RUBY_DEPS}"
     RUBY_BUILD_AND_TEST_JOB_ALLOC: "--time=60 --nodes=1"
   extends: .build_and_test_on_ruby
 
-# Overriding shared spec: Allow failures
-pgi_20_1_gcc_local_8_3_1:
+intel_19_1_2_gcc_8_5_0:
   variables:
-    SPEC: " ${PROJECT_RUBY_VARIANTS} %pgi@20.1 cxxflags==\"-rc=/usr/workspace/umpire/pgi/x86_64/local-gcc-8.3.1-rc\" cflags==\"-rc=/usr/workspace/umpire/pgi/x86_64/local-gcc-8.3.1-rc\" fflags==\"-rc=/usr/workspace/umpire/pgi/x86_64/local-gcc-8.3.1-rc\" ${PROJECT_RUBY_DEPS}"
+    SPEC: " +openmp %intel@19.1.2.gcc.8.5.0"
+    RUBY_BUILD_AND_TEST_JOB_ALLOC: "--time=40 --nodes=1"
   extends: .build_and_test_on_ruby
-  allow_failure: true
-
 
 ############
 # Extra jobs
@@ -35,16 +33,9 @@ pgi_20_1_gcc_local_8_3_1:
 # ${PROJECT_<MACHINE>_DEPS} in the extra jobs. There is no reason not to fully
 # describe the spec here.
 
-gcc_8_3_1_caliper:
+gcc_8_5_0_caliper:
   variables:
-    SPEC: " +openmp +caliper %gcc@8.3.1"
+    SPEC: " +openmp +caliper %gcc@8.5.0"
     RUBY_BUILD_AND_TEST_JOB_ALLOC: "--time=60 --nodes=1"
   extends: .build_and_test_on_ruby
 
-icpc_19_1_0:
-  variables:
-    SPEC: " +openmp %intel@19.1.0"
-    RUBY_BUILD_AND_TEST_JOB_ALLOC: "--time=40 --nodes=1"
-  before_script:
-    - export USE_DEV_SHM=False
-  extends: .build_and_test_on_ruby

--- a/.gitlab/subscribed-pipelines.yml
+++ b/.gitlab/subscribed-pipelines.yml
@@ -6,25 +6,76 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ##############################################################################
 
-# Uncomment pipelines to subscribe to a shared pipeline.
+# The template job to test whether a machine is up.
+# Expects CI_MACHINE defined to machine name.
+.machine-check:
+  stage: machine-checks
+  tags: [shell, oslic]
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - |
+      if [[ $(jq '.[env.CI_MACHINE].total_nodes_up' /usr/global/tools/lorenz/data/loginnodeStatus) == 0 ]]
+      then
+        echo -e "\e[31mNo node available on ${CI_MACHINE}\e[0m"
+        curl --url "https://api.github.com/repos/${GITHUB_PROJECT_ORG}/${GITHUB_PROJECT_NAME}/statuses/${CI_COMMIT_SHA}" \
+             --header 'Content-Type: application/json' \
+             --header "authorization: Bearer ${GITHUB_TOKEN}" \
+             --data "{ \"state\": \"failure\", \"target_url\": \"${CI_PIPELINE_URL}\", \"description\": \"GitLab ${CI_MACHINE} down\", \"context\": \"ci/gitlab/${CI_MACHINE}\" }"
+        exit 1
+      fi
 
-# Trigger a build-and-test pipeline for ruby, corona and lassen
+###
+# Trigger a build-and-test pipeline for a machine.
+# Comment the jobs for machines you don’t need.
+###
+
+# RUBY
+ruby-up-check:
+  variables:
+    CI_MACHINE: "ruby"
+  extends: [.machine-check]
+
 ruby-build-and-test:
   variables:
     CI_MACHINE: "ruby"
+  needs: [ruby-up-check]
   extends: [.build-and-test]
+
+# CORONA
+corona-up-check:
+  variables:
+    CI_MACHINE: "corona"
+  extends: [.machine-check]
 
 corona-build-and-test:
   variables:
     CI_MACHINE: "corona"
+  needs: [corona-up-check]
   extends: [.build-and-test]
+
+# TIOGA
+tioga-up-check:
+  variables:
+    CI_MACHINE: "tioga"
+  extends: [.machine-check]
 
 tioga-build-and-test:
   variables:
     CI_MACHINE: "tioga"
+  needs: [tioga-up-check]
   extends: [.build-and-test]
+
+# LASSEN
+lassen-up-check:
+  variables:
+    CI_MACHINE: "lassen"
+  extends: [.machine-check]
 
 lassen-build-and-test:
   variables:
     CI_MACHINE: "lassen"
+  needs: [lassen-up-check]
   extends: [.build-and-test]
+
+

--- a/.gitlab/tioga-build-and-test-extra.yml
+++ b/.gitlab/tioga-build-and-test-extra.yml
@@ -29,11 +29,11 @@ variables:
 # INFO: This job is activated in RAJA CI, but we don't use desul atomics here
 #rocmcc_5_4_3_hip_desul_atomics:
 #  variables:
-#    SPEC: "~shared +rocm ~openmp +desul +tests amdgpu_target=gfx90a %rocmcc@5.4.3 ^hip@5.4.3 ^blt@develop"
+#    SPEC: "~shared +rocm ~openmp +desul amdgpu_target=gfx90a %rocmcc@5.4.3 ^hip@5.4.3 ^blt@develop"
 #  extends: .build_and_test_on_tioga
 
 # INFO: This job is activated in RAJA CI, but we may not want to run openmp here
 #rocmcc_5_4_3_hip_openmp:
 #  variables:
-#    SPEC: "~shared +rocm +openmp +tests amdgpu_target=gfx90a %rocmcc@5.4.3 ^hip@5.4.3 ^blt@develop"
+#    SPEC: "~shared +rocm +openmp amdgpu_target=gfx90a %rocmcc@5.4.3 ^hip@5.4.3 ^blt@develop"
 #  extends: .build_and_test_on_tioga

--- a/.gitlab/tioga-build-and-test-extra.yml
+++ b/.gitlab/tioga-build-and-test-extra.yml
@@ -27,13 +27,13 @@ variables:
   INCLUDED_FILE_CANNOT_BE_EMPTY: "True"
 
 # INFO: This job is activated in RAJA CI, but we don't use desul atomics here
-#rocmcc_5_2_3_hip_desul_atomics:
+#rocmcc_5_4_3_hip_desul_atomics:
 #  variables:
-#    SPEC: "~shared +rocm ~openmp +desul +tests amdgpu_target=gfx90a %rocmcc@5.2.3 ^hip@5.2.3 ^blt@develop"
+#    SPEC: "~shared +rocm ~openmp +desul +tests amdgpu_target=gfx90a %rocmcc@5.4.3 ^hip@5.4.3 ^blt@develop"
 #  extends: .build_and_test_on_tioga
-#
+
 # INFO: This job is activated in RAJA CI, but we may not want to run openmp here
-#rocmcc_5_2_3_hip_openmp:
+#rocmcc_5_4_3_hip_openmp:
 #  variables:
-#    SPEC: "~shared +rocm +openmp +tests amdgpu_target=gfx90a %rocmcc@5.2.3 ^hip@5.2.3 ^blt@develop"
+#    SPEC: "~shared +rocm +openmp +tests amdgpu_target=gfx90a %rocmcc@5.4.3 ^hip@5.4.3 ^blt@develop"
 #  extends: .build_and_test_on_tioga

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -4,7 +4,7 @@
 "package_final_phase" : "initconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_branch": "v0.19.0",
+"spack_branch": "e4s-23.02",
 "spack_activate" : {},
 "spack_configs_path": "tpl/RAJA/scripts/radiuss-spack-configs",
 "spack_packages_path": "tpl/RAJA/scripts/radiuss-spack-configs/packages",


### PR DESCRIPTION
### This branch aims at updating the CI after the update of Ruby to toss4

#### Notes: 
- Intermittent segfault during testing of "clang@14.0.5" and "clang@14.0.5 +asan" and "clang@13.0.1 +libcpp" targets