### PR TITLE
Use coarse grained hip pinned memory

### DIFF
--- a/src/algorithm/REDUCE_SUM-Hip.cpp
+++ b/src/algorithm/REDUCE_SUM-Hip.cpp
@@ -82,7 +82,7 @@ void REDUCE_SUM::runHipVariantRocprim(VariantID vid)
     int len = iend - ibegin;
 
     Real_type* sum_storage;
-    allocData(DataSpace::HipPinned, sum_storage, 1);
+    allocData(DataSpace::HipPinnedCoarse, sum_storage, 1);
 
     // Determine temporary device storage requirements
     void* d_temp_storage = nullptr;
@@ -145,7 +145,7 @@ void REDUCE_SUM::runHipVariantRocprim(VariantID vid)
 
     // Free temporary storage
     deallocData(DataSpace::HipDevice, temp_storage);
-    deallocData(DataSpace::HipPinned, sum_storage);
+    deallocData(DataSpace::HipPinnedCoarse, sum_storage);
 
   } else {
 

--- a/src/apps/HALOEXCHANGE_FUSED-Hip.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED-Hip.cpp
@@ -26,28 +26,28 @@ namespace apps
   Int_ptr*    pack_list_ptrs; \
   Real_ptr*   pack_var_ptrs; \
   Index_type* pack_len_ptrs; \
-  allocData(DataSpace::HipPinned, pack_buffer_ptrs, num_neighbors * num_vars); \
-  allocData(DataSpace::HipPinned, pack_list_ptrs,   num_neighbors * num_vars); \
-  allocData(DataSpace::HipPinned, pack_var_ptrs,    num_neighbors * num_vars); \
-  allocData(DataSpace::HipPinned, pack_len_ptrs,    num_neighbors * num_vars); \
+  allocData(DataSpace::HipPinnedCoarse, pack_buffer_ptrs, num_neighbors * num_vars); \
+  allocData(DataSpace::HipPinnedCoarse, pack_list_ptrs,   num_neighbors * num_vars); \
+  allocData(DataSpace::HipPinnedCoarse, pack_var_ptrs,    num_neighbors * num_vars); \
+  allocData(DataSpace::HipPinnedCoarse, pack_len_ptrs,    num_neighbors * num_vars); \
   Real_ptr*   unpack_buffer_ptrs; \
   Int_ptr*    unpack_list_ptrs; \
   Real_ptr*   unpack_var_ptrs; \
   Index_type* unpack_len_ptrs; \
-  allocData(DataSpace::HipPinned, unpack_buffer_ptrs, num_neighbors * num_vars); \
-  allocData(DataSpace::HipPinned, unpack_list_ptrs,   num_neighbors * num_vars); \
-  allocData(DataSpace::HipPinned, unpack_var_ptrs,    num_neighbors * num_vars); \
-  allocData(DataSpace::HipPinned, unpack_len_ptrs,    num_neighbors * num_vars);
+  allocData(DataSpace::HipPinnedCoarse, unpack_buffer_ptrs, num_neighbors * num_vars); \
+  allocData(DataSpace::HipPinnedCoarse, unpack_list_ptrs,   num_neighbors * num_vars); \
+  allocData(DataSpace::HipPinnedCoarse, unpack_var_ptrs,    num_neighbors * num_vars); \
+  allocData(DataSpace::HipPinnedCoarse, unpack_len_ptrs,    num_neighbors * num_vars);
 
 #define HALOEXCHANGE_FUSED_MANUAL_FUSER_TEARDOWN_HIP \
-  deallocData(DataSpace::HipPinned, pack_buffer_ptrs); \
-  deallocData(DataSpace::HipPinned, pack_list_ptrs); \
-  deallocData(DataSpace::HipPinned, pack_var_ptrs); \
-  deallocData(DataSpace::HipPinned, pack_len_ptrs); \
-  deallocData(DataSpace::HipPinned, unpack_buffer_ptrs); \
-  deallocData(DataSpace::HipPinned, unpack_list_ptrs); \
-  deallocData(DataSpace::HipPinned, unpack_var_ptrs); \
-  deallocData(DataSpace::HipPinned, unpack_len_ptrs);
+  deallocData(DataSpace::HipPinnedCoarse, pack_buffer_ptrs); \
+  deallocData(DataSpace::HipPinnedCoarse, pack_list_ptrs); \
+  deallocData(DataSpace::HipPinnedCoarse, pack_var_ptrs); \
+  deallocData(DataSpace::HipPinnedCoarse, pack_len_ptrs); \
+  deallocData(DataSpace::HipPinnedCoarse, unpack_buffer_ptrs); \
+  deallocData(DataSpace::HipPinnedCoarse, unpack_list_ptrs); \
+  deallocData(DataSpace::HipPinnedCoarse, unpack_var_ptrs); \
+  deallocData(DataSpace::HipPinnedCoarse, unpack_len_ptrs);
 
 template < size_t block_size >
 __launch_bounds__(block_size)

--- a/src/basic/INDEXLIST-Hip.cpp
+++ b/src/basic/INDEXLIST-Hip.cpp
@@ -257,7 +257,7 @@ void INDEXLIST::runHipVariantImpl(VariantID vid)
     const size_t shmem_size = 0;
 
     Index_type* len;
-    allocData(DataSpace::HipPinned, len, 1);
+    allocData(DataSpace::HipPinnedCoarse, len, 1);
     Index_type* block_counts;
     allocData(DataSpace::HipDevice, block_counts, grid_size);
     Index_type* grid_counts;
@@ -282,7 +282,7 @@ void INDEXLIST::runHipVariantImpl(VariantID vid)
     }
     stopTimer();
 
-    deallocData(DataSpace::HipPinned, len);
+    deallocData(DataSpace::HipPinnedCoarse, len);
     deallocData(DataSpace::HipDevice, block_counts);
     deallocData(DataSpace::HipDevice, grid_counts);
     deallocData(DataSpace::HipDevice, block_readys);

--- a/src/basic/INDEXLIST_3LOOP-Hip.cpp
+++ b/src/basic/INDEXLIST_3LOOP-Hip.cpp
@@ -74,7 +74,7 @@ void INDEXLIST_3LOOP::runHipVariantImpl(VariantID vid)
     INDEXLIST_3LOOP_DATA_SETUP_HIP;
 
     Index_type* len;
-    allocData(DataSpace::HipPinned, len, 1);
+    allocData(DataSpace::HipPinnedCoarse, len, 1);
 
     hipStream_t stream = res.get_stream();
 
@@ -147,7 +147,7 @@ void INDEXLIST_3LOOP::runHipVariantImpl(VariantID vid)
     stopTimer();
 
     deallocData(DataSpace::HipDevice, temp_storage);
-    deallocData(DataSpace::HipPinned, len);
+    deallocData(DataSpace::HipPinnedCoarse, len);
 
     INDEXLIST_3LOOP_DATA_TEARDOWN_HIP;
 
@@ -156,7 +156,7 @@ void INDEXLIST_3LOOP::runHipVariantImpl(VariantID vid)
     INDEXLIST_3LOOP_DATA_SETUP_HIP;
 
     Index_type* len;
-    allocData(DataSpace::HipPinned, len, 1);
+    allocData(DataSpace::HipPinnedCoarse, len, 1);
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -187,7 +187,7 @@ void INDEXLIST_3LOOP::runHipVariantImpl(VariantID vid)
     }
     stopTimer();
 
-    deallocData(DataSpace::HipPinned, len);
+    deallocData(DataSpace::HipPinnedCoarse, len);
 
     INDEXLIST_3LOOP_DATA_TEARDOWN_HIP;
 

--- a/src/basic/REDUCE3_INT-Hip.cpp
+++ b/src/basic/REDUCE3_INT-Hip.cpp
@@ -89,7 +89,7 @@ void REDUCE3_INT::runHipVariantBlock(VariantID vid)
   if ( vid == Base_HIP ) {
 
     Int_ptr vmem_init;
-    allocData(DataSpace::HipPinned, vmem_init, 3);
+    allocData(DataSpace::HipPinnedCoarse, vmem_init, 3);
 
     Int_ptr vmem;
     allocData(DataSpace::HipDevice, vmem, 3);
@@ -125,7 +125,7 @@ void REDUCE3_INT::runHipVariantBlock(VariantID vid)
     stopTimer();
 
     deallocData(DataSpace::HipDevice, vmem);
-    deallocData(DataSpace::HipPinned, vmem_init);
+    deallocData(DataSpace::HipPinnedCoarse, vmem_init);
 
   } else if ( vid == RAJA_HIP ) {
 
@@ -167,7 +167,7 @@ void REDUCE3_INT::runHipVariantOccGS(VariantID vid)
   if ( vid == Base_HIP ) {
 
     Int_ptr vmem_init;
-    allocData(DataSpace::HipPinned, vmem_init, 3);
+    allocData(DataSpace::HipPinnedCoarse, vmem_init, 3);
 
     Int_ptr vmem;
     allocData(DataSpace::HipDevice, vmem, 3);
@@ -208,7 +208,7 @@ void REDUCE3_INT::runHipVariantOccGS(VariantID vid)
     stopTimer();
 
     deallocData(DataSpace::HipDevice, vmem);
-    deallocData(DataSpace::HipPinned, vmem_init);
+    deallocData(DataSpace::HipPinnedCoarse, vmem_init);
 
   } else if ( vid == RAJA_HIP ) {
 


### PR DESCRIPTION
# Use coarse grained hip pinned memory

Use coarse grained hip pinned memory in reducers and fused kernels.
This improves performance as it can be cached on device

- This PR is a feature
- It does the following:
  - Adds more spped at the request of me
