### PR TITLE
Fix scripts

### DIFF
--- a/scripts/lc-builds/blueos_clang.sh
+++ b/scripts/lc-builds/blueos_clang.sh
@@ -11,7 +11,7 @@ if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    blueos_clang.sh 11.0.1"
-  echo "  -or - "
+  echo "  - or - "
   echo "    blueos_clang.sh ibm-10.0.1-gcc-8.3.1"
   exit
 fi

--- a/scripts/lc-builds/blueos_clang.sh
+++ b/scripts/lc-builds/blueos_clang.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    blueos_clang.sh 11.0.1"

--- a/scripts/lc-builds/blueos_clang_omptarget.sh
+++ b/scripts/lc-builds/blueos_clang_omptarget.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    blueos_clang_omptarget.sh 10.0.1-gcc-8.3.1"

--- a/scripts/lc-builds/blueos_gcc.sh
+++ b/scripts/lc-builds/blueos_gcc.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    blueos_gcc.sh 8.3.1"

--- a/scripts/lc-builds/blueos_nvcc_clang.sh
+++ b/scripts/lc-builds/blueos_nvcc_clang.sh
@@ -45,6 +45,7 @@ cmake \
   -C ${RAJA_HOSTCONFIG} \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \
+  -DCUDA_SEPARABLE_COMPILATION=On \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER} \
   -DCMAKE_CUDA_COMPILER=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER}/bin/nvcc \
   -DCMAKE_CUDA_ARCHITECTURES=${COMP_ARCH} \

--- a/scripts/lc-builds/blueos_nvcc_clang.sh
+++ b/scripts/lc-builds/blueos_nvcc_clang.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [[ $# -ne 3 ]]; then
+if [[ $# -lt 3 ]]; then
   echo
   echo "You must pass 3 arguments to the script (in this order): "
   echo "   1) compiler version number for nvcc"

--- a/scripts/lc-builds/blueos_nvcc_clang_caliper.sh
+++ b/scripts/lc-builds/blueos_nvcc_clang_caliper.sh
@@ -49,6 +49,7 @@ cmake \
   -C ${RAJA_HOSTCONFIG} \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \
+  -DCUDA_SEPARABLE_COMPILATION=On \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER} \
   -DCMAKE_CUDA_COMPILER=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER}/bin/nvcc \
   -DCMAKE_CUDA_ARCHITECTURES=${COMP_ARCH} \

--- a/scripts/lc-builds/blueos_nvcc_clang_caliper.sh
+++ b/scripts/lc-builds/blueos_nvcc_clang_caliper.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [[ $# -ne 5 ]]; then
+if [[ $# -lt 5 ]]; then
   echo
   echo "You must pass 5 arguments to the script (in this order): "
   echo "   1) compiler version number for nvcc"

--- a/scripts/lc-builds/blueos_nvcc_gcc.sh
+++ b/scripts/lc-builds/blueos_nvcc_gcc.sh
@@ -45,6 +45,7 @@ cmake \
   -C ${RAJA_HOSTCONFIG} \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \
+  -DCUDA_SEPARABLE_COMPILATION=On \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER} \
   -DCMAKE_CUDA_COMPILER=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER}/bin/nvcc \
   -DCMAKE_CUDA_ARCHITECTURES=${COMP_ARCH} \

--- a/scripts/lc-builds/blueos_nvcc_gcc.sh
+++ b/scripts/lc-builds/blueos_nvcc_gcc.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [[ $# -ne 3 ]]; then
+if [[ $# -lt 3 ]]; then
   echo
   echo "You must pass 3 arguments to the script (in this order): "
   echo "   1) compiler version number for nvcc"

--- a/scripts/lc-builds/blueos_nvcc_xl.sh
+++ b/scripts/lc-builds/blueos_nvcc_xl.sh
@@ -45,6 +45,7 @@ cmake \
   -C ${RAJA_HOSTCONFIG} \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \
+  -DCUDA_SEPARABLE_COMPILATION=On \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER} \
   -DCMAKE_CUDA_COMPILER=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER}/bin/nvcc \
   -DCMAKE_CUDA_ARCHITECTURES=${COMP_ARCH} \

--- a/scripts/lc-builds/blueos_nvcc_xl.sh
+++ b/scripts/lc-builds/blueos_nvcc_xl.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [[ $# -ne 3 ]]; then
+if [[ $# -lt 3 ]]; then
   echo
   echo "You must pass 3 arguments to the script (in this order): "
   echo "   1) compiler version number for nvcc"

--- a/scripts/lc-builds/blueos_pgi.sh
+++ b/scripts/lc-builds/blueos_pgi.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    blueos_pgi.sh 21.1"

--- a/scripts/lc-builds/blueos_spectrum_nvcc_clang.sh
+++ b/scripts/lc-builds/blueos_spectrum_nvcc_clang.sh
@@ -49,6 +49,7 @@ cmake \
   -DENABLE_MPI=On \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \
+  -DCUDA_SEPARABLE_COMPILATION=On \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER} \
   -DCMAKE_CUDA_COMPILER=/usr/tce/packages/cuda/cuda-${COMP_NVCC_VER}/bin/nvcc \
   -DCMAKE_CUDA_ARCHITECTURES=${COMP_ARCH} \

--- a/scripts/lc-builds/blueos_xl.sh
+++ b/scripts/lc-builds/blueos_xl.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    blueos_xl.sh 2021.03.31"

--- a/scripts/lc-builds/blueos_xl_omptarget.sh
+++ b/scripts/lc-builds/blueos_xl_omptarget.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    blueos_xl_omptarget.sh 2022.08.19"

--- a/scripts/lc-builds/toss3_clang.sh
+++ b/scripts/lc-builds/toss3_clang.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    toss3_clang.sh 10.0.1"

--- a/scripts/lc-builds/toss3_gcc.sh
+++ b/scripts/lc-builds/toss3_gcc.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    toss3_gcc.sh 8.3.1"

--- a/scripts/lc-builds/toss3_hipcc.sh
+++ b/scripts/lc-builds/toss3_hipcc.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [[ $# -ne 2 ]]; then
+if [[ $# -lt 2 ]]; then
   echo
   echo "You must pass 2 arguments to the script (in this order): "
   echo "   1) compiler version number"

--- a/scripts/lc-builds/toss3_icpc.sh
+++ b/scripts/lc-builds/toss3_icpc.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    toss3_icpc.sh 19.1.0"

--- a/scripts/lc-builds/toss3_mvapich2_gcc.sh
+++ b/scripts/lc-builds/toss3_mvapich2_gcc.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 2 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    toss3_mvapich2_gcc.sh 2.3 10.2.1"

--- a/scripts/lc-builds/toss3_pgi.sh
+++ b/scripts/lc-builds/toss3_pgi.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    toss3_pgi.sh 20.1"

--- a/scripts/lc-builds/toss4_clang_caliper.sh
+++ b/scripts/lc-builds/toss4_clang_caliper.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [[ $# -ne 3 ]]; then
+if [[ $# -lt 3 ]]; then
   echo
   echo "You must pass 3 arguments to the script (in this order): "
   echo "   1) compiler version number"

--- a/scripts/lc-builds/toss4_cray-mpich_amdclang.sh
+++ b/scripts/lc-builds/toss4_cray-mpich_amdclang.sh
@@ -98,10 +98,11 @@ echo
 echo "    module unload rocm"
 echo "    srun -n1 make"
 echo
-echo "  Please note that cray-mpich requires libmodules.so.1 from cce to run."
+echo "  Please note that cray-mpich requires libmodules.so.1 from cce and"
+echo "  libpgmath.so from rocm/llvm to run."
 echo "  Until this is handled transparently in the build system you may add "
-echo "  cce to your LD_LIBRARY_PATH."
+echo "  cce and rocm/llvm to your LD_LIBRARY_PATH."
 echo
-echo "    export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/tce/packages/cce-tce/cce-13.0.2/cce/x86_64/lib/"
+echo "    export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/tce/packages/cce-tce/cce-13.0.2/cce/x86_64/lib/:/usr/rocm-5.7.0/llvm/lib"
 echo
 echo "***********************************************************************"

--- a/scripts/lc-builds/toss4_gcc_caliper.sh
+++ b/scripts/lc-builds/toss4_gcc_caliper.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [[ $# -ne 3 ]]; then
+if [[ $# -lt 3 ]]; then
   echo
   echo "You must pass 3 arguments to the script (in this order): "
   echo "   1) compiler version number"

--- a/scripts/ubuntu-builds/ubuntu_clang.sh
+++ b/scripts/ubuntu-builds/ubuntu_clang.sh
@@ -22,6 +22,8 @@ RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/ubuntu-builds/clang_X.cmake
 
 echo
 echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -39,5 +41,5 @@ cmake \
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"

--- a/scripts/ubuntu-builds/ubuntu_clang.sh
+++ b/scripts/ubuntu-builds/ubuntu_clang.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    ubuntu_clang.sh 10"

--- a/scripts/ubuntu-builds/ubuntu_gcc.sh
+++ b/scripts/ubuntu-builds/ubuntu_gcc.sh
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [ "$1" == "" ]; then
+if [[ $# -lt 1 ]]; then
   echo
   echo "You must pass a compiler version number to script. For example,"
   echo "    ubuntu_gcc.sh 8"

--- a/scripts/ubuntu-builds/ubuntu_gcc.sh
+++ b/scripts/ubuntu-builds/ubuntu_gcc.sh
@@ -22,6 +22,8 @@ RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/ubuntu-builds/gcc_X.cmake
 
 echo
 echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
 echo
 
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
@@ -39,5 +41,5 @@ cmake \
 
 echo
 echo "***********************************************************************"
-echo "cd into directory ${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
 echo "***********************************************************************"


### PR DESCRIPTION
# Fix our build scripts

Enable cuda relocatable device code in the scripts to ensure kernel fusion works.
Make the scripts more consistent.

Note that we should also add rdc to our hip build and we should add rdc to our CI builds if its not there already.

- This PR is a bugfix
  - Fixes cuda crash at runtime
