### PR TITLE
Changing array sizing datatype to size_t

### DIFF
--- a/src/common/DataUtils.cpp
+++ b/src/common/DataUtils.cpp
@@ -123,7 +123,7 @@ void incDataInitCount()
 /*
  * Copy memory len bytes from src to dst.
  */
-void copyHostData(void* dst_ptr, const void* src_ptr, size_t len)
+void copyHostData(void* dst_ptr, const void* src_ptr, Size_type len)
 {
   std::memcpy(dst_ptr, src_ptr, len);
 }
@@ -132,7 +132,7 @@ void copyHostData(void* dst_ptr, const void* src_ptr, size_t len)
 /*
  * Allocate data arrays of given type.
  */
-void* allocHostData(size_t len, size_t align)
+void* allocHostData(Size_type len, size_t align)
 {
   return RAJA::allocate_aligned_type<Int_type>(
       align, len);
@@ -153,7 +153,7 @@ void deallocHostData(void* ptr)
 /*
  * Allocate data arrays of given dataSpace.
  */
-void* allocData(DataSpace dataSpace, int nbytes, int align)
+void* allocData(DataSpace dataSpace, Size_type nbytes, int align)
 {
   void* ptr = nullptr;
 
@@ -257,7 +257,7 @@ void* allocData(DataSpace dataSpace, int nbytes, int align)
  */
 void copyData(DataSpace dst_dataSpace, void* dst_ptr,
               DataSpace src_dataSpace, const void* src_ptr,
-              size_t nbytes)
+              Size_type nbytes)
 {
   if (hostAccessibleDataSpace(dst_dataSpace) == dst_dataSpace &&
       hostAccessibleDataSpace(src_dataSpace) == src_dataSpace) {
@@ -369,23 +369,23 @@ void deallocData(DataSpace dataSpace, void* ptr)
  * \brief Initialize Int_type data array to
  * randomly signed positive and negative values.
  */
-void initData(Int_ptr& ptr, int len)
+void initData(Int_ptr& ptr, Size_type len)
 {
   srand(4793);
 
   Real_type signfact = 0.0;
 
-  for (int i = 0; i < len; ++i) {
+  for (Size_type i = 0; i < len; ++i) {
     signfact = Real_type(rand())/RAND_MAX;
     ptr[i] = ( signfact < 0.5 ? -1 : 1 );
   };
 
   signfact = Real_type(rand())/RAND_MAX;
-  Int_type ilo = len * signfact;
+  Size_type ilo = len * signfact;
   ptr[ilo] = -58;
 
   signfact = Real_type(rand())/RAND_MAX;
-  Int_type ihi = len * signfact;
+  Size_type ihi = len * signfact;
   ptr[ihi] = 19;
 
   incDataInitCount();
@@ -396,11 +396,11 @@ void initData(Int_ptr& ptr, int len)
  * positive values (0.0, 1.0) based on their array position
  * (index) and the order in which this method is called.
  */
-void initData(Real_ptr& ptr, int len)
+void initData(Real_ptr& ptr, Size_type len)
 {
   Real_type factor = ( data_init_count % 2 ? 0.1 : 0.2 );
 
-  for (int i = 0; i < len; ++i) {
+  for (Size_type i = 0; i < len; ++i) {
     ptr[i] = factor*(i + 1.1)/(i + 1.12345);
   }
 
@@ -410,9 +410,9 @@ void initData(Real_ptr& ptr, int len)
 /*
  * Initialize Real_type data array to constant values.
  */
-void initDataConst(Real_ptr& ptr, int len, Real_type val)
+void initDataConst(Real_ptr& ptr, Size_type len, Real_type val)
 {
-  for (int i = 0; i < len; ++i) {
+  for (Size_type i = 0; i < len; ++i) {
     ptr[i] = val;
   };
 
@@ -422,9 +422,9 @@ void initDataConst(Real_ptr& ptr, int len, Real_type val)
 /*
  * Initialize Index_type data array to constant values.
  */
-void initDataConst(Index_type*& ptr, int len, Index_type val)
+void initDataConst(Index_type*& ptr, Size_type len, Index_type val)
 {
-  for (int i = 0; i < len; ++i) {
+  for (Size_type i = 0; i < len; ++i) {
     ptr[i] = val;
   };
 
@@ -434,13 +434,13 @@ void initDataConst(Index_type*& ptr, int len, Index_type val)
 /*
  * Initialize Real_type data array with random sign.
  */
-void initDataRandSign(Real_ptr& ptr, int len)
+void initDataRandSign(Real_ptr& ptr, Size_type len)
 {
   Real_type factor = ( data_init_count % 2 ? 0.1 : 0.2 );
 
   srand(4793);
 
-  for (int i = 0; i < len; ++i) {
+  for (Size_type i = 0; i < len; ++i) {
     Real_type signfact = Real_type(rand())/RAND_MAX;
     signfact = ( signfact < 0.5 ? -1.0 : 1.0 );
     ptr[i] = signfact*factor*(i + 1.1)/(i + 1.12345);
@@ -452,11 +452,11 @@ void initDataRandSign(Real_ptr& ptr, int len)
 /*
  * Initialize Real_type data array with random values.
  */
-void initDataRandValue(Real_ptr& ptr, int len)
+void initDataRandValue(Real_ptr& ptr, Size_type len)
 {
   srand(4793);
 
-  for (int i = 0; i < len; ++i) {
+  for (Size_type i = 0; i < len; ++i) {
     ptr[i] = Real_type(rand())/RAND_MAX;
   };
 
@@ -466,12 +466,12 @@ void initDataRandValue(Real_ptr& ptr, int len)
 /*
  * Initialize Complex_type data array.
  */
-void initData(Complex_ptr& ptr, int len)
+void initData(Complex_ptr& ptr, Size_type len)
 {
   Complex_type factor = ( data_init_count % 2 ?  Complex_type(0.1,0.2) :
                                                  Complex_type(0.2,0.3) );
 
-  for (int i = 0; i < len; ++i) {
+  for (Size_type i = 0; i < len; ++i) {
     ptr[i] = factor*(i + 1.1)/(i + 1.12345);
   }
 
@@ -492,12 +492,12 @@ void initData(Real_type& d)
 /*
  * Calculate and return checksum for data arrays.
  */
-long double calcChecksum(Int_ptr ptr, int len,
+long double calcChecksum(Int_ptr ptr, Size_type len,
                          Real_type scale_factor)
 {
   long double tchk = 0.0;
   long double ckahan = 0.0;
-  for (Index_type j = 0; j < len; ++j) {
+  for (Size_type j = 0; j < len; ++j) {
     long double x = (std::abs(std::sin(j+1.0))+0.5) * ptr[j];
     long double y = x - ckahan;
     volatile long double t = tchk + y;
@@ -514,12 +514,12 @@ long double calcChecksum(Int_ptr ptr, int len,
   return tchk;
 }
 
-long double calcChecksum(Real_ptr ptr, int len,
+long double calcChecksum(Real_ptr ptr, Size_type len,
                          Real_type scale_factor)
 {
   long double tchk = 0.0;
   long double ckahan = 0.0;
-  for (Index_type j = 0; j < len; ++j) {
+  for (Size_type j = 0; j < len; ++j) {
     long double x = (std::abs(std::sin(j+1.0))+0.5) * ptr[j];
     long double y = x - ckahan;
     volatile long double t = tchk + y;
@@ -536,12 +536,12 @@ long double calcChecksum(Real_ptr ptr, int len,
   return tchk;
 }
 
-long double calcChecksum(Complex_ptr ptr, int len,
+long double calcChecksum(Complex_ptr ptr, Size_type len,
                          Real_type scale_factor)
 {
   long double tchk = 0.0;
   long double ckahan = 0.0;
-  for (Index_type j = 0; j < len; ++j) {
+  for (Size_type j = 0; j < len; ++j) {
     long double x = (std::abs(std::sin(j+1.0))+0.5) * (real(ptr[j])+imag(ptr[j]));
     long double y = x - ckahan;
     volatile long double t = tchk + y;

--- a/src/common/DataUtils.hpp
+++ b/src/common/DataUtils.hpp
@@ -44,12 +44,12 @@ void resetDataInitCount();
  */
 void incDataInitCount();
 
-void copyHostData(void* dst_ptr, const void* src_ptr, size_t len);
+void copyHostData(void* dst_ptr, const void* src_ptr, Size_type len);
 
 /*!
  * \brief Allocate data arrays.
  */
-void* allocHostData(size_t len, size_t align);
+void* allocHostData(Size_type len, size_t align);
 
 /*!
  * \brief Free data arrays.
@@ -60,14 +60,14 @@ void deallocHostData(void* ptr);
 /*!
  * \brief Allocate data array in dataSpace.
  */
-void* allocData(DataSpace dataSpace, int nbytes, int align);
+void* allocData(DataSpace dataSpace, Size_type nbytes, int align);
 
 /*!
  * \brief Copy data from one dataSpace to another.
  */
 void copyData(DataSpace dst_dataSpace, void* dst_ptr,
               DataSpace src_dataSpace, const void* src_ptr,
-              size_t nbytes);
+              Size_type nbytes);
 
 /*!
  * \brief Free data arrays in dataSpace.
@@ -82,7 +82,7 @@ void deallocData(DataSpace dataSpace, void* ptr);
  * Then, two randomly-chosen entries are reset, one to
  * a value > 1, one to a value < -1.
  */
-void initData(Int_ptr& ptr, int len);
+void initData(Int_ptr& ptr, Size_type len);
 
 /*!
  * \brief Initialize Real_type data array.
@@ -91,21 +91,21 @@ void initData(Int_ptr& ptr, int len);
  * in the interval (0.0, 1.0) based on their array position (index)
  * and the order in which this method is called.
  */
-void initData(Real_ptr& ptr, int len);
+void initData(Real_ptr& ptr, Size_type len);
 
 /*!
  * \brief Initialize Real_type data array.
  *
  * Array entries are set to given constant value.
  */
-void initDataConst(Real_ptr& ptr, int len, Real_type val);
+void initDataConst(Real_ptr& ptr, Size_type len, Real_type val);
 
 /*!
  * \brief Initialize Index_type data array.
  *
  * Array entries are set to given constant value.
  */
-void initDataConst(Index_type*& ptr, int len, Index_type val);
+void initDataConst(Index_type*& ptr, Size_type len, Index_type val);
 
 /*!
  * \brief Initialize Real_type data array with random sign.
@@ -113,14 +113,14 @@ void initDataConst(Index_type*& ptr, int len, Index_type val);
  * Array entries are initialized in the same way as the method
  * initData(Real_ptr& ptr...) above, but with random sign.
  */
-void initDataRandSign(Real_ptr& ptr, int len);
+void initDataRandSign(Real_ptr& ptr, Size_type len);
 
 /*!
  * \brief Initialize Real_type data array with random values.
  *
  * Array entries are initialized with random values in the interval [0.0, 1.0].
  */
-void initDataRandValue(Real_ptr& ptr, int len);
+void initDataRandValue(Real_ptr& ptr, Size_type len);
 
 /*!
  * \brief Initialize Complex_type data array.
@@ -128,7 +128,7 @@ void initDataRandValue(Real_ptr& ptr, int len);
  * Real and imaginary array entries are initialized in the same way as the
  * method allocAndInitData(Real_ptr& ptr...) above.
  */
-void initData(Complex_ptr& ptr, int len);
+void initData(Complex_ptr& ptr, Size_type len);
 
 /*!
  * \brief Initialize Real_type scalar data.
@@ -147,13 +147,13 @@ void initData(Real_type& d);
  *
  * Checksumn is multiplied by given scale factor.
  */
-long double calcChecksum(Int_ptr d, int len,
+long double calcChecksum(Int_ptr d, Size_type len,
                          Real_type scale_factor);
 ///
-long double calcChecksum(Real_ptr d, int len,
+long double calcChecksum(Real_ptr d, Size_type len,
                          Real_type scale_factor);
 ///
-long double calcChecksum(Complex_ptr d, int len,
+long double calcChecksum(Complex_ptr d, Size_type len,
                          Real_type scale_factor);
 
 }  // closing brace for detail namespace
@@ -171,16 +171,16 @@ DataSpace hostAccessibleDataSpace(DataSpace dataSpace);
  * \brief Allocate data array (ptr).
  */
 template <typename T>
-inline void allocData(DataSpace dataSpace, T*& ptr_ref, int len, int align)
+inline void allocData(DataSpace dataSpace, T*& ptr_ref, Size_type len, int align)
 {
-  size_t nbytes = len*sizeof(T);
+  Size_type nbytes = len*sizeof(T);
   T* ptr = static_cast<T*>(detail::allocData(dataSpace, nbytes, align));
 
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
   if (dataSpace == DataSpace::Omp) {
     // perform first touch on Omp Data
     #pragma omp parallel for
-    for (int i = 0; i < len; ++i) {
+    for (Size_type i = 0; i < len; ++i) {
       ptr[i] = T{};
     };
   }
@@ -205,9 +205,9 @@ inline void deallocData(DataSpace dataSpace, T*& ptr)
 template <typename T>
 inline void copyData(DataSpace dst_dataSpace, T* dst_ptr,
                      DataSpace src_dataSpace, const T* src_ptr,
-                     int len)
+                     Size_type len)
 {
-  size_t nbytes = len*sizeof(T);
+  Size_type nbytes = len*sizeof(T);
   detail::copyData(dst_dataSpace, dst_ptr, src_dataSpace, src_ptr, nbytes);
 }
 
@@ -216,7 +216,7 @@ inline void copyData(DataSpace dst_dataSpace, T* dst_ptr,
  */
 template <typename T>
 inline void moveData(DataSpace new_dataSpace, DataSpace old_dataSpace,
-                     T*& ptr, int len, int align)
+                     T*& ptr, Size_type len, int align)
 {
   if (new_dataSpace != old_dataSpace) {
 
@@ -237,7 +237,7 @@ template <typename T>
 struct AutoDataMover
 {
   AutoDataMover(DataSpace new_dataSpace, DataSpace old_dataSpace,
-                T*& ptr, int len, int align)
+                T*& ptr, Size_type len, int align)
     : m_ptr(&ptr)
     , m_new_dataSpace(new_dataSpace)
     , m_old_dataSpace(old_dataSpace)
@@ -284,7 +284,7 @@ private:
   T** m_ptr;
   DataSpace m_new_dataSpace;
   DataSpace m_old_dataSpace;
-  int m_len;
+  Size_type m_len;
   int m_align;
 };
 
@@ -292,7 +292,7 @@ private:
  * \brief Allocate and initialize data array.
  */
 template <typename T>
-inline void allocAndInitData(DataSpace dataSpace, T*& ptr, int len, int align)
+inline void allocAndInitData(DataSpace dataSpace, T*& ptr, Size_type len, int align)
 {
   DataSpace init_dataSpace = hostAccessibleDataSpace(dataSpace);
 
@@ -310,7 +310,7 @@ inline void allocAndInitData(DataSpace dataSpace, T*& ptr, int len, int align)
  * Array entries are initialized using the method initDataConst.
  */
 template <typename T>
-inline void allocAndInitDataConst(DataSpace dataSpace, T*& ptr, int len, int align,
+inline void allocAndInitDataConst(DataSpace dataSpace, T*& ptr, Size_type len, int align,
                                   T val)
 {
   DataSpace init_dataSpace = hostAccessibleDataSpace(dataSpace);
@@ -328,7 +328,7 @@ inline void allocAndInitDataConst(DataSpace dataSpace, T*& ptr, int len, int ali
  * Array is initialized using method initDataRandSign.
  */
 template <typename T>
-inline void allocAndInitDataRandSign(DataSpace dataSpace, T*& ptr, int len, int align)
+inline void allocAndInitDataRandSign(DataSpace dataSpace, T*& ptr, Size_type len, int align)
 {
   DataSpace init_dataSpace = hostAccessibleDataSpace(dataSpace);
 
@@ -346,7 +346,7 @@ inline void allocAndInitDataRandSign(DataSpace dataSpace, T*& ptr, int len, int 
  * Array is initialized using method initDataRandValue.
  */
 template <typename T>
-inline void allocAndInitDataRandValue(DataSpace dataSpace, T*& ptr, int len, int align)
+inline void allocAndInitDataRandValue(DataSpace dataSpace, T*& ptr, Size_type len, int align)
 {
   DataSpace init_dataSpace = hostAccessibleDataSpace(dataSpace);
 
@@ -361,7 +361,7 @@ inline void allocAndInitDataRandValue(DataSpace dataSpace, T*& ptr, int len, int
  * Calculate and return checksum for arrays.
  */
 template <typename T>
-inline long double calcChecksum(DataSpace dataSpace, T* ptr, int len, int align,
+inline long double calcChecksum(DataSpace dataSpace, T* ptr, Size_type len, int align,
                                 Real_type scale_factor)
 {
   T* check_ptr = ptr;
@@ -428,9 +428,9 @@ struct RAJAPoolAllocatorHolder
     }
 
     /*[[nodiscard]]*/
-    value_type* allocate(size_t num)
+    value_type* allocate(Size_type num)
     {
-      if (num > std::numeric_limits<size_t>::max() / sizeof(value_type)) {
+      if (num > std::numeric_limits<Size_type>::max() / sizeof(value_type)) {
         throw std::bad_alloc();
       }
 

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -264,7 +264,7 @@ public:
   DataSpace getHostAccessibleDataSpace(VariantID vid) const;
 
   template <typename T>
-  void allocData(DataSpace dataSpace, T& ptr, int len)
+  void allocData(DataSpace dataSpace, T& ptr, Size_type len)
   {
     rajaperf::allocData(dataSpace,
         ptr, len, getDataAlignment());
@@ -273,7 +273,7 @@ public:
   template <typename T>
   void copyData(DataSpace dst_dataSpace, T* dst_ptr,
                 DataSpace src_dataSpace, const T* src_ptr,
-                int len)
+                Size_type len)
   {
     rajaperf::copyData(dst_dataSpace, dst_ptr, src_dataSpace, src_ptr, len);
   }
@@ -285,42 +285,42 @@ public:
   }
 
   template <typename T>
-  void allocData(T*& ptr, int len, VariantID vid)
+  void allocData(T*& ptr, Size_type len, VariantID vid)
   {
     rajaperf::allocData(getDataSpace(vid),
         ptr, len, getDataAlignment());
   }
 
   template <typename T>
-  void allocAndInitData(T*& ptr, int len, VariantID vid)
+  void allocAndInitData(T*& ptr, Size_type len, VariantID vid)
   {
     rajaperf::allocAndInitData(getDataSpace(vid),
         ptr, len, getDataAlignment());
   }
 
   template <typename T>
-  void allocAndInitDataConst(T*& ptr, int len, T val, VariantID vid)
+  void allocAndInitDataConst(T*& ptr, Size_type len, T val, VariantID vid)
   {
     rajaperf::allocAndInitDataConst(getDataSpace(vid),
         ptr, len, getDataAlignment(), val);
   }
 
   template <typename T>
-  void allocAndInitDataRandSign(T*& ptr, int len, VariantID vid)
+  void allocAndInitDataRandSign(T*& ptr, Size_type len, VariantID vid)
   {
     rajaperf::allocAndInitDataRandSign(getDataSpace(vid),
         ptr, len, getDataAlignment());
   }
 
   template <typename T>
-  void allocAndInitDataRandValue(T*& ptr, int len, VariantID vid)
+  void allocAndInitDataRandValue(T*& ptr, Size_type len, VariantID vid)
   {
     rajaperf::allocAndInitDataRandValue(getDataSpace(vid),
         ptr, len, getDataAlignment());
   }
 
   template <typename T>
-  rajaperf::AutoDataMover<T> scopedMoveData(T*& ptr, int len, VariantID vid)
+  rajaperf::AutoDataMover<T> scopedMoveData(T*& ptr, Size_type len, VariantID vid)
   {
     rajaperf::moveData(getHostAccessibleDataSpace(vid), getDataSpace(vid),
         ptr, len, getDataAlignment());
@@ -341,14 +341,14 @@ public:
   }
 
   template <typename T>
-  long double calcChecksum(T* ptr, int len, VariantID vid)
+  long double calcChecksum(T* ptr, Size_type len, VariantID vid)
   {
     return rajaperf::calcChecksum(getDataSpace(vid),
       ptr, len, getDataAlignment(), 1.0);
   }
 
   template <typename T>
-  long double calcChecksum(T* ptr, int len, Real_type scale_factor, VariantID vid)
+  long double calcChecksum(T* ptr, Size_type len, Real_type scale_factor, VariantID vid)
   {
     return rajaperf::calcChecksum(getDataSpace(vid),
       ptr, len, getDataAlignment(), scale_factor);

--- a/src/common/RPTypes.hpp
+++ b/src/common/RPTypes.hpp
@@ -60,6 +60,8 @@ using Index_type = RAJA::Index_type;
 ///
 using Index_ptr = Index_type*;
 
+using Size_type = size_t;
+
 
 /*!
  ******************************************************************************


### PR DESCRIPTION
# Increasing size type for arrays

- This PR is a bugfix/feature
- It does the following:
   - Introduces Size_type (currently size_t)
   - Changes `len` (array sizing) parameters from int to Size_type
   - Closes #372 
   - Allows for running benchmarks at larger problem sizes

Do not merge this PR. Please review/approve https://github.com/LLNL/RAJAPerf/pull/374 for merging