### PR TITLE
Make INDEXLIST_3LOOP implementations consistent

### DIFF
--- a/src/basic/INDEXLIST_3LOOP-OMP.cpp
+++ b/src/basic/INDEXLIST_3LOOP-OMP.cpp
@@ -203,8 +203,6 @@ void INDEXLIST_3LOOP::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::ReduceSum<RAJA::omp_reduce, Index_type> len(0);
-
         RAJA::forall<RAJA::omp_parallel_for_exec>(
           RAJA::RangeSegment(ibegin, iend),
           [=](Index_type i) {
@@ -219,11 +217,10 @@ void INDEXLIST_3LOOP::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG
           [=](Index_type i) {
           if (counts[i] != counts[i+1]) {
             list[counts[i]] = i;
-            len += 1;
           }
         });
 
-        m_len = len.get();
+        m_len = counts[iend];
 
       }
       stopTimer();

--- a/src/basic/INDEXLIST_3LOOP-Seq.cpp
+++ b/src/basic/INDEXLIST_3LOOP-Seq.cpp
@@ -117,8 +117,6 @@ void INDEXLIST_3LOOP::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::ReduceSum<RAJA::seq_reduce, Index_type> len(0);
-
         RAJA::forall<RAJA::seq_exec>(
           RAJA::RangeSegment(ibegin, iend),
           [=](Index_type i) {
@@ -133,11 +131,10 @@ void INDEXLIST_3LOOP::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
           [=](Index_type i) {
           if (counts[i] != counts[i+1]) {
             list[counts[i]] = i;
-            len += 1;
           }
         });
 
-        m_len = len.get();
+        m_len = counts[iend];
 
       }
       stopTimer();


### PR DESCRIPTION
# Make INDEXLIST_3LOOP implementations consistent

This means reading the last member of the counts array instead of using a reducer for the RAJA variants.

- This PR is a (refactoring, bugfix, feature, something else)
- It does the following (modify list as needed):
  - Modifies/refactors (class or method) (how?)
  - Fixes (issue number(s))
  - Adds (specific feature) at the request of (project or person)
