### PR TITLE
Add RAJA GPU block atomic Tuning for Reduction Kernels

### DIFF
--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -29,9 +29,9 @@ variables:
 # Optimization notes: We have 4 jobs lasting at max 5 minutes and using 28
 # cores out of 112 available (see -j in scripts/gitlab/build_and_test.sh).
 # We allow allocation overlapping.
-  POODLE_SHARED_ALLOC: "--exclusive --partition=pdebug --time=12 --nodes=1"
+  POODLE_SHARED_ALLOC: "--exclusive --partition=pdebug --time=14 --nodes=1"
 # Arguments for job level allocation
-  POODLE_JOB_ALLOC: "--overlap --time=10 --nodes=1"
+  POODLE_JOB_ALLOC: "--overlap --time=12 --nodes=1"
 # Project specific variants for poodle
   PROJECT_POODLE_VARIANTS: "~shared +openmp"
 # Project specific deps for poodle

--- a/src/algorithm/REDUCE_SUM.hpp
+++ b/src/algorithm/REDUCE_SUM.hpp
@@ -64,13 +64,21 @@ public:
   void runCudaVariantCub(VariantID vid);
   void runHipVariantRocprim(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantBlock(VariantID vid);
+  void runCudaVariantBlockAtomic(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantOccGS(VariantID vid);
+  void runHipVariantBlockAtomic(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantOccGS(VariantID vid);
+  void runCudaVariantBlockOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockOccGS(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/basic/PI_REDUCE-Hip.cpp
+++ b/src/basic/PI_REDUCE-Hip.cpp
@@ -61,7 +61,7 @@ __global__ void pi_reduce(Real_type dx,
 
 
 template < size_t block_size >
-void PI_REDUCE::runHipVariantBlock(VariantID vid)
+void PI_REDUCE::runHipVariantBlockAtomic(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -104,7 +104,7 @@ void PI_REDUCE::runHipVariantBlock(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::ReduceSum<RAJA::hip_reduce, Real_type> pi(m_pi_init);
+      RAJA::ReduceSum<RAJA::hip_reduce_atomic, Real_type> pi(m_pi_init);
 
       RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >( res,
          RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
@@ -122,7 +122,7 @@ void PI_REDUCE::runHipVariantBlock(VariantID vid)
 }
 
 template < size_t block_size >
-void PI_REDUCE::runHipVariantOccGS(VariantID vid)
+void PI_REDUCE::runHipVariantBlockAtomicOccGS(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -169,6 +169,73 @@ void PI_REDUCE::runHipVariantOccGS(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      RAJA::ReduceSum<RAJA::hip_reduce_atomic, Real_type> pi(m_pi_init);
+
+      RAJA::forall< RAJA::hip_exec_occ_calc<block_size, true /*async*/> >( res,
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         PI_REDUCE_BODY;
+       });
+
+      m_pi = 4.0 * static_cast<Real_type>(pi.get());
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  PI_REDUCE : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+
+template < size_t block_size >
+void PI_REDUCE::runHipVariantBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  PI_REDUCE_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::hip_reduce, Real_type> pi(m_pi_init);
+
+      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >( res,
+         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+         PI_REDUCE_BODY;
+       });
+
+      m_pi = 4.0 * static_cast<Real_type>(pi.get());
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  PI_REDUCE : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t block_size >
+void PI_REDUCE::runHipVariantBlockOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  PI_REDUCE_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
       RAJA::ReduceSum<RAJA::hip_reduce, Real_type> pi(m_pi_init);
 
       RAJA::forall< RAJA::hip_exec_occ_calc<block_size, true /*async*/> >( res,
@@ -200,7 +267,7 @@ void PI_REDUCE::runHipVariant(VariantID vid, size_t tune_idx)
         if (tune_idx == t) {
 
           setBlockSize(block_size);
-          runHipVariantBlock<block_size>(vid);
+          runHipVariantBlockAtomic<block_size>(vid);
 
         }
 
@@ -209,11 +276,33 @@ void PI_REDUCE::runHipVariant(VariantID vid, size_t tune_idx)
         if (tune_idx == t) {
 
           setBlockSize(block_size);
-          runHipVariantOccGS<block_size>(vid);
+          runHipVariantBlockAtomicOccGS<block_size>(vid);
 
         }
 
         t += 1;
+
+        if ( vid == RAJA_HIP ) {
+
+          if (tune_idx == t) {
+
+            setBlockSize(block_size);
+            runHipVariantBlock<block_size>(vid);
+
+          }
+
+          t += 1;
+
+          if (tune_idx == t) {
+
+            setBlockSize(block_size);
+            runHipVariantBlockOccGS<block_size>(vid);
+
+          }
+
+          t += 1;
+
+        }
 
       }
 
@@ -236,10 +325,17 @@ void PI_REDUCE::setHipTuningDefinitions(VariantID vid)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+        addVariantTuningName(vid, "blkatm_"+std::to_string(block_size));
 
-        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+        addVariantTuningName(vid, "blkatm_occgs_"+std::to_string(block_size));
 
+        if ( vid == RAJA_HIP ) {
+
+          addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+          addVariantTuningName(vid, "block_occgs_"+std::to_string(block_size));
+
+        }
       }
 
     });

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -60,13 +60,21 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantBlock(VariantID vid);
+  void runCudaVariantBlockAtomic(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantOccGS(VariantID vid);
+  void runHipVariantBlockAtomic(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantOccGS(VariantID vid);
+  void runCudaVariantBlockOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockOccGS(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/basic/REDUCE3_INT-Cuda.cpp
+++ b/src/basic/REDUCE3_INT-Cuda.cpp
@@ -76,7 +76,7 @@ __global__ void reduce3int(Int_ptr vec,
 
 
 template < size_t block_size >
-void REDUCE3_INT::runCudaVariantBlock(VariantID vid)
+void REDUCE3_INT::runCudaVariantBlockAtomic(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -132,9 +132,9 @@ void REDUCE3_INT::runCudaVariantBlock(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::ReduceSum<RAJA::cuda_reduce, Int_type> vsum(m_vsum_init);
-      RAJA::ReduceMin<RAJA::cuda_reduce, Int_type> vmin(m_vmin_init);
-      RAJA::ReduceMax<RAJA::cuda_reduce, Int_type> vmax(m_vmax_init);
+      RAJA::ReduceSum<RAJA::cuda_reduce_atomic, Int_type> vsum(m_vsum_init);
+      RAJA::ReduceMin<RAJA::cuda_reduce_atomic, Int_type> vmin(m_vmin_init);
+      RAJA::ReduceMax<RAJA::cuda_reduce_atomic, Int_type> vmax(m_vmax_init);
 
       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >( res,
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
@@ -154,7 +154,7 @@ void REDUCE3_INT::runCudaVariantBlock(VariantID vid)
 }
 
 template < size_t block_size >
-void REDUCE3_INT::runCudaVariantOccGS(VariantID vid)
+void REDUCE3_INT::runCudaVariantBlockAtomicOccGS(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -214,6 +214,80 @@ void REDUCE3_INT::runCudaVariantOccGS(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      RAJA::ReduceSum<RAJA::cuda_reduce_atomic, Int_type> vsum(m_vsum_init);
+      RAJA::ReduceMin<RAJA::cuda_reduce_atomic, Int_type> vmin(m_vmin_init);
+      RAJA::ReduceMax<RAJA::cuda_reduce_atomic, Int_type> vmax(m_vmax_init);
+
+      RAJA::forall< RAJA::cuda_exec_occ_calc<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        REDUCE3_INT_BODY_RAJA;
+      });
+
+      m_vsum += static_cast<Int_type>(vsum.get());
+      m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
+      m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  REDUCE3_INT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t block_size >
+void REDUCE3_INT::runCudaVariantBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  REDUCE3_INT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce, Int_type> vsum(m_vsum_init);
+      RAJA::ReduceMin<RAJA::cuda_reduce, Int_type> vmin(m_vmin_init);
+      RAJA::ReduceMax<RAJA::cuda_reduce, Int_type> vmax(m_vmax_init);
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        REDUCE3_INT_BODY_RAJA;
+      });
+
+      m_vsum += static_cast<Int_type>(vsum.get());
+      m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
+      m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  REDUCE3_INT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t block_size >
+void REDUCE3_INT::runCudaVariantBlockOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  REDUCE3_INT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
       RAJA::ReduceSum<RAJA::cuda_reduce, Int_type> vsum(m_vsum_init);
       RAJA::ReduceMin<RAJA::cuda_reduce, Int_type> vmin(m_vmin_init);
       RAJA::ReduceMax<RAJA::cuda_reduce, Int_type> vmax(m_vmax_init);
@@ -249,7 +323,7 @@ void REDUCE3_INT::runCudaVariant(VariantID vid, size_t tune_idx)
         if (tune_idx == t) {
 
           setBlockSize(block_size);
-          runCudaVariantBlock<block_size>(vid);
+          runCudaVariantBlockAtomic<block_size>(vid);
 
         }
 
@@ -258,11 +332,33 @@ void REDUCE3_INT::runCudaVariant(VariantID vid, size_t tune_idx)
         if (tune_idx == t) {
 
           setBlockSize(block_size);
-          runCudaVariantOccGS<block_size>(vid);
+          runCudaVariantBlockAtomicOccGS<block_size>(vid);
 
         }
 
         t += 1;
+
+        if ( vid == RAJA_CUDA ) {
+
+          if (tune_idx == t) {
+
+            setBlockSize(block_size);
+            runCudaVariantBlock<block_size>(vid);
+
+          }
+
+          t += 1;
+
+          if (tune_idx == t) {
+
+            setBlockSize(block_size);
+            runCudaVariantBlockOccGS<block_size>(vid);
+
+          }
+
+          t += 1;
+
+        }
 
       }
 
@@ -285,9 +381,17 @@ void REDUCE3_INT::setCudaTuningDefinitions(VariantID vid)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+        addVariantTuningName(vid, "blkatm_"+std::to_string(block_size));
 
-        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+        addVariantTuningName(vid, "blkatm_occgs_"+std::to_string(block_size));
+
+        if ( vid == RAJA_CUDA ) {
+
+          addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+          addVariantTuningName(vid, "block_occgs_"+std::to_string(block_size));
+
+        }
 
       }
 

--- a/src/basic/REDUCE3_INT.hpp
+++ b/src/basic/REDUCE3_INT.hpp
@@ -75,13 +75,21 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantBlock(VariantID vid);
+  void runCudaVariantBlockAtomic(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantOccGS(VariantID vid);
+  void runHipVariantBlockAtomic(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantOccGS(VariantID vid);
+  void runCudaVariantBlockOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockOccGS(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/basic/REDUCE_STRUCT-Cuda.cpp
+++ b/src/basic/REDUCE_STRUCT-Cuda.cpp
@@ -97,8 +97,10 @@ __global__ void reduce_struct(Real_ptr x, Real_ptr y,
   }
 }
 
+
+
 template < size_t block_size >
-void REDUCE_STRUCT::runCudaVariantBlock(VariantID vid)
+void REDUCE_STRUCT::runCudaVariantBlockAtomic(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -151,12 +153,12 @@ void REDUCE_STRUCT::runCudaVariantBlock(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> xsum(m_init_sum);
-      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> ysum(m_init_sum);
-      RAJA::ReduceMin<RAJA::cuda_reduce, Real_type> xmin(m_init_min); 
-      RAJA::ReduceMin<RAJA::cuda_reduce, Real_type> ymin(m_init_min);
-      RAJA::ReduceMax<RAJA::cuda_reduce, Real_type> xmax(m_init_max); 
-      RAJA::ReduceMax<RAJA::cuda_reduce, Real_type> ymax(m_init_max);
+      RAJA::ReduceSum<RAJA::cuda_reduce_atomic, Real_type> xsum(m_init_sum);
+      RAJA::ReduceSum<RAJA::cuda_reduce_atomic, Real_type> ysum(m_init_sum);
+      RAJA::ReduceMin<RAJA::cuda_reduce_atomic, Real_type> xmin(m_init_min);
+      RAJA::ReduceMin<RAJA::cuda_reduce_atomic, Real_type> ymin(m_init_min);
+      RAJA::ReduceMax<RAJA::cuda_reduce_atomic, Real_type> xmax(m_init_max);
+      RAJA::ReduceMax<RAJA::cuda_reduce_atomic, Real_type> ymax(m_init_max);
 
       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >( res,
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
@@ -181,7 +183,7 @@ void REDUCE_STRUCT::runCudaVariantBlock(VariantID vid)
 }
 
 template < size_t block_size >
-void REDUCE_STRUCT::runCudaVariantOccGS(VariantID vid)
+void REDUCE_STRUCT::runCudaVariantBlockAtomicOccGS(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -238,6 +240,96 @@ void REDUCE_STRUCT::runCudaVariantOccGS(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      RAJA::ReduceSum<RAJA::cuda_reduce_atomic, Real_type> xsum(m_init_sum);
+      RAJA::ReduceSum<RAJA::cuda_reduce_atomic, Real_type> ysum(m_init_sum);
+      RAJA::ReduceMin<RAJA::cuda_reduce_atomic, Real_type> xmin(m_init_min);
+      RAJA::ReduceMin<RAJA::cuda_reduce_atomic, Real_type> ymin(m_init_min);
+      RAJA::ReduceMax<RAJA::cuda_reduce_atomic, Real_type> xmax(m_init_max);
+      RAJA::ReduceMax<RAJA::cuda_reduce_atomic, Real_type> ymax(m_init_max);
+
+      RAJA::forall< RAJA::cuda_exec_occ_calc<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          REDUCE_STRUCT_BODY_RAJA;
+      });
+
+      points.SetCenter((xsum.get()/(points.N)),
+                       (ysum.get()/(points.N)));
+      points.SetXMin((xmin.get()));
+      points.SetXMax((xmax.get()));
+      points.SetYMin((ymin.get()));
+      points.SetYMax((ymax.get()));
+      m_points=points;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  REDUCE_STRUCT : Unknown CUDA variant id = " << vid << std::endl;
+  }
+
+}
+
+template < size_t block_size >
+void REDUCE_STRUCT::runCudaVariantBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  REDUCE_STRUCT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> xsum(m_init_sum);
+      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> ysum(m_init_sum);
+      RAJA::ReduceMin<RAJA::cuda_reduce, Real_type> xmin(m_init_min);
+      RAJA::ReduceMin<RAJA::cuda_reduce, Real_type> ymin(m_init_min);
+      RAJA::ReduceMax<RAJA::cuda_reduce, Real_type> xmax(m_init_max);
+      RAJA::ReduceMax<RAJA::cuda_reduce, Real_type> ymax(m_init_max);
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          REDUCE_STRUCT_BODY_RAJA;
+      });
+
+      points.SetCenter((xsum.get()/(points.N)),
+                       (ysum.get()/(points.N)));
+      points.SetXMin((xmin.get()));
+      points.SetXMax((xmax.get()));
+      points.SetYMin((ymin.get()));
+      points.SetYMax((ymax.get()));
+      m_points=points;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  REDUCE_STRUCT : Unknown CUDA variant id = " << vid << std::endl;
+  }
+
+}
+
+template < size_t block_size >
+void REDUCE_STRUCT::runCudaVariantBlockOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  REDUCE_STRUCT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
       RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> xsum(m_init_sum);
       RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> ysum(m_init_sum);
       RAJA::ReduceMin<RAJA::cuda_reduce, Real_type> xmin(m_init_min);
@@ -281,7 +373,7 @@ void REDUCE_STRUCT::runCudaVariant(VariantID vid, size_t tune_idx)
         if (tune_idx == t) {
 
           setBlockSize(block_size);
-          runCudaVariantBlock<block_size>(vid);
+          runCudaVariantBlockAtomic<block_size>(vid);
 
         }
 
@@ -290,11 +382,33 @@ void REDUCE_STRUCT::runCudaVariant(VariantID vid, size_t tune_idx)
         if (tune_idx == t) {
 
           setBlockSize(block_size);
-          runCudaVariantOccGS<block_size>(vid);
+          runCudaVariantBlockAtomicOccGS<block_size>(vid);
 
         }
 
         t += 1;
+
+        if ( vid == RAJA_CUDA ) {
+
+          if (tune_idx == t) {
+
+            setBlockSize(block_size);
+            runCudaVariantBlock<block_size>(vid);
+
+          }
+
+          t += 1;
+
+          if (tune_idx == t) {
+
+            setBlockSize(block_size);
+            runCudaVariantBlockOccGS<block_size>(vid);
+
+          }
+
+          t += 1;
+
+        }
 
       }
 
@@ -317,9 +431,17 @@ void REDUCE_STRUCT::setCudaTuningDefinitions(VariantID vid)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+        addVariantTuningName(vid, "blkatm_"+std::to_string(block_size));
 
-        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+        addVariantTuningName(vid, "blkatm_occgs_"+std::to_string(block_size));
+
+        if ( vid == RAJA_CUDA ) {
+
+          addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+          addVariantTuningName(vid, "block_occgs_"+std::to_string(block_size));
+
+        }
 
       }
 

--- a/src/basic/REDUCE_STRUCT.hpp
+++ b/src/basic/REDUCE_STRUCT.hpp
@@ -90,13 +90,21 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantBlock(VariantID vid);
+  void runCudaVariantBlockAtomic(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantOccGS(VariantID vid);
+  void runHipVariantBlockAtomic(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantOccGS(VariantID vid);
+  void runCudaVariantBlockOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockOccGS(VariantID vid);
 
   struct PointsType {
     Int_type N;

--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -81,7 +81,7 @@ __global__ void trapint(Real_type x0, Real_type xp,
 
 
 template < size_t block_size >
-void TRAP_INT::runCudaVariantBlock(VariantID vid)
+void TRAP_INT::runCudaVariantBlockAtomic(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -128,7 +128,7 @@ void TRAP_INT::runCudaVariantBlock(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> sumx(m_sumx_init);
+      RAJA::ReduceSum<RAJA::cuda_reduce_atomic, Real_type> sumx(m_sumx_init);
 
       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >( res,
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
@@ -146,7 +146,7 @@ void TRAP_INT::runCudaVariantBlock(VariantID vid)
 }
 
 template < size_t block_size >
-void TRAP_INT::runCudaVariantOccGS(VariantID vid)
+void TRAP_INT::runCudaVariantBlockAtomicOccGS(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -197,6 +197,72 @@ void TRAP_INT::runCudaVariantOccGS(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      RAJA::ReduceSum<RAJA::cuda_reduce_atomic, Real_type> sumx(m_sumx_init);
+
+      RAJA::forall< RAJA::cuda_exec_occ_calc<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        TRAP_INT_BODY;
+      });
+
+      m_sumx += static_cast<Real_type>(sumx.get()) * h;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  TRAP_INT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t block_size >
+void TRAP_INT::runCudaVariantBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  TRAP_INT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> sumx(m_sumx_init);
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+        TRAP_INT_BODY;
+      });
+
+      m_sumx += static_cast<Real_type>(sumx.get()) * h;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  TRAP_INT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t block_size >
+void TRAP_INT::runCudaVariantBlockOccGS(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  TRAP_INT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
       RAJA::ReduceSum<RAJA::cuda_reduce, Real_type> sumx(m_sumx_init);
 
       RAJA::forall< RAJA::cuda_exec_occ_calc<block_size, true /*async*/> >( res,
@@ -228,7 +294,7 @@ void TRAP_INT::runCudaVariant(VariantID vid, size_t tune_idx)
         if (tune_idx == t) {
 
           setBlockSize(block_size);
-          runCudaVariantBlock<block_size>(vid);
+          runCudaVariantBlockAtomic<block_size>(vid);
 
         }
 
@@ -237,11 +303,33 @@ void TRAP_INT::runCudaVariant(VariantID vid, size_t tune_idx)
         if (tune_idx == t) {
 
           setBlockSize(block_size);
-          runCudaVariantOccGS<block_size>(vid);
+          runCudaVariantBlockAtomicOccGS<block_size>(vid);
 
         }
 
         t += 1;
+
+        if ( vid == RAJA_CUDA ) {
+
+          if (tune_idx == t) {
+
+            setBlockSize(block_size);
+            runCudaVariantBlock<block_size>(vid);
+
+          }
+
+          t += 1;
+
+          if (tune_idx == t) {
+
+            setBlockSize(block_size);
+            runCudaVariantBlockOccGS<block_size>(vid);
+
+          }
+
+          t += 1;
+
+        }
 
       }
 
@@ -264,9 +352,17 @@ void TRAP_INT::setCudaTuningDefinitions(VariantID vid)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+        addVariantTuningName(vid, "blkatm_"+std::to_string(block_size));
 
-        addVariantTuningName(vid, "occgs_"+std::to_string(block_size));
+        addVariantTuningName(vid, "blkatm_occgs_"+std::to_string(block_size));
+
+        if ( vid == RAJA_CUDA ) {
+
+          addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+          addVariantTuningName(vid, "block_occgs_"+std::to_string(block_size));
+
+        }
 
       }
 

--- a/src/basic/TRAP_INT.hpp
+++ b/src/basic/TRAP_INT.hpp
@@ -72,13 +72,21 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantBlock(VariantID vid);
+  void runCudaVariantBlockAtomic(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantOccGS(VariantID vid);
+  void runHipVariantBlockAtomic(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantOccGS(VariantID vid);
+  void runCudaVariantBlockOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockOccGS(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -56,13 +56,21 @@ public:
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantBlock(VariantID vid);
+  void runCudaVariantBlockAtomic(VariantID vid);
   template < size_t block_size >
-  void runCudaVariantOccGS(VariantID vid);
+  void runHipVariantBlockAtomic(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockAtomicOccGS(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantBlock(VariantID vid);
   template < size_t block_size >
   void runHipVariantBlock(VariantID vid);
   template < size_t block_size >
-  void runHipVariantOccGS(VariantID vid);
+  void runCudaVariantBlockOccGS(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantBlockOccGS(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;


### PR DESCRIPTION
# Add RAJA GPU block atomic Tuning for Reduction Kernels

Make more apples to apples comparisons possible in reduction kernels by adding a RAJA GPU block atomic (blkatm) tuning that more closely matches the Base implementation.
Note there is currently false sharing/extra atomic contention when there are multiple reducers in the blkatm tunings, but this is not addressed here.

- This PR is a feature
- It does the following:
  - Adds the ability to compare GPU reduction performance in a more apple to apples way at the request of me
