### PR TITLE
New RAJA GPU Indexing

### DIFF
--- a/src/apps/CONVECTION3DPA-Cuda.cpp
+++ b/src/apps/CONVECTION3DPA-Cuda.cpp
@@ -165,13 +165,13 @@ void CONVECTION3DPA::runCudaVariantImpl(VariantID vid) {
         RAJA::LoopPolicy<RAJA::cuda_block_x_direct>;
 
     using inner_x =
-        RAJA::LoopPolicy<RAJA::cuda_thread_x_loop>;
+        RAJA::LoopPolicy<RAJA::cuda_thread_size_x_loop<CPA_Q1D>>;
 
     using inner_y =
-        RAJA::LoopPolicy<RAJA::cuda_thread_y_loop>;
+        RAJA::LoopPolicy<RAJA::cuda_thread_size_y_loop<CPA_Q1D>>;
 
     using inner_z =
-        RAJA::LoopPolicy<RAJA::cuda_thread_z_loop>;
+        RAJA::LoopPolicy<RAJA::cuda_thread_size_z_loop<CPA_Q1D>>;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/apps/CONVECTION3DPA-Hip.cpp
+++ b/src/apps/CONVECTION3DPA-Hip.cpp
@@ -167,13 +167,13 @@ void CONVECTION3DPA::runHipVariantImpl(VariantID vid) {
         RAJA::LoopPolicy<RAJA::hip_block_x_direct>;
 
     using inner_x =
-        RAJA::LoopPolicy<RAJA::hip_thread_x_loop>;
+        RAJA::LoopPolicy<RAJA::hip_thread_size_x_loop<CPA_Q1D>>;
 
     using inner_y =
-        RAJA::LoopPolicy<RAJA::hip_thread_y_loop>;
+        RAJA::LoopPolicy<RAJA::hip_thread_size_y_loop<CPA_Q1D>>;
 
     using inner_z =
-        RAJA::LoopPolicy<RAJA::hip_thread_z_loop>;
+        RAJA::LoopPolicy<RAJA::hip_thread_size_z_loop<CPA_Q1D>>;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/apps/DIFFUSION3DPA-Cuda.cpp
+++ b/src/apps/DIFFUSION3DPA-Cuda.cpp
@@ -141,13 +141,13 @@ void DIFFUSION3DPA::runCudaVariantImpl(VariantID vid) {
         RAJA::LoopPolicy<RAJA::cuda_block_x_direct>;
 
     using inner_x =
-        RAJA::LoopPolicy<RAJA::cuda_thread_x_loop>;
+        RAJA::LoopPolicy<RAJA::cuda_thread_size_x_loop<DPA_Q1D>>;
 
     using inner_y =
-        RAJA::LoopPolicy<RAJA::cuda_thread_y_loop>;
+        RAJA::LoopPolicy<RAJA::cuda_thread_size_y_loop<DPA_Q1D>>;
 
     using inner_z =
-        RAJA::LoopPolicy<RAJA::cuda_thread_z_loop>;
+        RAJA::LoopPolicy<RAJA::cuda_thread_size_z_loop<DPA_Q1D>>;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/apps/DIFFUSION3DPA-Hip.cpp
+++ b/src/apps/DIFFUSION3DPA-Hip.cpp
@@ -143,13 +143,13 @@ void DIFFUSION3DPA::runHipVariantImpl(VariantID vid) {
         RAJA::LoopPolicy<RAJA::hip_block_x_direct>;
 
     using inner_x =
-        RAJA::LoopPolicy<RAJA::hip_thread_x_loop>;
+        RAJA::LoopPolicy<RAJA::hip_thread_size_x_loop<DPA_Q1D>>;
 
     using inner_y =
-        RAJA::LoopPolicy<RAJA::hip_thread_y_loop>;
+        RAJA::LoopPolicy<RAJA::hip_thread_size_y_loop<DPA_Q1D>>;
 
     using inner_z =
-        RAJA::LoopPolicy<RAJA::hip_thread_z_loop>;
+        RAJA::LoopPolicy<RAJA::hip_thread_size_z_loop<DPA_Q1D>>;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -129,20 +129,11 @@ void LTIMES::runCudaVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
-          RAJA::statement::Tile<1, RAJA::tile_fixed<z_block_sz>,
-                                   RAJA::cuda_block_z_direct,
-            RAJA::statement::Tile<2, RAJA::tile_fixed<g_block_sz>,
-                                     RAJA::cuda_block_y_direct,
-              RAJA::statement::Tile<3, RAJA::tile_fixed<m_block_sz>,
-                                       RAJA::cuda_block_x_direct,
-                RAJA::statement::For<1, RAJA::cuda_thread_z_direct,     //z
-                  RAJA::statement::For<2, RAJA::cuda_thread_y_direct,   //g
-                    RAJA::statement::For<3, RAJA::cuda_thread_x_direct, //m
-                      RAJA::statement::For<0, RAJA::seq_exec,           //d
-                        RAJA::statement::Lambda<0>
-                      >
-                    >
-                  >
+          RAJA::statement::For<1, RAJA::cuda_global_size_z_direct<z_block_sz>,     //z
+            RAJA::statement::For<2, RAJA::cuda_global_size_y_direct<g_block_sz>,   //g
+              RAJA::statement::For<3, RAJA::cuda_global_size_x_direct<m_block_sz>, //m
+                RAJA::statement::For<0, RAJA::seq_exec,           //d
+                  RAJA::statement::Lambda<0>
                 >
               >
             >

--- a/src/apps/LTIMES-Hip.cpp
+++ b/src/apps/LTIMES-Hip.cpp
@@ -131,20 +131,11 @@ void LTIMES::runHipVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
-          RAJA::statement::Tile<1, RAJA::tile_fixed<z_block_sz>,
-                                   RAJA::hip_block_z_direct,
-            RAJA::statement::Tile<2, RAJA::tile_fixed<g_block_sz>,
-                                     RAJA::hip_block_y_direct,
-              RAJA::statement::Tile<3, RAJA::tile_fixed<m_block_sz>,
-                                       RAJA::hip_block_x_direct,
-                RAJA::statement::For<1, RAJA::hip_thread_z_direct,     //z
-                  RAJA::statement::For<2, RAJA::hip_thread_y_direct,   //g
-                    RAJA::statement::For<3, RAJA::hip_thread_x_direct, //m
-                      RAJA::statement::For<0, RAJA::seq_exec,          //d
-                        RAJA::statement::Lambda<0>
-                      >
-                    >
-                  >
+          RAJA::statement::For<1, RAJA::hip_global_size_z_direct<z_block_sz>,     //z
+            RAJA::statement::For<2, RAJA::hip_global_size_y_direct<g_block_sz>,   //g
+              RAJA::statement::For<3, RAJA::hip_global_size_x_direct<m_block_sz>, //m
+                RAJA::statement::For<0, RAJA::seq_exec,          //d
+                  RAJA::statement::Lambda<0>
                 >
               >
             >

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -126,20 +126,11 @@ void LTIMES_NOVIEW::runCudaVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
-          RAJA::statement::Tile<1, RAJA::tile_fixed<z_block_sz>,
-                                   RAJA::cuda_block_z_direct,
-            RAJA::statement::Tile<2, RAJA::tile_fixed<g_block_sz>,
-                                     RAJA::cuda_block_y_direct,
-              RAJA::statement::Tile<3, RAJA::tile_fixed<m_block_sz>,
-                                       RAJA::cuda_block_x_direct,
-                RAJA::statement::For<1, RAJA::cuda_thread_z_direct,     //z
-                  RAJA::statement::For<2, RAJA::cuda_thread_y_direct,   //g
-                    RAJA::statement::For<3, RAJA::cuda_thread_x_direct, //m
-                      RAJA::statement::For<0, RAJA::seq_exec,           //d
-                        RAJA::statement::Lambda<0>
-                      >
-                    >
-                  >
+          RAJA::statement::For<1, RAJA::cuda_global_size_z_direct<z_block_sz>,     //z
+            RAJA::statement::For<2, RAJA::cuda_global_size_y_direct<g_block_sz>,   //g
+              RAJA::statement::For<3, RAJA::cuda_global_size_x_direct<m_block_sz>, //m
+                RAJA::statement::For<0, RAJA::seq_exec,           //d
+                  RAJA::statement::Lambda<0>
                 >
               >
             >

--- a/src/apps/LTIMES_NOVIEW-Hip.cpp
+++ b/src/apps/LTIMES_NOVIEW-Hip.cpp
@@ -130,20 +130,11 @@ void LTIMES_NOVIEW::runHipVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
-          RAJA::statement::Tile<1, RAJA::tile_fixed<z_block_sz>,
-                                   RAJA::hip_block_z_direct,
-            RAJA::statement::Tile<2, RAJA::tile_fixed<g_block_sz>,
-                                     RAJA::hip_block_y_direct,
-              RAJA::statement::Tile<3, RAJA::tile_fixed<m_block_sz>,
-                                       RAJA::hip_block_x_direct,
-                RAJA::statement::For<1, RAJA::hip_thread_z_direct,     //z
-                  RAJA::statement::For<2, RAJA::hip_thread_y_direct,   //g
-                    RAJA::statement::For<3, RAJA::hip_thread_x_direct, //m
-                      RAJA::statement::For<0, RAJA::seq_exec,          //d
-                        RAJA::statement::Lambda<0>
-                      >
-                    >
-                  >
+          RAJA::statement::For<1, RAJA::hip_global_size_z_direct<z_block_sz>,     //z
+            RAJA::statement::For<2, RAJA::hip_global_size_y_direct<g_block_sz>,   //g
+              RAJA::statement::For<3, RAJA::hip_global_size_x_direct<m_block_sz>, //m
+                RAJA::statement::For<0, RAJA::seq_exec,          //d
+                  RAJA::statement::Lambda<0>
                 >
               >
             >

--- a/src/apps/MASS3DEA-Cuda.cpp
+++ b/src/apps/MASS3DEA-Cuda.cpp
@@ -92,11 +92,11 @@ void MASS3DEA::runCudaVariantImpl(VariantID vid) {
 
     using outer_x = RAJA::LoopPolicy<RAJA::cuda_block_x_direct>;
 
-    using inner_x = RAJA::LoopPolicy<RAJA::cuda_thread_x_loop>;
+    using inner_x = RAJA::LoopPolicy<RAJA::cuda_thread_size_x_loop<MEA_D1D>>;
 
-    using inner_y = RAJA::LoopPolicy<RAJA::cuda_thread_y_loop>;
+    using inner_y = RAJA::LoopPolicy<RAJA::cuda_thread_size_y_loop<MEA_D1D>>;
 
-    using inner_z = RAJA::LoopPolicy<RAJA::cuda_thread_z_loop>;
+    using inner_z = RAJA::LoopPolicy<RAJA::cuda_thread_size_z_loop<MEA_D1D>>;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/apps/MASS3DEA-Hip.cpp
+++ b/src/apps/MASS3DEA-Hip.cpp
@@ -94,11 +94,11 @@ void MASS3DEA::runHipVariantImpl(VariantID vid) {
 
     using outer_x = RAJA::LoopPolicy<RAJA::hip_block_x_direct>;
 
-    using inner_x = RAJA::LoopPolicy<RAJA::hip_thread_x_loop>;
+    using inner_x = RAJA::LoopPolicy<RAJA::hip_thread_size_x_loop<MEA_D1D>>;
 
-    using inner_y = RAJA::LoopPolicy<RAJA::hip_thread_y_loop>;
+    using inner_y = RAJA::LoopPolicy<RAJA::hip_thread_size_y_loop<MEA_D1D>>;
 
-    using inner_z = RAJA::LoopPolicy<RAJA::hip_thread_z_loop>;
+    using inner_z = RAJA::LoopPolicy<RAJA::hip_thread_size_z_loop<MEA_D1D>>;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/apps/MASS3DPA-Cuda.cpp
+++ b/src/apps/MASS3DPA-Cuda.cpp
@@ -122,9 +122,9 @@ void MASS3DPA::runCudaVariantImpl(VariantID vid) {
 
     using outer_x = RAJA::LoopPolicy<RAJA::cuda_block_x_direct>;
 
-    using inner_x = RAJA::LoopPolicy<RAJA::cuda_thread_x_loop>;
+    using inner_x = RAJA::LoopPolicy<RAJA::cuda_thread_size_x_loop<MPA_Q1D>>;
 
-    using inner_y = RAJA::LoopPolicy<RAJA::cuda_thread_y_loop>;
+    using inner_y = RAJA::LoopPolicy<RAJA::cuda_thread_size_y_loop<MPA_Q1D>>;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/apps/MASS3DPA-Hip.cpp
+++ b/src/apps/MASS3DPA-Hip.cpp
@@ -125,9 +125,9 @@ void MASS3DPA::runHipVariantImpl(VariantID vid) {
 
     using outer_x = RAJA::LoopPolicy<RAJA::hip_block_x_direct>;
 
-    using inner_x = RAJA::LoopPolicy<RAJA::hip_thread_x_loop>;
+    using inner_x = RAJA::LoopPolicy<RAJA::hip_thread_size_x_loop<MPA_Q1D>>;
 
-    using inner_y = RAJA::LoopPolicy<RAJA::hip_thread_y_loop>;
+    using inner_y = RAJA::LoopPolicy<RAJA::hip_thread_size_y_loop<MPA_Q1D>>;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/basic/MAT_MAT_SHARED-Cuda.cpp
+++ b/src/basic/MAT_MAT_SHARED-Cuda.cpp
@@ -187,9 +187,9 @@ void MAT_MAT_SHARED::runCudaVariantImpl(VariantID vid)
 
     using teams_y = RAJA::LoopPolicy<RAJA::cuda_block_y_direct>;
 
-    using threads_x = RAJA::LoopPolicy<RAJA::cuda_thread_x_direct>;
+    using threads_x = RAJA::LoopPolicy<RAJA::cuda_thread_size_x_direct<tile_size>>;
 
-    using threads_y = RAJA::LoopPolicy<RAJA::cuda_thread_y_direct>;
+    using threads_y = RAJA::LoopPolicy<RAJA::cuda_thread_size_y_direct<tile_size>>;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/basic/MAT_MAT_SHARED-Hip.cpp
+++ b/src/basic/MAT_MAT_SHARED-Hip.cpp
@@ -192,9 +192,9 @@ void MAT_MAT_SHARED::runHipVariantImpl(VariantID vid)
 
     using teams_y = RAJA::LoopPolicy<RAJA::hip_block_y_direct>;
 
-    using threads_x = RAJA::LoopPolicy<RAJA::hip_thread_x_direct>;
+    using threads_x = RAJA::LoopPolicy<RAJA::hip_thread_size_x_direct<tile_size>>;
 
-    using threads_y = RAJA::LoopPolicy<RAJA::hip_thread_y_direct>;
+    using threads_y = RAJA::LoopPolicy<RAJA::hip_thread_size_y_direct<tile_size>>;
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -118,16 +118,10 @@ void NESTED_INIT::runCudaVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
-          RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                   RAJA::cuda_block_y_direct,
-            RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
-                                     RAJA::cuda_block_x_direct,
-              RAJA::statement::For<2, RAJA::cuda_block_z_direct,      // k
-                RAJA::statement::For<1, RAJA::cuda_thread_y_direct,   // j
-                  RAJA::statement::For<0, RAJA::cuda_thread_x_direct, // i
-                    RAJA::statement::Lambda<0>
-                  >
-                >
+          RAJA::statement::For<2, RAJA::cuda_block_z_direct,      // k
+            RAJA::statement::For<1, RAJA::cuda_global_size_y_direct<j_block_sz>,   // j
+              RAJA::statement::For<0, RAJA::cuda_global_size_x_direct<i_block_sz>, // i
+                RAJA::statement::Lambda<0>
               >
             >
           >

--- a/src/basic/NESTED_INIT-Hip.cpp
+++ b/src/basic/NESTED_INIT-Hip.cpp
@@ -120,16 +120,10 @@ void NESTED_INIT::runHipVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
        RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
-          RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                   RAJA::hip_block_y_direct,
-            RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
-                                     RAJA::hip_block_x_direct,
-              RAJA::statement::For<2, RAJA::hip_block_z_direct,      // k
-                RAJA::statement::For<1, RAJA::hip_thread_y_direct,   // j
-                  RAJA::statement::For<0, RAJA::hip_thread_x_direct, // i
-                    RAJA::statement::Lambda<0>
-                  >
-                >
+          RAJA::statement::For<2, RAJA::hip_block_z_direct,      // k
+            RAJA::statement::For<1, RAJA::hip_global_size_y_direct<j_block_sz>,   // j
+              RAJA::statement::For<0, RAJA::hip_global_size_x_direct<i_block_sz>, // i
+                RAJA::statement::Lambda<0>
               >
             >
           >

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -80,38 +80,6 @@ __global__ void lambda_cuda(Lambda body)
   body();
 }
 
-/*!
- * \brief Getters for cuda kernel indices.
- */
-template < typename Index >
-__device__ inline Index_type lambda_cuda_get_index();
-
-template < >
-__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_thread_x_direct>() {
-  return threadIdx.x;
-}
-template < >
-__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_thread_y_direct>() {
-  return threadIdx.y;
-}
-template < >
-__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_thread_z_direct>() {
-  return threadIdx.z;
-}
-
-template < >
-__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_block_x_direct>() {
-  return blockIdx.x;
-}
-template < >
-__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_block_y_direct>() {
-  return blockIdx.y;
-}
-template < >
-__device__ inline Index_type lambda_cuda_get_index<RAJA::cuda_block_z_direct>() {
-  return blockIdx.z;
-}
-
 
 namespace detail
 {

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -67,38 +67,6 @@ __global__ void lambda_hip(Lambda body)
   body();
 }
 
-/*!
- * \brief Getters for hip kernel indices.
- */
-template < typename Index >
-__device__ inline Index_type lambda_hip_get_index();
-
-template < >
-__device__ inline Index_type lambda_hip_get_index<RAJA::hip_thread_x_direct>() {
-  return threadIdx.x;
-}
-template < >
-__device__ inline Index_type lambda_hip_get_index<RAJA::hip_thread_y_direct>() {
-  return threadIdx.y;
-}
-template < >
-__device__ inline Index_type lambda_hip_get_index<RAJA::hip_thread_z_direct>() {
-  return threadIdx.z;
-}
-
-template < >
-__device__ inline Index_type lambda_hip_get_index<RAJA::hip_block_x_direct>() {
-  return blockIdx.x;
-}
-template < >
-__device__ inline Index_type lambda_hip_get_index<RAJA::hip_block_y_direct>() {
-  return blockIdx.y;
-}
-template < >
-__device__ inline Index_type lambda_hip_get_index<RAJA::hip_block_z_direct>() {
-  return blockIdx.z;
-}
-
 
 namespace detail
 {

--- a/src/lcals/HYDRO_2D-Cuda.cpp
+++ b/src/lcals/HYDRO_2D-Cuda.cpp
@@ -141,15 +141,9 @@ void HYDRO_2D::runCudaVariantImpl(VariantID vid)
     using EXECPOL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<j_block_sz * k_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<k_block_sz>,
-                                   RAJA::cuda_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                   RAJA::cuda_block_x_direct,
-              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // k
-                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // j
-                  RAJA::statement::Lambda<0>
-                >
-              >
+          RAJA::statement::For<0, RAJA::cuda_global_size_y_direct<k_block_sz>,   // k
+            RAJA::statement::For<1, RAJA::cuda_global_size_x_direct<j_block_sz>, // j
+              RAJA::statement::Lambda<0>
             >
           >
         >

--- a/src/lcals/HYDRO_2D-Hip.cpp
+++ b/src/lcals/HYDRO_2D-Hip.cpp
@@ -144,15 +144,9 @@ void HYDRO_2D::runHipVariantImpl(VariantID vid)
     using EXECPOL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<j_block_sz * k_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<k_block_sz>,
-                                   RAJA::hip_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                   RAJA::hip_block_x_direct,
-              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // k
-                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // j
-                  RAJA::statement::Lambda<0>
-                >
-              >
+          RAJA::statement::For<0, RAJA::hip_global_size_y_direct<k_block_sz>,   // k
+            RAJA::statement::For<1, RAJA::hip_global_size_x_direct<j_block_sz>, // j
+              RAJA::statement::Lambda<0>
             >
           >
         >

--- a/src/polybench/POLYBENCH_2MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_2MM-Cuda.cpp
@@ -179,19 +179,13 @@ void POLYBENCH_2MM::runCudaVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<out_block_sz * in_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<out_block_sz>,
-                                   RAJA::cuda_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<in_block_sz>,
-                                     RAJA::cuda_block_x_direct,
-              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // outer
-                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // inner
-                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
-                  RAJA::statement::For<2, RAJA::seq_exec,
-                    RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-                  >,
-                  RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
-                >
-              >
+          RAJA::statement::For<0, RAJA::cuda_global_size_y_direct<out_block_sz>,   // outer
+            RAJA::statement::For<1, RAJA::cuda_global_size_x_direct<in_block_sz>, // inner
+              RAJA::statement::Lambda<0, RAJA::Params<0>>,
+              RAJA::statement::For<2, RAJA::seq_exec,
+                RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+              >,
+              RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
             >
           >
         >

--- a/src/polybench/POLYBENCH_2MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_2MM-Hip.cpp
@@ -183,19 +183,13 @@ void POLYBENCH_2MM::runHipVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<out_block_sz * in_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<out_block_sz>,
-                                   RAJA::hip_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<in_block_sz>,
-                                     RAJA::hip_block_x_direct,
-              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // outer
-                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // inner
-                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
-                  RAJA::statement::For<2, RAJA::seq_exec,
-                    RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-                  >,
-                  RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
-                >
-              >
+          RAJA::statement::For<0, RAJA::hip_global_size_y_direct<out_block_sz>,   // outer
+            RAJA::statement::For<1, RAJA::hip_global_size_x_direct<in_block_sz>, // inner
+              RAJA::statement::Lambda<0, RAJA::Params<0>>,
+              RAJA::statement::For<2, RAJA::seq_exec,
+                RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+              >,
+              RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
             >
           >
         >

--- a/src/polybench/POLYBENCH_3MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_3MM-Cuda.cpp
@@ -236,19 +236,13 @@ void POLYBENCH_3MM::runCudaVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<out_block_sz * in_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<out_block_sz>,
-                                   RAJA::cuda_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<in_block_sz>,
-                                     RAJA::cuda_block_x_direct,
-              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // outer
-                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // inner
-                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
-                  RAJA::statement::For<2, RAJA::seq_exec,
-                    RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-                  >,
-                  RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
-                >
-              >
+          RAJA::statement::For<0, RAJA::cuda_global_size_y_direct<out_block_sz>,   // outer
+            RAJA::statement::For<1, RAJA::cuda_global_size_x_direct<in_block_sz>, // inner
+              RAJA::statement::Lambda<0, RAJA::Params<0>>,
+              RAJA::statement::For<2, RAJA::seq_exec,
+                RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+              >,
+              RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
             >
           >
         >

--- a/src/polybench/POLYBENCH_3MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_3MM-Hip.cpp
@@ -241,19 +241,13 @@ void POLYBENCH_3MM::runHipVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<out_block_sz * in_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<out_block_sz>,
-                                   RAJA::hip_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<in_block_sz>,
-                                     RAJA::hip_block_x_direct,
-              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // outer
-                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // inner
-                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
-                  RAJA::statement::For<2, RAJA::seq_exec,
-                    RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-                  >,
-                  RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
-                >
-              >
+          RAJA::statement::For<0, RAJA::hip_global_size_y_direct<out_block_sz>,   // outer
+            RAJA::statement::For<1, RAJA::hip_global_size_x_direct<in_block_sz>, // inner
+              RAJA::statement::Lambda<0, RAJA::Params<0>>,
+              RAJA::statement::For<2, RAJA::seq_exec,
+                RAJA::statement::Lambda<1, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+              >,
+              RAJA::statement::Lambda<2, RAJA::Segs<0,1>, RAJA::Params<0>>
             >
           >
         >

--- a/src/polybench/POLYBENCH_ADI-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ADI-Cuda.cpp
@@ -157,17 +157,14 @@ void POLYBENCH_ADI::runCudaVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<block_size,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::cuda_block_x_direct,
-            RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-              RAJA::statement::Lambda<0, RAJA::Segs<0>>,
-              RAJA::statement::For<1, RAJA::seq_exec,
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0>>,
-              RAJA::statement::For<2, RAJA::seq_exec,
-                RAJA::statement::Lambda<3, RAJA::Segs<0,2>>
-              >
+          RAJA::statement::For<0, RAJA::cuda_global_size_x_direct<block_size>,
+            RAJA::statement::Lambda<0, RAJA::Segs<0>>,
+            RAJA::statement::For<1, RAJA::seq_exec,
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>>
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<0>>,
+            RAJA::statement::For<2, RAJA::seq_exec,
+              RAJA::statement::Lambda<3, RAJA::Segs<0,2>>
             >
           >
         >

--- a/src/polybench/POLYBENCH_ADI-Hip.cpp
+++ b/src/polybench/POLYBENCH_ADI-Hip.cpp
@@ -165,17 +165,14 @@ void POLYBENCH_ADI::runHipVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<block_size,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::hip_block_x_direct,
-            RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-              RAJA::statement::Lambda<0, RAJA::Segs<0>>,
-              RAJA::statement::For<1, RAJA::seq_exec,
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0>>,
-              RAJA::statement::For<2, RAJA::seq_exec,
-                RAJA::statement::Lambda<3, RAJA::Segs<0,2>>
-              >
+          RAJA::statement::For<0, RAJA::hip_global_size_x_direct<block_size>,
+            RAJA::statement::Lambda<0, RAJA::Segs<0>>,
+            RAJA::statement::For<1, RAJA::seq_exec,
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>>
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<0>>,
+            RAJA::statement::For<2, RAJA::seq_exec,
+              RAJA::statement::Lambda<3, RAJA::Segs<0,2>>
             >
           >
         >

--- a/src/polybench/POLYBENCH_ATAX-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Cuda.cpp
@@ -132,15 +132,12 @@ void POLYBENCH_ATAX::runCudaVariantImpl(VariantID vid)
     using EXEC_POL1 =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<block_size,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::cuda_block_x_direct,
-            RAJA::statement::For<0, RAJA::cuda_thread_x_direct,
-              RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
-              RAJA::statement::For<1, RAJA::seq_exec,
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
-            >
+          RAJA::statement::For<0, RAJA::cuda_global_size_x_direct<block_size>,
+            RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
+            RAJA::statement::For<1, RAJA::seq_exec,
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
           >
         >
       >;
@@ -148,15 +145,12 @@ void POLYBENCH_ATAX::runCudaVariantImpl(VariantID vid)
     using EXEC_POL2 =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<block_size,
-          RAJA::statement::Tile<1, RAJA::tile_fixed<block_size>,
-                                   RAJA::cuda_block_x_direct,
-            RAJA::statement::For<1, RAJA::cuda_thread_x_direct,
-              RAJA::statement::Lambda<0, RAJA::Segs<1>, RAJA::Params<0>>,
-              RAJA::statement::For<0, RAJA::seq_exec,
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<1>, RAJA::Params<0>>
-            >
+          RAJA::statement::For<1, RAJA::cuda_global_size_x_direct<block_size>,
+            RAJA::statement::Lambda<0, RAJA::Segs<1>, RAJA::Params<0>>,
+            RAJA::statement::For<0, RAJA::seq_exec,
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<1>, RAJA::Params<0>>
           >
         >
       >;

--- a/src/polybench/POLYBENCH_ATAX-Hip.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Hip.cpp
@@ -140,15 +140,12 @@ void POLYBENCH_ATAX::runHipVariantImpl(VariantID vid)
     using EXEC_POL1 =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<block_size,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::hip_block_x_direct,
-            RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-              RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
-              RAJA::statement::For<1, RAJA::seq_exec,
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
-            >
+          RAJA::statement::For<0, RAJA::hip_global_size_x_direct<block_size>,
+            RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
+            RAJA::statement::For<1, RAJA::seq_exec,
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
           >
         >
       >;
@@ -156,15 +153,12 @@ void POLYBENCH_ATAX::runHipVariantImpl(VariantID vid)
     using EXEC_POL2 =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<block_size,
-          RAJA::statement::Tile<1, RAJA::tile_fixed<block_size>,
-                                   RAJA::hip_block_x_direct,
-            RAJA::statement::For<1, RAJA::hip_thread_x_direct,
-              RAJA::statement::Lambda<0, RAJA::Segs<1>, RAJA::Params<0>>,
-              RAJA::statement::For<0, RAJA::seq_exec,
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<1>, RAJA::Params<0>>
-            >
+          RAJA::statement::For<1, RAJA::hip_global_size_x_direct<block_size>,
+            RAJA::statement::Lambda<0, RAJA::Segs<1>, RAJA::Params<0>>,
+            RAJA::statement::For<0, RAJA::seq_exec,
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<1>, RAJA::Params<0>>
           >
         >
       >;

--- a/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
@@ -240,15 +240,9 @@ void POLYBENCH_FDTD_2D::runCudaVariantImpl(VariantID vid)
     using EXEC_POL234 =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
-                                   RAJA::cuda_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                     RAJA::cuda_block_x_direct,
-              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // i
-                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // j
-                  RAJA::statement::Lambda<0>
-                >
-              >
+          RAJA::statement::For<0, RAJA::cuda_global_size_y_direct<i_block_sz>,   // i
+            RAJA::statement::For<1, RAJA::cuda_global_size_x_direct<j_block_sz>, // j
+              RAJA::statement::Lambda<0>
             >
           >
         >

--- a/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
@@ -253,15 +253,9 @@ void POLYBENCH_FDTD_2D::runHipVariantImpl(VariantID vid)
     using EXEC_POL234 =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
-                                   RAJA::hip_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                     RAJA::hip_block_x_direct,
-              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // i
-                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // j
-                  RAJA::statement::Lambda<0>
-                >
-              >
+          RAJA::statement::For<0, RAJA::hip_global_size_y_direct<i_block_sz>,   // i
+            RAJA::statement::For<1, RAJA::hip_global_size_x_direct<j_block_sz>, // j
+              RAJA::statement::Lambda<0>
             >
           >
         >

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
@@ -126,15 +126,9 @@ void POLYBENCH_FLOYD_WARSHALL::runCudaVariantImpl(VariantID vid)
       RAJA::KernelPolicy<
         RAJA::statement::For<0, RAJA::seq_exec,
           RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<i_block_sz>,
-                                     RAJA::cuda_block_y_direct,
-              RAJA::statement::Tile<2, RAJA::tile_fixed<j_block_sz>,
-                                       RAJA::cuda_block_x_direct,
-                RAJA::statement::For<1, RAJA::cuda_thread_y_direct,   // i
-                  RAJA::statement::For<2, RAJA::cuda_thread_x_direct, // j
-                    RAJA::statement::Lambda<0>
-                  >
-                >
+            RAJA::statement::For<1, RAJA::cuda_global_size_y_direct<i_block_sz>,   // i
+              RAJA::statement::For<2, RAJA::cuda_global_size_x_direct<j_block_sz>, // j
+                RAJA::statement::Lambda<0>
               >
             >
           >

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
@@ -131,15 +131,9 @@ void POLYBENCH_FLOYD_WARSHALL::runHipVariantImpl(VariantID vid)
       RAJA::KernelPolicy<
         RAJA::statement::For<0, RAJA::seq_exec,
           RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<i_block_sz>,
-                                     RAJA::hip_block_y_direct,
-              RAJA::statement::Tile<2, RAJA::tile_fixed<j_block_sz>,
-                                       RAJA::hip_block_x_direct,
-                RAJA::statement::For<1, RAJA::hip_thread_y_direct,   // i
-                  RAJA::statement::For<2, RAJA::hip_thread_x_direct, // j
-                    RAJA::statement::Lambda<0>
-                  >
-                >
+            RAJA::statement::For<1, RAJA::hip_global_size_y_direct<i_block_sz>,   // i
+              RAJA::statement::For<2, RAJA::hip_global_size_x_direct<j_block_sz>, // j
+                RAJA::statement::Lambda<0>
               >
             >
           >

--- a/src/polybench/POLYBENCH_GEMM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Cuda.cpp
@@ -131,20 +131,14 @@ void POLYBENCH_GEMM::runCudaVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
-                                   RAJA::cuda_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                     RAJA::cuda_block_x_direct,
-              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // i
-                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // j
-                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
-                  RAJA::statement::Lambda<1, RAJA::Segs<0,1>>,
-                  RAJA::statement::For<2, RAJA::seq_exec,           // k
-                    RAJA::statement::Lambda<2, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-                  >,
-                  RAJA::statement::Lambda<3, RAJA::Segs<0,1>, RAJA::Params<0>>
-                >
-              >
+          RAJA::statement::For<0, RAJA::cuda_global_size_y_direct<i_block_sz>,   // i
+            RAJA::statement::For<1, RAJA::cuda_global_size_x_direct<j_block_sz>, // j
+              RAJA::statement::Lambda<0, RAJA::Params<0>>,
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>>,
+              RAJA::statement::For<2, RAJA::seq_exec,           // k
+                RAJA::statement::Lambda<2, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+              >,
+              RAJA::statement::Lambda<3, RAJA::Segs<0,1>, RAJA::Params<0>>
             >
           >
         >

--- a/src/polybench/POLYBENCH_GEMM-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Hip.cpp
@@ -132,20 +132,14 @@ void POLYBENCH_GEMM::runHipVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
-                                   RAJA::hip_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                     RAJA::hip_block_x_direct,
-              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // i
-                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // j
-                  RAJA::statement::Lambda<0, RAJA::Params<0>>,
-                  RAJA::statement::Lambda<1, RAJA::Segs<0,1>>,
-                  RAJA::statement::For<2, RAJA::seq_exec,           // k
-                    RAJA::statement::Lambda<2, RAJA::Segs<0,1,2>, RAJA::Params<0>>
-                  >,
-                  RAJA::statement::Lambda<3, RAJA::Segs<0,1>, RAJA::Params<0>>
-                >
-              >
+          RAJA::statement::For<0, RAJA::hip_global_size_y_direct<i_block_sz>,   // i
+            RAJA::statement::For<1, RAJA::hip_global_size_x_direct<j_block_sz>, // j
+              RAJA::statement::Lambda<0, RAJA::Params<0>>,
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>>,
+              RAJA::statement::For<2, RAJA::seq_exec,           // k
+                RAJA::statement::Lambda<2, RAJA::Segs<0,1,2>, RAJA::Params<0>>
+              >,
+              RAJA::statement::Lambda<3, RAJA::Segs<0,1>, RAJA::Params<0>>
             >
           >
         >

--- a/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
@@ -222,15 +222,9 @@ void POLYBENCH_GEMVER::runCudaVariantImpl(VariantID vid)
     using EXEC_POL1 =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
-                                   RAJA::cuda_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                     RAJA::cuda_block_x_direct,
-              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // i
-                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // j
-                  RAJA::statement::Lambda<0>
-                >
-              >
+          RAJA::statement::For<0, RAJA::cuda_global_size_y_direct<i_block_sz>,   // i
+            RAJA::statement::For<1, RAJA::cuda_global_size_x_direct<j_block_sz>, // j
+              RAJA::statement::Lambda<0>
             >
           >
         >
@@ -239,15 +233,12 @@ void POLYBENCH_GEMVER::runCudaVariantImpl(VariantID vid)
     using EXEC_POL24 =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<block_size,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::cuda_block_x_direct,
-            RAJA::statement::For<0, RAJA::cuda_thread_x_direct,   // i
-              RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
-              RAJA::statement::For<1, RAJA::seq_exec,             // j
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>,
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
-            >
+          RAJA::statement::For<0, RAJA::cuda_global_size_x_direct<block_size>,   // i
+            RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
+            RAJA::statement::For<1, RAJA::seq_exec,             // j
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>,
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
           >
         >
       >;

--- a/src/polybench/POLYBENCH_GEMVER-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Hip.cpp
@@ -230,15 +230,9 @@ void POLYBENCH_GEMVER::runHipVariantImpl(VariantID vid)
     using EXEC_POL1 =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
-                                   RAJA::hip_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                     RAJA::hip_block_x_direct,
-              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // i
-                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // j
-                  RAJA::statement::Lambda<0>
-                >
-              >
+          RAJA::statement::For<0, RAJA::hip_global_size_y_direct<i_block_sz>,   // i
+            RAJA::statement::For<1, RAJA::hip_global_size_x_direct<j_block_sz>, // j
+              RAJA::statement::Lambda<0>
             >
           >
         >
@@ -247,15 +241,12 @@ void POLYBENCH_GEMVER::runHipVariantImpl(VariantID vid)
     using EXEC_POL24 =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<block_size,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::hip_block_x_direct,
-            RAJA::statement::For<0, RAJA::hip_thread_x_direct,   // i
-              RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
-              RAJA::statement::For<1, RAJA::seq_exec,            // j
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
-            >
+          RAJA::statement::For<0, RAJA::hip_global_size_x_direct<block_size>,   // i
+            RAJA::statement::Lambda<0, RAJA::Segs<0>, RAJA::Params<0>>,
+            RAJA::statement::For<1, RAJA::seq_exec,            // j
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
           >
         >
       >;

--- a/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
@@ -72,15 +72,12 @@ void POLYBENCH_GESUMMV::runCudaVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<block_size,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::cuda_block_x_direct,
-            RAJA::statement::For<0, RAJA::cuda_thread_x_direct,  // i
-              RAJA::statement::Lambda<0, RAJA::Params<0,1>>,
-              RAJA::statement::For<1, RAJA::seq_exec,            // j
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0,1>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0,1>>
-            >
+          RAJA::statement::For<0, RAJA::cuda_global_size_x_direct<block_size>,  // i
+            RAJA::statement::Lambda<0, RAJA::Params<0,1>>,
+            RAJA::statement::For<1, RAJA::seq_exec,            // j
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0,1>>
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0,1>>
           >
         >
       >;

--- a/src/polybench/POLYBENCH_GESUMMV-Hip.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Hip.cpp
@@ -74,15 +74,12 @@ void POLYBENCH_GESUMMV::runHipVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<block_size,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::hip_block_x_direct,
-            RAJA::statement::For<0, RAJA::hip_thread_x_direct,
-              RAJA::statement::Lambda<0, RAJA::Params<0,1>>,
-              RAJA::statement::For<1, RAJA::seq_exec,
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0,1>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0,1>>
-            >
+          RAJA::statement::For<0, RAJA::hip_global_size_x_direct<block_size>,
+            RAJA::statement::Lambda<0, RAJA::Params<0,1>>,
+            RAJA::statement::For<1, RAJA::seq_exec,
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0,1>>
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0,1>>
           >
         >
       >;

--- a/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
@@ -152,16 +152,10 @@ void POLYBENCH_HEAT_3D::runCudaVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<j_block_sz * k_block_sz,
-          RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                   RAJA::cuda_block_y_direct,
-            RAJA::statement::Tile<2, RAJA::tile_fixed<k_block_sz>,
-                                     RAJA::cuda_block_x_direct,
-              RAJA::statement::For<0, RAJA::cuda_block_z_direct,      // i
-                RAJA::statement::For<1, RAJA::cuda_thread_y_direct,   // j
-                  RAJA::statement::For<2, RAJA::cuda_thread_x_direct, // k
-                    RAJA::statement::Lambda<0>
-                  >
-                >
+          RAJA::statement::For<0, RAJA::cuda_block_z_direct,      // i
+            RAJA::statement::For<1, RAJA::cuda_global_size_y_direct<j_block_sz>,   // j
+              RAJA::statement::For<2, RAJA::cuda_global_size_x_direct<k_block_sz>, // k
+                RAJA::statement::Lambda<0>
               >
             >
           >

--- a/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
@@ -159,16 +159,10 @@ void POLYBENCH_HEAT_3D::runHipVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<j_block_sz * k_block_sz,
-          RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                   RAJA::hip_block_y_direct,
-            RAJA::statement::Tile<2, RAJA::tile_fixed<k_block_sz>,
-                                     RAJA::hip_block_x_direct,
-              RAJA::statement::For<0, RAJA::hip_block_z_direct,      // i
-                RAJA::statement::For<1, RAJA::hip_thread_y_direct,   // j
-                  RAJA::statement::For<2, RAJA::hip_thread_x_direct, // k
-                    RAJA::statement::Lambda<0>
-                  >
-                >
+          RAJA::statement::For<0, RAJA::hip_block_z_direct,      // i
+            RAJA::statement::For<1, RAJA::hip_global_size_y_direct<j_block_sz>,   // j
+              RAJA::statement::For<2, RAJA::hip_global_size_x_direct<k_block_sz>, // k
+                RAJA::statement::Lambda<0>
               >
             >
           >

--- a/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
@@ -148,15 +148,9 @@ void POLYBENCH_JACOBI_2D::runCudaVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<i_block_sz * j_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
-                                   RAJA::cuda_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                     RAJA::cuda_block_x_direct,
-              RAJA::statement::For<0, RAJA::cuda_thread_y_direct,   // i
-                RAJA::statement::For<1, RAJA::cuda_thread_x_direct, // j
-                  RAJA::statement::Lambda<0>
-                >
-              >
+          RAJA::statement::For<0, RAJA::cuda_global_size_y_direct<i_block_sz>,   // i
+            RAJA::statement::For<1, RAJA::cuda_global_size_x_direct<j_block_sz>, // j
+              RAJA::statement::Lambda<0>
             >
           >
         >

--- a/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
@@ -154,15 +154,9 @@ void POLYBENCH_JACOBI_2D::runHipVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<i_block_sz * j_block_sz,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<i_block_sz>,
-                                   RAJA::hip_block_y_direct,
-            RAJA::statement::Tile<1, RAJA::tile_fixed<j_block_sz>,
-                                     RAJA::hip_block_x_direct,
-              RAJA::statement::For<0, RAJA::hip_thread_y_direct,   // i
-                RAJA::statement::For<1, RAJA::hip_thread_x_direct, // j
-                  RAJA::statement::Lambda<0>
-                >
-              >
+          RAJA::statement::For<0, RAJA::hip_global_size_y_direct<i_block_sz>,   // i
+            RAJA::statement::For<1, RAJA::hip_global_size_x_direct<j_block_sz>, // j
+              RAJA::statement::Lambda<0>
             >
           >
         >

--- a/src/polybench/POLYBENCH_MVT-Cuda.cpp
+++ b/src/polybench/POLYBENCH_MVT-Cuda.cpp
@@ -87,15 +87,12 @@ void POLYBENCH_MVT::runCudaVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::CudaKernelFixedAsync<block_size,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::cuda_block_x_direct,
-            RAJA::statement::For<0, RAJA::cuda_thread_x_direct,  // i
-              RAJA::statement::Lambda<0, RAJA::Params<0>>,
-              RAJA::statement::For<1, RAJA::seq_exec,            // j
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
-            >
+          RAJA::statement::For<0, RAJA::cuda_global_size_x_direct<block_size>,  // i
+            RAJA::statement::Lambda<0, RAJA::Params<0>>,
+            RAJA::statement::For<1, RAJA::seq_exec,            // j
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
           >
         >
       >;

--- a/src/polybench/POLYBENCH_MVT-Hip.cpp
+++ b/src/polybench/POLYBENCH_MVT-Hip.cpp
@@ -91,15 +91,12 @@ void POLYBENCH_MVT::runHipVariantImpl(VariantID vid)
     using EXEC_POL =
       RAJA::KernelPolicy<
         RAJA::statement::HipKernelFixedAsync<block_size,
-          RAJA::statement::Tile<0, RAJA::tile_fixed<block_size>,
-                                   RAJA::hip_block_x_direct,
-            RAJA::statement::For<0, RAJA::hip_thread_x_direct,  // i
-              RAJA::statement::Lambda<0, RAJA::Params<0>>,
-              RAJA::statement::For<1, RAJA::seq_exec,           // j
-                RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
-              >,
-              RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
-            >
+          RAJA::statement::For<0, RAJA::hip_global_size_x_direct<block_size>,  // i
+            RAJA::statement::Lambda<0, RAJA::Params<0>>,
+            RAJA::statement::For<1, RAJA::seq_exec,           // j
+              RAJA::statement::Lambda<1, RAJA::Segs<0,1>, RAJA::Params<0>>
+            >,
+            RAJA::statement::Lambda<2, RAJA::Segs<0>, RAJA::Params<0>>
           >
         >
       >;


### PR DESCRIPTION
# Use new RAJA GPU indexing policies

This gives compile time knowledge of the block sizes in some kernels. This brings the RAJA variants closer in line with the base variants.
The base variants can still take a advantage of the knowledge that the ranges start at 0.

- This PR is a feature
- It does the following:
  - Adds an example of using the new GPU indexing policies at the request of @rhornung67 
