### PR TITLE
[WIP] Rework input parsing and error checking

### DIFF
--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -130,37 +130,8 @@ void Executor::setupSuite()
 
   using Slist = list<string>;
   using Svector = vector<string>;
-  using COvector = vector<RunParams::CombinerOpt>;
   using KIDset = set<KernelID>;
   using VIDset = set<VariantID>;
-
-  //
-  // Determine which kernels to exclude from input.
-  // exclude_kern will be non-duplicated ordered set of IDs of kernel to exclude.
-  //
-  const Svector& npasses_combiner_input = run_params.getNpassesCombinerOptInput();
-  if ( !npasses_combiner_input.empty() ) {
-
-    COvector combiners;
-    Svector invalid;
-    for (const std::string& combiner_name : npasses_combiner_input) {
-
-      if (combiner_name == RunParams::CombinerOptToStr(RunParams::CombinerOpt::Average)) {
-        combiners.emplace_back(RunParams::CombinerOpt::Average);
-      } else if (combiner_name == RunParams::CombinerOptToStr(RunParams::CombinerOpt::Minimum)) {
-        combiners.emplace_back(RunParams::CombinerOpt::Minimum);
-      } else if (combiner_name == RunParams::CombinerOptToStr(RunParams::CombinerOpt::Maximum)) {
-        combiners.emplace_back(RunParams::CombinerOpt::Maximum);
-      } else {
-        invalid.emplace_back(combiner_name);
-      }
-
-    }
-
-    run_params.setNpassesCombinerOpts(combiners);
-    run_params.setInvalidNpassesCombinerOptInput(invalid);
-
-  }
 
   //
   // Determine which kernels to exclude from input.
@@ -579,12 +550,8 @@ void Executor::setupSuite()
   // A message will be emitted later so user can sort it out...
   //
 
-  if ( !(run_params.getInvalidNpassesCombinerOptInput().empty()) ) {
-
-    run_params.setInputState(RunParams::BadInput);
-
-  } else if ( !(run_params.getInvalidKernelInput().empty()) ||
-              !(run_params.getInvalidExcludeKernelInput().empty()) ) {
+  if ( !(run_params.getInvalidKernelInput().empty()) ||
+       !(run_params.getInvalidExcludeKernelInput().empty()) ) {
 
     run_params.setInputState(RunParams::BadInput);
 
@@ -605,7 +572,7 @@ void Executor::setupSuite()
 
        run_params.setInputState(RunParams::BadInput);
 
-    } else { // variant input lools good
+    } else { // variant input looks good
 
       for (VIDset::iterator vid = run_var.begin();
            vid != run_var.end(); ++vid) {
@@ -922,7 +889,7 @@ void Executor::runSuite()
     return;
   }
 
-  if (!run_params.getDisableWarmup()) {
+  if ( !run_params.getDisableWarmup() ) {
     getCout() << "\n\nRun warmup kernels...\n";
 
     vector<KernelBase*> warmup_kernels;

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -115,9 +115,6 @@ public:
 
   const std::vector<CombinerOpt>& getNpassesCombinerOpts() const
   { return npasses_combiners; }
-  void setNpassesCombinerOpts( std::vector<CombinerOpt>& cvec )
-  { npasses_combiners = cvec; }
-
 
   SizeMeaning getSizeMeaning() const { return size_meaning; }
 
@@ -208,13 +205,6 @@ public:
   const std::vector<std::string>& getInvalidExcludeFeatureInput() const
                                   { return invalid_exclude_feature_input; }
 
-  const std::vector<std::string>& getNpassesCombinerOptInput() const
-                                  { return npasses_combiner_input; }
-  const std::vector<std::string>& getInvalidNpassesCombinerOptInput() const
-                                  { return invalid_npasses_combiner_input; }
-  void setInvalidNpassesCombinerOptInput( std::vector<std::string>& svec )
-                              { invalid_npasses_combiner_input = svec; }
-
   const std::string& getOutputDirName() const { return outdir; }
   const std::string& getOutputFilePrefix() const { return outfile_prefix; }
 
@@ -243,6 +233,8 @@ private:
   void printFeatureNames(std::ostream& str) const;
   void printFeatureKernels(std::ostream& str) const;
   void printKernelFeatures(std::ostream& str) const;
+
+  void checkNpassesCombinerInput();
 //@}
 
   InputOpt input_state;  /*!< state of command line input */


### PR DESCRIPTION
# Summary Rework input parsing and error checking to make code less complex

- This PR is a refactoring that moves input processing out of the Executor class and into the RunParams class.
   - This simplifies the large and complex `Executor::setupSuite()` method.
   - It eliminates a bunch of single use methods that exist only for RunParams and Executor class object interactions.
   - It partitions the input parsing and error checking into manageable subsets that are easier to understand and maintain.
