### PR TITLE
Add CudaManaged DataSpaces with Advice

### DIFF
--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -131,7 +131,7 @@ inline void copyCudaData(void* dst_ptr, const void* src_ptr, Size_type len)
 }
 
 /*!
- * \brief Allocate CUDA device data array (dptr).
+ * \brief Allocate CUDA device data array.
  */
 inline void* allocCudaDeviceData(Size_type len)
 {
@@ -141,7 +141,7 @@ inline void* allocCudaDeviceData(Size_type len)
 }
 
 /*!
- * \brief Allocate CUDA managed data array (dptr).
+ * \brief Allocate CUDA managed data array.
  */
 inline void* allocCudaManagedData(Size_type len)
 {
@@ -151,7 +151,53 @@ inline void* allocCudaManagedData(Size_type len)
 }
 
 /*!
- * \brief Allocate CUDA pinned data array (pptr).
+ * \brief Allocate CUDA managed host preferred data array.
+ */
+inline void* allocCudaManagedHostPreferredData(Size_type len)
+{
+  void* mptr = nullptr;
+  cudaErrchk( cudaMallocManaged( &mptr, len, cudaMemAttachGlobal ) );
+  cudaErrchk( cudaMemAdvise( mptr, len, cudaMemAdviseSetPreferredLocation, cudaCpuDeviceId ) );
+  return mptr;
+}
+
+/*!
+ * \brief Allocate CUDA managed device preferred data array.
+ */
+inline void* allocCudaManagedDevicePreferredData(Size_type len)
+{
+  void* mptr = nullptr;
+  cudaErrchk( cudaMallocManaged( &mptr, len, cudaMemAttachGlobal ) );
+  cudaErrchk( cudaMemAdvise( mptr, len, cudaMemAdviseSetPreferredLocation, getCudaDevice() ) );
+  return mptr;
+}
+
+/*!
+ * \brief Allocate CUDA managed host preferred host accessed data array.
+ */
+inline void* allocCudaManagedHostPreferredDeviceAccessedData(Size_type len)
+{
+  void* mptr = nullptr;
+  cudaErrchk( cudaMallocManaged( &mptr, len, cudaMemAttachGlobal ) );
+  cudaErrchk( cudaMemAdvise( mptr, len, cudaMemAdviseSetPreferredLocation, cudaCpuDeviceId ) );
+  cudaErrchk( cudaMemAdvise( mptr, len, cudaMemAdviseSetAccessedBy, getCudaDevice() ) );
+  return mptr;
+}
+
+/*!
+ * \brief Allocate CUDA managed device preferred host accessed data array.
+ */
+inline void* allocCudaManagedDevicePreferredHostAccessedData(Size_type len)
+{
+  void* mptr = nullptr;
+  cudaErrchk( cudaMallocManaged( &mptr, len, cudaMemAttachGlobal ) );
+  cudaErrchk( cudaMemAdvise( mptr, len, cudaMemAdviseSetPreferredLocation, getCudaDevice() ) );
+  cudaErrchk( cudaMemAdvise( mptr, len, cudaMemAdviseSetAccessedBy, cudaCpuDeviceId ) );
+  return mptr;
+}
+
+/*!
+ * \brief Allocate CUDA pinned data array.
  */
 inline void* allocCudaPinnedData(Size_type len)
 {
@@ -162,7 +208,7 @@ inline void* allocCudaPinnedData(Size_type len)
 
 
 /*!
- * \brief Free device data array.
+ * \brief Free CUDA device data array.
  */
 inline void deallocCudaDeviceData(void* dptr)
 {
@@ -170,7 +216,7 @@ inline void deallocCudaDeviceData(void* dptr)
 }
 
 /*!
- * \brief Free managed data array.
+ * \brief Free CUDA managed data array.
  */
 inline void deallocCudaManagedData(void* mptr)
 {
@@ -178,7 +224,39 @@ inline void deallocCudaManagedData(void* mptr)
 }
 
 /*!
- * \brief Free pinned data array.
+ * \brief Free CUDA managed host preferred data array.
+ */
+inline void deallocCudaManagedHostPreferredData(void* mptr)
+{
+  cudaErrchk( cudaFree( mptr ) );
+}
+
+/*!
+ * \brief Free CUDA managed device preferred data array.
+ */
+inline void deallocCudaManagedDevicePreferredData(void* mptr)
+{
+  cudaErrchk( cudaFree( mptr ) );
+}
+
+/*!
+ * \brief Free CUDA managed host preferred host accessed data array.
+ */
+inline void deallocCudaManagedHostPreferredDeviceAccessedData(void* mptr)
+{
+  cudaErrchk( cudaFree( mptr ) );
+}
+
+/*!
+ * \brief Free CUDA managed device preferred host accessed data array.
+ */
+inline void deallocCudaManagedDevicePreferredHostAccessedData(void* mptr)
+{
+  cudaErrchk( cudaFree( mptr ) );
+}
+
+/*!
+ * \brief Free CUDA pinned data array.
  */
 inline void deallocCudaPinnedData(void* pptr)
 {

--- a/src/common/DataUtils.cpp
+++ b/src/common/DataUtils.cpp
@@ -72,6 +72,10 @@ bool isCudaDataSpace(DataSpace dataSpace)
   switch (dataSpace) {
     case DataSpace::CudaPinned:
     case DataSpace::CudaManaged:
+    case DataSpace::CudaManagedHostPreferred:
+    case DataSpace::CudaManagedDevicePreferred:
+    case DataSpace::CudaManagedHostPreferredDeviceAccessed:
+    case DataSpace::CudaManagedDevicePreferredHostAccessed:
     case DataSpace::CudaDevice:
       return true;
     default:
@@ -185,6 +189,22 @@ void* allocData(DataSpace dataSpace, Size_type nbytes, Size_type align)
     case DataSpace::CudaManaged:
     {
       ptr = detail::allocCudaManagedData(nbytes);
+    } break;
+    case DataSpace::CudaManagedHostPreferred:
+    {
+      ptr = detail::allocCudaManagedHostPreferredData(nbytes);
+    } break;
+    case DataSpace::CudaManagedDevicePreferred:
+    {
+      ptr = detail::allocCudaManagedDevicePreferredData(nbytes);
+    } break;
+    case DataSpace::CudaManagedHostPreferredDeviceAccessed:
+    {
+      ptr = detail::allocCudaManagedHostPreferredDeviceAccessedData(nbytes);
+    } break;
+    case DataSpace::CudaManagedDevicePreferredHostAccessed:
+    {
+      ptr = detail::allocCudaManagedDevicePreferredHostAccessedData(nbytes);
     } break;
     case DataSpace::CudaDevice:
     {
@@ -328,6 +348,22 @@ void deallocData(DataSpace dataSpace, void* ptr)
     case DataSpace::CudaManaged:
     {
       detail::deallocCudaManagedData(ptr);
+    } break;
+    case DataSpace::CudaManagedHostPreferred:
+    {
+      detail::deallocCudaManagedHostPreferredData(ptr);
+    } break;
+    case DataSpace::CudaManagedDevicePreferred:
+    {
+      detail::deallocCudaManagedDevicePreferredData(ptr);
+    } break;
+    case DataSpace::CudaManagedHostPreferredDeviceAccessed:
+    {
+      detail::deallocCudaManagedHostPreferredDeviceAccessedData(ptr);
+    } break;
+    case DataSpace::CudaManagedDevicePreferredHostAccessed:
+    {
+      detail::deallocCudaManagedDevicePreferredHostAccessedData(ptr);
     } break;
     case DataSpace::CudaDevice:
     {
@@ -581,9 +617,13 @@ DataSpace hostAccessibleDataSpace(DataSpace dataSpace)
       return DataSpace::Host;
 
     case DataSpace::CudaManaged:
+    case DataSpace::CudaManagedDevicePreferred:
+    case DataSpace::CudaManagedDevicePreferredHostAccessed:
     case DataSpace::CudaDevice:
       return DataSpace::CudaPinned;
 
+    case DataSpace::CudaManagedHostPreferred:
+    case DataSpace::CudaManagedHostPreferredDeviceAccessed:
     case DataSpace::HipManaged:
     case DataSpace::HipManagedAdviseFine:
     case DataSpace::HipManagedAdviseCoarse:

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -348,6 +348,10 @@ static const std::string DataSpaceNames [] =
 
   std::string("CudaPinned"),
   std::string("CudaManaged"),
+  std::string("CudaManagedHostPreferred"),
+  std::string("CudaManagedDevicePreferred"),
+  std::string("CudaManagedHostPreferredDeviceAccessed"),
+  std::string("CudaManagedDevicePreferredHostAccessed"),
   std::string("CudaDevice"),
 
   std::string("HipHostAdviseFine"),
@@ -595,6 +599,10 @@ bool isDataSpaceAvailable(DataSpace dataSpace)
 #if defined(RAJA_ENABLE_CUDA)
     case DataSpace::CudaPinned:
     case DataSpace::CudaManaged:
+    case DataSpace::CudaManagedHostPreferred:
+    case DataSpace::CudaManagedDevicePreferred:
+    case DataSpace::CudaManagedHostPreferredDeviceAccessed:
+    case DataSpace::CudaManagedDevicePreferredHostAccessed:
     case DataSpace::CudaDevice:
       ret_val = true; break;
 #endif

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -266,6 +266,10 @@ enum struct DataSpace {
 
   CudaPinned,
   CudaManaged,
+  CudaManagedHostPreferred,
+  CudaManagedDevicePreferred,
+  CudaManagedHostPreferredDeviceAccessed,
+  CudaManagedDevicePreferredHostAccessed,
   CudaDevice,
 
   HipHostAdviseFine,


### PR DESCRIPTION
# Add CudaManaged DataSpaces with Advice
This adds these additional DataSpaces so we can try them out.
- CudaManagedHostPreferred
- CudaManagedDevicePreferred
- CudaManagedHostPreferredDeviceAccessed
- CudaManagedDevicePreferredHostAccessed

- This PR is a feature
- It does the following:
  - Adds more cuda DataSpaces at the request of me
