### PR TITLE
fix omp clang hip build in mat mat shared kernel

### DIFF
--- a/src/basic/MAT_MAT_SHARED-OMP.cpp
+++ b/src/basic/MAT_MAT_SHARED-OMP.cpp
@@ -39,7 +39,9 @@ void MAT_MAT_SHARED::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(
         for (Index_type by = 0; by < Ny; ++by) {
           for (Index_type bx = 0; bx < Nx; ++bx) {
 
-            MAT_MAT_SHARED_BODY_0(TL_SZ)
+            //Work around for when compiling with CLANG and HIP
+            //See notes in MAT_MAT_SHARED.hpp
+            MAT_MAT_SHARED_BODY_0_CLANG_HIP_CPU(TL_SZ)
 
             for (Index_type ty = 0; ty < TL_SZ; ++ty) {
               for (Index_type tx = 0; tx < TL_SZ; ++tx) {


### PR DESCRIPTION
We can't use the RAJA_TEAM_SHARED macro in purely host code as, clang + hip throws errors when trying to detect if code is a gpu kernel or not. 