### PR TITLE
Add grid stride tunings of reduction kernels

### DIFF
--- a/src/algorithm/REDUCE_SUM-Cuda.cpp
+++ b/src/algorithm/REDUCE_SUM-Cuda.cpp
@@ -18,6 +18,8 @@
 #include "cub/util_allocator.cuh"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -190,11 +192,79 @@ void REDUCE_SUM::runCudaVariantBlock(VariantID vid)
 
 }
 
-void REDUCE_SUM::runCudaVariant(VariantID vid, size_t tune_idx)
+template < size_t block_size >
+void REDUCE_SUM::runCudaVariantOccGS(VariantID vid)
 {
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  REDUCE_SUM_DATA_SETUP;
+
   if ( vid == Base_CUDA ) {
 
-    size_t t = 0;
+    Real_ptr dsum;
+    allocData(DataSpace::CudaDevice, dsum, 1);
+
+    constexpr size_t shmem = sizeof(Real_type)*block_size;
+    const size_t max_grid_size = detail::getCudaOccupancyMaxBlocks(
+        (reduce_sum<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      cudaErrchk( cudaMemcpyAsync( dsum, &m_sum_init, sizeof(Real_type),
+                                   cudaMemcpyHostToDevice, res.get_stream() ) );
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      reduce_sum<block_size><<<grid_size, block_size,
+                  shmem, res.get_stream()>>>( x,
+                                                   dsum, m_sum_init,
+                                                   iend );
+      cudaErrchk( cudaGetLastError() );
+
+      cudaErrchk( cudaMemcpyAsync( &m_sum, dsum, sizeof(Real_type),
+                                   cudaMemcpyDeviceToHost, res.get_stream() ) );
+      cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::CudaDevice, dsum);
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> sum(m_sum_init);
+
+      RAJA::forall< RAJA::cuda_exec_occ_calc<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          REDUCE_SUM_BODY;
+      });
+
+      m_sum = sum.get();
+
+    }
+    stopTimer();
+
+  } else {
+
+    getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void REDUCE_SUM::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_CUDA ) {
 
     if (tune_idx == t) {
 
@@ -204,12 +274,17 @@ void REDUCE_SUM::runCudaVariant(VariantID vid, size_t tune_idx)
 
     t += 1;
 
+  }
+
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
         if (tune_idx == t) {
+
           setBlockSize(block_size);
           runCudaVariantBlock<block_size>(vid);
 
@@ -217,22 +292,10 @@ void REDUCE_SUM::runCudaVariant(VariantID vid, size_t tune_idx)
 
         t += 1;
 
-      }
-
-    });
-
-  } else if ( vid == RAJA_CUDA ) {
-
-    size_t t = 0;
-
-    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
-
-      if (run_params.numValidGPUBlockSize() == 0u ||
-          run_params.validGPUBlockSize(block_size)) {
-
         if (tune_idx == t) {
 
-          runCudaVariantBlock<block_size>(vid);
+          setBlockSize(block_size);
+          runCudaVariantOccGS<block_size>(vid);
 
         }
 
@@ -256,18 +319,9 @@ void REDUCE_SUM::setCudaTuningDefinitions(VariantID vid)
 
     addVariantTuningName(vid, "cub");
 
-    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+  }
 
-      if (run_params.numValidGPUBlockSize() == 0u ||
-          run_params.validGPUBlockSize(block_size)) {
-
-        addVariantTuningName(vid, "block_"+std::to_string(block_size));
-
-      }
-
-    });
-
-  } else if ( vid == RAJA_CUDA ) {
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
 
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 
@@ -275,6 +329,8 @@ void REDUCE_SUM::setCudaTuningDefinitions(VariantID vid)
           run_params.validGPUBlockSize(block_size)) {
 
         addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
 
       }
 

--- a/src/algorithm/REDUCE_SUM-Cuda.cpp
+++ b/src/algorithm/REDUCE_SUM-Cuda.cpp
@@ -221,7 +221,7 @@ void REDUCE_SUM::runCudaVariantOccGS(VariantID vid)
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
       reduce_sum<block_size><<<grid_size, block_size,
-                  shmem, res.get_stream()>>>( x,
+                               shmem, res.get_stream()>>>( x,
                                                    dsum, m_sum_init,
                                                    iend );
       cudaErrchk( cudaGetLastError() );

--- a/src/algorithm/REDUCE_SUM-Hip.cpp
+++ b/src/algorithm/REDUCE_SUM-Hip.cpp
@@ -23,6 +23,8 @@
 #include "common/HipDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -216,11 +218,78 @@ void REDUCE_SUM::runHipVariantBlock(VariantID vid)
 
 }
 
-void REDUCE_SUM::runHipVariant(VariantID vid, size_t tune_idx)
+template < size_t block_size >
+void REDUCE_SUM::runHipVariantOccGS(VariantID vid)
 {
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  REDUCE_SUM_DATA_SETUP;
+
   if ( vid == Base_HIP ) {
 
-    size_t t = 0;
+    Real_ptr dsum;
+    allocData(DataSpace::HipDevice, dsum, 1);
+
+    constexpr size_t shmem = sizeof(Real_type)*block_size;
+    const size_t max_grid_size = detail::getHipOccupancyMaxBlocks(
+        (reduce_sum<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      hipErrchk( hipMemcpyAsync( dsum, &m_sum_init, sizeof(Real_type),
+                                 hipMemcpyHostToDevice, res.get_stream() ) );
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      hipLaunchKernelGGL( (reduce_sum<block_size>), dim3(grid_size), dim3(block_size),
+                          shmem, res.get_stream(),
+                          x, dsum, m_sum_init, iend );
+      hipErrchk( hipGetLastError() );
+
+      hipErrchk( hipMemcpyAsync( &m_sum, dsum, sizeof(Real_type),
+                                 hipMemcpyDeviceToHost, res.get_stream() ) );
+      hipErrchk( hipStreamSynchronize( res.get_stream() ) );
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::HipDevice, dsum);
+
+  } else if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::hip_reduce, Real_type> sum(m_sum_init);
+
+      RAJA::forall< RAJA::hip_exec_occ_calc<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          REDUCE_SUM_BODY;
+      });
+
+      m_sum = sum.get();
+
+    }
+    stopTimer();
+
+  } else {
+
+    getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void REDUCE_SUM::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_HIP ) {
 
     if (tune_idx == t) {
 
@@ -230,12 +299,17 @@ void REDUCE_SUM::runHipVariant(VariantID vid, size_t tune_idx)
 
     t += 1;
 
+  }
+
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
         if (tune_idx == t) {
+
           setBlockSize(block_size);
           runHipVariantBlock<block_size>(vid);
 
@@ -243,22 +317,10 @@ void REDUCE_SUM::runHipVariant(VariantID vid, size_t tune_idx)
 
         t += 1;
 
-      }
-
-    });
-
-  } else if ( vid == RAJA_HIP ) {
-
-    size_t t = 0;
-
-    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
-
-      if (run_params.numValidGPUBlockSize() == 0u ||
-          run_params.validGPUBlockSize(block_size)) {
-
         if (tune_idx == t) {
 
-          runHipVariantBlock<block_size>(vid);
+          setBlockSize(block_size);
+          runHipVariantOccGS<block_size>(vid);
 
         }
 
@@ -286,18 +348,9 @@ void REDUCE_SUM::setHipTuningDefinitions(VariantID vid)
     addVariantTuningName(vid, "cub");
 #endif
 
-    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+  }
 
-      if (run_params.numValidGPUBlockSize() == 0u ||
-          run_params.validGPUBlockSize(block_size)) {
-
-        addVariantTuningName(vid, "block_"+std::to_string(block_size));
-
-      }
-
-    });
-
-  } else if ( vid == RAJA_HIP ) {
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
 
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 
@@ -305,6 +358,8 @@ void REDUCE_SUM::setHipTuningDefinitions(VariantID vid)
           run_params.validGPUBlockSize(block_size)) {
 
         addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
 
       }
 

--- a/src/algorithm/REDUCE_SUM.hpp
+++ b/src/algorithm/REDUCE_SUM.hpp
@@ -66,7 +66,11 @@ public:
   template < size_t block_size >
   void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
+  void runCudaVariantOccGS(VariantID vid);
+  template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantOccGS(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/basic/PI_REDUCE-Cuda.cpp
+++ b/src/basic/PI_REDUCE-Cuda.cpp
@@ -15,6 +15,8 @@
 #include "common/CudaDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -59,7 +61,7 @@ __global__ void pi_reduce(Real_type dx,
 
 
 template < size_t block_size >
-void PI_REDUCE::runCudaVariantImpl(VariantID vid)
+void PI_REDUCE::runCudaVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -120,7 +122,132 @@ void PI_REDUCE::runCudaVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(PI_REDUCE, Cuda)
+template < size_t block_size >
+void PI_REDUCE::runCudaVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  PI_REDUCE_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    Real_ptr dpi;
+    allocData(DataSpace::CudaDevice, dpi, 1);
+
+    constexpr size_t shmem = sizeof(Real_type)*block_size;
+    const size_t max_grid_size = detail::getCudaOccupancyMaxBlocks(
+        (pi_reduce<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      cudaErrchk( cudaMemcpyAsync( dpi, &m_pi_init, sizeof(Real_type),
+                                   cudaMemcpyHostToDevice, res.get_stream() ) );
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      pi_reduce<block_size><<<grid_size, block_size,
+                  shmem, res.get_stream()>>>( dx,
+                                                   dpi, m_pi_init,
+                                                   iend );
+      cudaErrchk( cudaGetLastError() );
+
+      cudaErrchk( cudaMemcpyAsync( &m_pi, dpi, sizeof(Real_type),
+                                   cudaMemcpyDeviceToHost, res.get_stream() ) );
+      cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
+      m_pi *= 4.0;
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::CudaDevice, dpi);
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> pi(m_pi_init);
+
+      RAJA::forall< RAJA::cuda_exec_occ_calc<block_size, true /*async*/> >( res,
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         PI_REDUCE_BODY;
+       });
+
+      m_pi = 4.0 * static_cast<Real_type>(pi.get());
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  PI_REDUCE : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+void PI_REDUCE::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  PI_REDUCE : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void PI_REDUCE::setCudaTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/PI_REDUCE-Cuda.cpp
+++ b/src/basic/PI_REDUCE-Cuda.cpp
@@ -151,7 +151,7 @@ void PI_REDUCE::runCudaVariantOccGS(VariantID vid)
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
       pi_reduce<block_size><<<grid_size, block_size,
-                  shmem, res.get_stream()>>>( dx,
+                              shmem, res.get_stream()>>>( dx,
                                                    dpi, m_pi_init,
                                                    iend );
       cudaErrchk( cudaGetLastError() );

--- a/src/basic/PI_REDUCE-Hip.cpp
+++ b/src/basic/PI_REDUCE-Hip.cpp
@@ -15,6 +15,8 @@
 #include "common/HipDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -59,7 +61,7 @@ __global__ void pi_reduce(Real_type dx,
 
 
 template < size_t block_size >
-void PI_REDUCE::runHipVariantImpl(VariantID vid)
+void PI_REDUCE::runHipVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -119,7 +121,132 @@ void PI_REDUCE::runHipVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(PI_REDUCE, Hip)
+template < size_t block_size >
+void PI_REDUCE::runHipVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  PI_REDUCE_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    Real_ptr dpi;
+    allocData(DataSpace::HipDevice, dpi, 1);
+
+    constexpr size_t shmem = sizeof(Real_type)*block_size;
+    const size_t max_grid_size = detail::getHipOccupancyMaxBlocks(
+        (pi_reduce<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      hipErrchk( hipMemcpyAsync( dpi, &m_pi_init, sizeof(Real_type),
+                                 hipMemcpyHostToDevice, res.get_stream() ) );
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      hipLaunchKernelGGL( (pi_reduce<block_size>), dim3(grid_size), dim3(block_size),
+                          shmem, res.get_stream(),
+                          dx, dpi, m_pi_init, iend );
+      hipErrchk( hipGetLastError() );
+
+      hipErrchk( hipMemcpyAsync( &m_pi, dpi, sizeof(Real_type),
+                                 hipMemcpyDeviceToHost, res.get_stream() ) );
+      hipErrchk( hipStreamSynchronize( res.get_stream() ) );
+      m_pi *= 4.0;
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::HipDevice, dpi);
+
+  } else if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::hip_reduce, Real_type> pi(m_pi_init);
+
+      RAJA::forall< RAJA::hip_exec_occ_calc<block_size, true /*async*/> >( res,
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         PI_REDUCE_BODY;
+       });
+
+      m_pi = 4.0 * static_cast<Real_type>(pi.get());
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  PI_REDUCE : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+void PI_REDUCE::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  PI_REDUCE : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void PI_REDUCE::setHipTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -60,9 +60,13 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantImpl(VariantID vid);
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantImpl(VariantID vid);
+  void runCudaVariantOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlock(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantOccGS(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/basic/REDUCE3_INT-Cuda.cpp
+++ b/src/basic/REDUCE3_INT-Cuda.cpp
@@ -15,6 +15,8 @@
 #include "common/CudaDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -74,7 +76,7 @@ __global__ void reduce3int(Int_ptr vec,
 
 
 template < size_t block_size >
-void REDUCE3_INT::runCudaVariantImpl(VariantID vid)
+void REDUCE3_INT::runCudaVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -151,7 +153,148 @@ void REDUCE3_INT::runCudaVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(REDUCE3_INT, Cuda)
+template < size_t block_size >
+void REDUCE3_INT::runCudaVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  REDUCE3_INT_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    Int_ptr vmem_init;
+    allocData(DataSpace::CudaPinned, vmem_init, 3);
+
+    Int_ptr vmem;
+    allocData(DataSpace::CudaDevice, vmem, 3);
+
+    constexpr size_t shmem = 3*sizeof(Int_type)*block_size;
+    const size_t max_grid_size = detail::getCudaOccupancyMaxBlocks(
+        (reduce3int<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      vmem_init[0] = m_vsum_init;
+      vmem_init[1] = m_vmin_init;
+      vmem_init[2] = m_vmax_init;
+      cudaErrchk( cudaMemcpyAsync( vmem, vmem_init, 3*sizeof(Int_type),
+                                   cudaMemcpyHostToDevice, res.get_stream() ) );
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      reduce3int<block_size><<<grid_size, block_size,
+                   shmem, res.get_stream()>>>(vec,
+                                                    vmem + 0, m_vsum_init,
+                                                    vmem + 1, m_vmin_init,
+                                                    vmem + 2, m_vmax_init,
+                                                    iend );
+      cudaErrchk( cudaGetLastError() );
+
+      Int_type lmem[3];
+      cudaErrchk( cudaMemcpyAsync( &lmem[0], vmem, 3*sizeof(Int_type),
+                                   cudaMemcpyDeviceToHost, res.get_stream() ) );
+      cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
+      m_vsum += lmem[0];
+      m_vmin = RAJA_MIN(m_vmin, lmem[1]);
+      m_vmax = RAJA_MAX(m_vmax, lmem[2]);
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::CudaDevice, vmem);
+    deallocData(DataSpace::CudaPinned, vmem_init);
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce, Int_type> vsum(m_vsum_init);
+      RAJA::ReduceMin<RAJA::cuda_reduce, Int_type> vmin(m_vmin_init);
+      RAJA::ReduceMax<RAJA::cuda_reduce, Int_type> vmax(m_vmax_init);
+
+      RAJA::forall< RAJA::cuda_exec_occ_calc<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        REDUCE3_INT_BODY_RAJA;
+      });
+
+      m_vsum += static_cast<Int_type>(vsum.get());
+      m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
+      m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  REDUCE3_INT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+void REDUCE3_INT::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  REDUCE3_INT : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void REDUCE3_INT::setCudaTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/REDUCE3_INT-Cuda.cpp
+++ b/src/basic/REDUCE3_INT-Cuda.cpp
@@ -188,7 +188,7 @@ void REDUCE3_INT::runCudaVariantOccGS(VariantID vid)
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
       reduce3int<block_size><<<grid_size, block_size,
-                   shmem, res.get_stream()>>>(vec,
+                               shmem, res.get_stream()>>>(vec,
                                                     vmem + 0, m_vsum_init,
                                                     vmem + 1, m_vmin_init,
                                                     vmem + 2, m_vmax_init,

--- a/src/basic/REDUCE3_INT-Hip.cpp
+++ b/src/basic/REDUCE3_INT-Hip.cpp
@@ -187,7 +187,8 @@ void REDUCE3_INT::runHipVariantOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      hipLaunchKernelGGL((reduce3int<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
+      hipLaunchKernelGGL((reduce3int<block_size>), dim3(grid_size), dim3(block_size),
+                                                   shmem, res.get_stream(),
                                                     vec,
                                                     vmem + 0, m_vsum_init,
                                                     vmem + 1, m_vmin_init,

--- a/src/basic/REDUCE3_INT-Hip.cpp
+++ b/src/basic/REDUCE3_INT-Hip.cpp
@@ -15,6 +15,8 @@
 #include "common/HipDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -74,7 +76,7 @@ __global__ void reduce3int(Int_ptr vec,
 
 
 template < size_t block_size >
-void REDUCE3_INT::runHipVariantImpl(VariantID vid)
+void REDUCE3_INT::runHipVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -151,7 +153,149 @@ void REDUCE3_INT::runHipVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(REDUCE3_INT, Hip)
+template < size_t block_size >
+void REDUCE3_INT::runHipVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  REDUCE3_INT_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    Int_ptr vmem_init;
+    allocData(DataSpace::HipPinned, vmem_init, 3);
+
+    Int_ptr vmem;
+    allocData(DataSpace::HipDevice, vmem, 3);
+
+    constexpr size_t shmem = 3*sizeof(Int_type)*block_size;
+    const size_t max_grid_size = detail::getHipOccupancyMaxBlocks(
+        (reduce3int<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      vmem_init[0] = m_vsum_init;
+      vmem_init[1] = m_vmin_init;
+      vmem_init[2] = m_vmax_init;
+      hipErrchk( hipMemcpyAsync( vmem, vmem_init, 3*sizeof(Int_type),
+                                 hipMemcpyHostToDevice, res.get_stream() ) );
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      hipLaunchKernelGGL((reduce3int<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
+                                                    vec,
+                                                    vmem + 0, m_vsum_init,
+                                                    vmem + 1, m_vmin_init,
+                                                    vmem + 2, m_vmax_init,
+                                                    iend );
+      hipErrchk( hipGetLastError() );
+
+      Int_type lmem[3];
+      hipErrchk( hipMemcpyAsync( &lmem[0], vmem, 3*sizeof(Int_type),
+                                 hipMemcpyDeviceToHost, res.get_stream() ) );
+      hipErrchk( hipStreamSynchronize( res.get_stream() ) );
+      m_vsum += lmem[0];
+      m_vmin = RAJA_MIN(m_vmin, lmem[1]);
+      m_vmax = RAJA_MAX(m_vmax, lmem[2]);
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::HipDevice, vmem);
+    deallocData(DataSpace::HipPinned, vmem_init);
+
+  } else if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::hip_reduce, Int_type> vsum(m_vsum_init);
+      RAJA::ReduceMin<RAJA::hip_reduce, Int_type> vmin(m_vmin_init);
+      RAJA::ReduceMax<RAJA::hip_reduce, Int_type> vmax(m_vmax_init);
+
+      RAJA::forall< RAJA::hip_exec_occ_calc<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        REDUCE3_INT_BODY_RAJA;
+      });
+
+      m_vsum += static_cast<Int_type>(vsum.get());
+      m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
+      m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  REDUCE3_INT : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+void REDUCE3_INT::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  REDUCE3_INT : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void REDUCE3_INT::setHipTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/REDUCE3_INT.hpp
+++ b/src/basic/REDUCE3_INT.hpp
@@ -75,9 +75,13 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantImpl(VariantID vid);
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantImpl(VariantID vid);
+  void runCudaVariantOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlock(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantOccGS(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/basic/REDUCE_STRUCT-Cuda.cpp
+++ b/src/basic/REDUCE_STRUCT-Cuda.cpp
@@ -15,6 +15,8 @@
 #include "common/CudaDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -96,7 +98,7 @@ __global__ void reduce_struct(Real_ptr x, Real_ptr y,
 }
 
 template < size_t block_size >
-void REDUCE_STRUCT::runCudaVariantImpl(VariantID vid)
+void REDUCE_STRUCT::runCudaVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -178,7 +180,153 @@ void REDUCE_STRUCT::runCudaVariantImpl(VariantID vid)
 
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(REDUCE_STRUCT, Cuda)
+template < size_t block_size >
+void REDUCE_STRUCT::runCudaVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  REDUCE_STRUCT_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    Real_ptr mem; //xcenter,xmin,xmax,ycenter,ymin,ymax
+    allocData(DataSpace::CudaDevice, mem,6);
+
+    constexpr size_t shmem = 6*sizeof(Real_type)*block_size;
+    const size_t max_grid_size = detail::getCudaOccupancyMaxBlocks(
+        (reduce_struct<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      cudaErrchk(cudaMemsetAsync(mem, 0.0, 6*sizeof(Real_type), res.get_stream()));
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      reduce_struct<block_size><<<grid_size, block_size,
+                                  shmem, res.get_stream()>>>(
+        points.x, points.y,
+        mem, mem+1, mem+2,    // xcenter,xmin,xmax
+        mem+3, mem+4, mem+5,  // ycenter,ymin,ymax
+        m_init_sum, m_init_min, m_init_max,
+        points.N);
+      cudaErrchk( cudaGetLastError() );
+
+      Real_type lmem[6]={0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+      cudaErrchk( cudaMemcpyAsync( &lmem[0], mem, 6*sizeof(Real_type),
+                                   cudaMemcpyDeviceToHost, res.get_stream() ) );
+      cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
+
+      points.SetCenter(lmem[0]/points.N, lmem[3]/points.N);
+      points.SetXMin(lmem[1]);
+      points.SetXMax(lmem[2]);
+      points.SetYMin(lmem[4]);
+      points.SetYMax(lmem[5]);
+      m_points=points;
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::CudaDevice, mem);
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> xsum(m_init_sum);
+      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> ysum(m_init_sum);
+      RAJA::ReduceMin<RAJA::cuda_reduce, Real_type> xmin(m_init_min);
+      RAJA::ReduceMin<RAJA::cuda_reduce, Real_type> ymin(m_init_min);
+      RAJA::ReduceMax<RAJA::cuda_reduce, Real_type> xmax(m_init_max);
+      RAJA::ReduceMax<RAJA::cuda_reduce, Real_type> ymax(m_init_max);
+
+      RAJA::forall< RAJA::cuda_exec_occ_calc<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          REDUCE_STRUCT_BODY_RAJA;
+      });
+
+      points.SetCenter((xsum.get()/(points.N)),
+                       (ysum.get()/(points.N)));
+      points.SetXMin((xmin.get()));
+      points.SetXMax((xmax.get()));
+      points.SetYMin((ymin.get()));
+      points.SetYMax((ymax.get()));
+      m_points=points;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  REDUCE_STRUCT : Unknown CUDA variant id = " << vid << std::endl;
+  }
+
+}
+
+void REDUCE_STRUCT::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  REDUCE_STRUCT : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void REDUCE_STRUCT::setCudaTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/REDUCE_STRUCT-Hip.cpp
+++ b/src/basic/REDUCE_STRUCT-Hip.cpp
@@ -15,6 +15,8 @@
 #include "common/HipDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -97,7 +99,7 @@ __global__ void reduce_struct(Real_ptr x, Real_ptr y,
 
 
 template < size_t block_size >
-void REDUCE_STRUCT::runHipVariantImpl(VariantID vid)
+void REDUCE_STRUCT::runHipVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -180,8 +182,155 @@ void REDUCE_STRUCT::runHipVariantImpl(VariantID vid)
   }
 
 }
+template < size_t block_size >
+void REDUCE_STRUCT::runHipVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(REDUCE_STRUCT, Hip)
+  auto res{getHipResource()};
+
+  REDUCE_STRUCT_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    Real_ptr mem; //xcenter,xmin,xmax,ycenter,ymin,ymax
+    allocData(DataSpace::HipDevice, mem,6);
+
+    constexpr size_t shmem = 6*sizeof(Real_type)*block_size;
+    const size_t max_grid_size = detail::getHipOccupancyMaxBlocks(
+        (reduce_struct<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      hipErrchk(hipMemsetAsync(mem, 0.0, 6*sizeof(Real_type), res.get_stream()));
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      hipLaunchKernelGGL((reduce_struct<block_size>),
+                         dim3(grid_size), dim3(block_size),
+                         shmem, res.get_stream(),
+                   points.x, points.y,
+                         mem, mem+1, mem+2,    // xcenter,xmin,xmax
+                         mem+3, mem+4, mem+5,  // ycenter,ymin,ymax
+                         m_init_sum, m_init_min, m_init_max,
+                         points.N);
+      hipErrchk( hipGetLastError() );
+
+      Real_type lmem[6]={0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+      hipErrchk( hipMemcpyAsync( &lmem[0], mem, 6*sizeof(Real_type),
+                                 hipMemcpyDeviceToHost, res.get_stream() ) );
+      hipErrchk( hipStreamSynchronize( res.get_stream() ) );
+
+      points.SetCenter(lmem[0]/points.N, lmem[3]/points.N);
+      points.SetXMin(lmem[1]);
+      points.SetXMax(lmem[2]);
+      points.SetYMin(lmem[4]);
+      points.SetYMax(lmem[5]);
+      m_points=points;
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::HipDevice, mem);
+
+  } else if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::hip_reduce, Real_type> xsum(m_init_sum);
+      RAJA::ReduceSum<RAJA::hip_reduce, Real_type> ysum(m_init_sum);
+      RAJA::ReduceMin<RAJA::hip_reduce, Real_type> xmin(m_init_min);
+      RAJA::ReduceMin<RAJA::hip_reduce, Real_type> ymin(m_init_min);
+      RAJA::ReduceMax<RAJA::hip_reduce, Real_type> xmax(m_init_max);
+      RAJA::ReduceMax<RAJA::hip_reduce, Real_type> ymax(m_init_max);
+
+      RAJA::forall< RAJA::hip_exec_occ_calc<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          REDUCE_STRUCT_BODY_RAJA;
+      });
+
+      points.SetCenter((xsum.get()/(points.N)),
+                       (ysum.get()/(points.N)));
+      points.SetXMin((xmin.get()));
+      points.SetXMax((xmax.get()));
+      points.SetYMin((ymin.get()));
+      points.SetYMax((ymax.get()));
+      m_points=points;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  REDUCE_STRUCT : Unknown Hip variant id = " << vid << std::endl;
+  }
+
+}
+
+void REDUCE_STRUCT::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  REDUCE_STRUCT : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void REDUCE_STRUCT::setHipTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/REDUCE_STRUCT-Hip.cpp
+++ b/src/basic/REDUCE_STRUCT-Hip.cpp
@@ -212,7 +212,7 @@ void REDUCE_STRUCT::runHipVariantOccGS(VariantID vid)
       hipLaunchKernelGGL((reduce_struct<block_size>),
                          dim3(grid_size), dim3(block_size),
                          shmem, res.get_stream(),
-                   points.x, points.y,
+                         points.x, points.y,
                          mem, mem+1, mem+2,    // xcenter,xmin,xmax
                          mem+3, mem+4, mem+5,  // ycenter,ymin,ymax
                          m_init_sum, m_init_min, m_init_max,

--- a/src/basic/REDUCE_STRUCT.hpp
+++ b/src/basic/REDUCE_STRUCT.hpp
@@ -90,9 +90,13 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantImpl(VariantID vid);
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantImpl(VariantID vid);
+  void runCudaVariantOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlock(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantOccGS(VariantID vid);
 
   struct PointsType {
     Int_type N;

--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -174,7 +174,7 @@ void TRAP_INT::runCudaVariantOccGS(VariantID vid)
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
       trapint<block_size><<<grid_size, block_size,
-                shmem, res.get_stream()>>>(x0, xp,
+                            shmem, res.get_stream()>>>(x0, xp,
                                                 y, yp,
                                                 h,
                                                 sumx,

--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -15,6 +15,8 @@
 #include "common/CudaDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -79,7 +81,7 @@ __global__ void trapint(Real_type x0, Real_type xp,
 
 
 template < size_t block_size >
-void TRAP_INT::runCudaVariantImpl(VariantID vid)
+void TRAP_INT::runCudaVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -143,7 +145,135 @@ void TRAP_INT::runCudaVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(TRAP_INT, Cuda)
+template < size_t block_size >
+void TRAP_INT::runCudaVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  TRAP_INT_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    Real_ptr sumx;
+    allocData(DataSpace::CudaDevice, sumx, 1);
+
+    constexpr size_t shmem = sizeof(Real_type)*block_size;
+    const size_t max_grid_size = detail::getCudaOccupancyMaxBlocks(
+        (trapint<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      cudaErrchk( cudaMemcpyAsync( sumx, &m_sumx_init, sizeof(Real_type),
+                                   cudaMemcpyHostToDevice, res.get_stream() ) );
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      trapint<block_size><<<grid_size, block_size,
+                shmem, res.get_stream()>>>(x0, xp,
+                                                y, yp,
+                                                h,
+                                                sumx,
+                                                iend);
+      cudaErrchk( cudaGetLastError() );
+
+      Real_type lsumx;
+      cudaErrchk( cudaMemcpyAsync( &lsumx, sumx, sizeof(Real_type),
+                                   cudaMemcpyDeviceToHost, res.get_stream() ) );
+      cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
+      m_sumx += lsumx * h;
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::CudaDevice, sumx);
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> sumx(m_sumx_init);
+
+      RAJA::forall< RAJA::cuda_exec_occ_calc<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        TRAP_INT_BODY;
+      });
+
+      m_sumx += static_cast<Real_type>(sumx.get()) * h;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  TRAP_INT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+void TRAP_INT::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  TRAP_INT : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void TRAP_INT::setCudaTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/TRAP_INT-Hip.cpp
+++ b/src/basic/TRAP_INT-Hip.cpp
@@ -172,7 +172,8 @@ void TRAP_INT::runHipVariantOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      hipLaunchKernelGGL((trapint<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(), x0, xp,
+      hipLaunchKernelGGL((trapint<block_size>), dim3(grid_size), dim3(block_size),
+                                                shmem, res.get_stream(), x0, xp,
                                                 y, yp,
                                                 h,
                                                 sumx,

--- a/src/basic/TRAP_INT-Hip.cpp
+++ b/src/basic/TRAP_INT-Hip.cpp
@@ -15,6 +15,8 @@
 #include "common/HipDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -79,7 +81,7 @@ __global__ void trapint(Real_type x0, Real_type xp,
 
 
 template < size_t block_size >
-void TRAP_INT::runHipVariantImpl(VariantID vid)
+void TRAP_INT::runHipVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -142,7 +144,135 @@ void TRAP_INT::runHipVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(TRAP_INT, Hip)
+template < size_t block_size >
+void TRAP_INT::runHipVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  TRAP_INT_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    Real_ptr sumx;
+    allocData(DataSpace::HipDevice, sumx, 1);
+
+    constexpr size_t shmem = sizeof(Real_type)*block_size;
+    const size_t max_grid_size = detail::getHipOccupancyMaxBlocks(
+        (trapint<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      hipErrchk( hipMemcpyAsync( sumx, &m_sumx_init, sizeof(Real_type),
+                                 hipMemcpyHostToDevice, res.get_stream() ) );
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      hipLaunchKernelGGL((trapint<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(), x0, xp,
+                                                y, yp,
+                                                h,
+                                                sumx,
+                                                iend);
+      hipErrchk( hipGetLastError() );
+
+      Real_type lsumx;
+      hipErrchk( hipMemcpyAsync( &lsumx, sumx, sizeof(Real_type),
+                                 hipMemcpyDeviceToHost, res.get_stream() ) );
+      hipErrchk( hipStreamSynchronize( res.get_stream() ) );
+      m_sumx += lsumx * h;
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::HipDevice, sumx);
+
+  } else if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::hip_reduce, Real_type> sumx(m_sumx_init);
+
+      RAJA::forall< RAJA::hip_exec_occ_calc<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        TRAP_INT_BODY;
+      });
+
+      m_sumx += static_cast<Real_type>(sumx.get()) * h;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  TRAP_INT : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+void TRAP_INT::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  TRAP_INT : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void TRAP_INT::setHipTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/TRAP_INT.hpp
+++ b/src/basic/TRAP_INT.hpp
@@ -72,9 +72,13 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantImpl(VariantID vid);
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantImpl(VariantID vid);
+  void runCudaVariantOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlock(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantOccGS(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -81,6 +81,33 @@ inline int getHipDevice()
   return device;
 }
 
+/*!
+ * \brief Get properties of the current hip device.
+ */
+inline hipDeviceProp_t getHipDeviceProp()
+{
+  hipDeviceProp_t prop;
+  hipErrchk(hipGetDeviceProperties(&prop, getHipDevice()));
+  return prop;
+}
+
+/*!
+ * \brief Get max occupancy in blocks for the given kernel for the current
+ *        hip device.
+ */
+template < typename Func >
+RAJA_INLINE
+int getHipOccupancyMaxBlocks(Func&& func, int num_threads, size_t shmem_size)
+{
+  int max_blocks = -1;
+  hipErrchk(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &max_blocks, func, num_threads, shmem_size));
+
+  size_t multiProcessorCount = getHipDeviceProp().multiProcessorCount;
+
+  return max_blocks * multiProcessorCount;
+}
+
 /*
  * Copy memory len bytes from src to dst.
  */

--- a/src/lcals/FIRST_MIN-Cuda.cpp
+++ b/src/lcals/FIRST_MIN-Cuda.cpp
@@ -15,6 +15,8 @@
 #include "common/CudaDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -57,7 +59,7 @@ __global__ void first_min(Real_ptr x,
 
 
 template < size_t block_size >
-void FIRST_MIN::runCudaVariantImpl(VariantID vid)
+void FIRST_MIN::runCudaVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -127,7 +129,142 @@ void FIRST_MIN::runCudaVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(FIRST_MIN, Cuda)
+template < size_t block_size >
+void FIRST_MIN::runCudaVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  FIRST_MIN_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    constexpr size_t shmem = sizeof(MyMinLoc)*block_size;
+    const size_t max_grid_size = detail::getCudaOccupancyMaxBlocks(
+        (first_min<block_size>), block_size, shmem);
+
+    const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+    const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+
+    MyMinLoc* mymin_block = new MyMinLoc[grid_size]; //per-block min value
+
+    MyMinLoc* dminloc;
+    cudaErrchk( cudaMalloc( (void**)&dminloc,
+                            grid_size * sizeof(MyMinLoc) ) );
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      FIRST_MIN_MINLOC_INIT;
+
+      first_min<block_size><<<grid_size, block_size,
+                              shmem, res.get_stream()>>>(x, dminloc, mymin, iend);
+      cudaErrchk( cudaGetLastError() );
+
+      cudaErrchk( cudaMemcpyAsync( mymin_block, dminloc,
+                                   grid_size * sizeof(MyMinLoc),
+                                   cudaMemcpyDeviceToHost, res.get_stream() ) );
+      cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
+
+      for (Index_type i = 0; i < static_cast<Index_type>(grid_size); i++) {
+        if ( mymin_block[i].val < mymin.val ) {
+          mymin = mymin_block[i];
+        }
+      }
+      m_minloc = RAJA_MAX(m_minloc, mymin.loc);
+
+    }
+    stopTimer();
+
+    cudaErrchk( cudaFree( dminloc ) );
+    delete[] mymin_block;
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::ReduceMinLoc<RAJA::cuda_reduce, Real_type, Index_type> loc(
+                                                        m_xmin_init, m_initloc);
+
+       RAJA::forall< RAJA::cuda_exec_occ_calc<block_size, true /*async*/> >( res,
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         FIRST_MIN_BODY_RAJA;
+       });
+
+       m_minloc = loc.getLoc();
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  FIRST_MIN : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+void FIRST_MIN::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  FIRST_MIN : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void FIRST_MIN::setCudaTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+}
 
 } // end namespace lcals
 } // end namespace rajaperf

--- a/src/lcals/FIRST_MIN-Hip.cpp
+++ b/src/lcals/FIRST_MIN-Hip.cpp
@@ -15,6 +15,8 @@
 #include "common/HipDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
+
 
 namespace rajaperf
 {
@@ -57,7 +59,7 @@ __global__ void first_min(Real_ptr x,
 
 
 template < size_t block_size >
-void FIRST_MIN::runHipVariantImpl(VariantID vid)
+void FIRST_MIN::runHipVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -130,7 +132,146 @@ void FIRST_MIN::runHipVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(FIRST_MIN, Hip)
+template < size_t block_size >
+void FIRST_MIN::runHipVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  FIRST_MIN_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    constexpr size_t shmem = sizeof(MyMinLoc)*block_size;
+    const size_t max_grid_size = detail::getHipOccupancyMaxBlocks(
+        (first_min<block_size>), block_size, shmem);
+
+    const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+    const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+
+    MyMinLoc* mymin_block = new MyMinLoc[grid_size]; //per-block min value
+
+    MyMinLoc* dminloc;
+    hipErrchk( hipMalloc( (void**)&dminloc,
+                          grid_size * sizeof(MyMinLoc) ) );
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      FIRST_MIN_MINLOC_INIT;
+
+      hipLaunchKernelGGL( (first_min<block_size>), grid_size, block_size,
+                           shmem, res.get_stream(), x,
+                           dminloc,
+                           mymin,
+                           iend );
+      hipErrchk( hipGetLastError() );
+
+      hipErrchk( hipMemcpyAsync( mymin_block, dminloc,
+                                 grid_size * sizeof(MyMinLoc),
+                                 hipMemcpyDeviceToHost, res.get_stream() ) );
+      hipErrchk( hipStreamSynchronize( res.get_stream() ) );
+
+      for (Index_type i = 0; i < static_cast<Index_type>(grid_size); i++) {
+        if ( mymin_block[i].val < mymin.val ) {
+          mymin = mymin_block[i];
+        }
+      }
+      m_minloc = mymin.loc;
+
+    }
+    stopTimer();
+
+    hipErrchk( hipFree( dminloc ) );
+    delete[] mymin_block;
+
+  } else if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::ReduceMinLoc<RAJA::hip_reduce, Real_type, Index_type> loc(
+                                                        m_xmin_init, m_initloc);
+
+       RAJA::forall< RAJA::hip_exec_occ_calc<block_size, true /*async*/> >( res,
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         FIRST_MIN_BODY_RAJA;
+       });
+
+       m_minloc = loc.getLoc();
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  FIRST_MIN : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+void FIRST_MIN::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  FIRST_MIN : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void FIRST_MIN::setHipTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+
+}
 
 } // end namespace lcals
 } // end namespace rajaperf

--- a/src/lcals/FIRST_MIN.hpp
+++ b/src/lcals/FIRST_MIN.hpp
@@ -84,9 +84,13 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantImpl(VariantID vid);
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantImpl(VariantID vid);
+  void runCudaVariantOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlock(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantOccGS(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/stream/DOT-Cuda.cpp
+++ b/src/stream/DOT-Cuda.cpp
@@ -15,6 +15,7 @@
 #include "common/CudaDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
 
 
 namespace rajaperf
@@ -59,7 +60,7 @@ __global__ void dot(Real_ptr a, Real_ptr b,
 
 
 template < size_t block_size >
-void DOT::runCudaVariantImpl(VariantID vid)
+void DOT::runCudaVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -119,7 +120,131 @@ void DOT::runCudaVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(DOT, Cuda)
+template < size_t block_size >
+void DOT::runCudaVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  DOT_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    Real_ptr dprod;
+    allocData(DataSpace::CudaDevice, dprod, 1);
+
+    constexpr size_t shmem = sizeof(Real_type)*block_size;
+    const size_t max_grid_size = detail::getCudaOccupancyMaxBlocks(
+        (dot<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      cudaErrchk( cudaMemcpyAsync( dprod, &m_dot_init, sizeof(Real_type),
+                                   cudaMemcpyHostToDevice, res.get_stream() ) );
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      dot<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
+          a, b, dprod, m_dot_init, iend );
+      cudaErrchk( cudaGetLastError() );
+
+      Real_type lprod;
+      cudaErrchk( cudaMemcpyAsync( &lprod, dprod, sizeof(Real_type),
+                                   cudaMemcpyDeviceToHost, res.get_stream() ) );
+      cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
+      m_dot += lprod;
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::CudaDevice, dprod);
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> dot(m_dot_init);
+
+       RAJA::forall< RAJA::cuda_exec_occ_calc<block_size, true /*async*/> >( res,
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         DOT_BODY;
+       });
+
+       m_dot += static_cast<Real_type>(dot.get());
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  DOT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+void DOT::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  DOT : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void DOT::setCudaTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+}
 
 } // end namespace stream
 } // end namespace rajaperf

--- a/src/stream/DOT-Hip.cpp
+++ b/src/stream/DOT-Hip.cpp
@@ -15,6 +15,7 @@
 #include "common/HipDataUtils.hpp"
 
 #include <iostream>
+#include <utility>
 
 
 namespace rajaperf
@@ -60,7 +61,7 @@ __global__ void dot(Real_ptr a, Real_ptr b,
 
 
 template < size_t block_size >
-void DOT::runHipVariantImpl(VariantID vid)
+void DOT::runHipVariantBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -121,7 +122,133 @@ void DOT::runHipVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(DOT, Hip)
+template < size_t block_size >
+void DOT::runHipVariantOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  DOT_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    Real_ptr dprod;
+    allocData(DataSpace::HipDevice, dprod, 1);
+
+    constexpr size_t shmem = sizeof(Real_type)*block_size;
+    const size_t max_grid_size = detail::getHipOccupancyMaxBlocks(
+        (dot<block_size>), block_size, shmem);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      hipErrchk( hipMemcpyAsync( dprod, &m_dot_init, sizeof(Real_type),
+                                 hipMemcpyHostToDevice, res.get_stream() ) );
+
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
+      hipLaunchKernelGGL((dot<block_size>), dim3(grid_size), dim3(block_size),
+                                            shmem, res.get_stream(),
+                         a, b, dprod, m_dot_init, iend );
+      hipErrchk( hipGetLastError() );
+
+      Real_type lprod;
+      hipErrchk( hipMemcpyAsync( &lprod, dprod, sizeof(Real_type),
+                                 hipMemcpyDeviceToHost, res.get_stream() ) );
+      hipErrchk( hipStreamSynchronize( res.get_stream() ) );
+      m_dot += lprod;
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::HipDevice, dprod);
+
+  } else if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       RAJA::ReduceSum<RAJA::hip_reduce, Real_type> dot(m_dot_init);
+
+       RAJA::forall< RAJA::hip_exec_occ_calc<block_size, true /*async*/> >( res,
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         DOT_BODY;
+       });
+
+       m_dot += static_cast<Real_type>(dot.get());
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  DOT : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+void DOT::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantBlock<block_size>(vid);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantOccGS<block_size>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  DOT : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void DOT::setHipTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+
+      }
+
+    });
+
+  }
+
+}
 
 } // end namespace stream
 } // end namespace rajaperf

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -56,9 +56,13 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantImpl(VariantID vid);
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantImpl(VariantID vid);
+  void runCudaVariantOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlock(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantOccGS(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;


### PR DESCRIPTION
# Add grid stride tunings of reduction kernels

Add a occupancy calculator grid stride (occgs_<block_size>) tuning for Cuda and Hip variants of reduction kernels.

This generally improves performance at problem sizes greater than the maximum occupancy of the device. This happens because the amount of work to finalize the reduction is proportional to the number of blocks.

The occupancy calculator grid stride tuning works by launching fewer total threads than iterates and uses a grid stride loop to assign multiple iterates to each thread. The maximum number of blocks is determined by the occupancy calculator to maximize occupancy.

- This PR is a feature
- It does the following:
  - Adds better GPU reduction tunings at the request of myself
