### PR TITLE
Unify GPU kernel launches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ else()
 endif()
 
 option(ENABLE_RAJA_SEQUENTIAL "Run sequential variants of RAJA kernels. Disable
-this, and all other variants, to run _only_ raw C loops." On)
+this, and all other variants, to run _only_ base variants." On)
 option(ENABLE_KOKKOS "Include Kokkos implementations of the kernels in the RAJA Perfsuite" Off)
 
 #

--- a/src/algorithm/MEMCPY-Cuda.cpp
+++ b/src/algorithm/MEMCPY-Cuda.cpp
@@ -48,7 +48,9 @@ void MEMCPY::runCudaVariantLibrary(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      cudaErrchk( cudaMemcpyAsync(MEMCPY_STD_ARGS, cudaMemcpyDefault, res.get_stream()) );
+      cudaErrchk( cudaMemcpyAsync(MEMCPY_STD_ARGS,
+                                  cudaMemcpyDefault,
+                                  res.get_stream()) );
 
     }
     stopTimer();
@@ -89,8 +91,11 @@ void MEMCPY::runCudaVariantBlock(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      memcpy<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-          x, y, iend );
+
+      RPlaunchCudaKernel( (memcpy<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x, y, iend );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -107,8 +112,12 @@ void MEMCPY::runCudaVariantBlock(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      lambda_cuda_forall<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-          ibegin, iend, memcpy_lambda );
+
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size,
+                                              decltype(memcpy_lambda)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend, memcpy_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/algorithm/MEMCPY-Hip.cpp
+++ b/src/algorithm/MEMCPY-Hip.cpp
@@ -48,7 +48,9 @@ void MEMCPY::runHipVariantLibrary(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      hipErrchk( hipMemcpyAsync(MEMCPY_STD_ARGS, hipMemcpyDefault, res.get_stream()) );
+      hipErrchk( hipMemcpyAsync(MEMCPY_STD_ARGS,
+                                hipMemcpyDefault,
+                                res.get_stream()) );
 
     }
     stopTimer();
@@ -89,9 +91,11 @@ void MEMCPY::runHipVariantBlock(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL( (memcpy<block_size>),
-          dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-          x, y, iend );
+
+      RPlaunchHipKernel( (memcpy<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         x, y, iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -108,9 +112,12 @@ void MEMCPY::runHipVariantBlock(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(memcpy_lambda)>),
-          grid_size, block_size, shmem, res.get_stream(),
-          ibegin, iend, memcpy_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(memcpy_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, memcpy_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/algorithm/MEMSET-Cuda.cpp
+++ b/src/algorithm/MEMSET-Cuda.cpp
@@ -89,10 +89,11 @@ void MEMSET::runCudaVariantBlock(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      memset<block_size><<<grid_size, block_size,
-                  shmem, res.get_stream()>>>( x,
-                                                   val,
-                                                   iend );
+
+      RPlaunchCudaKernel( (memset<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x, val, iend );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -109,8 +110,12 @@ void MEMSET::runCudaVariantBlock(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      lambda_cuda_forall<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-          ibegin, iend, memset_lambda );
+
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size,
+                                              decltype(memset_lambda)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend, memset_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/algorithm/MEMSET-Hip.cpp
+++ b/src/algorithm/MEMSET-Hip.cpp
@@ -89,9 +89,11 @@ void MEMSET::runHipVariantBlock(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL( (memset<block_size>),
-          dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-          x, val, iend );
+
+      RPlaunchHipKernel( (memset<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         x, val, iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -108,9 +110,12 @@ void MEMSET::runHipVariantBlock(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(memset_lambda)>),
-          grid_size, block_size, shmem, res.get_stream(),
-          ibegin, iend, memset_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(memset_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, memset_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/algorithm/REDUCE_SUM-Cuda.cpp
+++ b/src/algorithm/REDUCE_SUM-Cuda.cpp
@@ -148,10 +148,11 @@ void REDUCE_SUM::runCudaVariantBlockAtomic(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = sizeof(Real_type)*block_size;
-      reduce_sum<block_size><<<grid_size, block_size,
-                  shmem, res.get_stream()>>>( x,
-                                                   sum, m_sum_init,
-                                                   iend );
+
+      RPlaunchCudaKernel( (reduce_sum<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x, sum, m_sum_init, iend );
       cudaErrchk( cudaGetLastError() );
 
       RAJAPERF_CUDA_REDUCER_COPY_BACK(&m_sum, sum, hsum, 1);
@@ -212,10 +213,11 @@ void REDUCE_SUM::runCudaVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      reduce_sum<block_size><<<grid_size, block_size,
-                               shmem, res.get_stream()>>>( x,
-                                                   sum, m_sum_init,
-                                                   iend );
+
+      RPlaunchCudaKernel( (reduce_sum<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x, sum, m_sum_init, iend );
       cudaErrchk( cudaGetLastError() );
 
       RAJAPERF_CUDA_REDUCER_COPY_BACK(&m_sum, sum, hsum, 1);

--- a/src/algorithm/REDUCE_SUM-Hip.cpp
+++ b/src/algorithm/REDUCE_SUM-Hip.cpp
@@ -175,9 +175,11 @@ void REDUCE_SUM::runHipVariantBlockAtomic(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = sizeof(Real_type)*block_size;
-      hipLaunchKernelGGL( (reduce_sum<block_size>), dim3(grid_size), dim3(block_size),
-                          shmem, res.get_stream(),
-                          x, sum, m_sum_init, iend );
+
+      RPlaunchHipKernel( (reduce_sum<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         x, sum, m_sum_init, iend );
       hipErrchk( hipGetLastError() );
 
       RAJAPERF_HIP_REDUCER_COPY_BACK(&m_sum, sum, hsum, 1);
@@ -238,9 +240,11 @@ void REDUCE_SUM::runHipVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      hipLaunchKernelGGL( (reduce_sum<block_size>), dim3(grid_size), dim3(block_size),
-                          shmem, res.get_stream(),
-                          x, sum, m_sum_init, iend );
+
+      RPlaunchHipKernel( (reduce_sum<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         x, sum, m_sum_init, iend );
       hipErrchk( hipGetLastError() );
 
       RAJAPERF_HIP_REDUCER_COPY_BACK(&m_sum, sum, hsum, 1);

--- a/src/apps/CONVECTION3DPA-Cuda.cpp
+++ b/src/apps/CONVECTION3DPA-Cuda.cpp
@@ -138,15 +138,16 @@ void CONVECTION3DPA::runCudaVariantImpl(VariantID vid) {
 
   case Base_CUDA: {
 
-    dim3 nthreads_per_block(CPA_Q1D, CPA_Q1D, CPA_Q1D);
-
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      dim3 nthreads_per_block(CPA_Q1D, CPA_Q1D, CPA_Q1D);
       constexpr size_t shmem = 0;
-      Convection3DPA<block_size><<<NE, nthreads_per_block, shmem, res.get_stream()>>>
-        (Basis, tBasis, dBasis, D, X, Y);
 
+      RPlaunchCudaKernel( (Convection3DPA<block_size>),
+                          NE, nthreads_per_block,
+                          shmem, res.get_stream(),
+                          Basis, tBasis, dBasis, D, X, Y );
       cudaErrchk(cudaGetLastError());
     }
     stopTimer();

--- a/src/apps/CONVECTION3DPA-Hip.cpp
+++ b/src/apps/CONVECTION3DPA-Hip.cpp
@@ -138,17 +138,16 @@ void CONVECTION3DPA::runHipVariantImpl(VariantID vid) {
 
   case Base_HIP: {
 
-    dim3 nblocks(NE);
-    dim3 nthreads_per_block(CPA_Q1D, CPA_Q1D, CPA_Q1D);
-
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      dim3 nthreads_per_block(CPA_Q1D, CPA_Q1D, CPA_Q1D);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((Convection3DPA<block_size>),
-                         dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         Basis, tBasis, dBasis, D, X, Y);
-
+      
+      RPlaunchHipKernel( (Convection3DPA<block_size>),
+                         NE, nthreads_per_block,
+                         shmem, res.get_stream(),
+                         Basis, tBasis, dBasis, D, X, Y );      
       hipErrchk(hipGetLastError());
     }
     stopTimer();

--- a/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-Cuda.cpp
@@ -52,6 +52,7 @@ template < size_t block_size >
 void DEL_DOT_VEC_2D::runCudaVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
   const Index_type iend = m_domain->n_real_zones;
 
   auto res{getCudaResource()};
@@ -64,16 +65,19 @@ void DEL_DOT_VEC_2D::runCudaVariantImpl(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-
       constexpr size_t shmem = 0;
-      deldotvec2d<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(div,
-                                             x1, x2, x3, x4,
-                                             y1, y2, y3, y4,
-                                             fx1, fx2, fx3, fx4,
-                                             fy1, fy2, fy3, fy4,
-                                             real_zones,
-                                             half, ptiny,
-                                             iend);
+
+      RPlaunchCudaKernel( (deldotvec2d<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          div,
+                          x1, x2, x3, x4,
+                          y1, y2, y3, y4,
+                          fx1, fx2, fx3, fx4,
+                          fy1, fy2, fy3, fy4,
+                          real_zones,
+                          half, ptiny,
+                          iend );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -84,16 +88,20 @@ void DEL_DOT_VEC_2D::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-
-      constexpr size_t shmem = 0;
-      lambda_cuda_forall<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-        0, iend,
-        [=] __device__ (Index_type ii) {
-
+      auto deldotvec2d_lambda = [=] __device__ (Index_type ii) {
         DEL_DOT_VEC_2D_BODY_INDEX;
         DEL_DOT_VEC_2D_BODY;
-      });
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size,
+                                              decltype(deldotvec2d_lambda)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend,
+                          deldotvec2d_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/apps/DIFFUSION3DPA-Cuda.cpp
+++ b/src/apps/DIFFUSION3DPA-Cuda.cpp
@@ -117,15 +117,16 @@ void DIFFUSION3DPA::runCudaVariantImpl(VariantID vid) {
 
   case Base_CUDA: {
 
-    dim3 nthreads_per_block(DPA_Q1D, DPA_Q1D, DPA_Q1D);
-
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      dim3 nthreads_per_block(DPA_Q1D, DPA_Q1D, DPA_Q1D);
       constexpr size_t shmem = 0;
-      Diffusion3DPA<block_size><<<NE, nthreads_per_block, shmem, res.get_stream()>>>(
-          Basis, dBasis, D, X, Y, symmetric);
 
+      RPlaunchCudaKernel( (Diffusion3DPA<block_size>),
+                          NE, nthreads_per_block,
+                          shmem, res.get_stream(),
+                          Basis, dBasis, D, X, Y, symmetric );
       cudaErrchk(cudaGetLastError());
     }
     stopTimer();

--- a/src/apps/DIFFUSION3DPA-Hip.cpp
+++ b/src/apps/DIFFUSION3DPA-Hip.cpp
@@ -117,17 +117,16 @@ void DIFFUSION3DPA::runHipVariantImpl(VariantID vid) {
 
   case Base_HIP: {
 
-    dim3 nblocks(NE);
-    dim3 nthreads_per_block(DPA_Q1D, DPA_Q1D, DPA_Q1D);
-
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      dim3 nthreads_per_block(DPA_Q1D, DPA_Q1D, DPA_Q1D);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((Diffusion3DPA<block_size>),
-          dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-          Basis, dBasis, D, X, Y, symmetric);
 
+      RPlaunchHipKernel( (Diffusion3DPA<block_size>),
+                         NE, nthreads_per_block,
+                         shmem, res.get_stream(),
+                         Basis, dBasis, D, X, Y, symmetric );
       hipErrchk(hipGetLastError());
     }
     stopTimer();

--- a/src/apps/EDGE3D-Hip.cpp
+++ b/src/apps/EDGE3D-Hip.cpp
@@ -65,12 +65,15 @@ void EDGE3D::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-
-      hipLaunchKernelGGL((edge3d<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(), sum,
-                                       x0, x1, x2, x3, x4, x5, x6, x7,
-                                       y0, y1, y2, y3, y4, y5, y6, y7,
-                                       z0, z1, z2, z3, z4, z5, z6, z7,
-                                       ibegin, iend);
+     
+      RPlaunchHipKernel( (edge3d<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         sum,
+                         x0, x1, x2, x3, x4, x5, x6, x7,
+                         y0, y1, y2, y3, y4, y5, y6, y7,
+                         z0, z1, z2, z3, z4, z5, z6, z7,
+                         ibegin, iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -81,15 +84,17 @@ void EDGE3D::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      auto edge3d_lambda = [=] __device__ (Index_type i) { EDGE3D_BODY; };
+
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
 
-      auto edge3d_lam = [=] __device__ (Index_type i) { EDGE3D_BODY; };
-
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(edge3d_lam)>),
-        grid_size, block_size, shmem, res.get_stream(),
-        ibegin, iend,  edge3d_lam);
-
+      RPlaunchHipKernel( (lambda_cuda_forall<block_size,
+                                             decltype(edge3d_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend,
+                         edge3d_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/apps/EDGE3D-Hip.cpp
+++ b/src/apps/EDGE3D-Hip.cpp
@@ -89,8 +89,8 @@ void EDGE3D::runHipVariantImpl(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
 
-      RPlaunchHipKernel( (lambda_cuda_forall<block_size,
-                                             decltype(edge3d_lambda)>),
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(edge3d_lambda)>),
                          grid_size, block_size,
                          shmem, res.get_stream(),
                          ibegin, iend,

--- a/src/apps/ENERGY-Cuda.cpp
+++ b/src/apps/ENERGY-Cuda.cpp
@@ -123,51 +123,69 @@ void ENERGY::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       constexpr size_t shmem = 0;
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
 
-       energycalc1<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( e_new, e_old, delvc,
-                                               p_old, q_old, work,
-                                               iend );
-       cudaErrchk( cudaGetLastError() );
+      RPlaunchCudaKernel( (energycalc1<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          e_new, e_old, delvc,
+                          p_old, q_old, work,
+                          iend );
+      cudaErrchk( cudaGetLastError() );
 
-       energycalc2<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( delvc, q_new,
-                                               compHalfStep, pHalfStep,
-                                               e_new, bvc, pbvc,
-                                               ql_old, qq_old,
-                                               rho0,
-                                               iend );
-       cudaErrchk( cudaGetLastError() );
+      RPlaunchCudaKernel( (energycalc2<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          delvc, q_new,
+                          compHalfStep, pHalfStep,
+                          e_new, bvc, pbvc,
+                          ql_old, qq_old,
+                          rho0,
+                          iend );
+      cudaErrchk( cudaGetLastError() );
 
-       energycalc3<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( e_new, delvc,
-                                               p_old, q_old,
-                                               pHalfStep, q_new,
-                                               iend );
-       cudaErrchk( cudaGetLastError() );
+      RPlaunchCudaKernel( (energycalc3<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          e_new, delvc,
+                          p_old, q_old,
+                          pHalfStep, q_new,
+                          iend );
+      cudaErrchk( cudaGetLastError() );
 
-       energycalc4<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( e_new, work,
-                                               e_cut, emin,
-                                               iend );
-       cudaErrchk( cudaGetLastError() );
+      RPlaunchCudaKernel( (energycalc4<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          e_new, work,
+                          e_cut, emin,
+                          iend );
+      cudaErrchk( cudaGetLastError() );
 
-       energycalc5<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( delvc,
-                                               pbvc, e_new, vnewc,
-                                               bvc, p_new,
-                                               ql_old, qq_old,
-                                               p_old, q_old,
-                                               pHalfStep, q_new,
-                                               rho0, e_cut, emin,
-                                               iend );
-       cudaErrchk( cudaGetLastError() );
+      RPlaunchCudaKernel( (energycalc5<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          delvc,
+                          pbvc, e_new, vnewc,
+                          bvc, p_new,
+                          ql_old, qq_old,
+                          p_old, q_old,
+                          pHalfStep, q_new,
+                          rho0, e_cut, emin,
+                          iend );
+      cudaErrchk( cudaGetLastError() );
 
-       energycalc6<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( delvc,
-                                               pbvc, e_new, vnewc,
-                                               bvc, p_new,
-                                               q_new,
-                                               ql_old, qq_old,
-                                               rho0, q_cut,
-                                               iend );
-       cudaErrchk( cudaGetLastError() );
+      RPlaunchCudaKernel( (energycalc6<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          delvc,
+                          pbvc, e_new, vnewc,
+                          bvc, p_new,
+                          q_new,
+                          ql_old, qq_old,
+                          rho0, q_cut,
+                          iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/ENERGY-Hip.cpp
+++ b/src/apps/ENERGY-Hip.cpp
@@ -123,51 +123,69 @@ void ENERGY::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       constexpr size_t shmem = 0;
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
 
-       hipLaunchKernelGGL((energycalc1<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  e_new, e_old, delvc,
-                                               p_old, q_old, work,
-                                               iend );
-       hipErrchk( hipGetLastError() );
+      RPlaunchHipKernel( (energycalc1<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         e_new, e_old, delvc,
+                         p_old, q_old, work,
+                         iend );
+      hipErrchk( hipGetLastError() );
 
-       hipLaunchKernelGGL((energycalc2<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  delvc, q_new,
-                                               compHalfStep, pHalfStep,
-                                               e_new, bvc, pbvc,
-                                               ql_old, qq_old,
-                                               rho0,
-                                               iend );
-       hipErrchk( hipGetLastError() );
+      RPlaunchHipKernel( (energycalc2<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         delvc, q_new,
+                         compHalfStep, pHalfStep,
+                         e_new, bvc, pbvc,
+                         ql_old, qq_old,
+                         rho0,
+                         iend );
+      hipErrchk( hipGetLastError() );
 
-       hipLaunchKernelGGL((energycalc3<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  e_new, delvc,
-                                               p_old, q_old,
-                                               pHalfStep, q_new,
-                                               iend );
-       hipErrchk( hipGetLastError() );
+      RPlaunchHipKernel( (energycalc3<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         e_new, delvc,
+                         p_old, q_old,
+                         pHalfStep, q_new,
+                         iend );
+      hipErrchk( hipGetLastError() );
 
-       hipLaunchKernelGGL((energycalc4<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  e_new, work,
-                                               e_cut, emin,
-                                               iend );
-       hipErrchk( hipGetLastError() );
+      RPlaunchHipKernel( (energycalc4<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         e_new, work,
+                         e_cut, emin,
+                         iend ); 
+      hipErrchk( hipGetLastError() );
 
-       hipLaunchKernelGGL((energycalc5<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  delvc,
-                                               pbvc, e_new, vnewc,
-                                               bvc, p_new,
-                                               ql_old, qq_old,
-                                               p_old, q_old,
-                                               pHalfStep, q_new,
-                                               rho0, e_cut, emin,
-                                               iend );
-       hipErrchk( hipGetLastError() );
+      RPlaunchHipKernel( (energycalc5<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         delvc,
+                         pbvc, e_new, vnewc,
+                         bvc, p_new,
+                         ql_old, qq_old,
+                         p_old, q_old,
+                         pHalfStep, q_new,
+                         rho0, e_cut, emin,
+                         iend );
+      hipErrchk( hipGetLastError() );
 
-       hipLaunchKernelGGL((energycalc6<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  delvc,
-                                               pbvc, e_new, vnewc,
-                                               bvc, p_new,
-                                               q_new,
-                                               ql_old, qq_old,
-                                               rho0, q_cut,
-                                               iend );
-       hipErrchk( hipGetLastError() );
+      RPlaunchHipKernel( (energycalc6<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         delvc,
+                         pbvc, e_new, vnewc,
+                         bvc, p_new,
+                         q_new,
+                         ql_old, qq_old,
+                         rho0, q_cut,
+                         iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/FIR-Cuda.cpp
+++ b/src/apps/FIR-Cuda.cpp
@@ -98,20 +98,26 @@ void FIR::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       constexpr size_t shmem = 0;
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
 
 #if defined(USE_CUDA_CONSTANT_MEMORY)
-       fir<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( out, in,
-                                       coefflen,
-                                       iend );
-       cudaErrchk( cudaGetLastError() );
+      RPlaunchCudaKernel( (fir<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          out, in,
+                          coefflen,
+                          iend ); 
+      cudaErrchk( cudaGetLastError() );
 #else
-       fir<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( out, in,
-                                       coeff,
-                                       coefflen,
-                                       iend );
-       cudaErrchk( cudaGetLastError() );
+      RPlaunchCudaKernel( (fir<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          out, in,
+                          coeff,
+                          coefflen,
+                          iend );
+      udaErrchk( cudaGetLastError() );
 #endif
 
     }

--- a/src/apps/FIR-Hip.cpp
+++ b/src/apps/FIR-Hip.cpp
@@ -96,20 +96,26 @@ void FIR::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       constexpr size_t shmem = 0;
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
 
 #if defined(USE_HIP_CONSTANT_MEMORY)
-       hipLaunchKernelGGL((fir<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  out, in,
-                                       coefflen,
-                                       iend );
-       hipErrchk( hipGetLastError() );
+      RPlaunchHipKernel( (fir<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         out, in,
+                         coefflen,
+                         iend ); 
+      hipErrchk( hipGetLastError() );
 #else
-       hipLaunchKernelGGL((fir<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  out, in,
-                                       coeff,
-                                       coefflen,
-                                       iend );
-       hipErrchk( hipGetLastError() );
+      RPlaunchHipKernel( (fir<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         out, in,
+                         coeff,
+                         coefflen,
+                         iend ); 
+      hipErrchk( hipGetLastError() );
 #endif
 
     }

--- a/src/apps/HALOEXCHANGE-Cuda.cpp
+++ b/src/apps/HALOEXCHANGE-Cuda.cpp
@@ -115,11 +115,11 @@ void HALOEXCHANGE::runCudaVariantImpl(VariantID vid)
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           auto haloexchange_pack_base_lam = [=] __device__ (Index_type i) {
-                HALOEXCHANGE_PACK_BODY;
-              };
+            HALOEXCHANGE_PACK_BODY;
+          };
           RAJA::forall<EXEC_POL>( res,
-              RAJA::TypedRangeSegment<Index_type>(0, len),
-              haloexchange_pack_base_lam );
+                                  RAJA::TypedRangeSegment<Index_type>(0, len),
+                                  haloexchange_pack_base_lam );
           buffer += len;
         }
       }
@@ -132,11 +132,11 @@ void HALOEXCHANGE::runCudaVariantImpl(VariantID vid)
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           auto haloexchange_unpack_base_lam = [=] __device__ (Index_type i) {
-                HALOEXCHANGE_UNPACK_BODY;
-              };
+            HALOEXCHANGE_UNPACK_BODY;
+          };
           RAJA::forall<EXEC_POL>( res,
-              RAJA::TypedRangeSegment<Index_type>(0, len),
-              haloexchange_unpack_base_lam );
+                                  RAJA::TypedRangeSegment<Index_type>(0, len),
+                                  haloexchange_unpack_base_lam );
           buffer += len;
         }
       }

--- a/src/apps/HALOEXCHANGE-Cuda.cpp
+++ b/src/apps/HALOEXCHANGE-Cuda.cpp
@@ -69,7 +69,10 @@ void HALOEXCHANGE::runCudaVariantImpl(VariantID vid)
           dim3 nthreads_per_block(block_size);
           dim3 nblocks((len + block_size-1) / block_size);
           constexpr size_t shmem = 0;
-          haloexchange_pack<block_size><<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(buffer, list, var, len);
+          RPlaunchCudaKernel( (haloexchange_pack<block_size>),
+                              nblocks, nthreads_per_block,
+                              shmem, res.get_stream(),
+                              buffer, list, var, len ); 
           cudaErrchk( cudaGetLastError() );
           buffer += len;
         }
@@ -85,7 +88,10 @@ void HALOEXCHANGE::runCudaVariantImpl(VariantID vid)
           dim3 nthreads_per_block(block_size);
           dim3 nblocks((len + block_size-1) / block_size);
           constexpr size_t shmem = 0;
-          haloexchange_unpack<block_size><<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(buffer, list, var, len);
+          RPlaunchCudaKernel( (haloexchange_unpack<block_size>),
+                              nblocks, nthreads_per_block,
+                              shmem, res.get_stream(),
+                              buffer, list, var, len ); 
           cudaErrchk( cudaGetLastError() );
           buffer += len;
         }

--- a/src/apps/HALOEXCHANGE-Hip.cpp
+++ b/src/apps/HALOEXCHANGE-Hip.cpp
@@ -115,11 +115,11 @@ void HALOEXCHANGE::runHipVariantImpl(VariantID vid)
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           auto haloexchange_pack_base_lam = [=] __device__ (Index_type i) {
-                HALOEXCHANGE_PACK_BODY;
-              };
+            HALOEXCHANGE_PACK_BODY;
+          };
           RAJA::forall<EXEC_POL>( res,
-              RAJA::TypedRangeSegment<Index_type>(0, len),
-              haloexchange_pack_base_lam );
+                                  RAJA::TypedRangeSegment<Index_type>(0, len),
+                                  haloexchange_pack_base_lam );
           buffer += len;
         }
       }
@@ -132,11 +132,11 @@ void HALOEXCHANGE::runHipVariantImpl(VariantID vid)
         for (Index_type v = 0; v < num_vars; ++v) {
           Real_ptr var = vars[v];
           auto haloexchange_unpack_base_lam = [=] __device__ (Index_type i) {
-                HALOEXCHANGE_UNPACK_BODY;
-              };
+            HALOEXCHANGE_UNPACK_BODY;
+          };
           RAJA::forall<EXEC_POL>( res,
-              RAJA::TypedRangeSegment<Index_type>(0, len),
-              haloexchange_unpack_base_lam );
+                                  RAJA::TypedRangeSegment<Index_type>(0, len),
+                                  haloexchange_unpack_base_lam );
           buffer += len;
         }
       }

--- a/src/apps/HALOEXCHANGE-Hip.cpp
+++ b/src/apps/HALOEXCHANGE-Hip.cpp
@@ -69,8 +69,10 @@ void HALOEXCHANGE::runHipVariantImpl(VariantID vid)
           dim3 nthreads_per_block(block_size);
           dim3 nblocks((len + block_size-1) / block_size);
           constexpr size_t shmem = 0;
-          hipLaunchKernelGGL((haloexchange_pack<block_size>), nblocks, nthreads_per_block, shmem, res.get_stream(),
-              buffer, list, var, len);
+          RPlaunchHipKernel( (haloexchange_pack<block_size>),
+                             nblocks, nthreads_per_block,
+                             shmem, res.get_stream(),
+                             buffer, list, var, len );
           hipErrchk( hipGetLastError() );
           buffer += len;
         }
@@ -86,8 +88,10 @@ void HALOEXCHANGE::runHipVariantImpl(VariantID vid)
           dim3 nthreads_per_block(block_size);
           dim3 nblocks((len + block_size-1) / block_size);
           constexpr size_t shmem = 0;
-          hipLaunchKernelGGL((haloexchange_unpack<block_size>), nblocks, nthreads_per_block, shmem, res.get_stream(),
-              buffer, list, var, len);
+          RPlaunchHipKernel( (haloexchange_unpack<block_size>),
+                             nblocks, nthreads_per_block,
+                             shmem, res.get_stream(),
+                             buffer, list, var, len );
           hipErrchk( hipGetLastError() );
           buffer += len;
         }

--- a/src/apps/HALOEXCHANGE_FUSED-Cuda.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED-Cuda.cpp
@@ -307,7 +307,8 @@ void HALOEXCHANGE_FUSED::runCudaVariant(VariantID vid, size_t tune_idx)
 
           if (tune_idx == t) {
 
-            runCudaVariantWorkGroup<decltype(block_size){}, decltype(dispatch_helper)>(vid);
+            runCudaVariantWorkGroup<decltype(block_size){},
+                                    decltype(dispatch_helper)>(vid);
 
           }
 

--- a/src/apps/HALOEXCHANGE_FUSED-Cuda.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED-Cuda.cpp
@@ -51,8 +51,10 @@ namespace apps
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void haloexchange_fused_pack(Real_ptr* pack_buffer_ptrs, Int_ptr* pack_list_ptrs,
-                                        Real_ptr* pack_var_ptrs, Index_type* pack_len_ptrs)
+__global__ void haloexchange_fused_pack(Real_ptr* pack_buffer_ptrs,
+                                        Int_ptr* pack_list_ptrs,
+                                        Real_ptr* pack_var_ptrs,
+                                        Index_type* pack_len_ptrs)
 {
   Index_type j = blockIdx.y;
 
@@ -70,8 +72,10 @@ __global__ void haloexchange_fused_pack(Real_ptr* pack_buffer_ptrs, Int_ptr* pac
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void haloexchange_fused_unpack(Real_ptr* unpack_buffer_ptrs, Int_ptr* unpack_list_ptrs,
-                                          Real_ptr* unpack_var_ptrs, Index_type* unpack_len_ptrs)
+__global__ void haloexchange_fused_unpack(Real_ptr* unpack_buffer_ptrs,
+                                          Int_ptr* unpack_list_ptrs,
+                                          Real_ptr* unpack_var_ptrs,
+                                          Index_type* unpack_len_ptrs)
 {
   Index_type j = blockIdx.y;
 
@@ -127,8 +131,13 @@ void HALOEXCHANGE_FUSED::runCudaVariantDirect(VariantID vid)
       Index_type pack_len_ave = (pack_len_sum + pack_index-1) / pack_index;
       dim3 pack_nthreads_per_block(block_size);
       dim3 pack_nblocks((pack_len_ave + block_size-1) / block_size, pack_index);
-      haloexchange_fused_pack<block_size><<<pack_nblocks, pack_nthreads_per_block, shmem, res.get_stream()>>>(
-          pack_buffer_ptrs, pack_list_ptrs, pack_var_ptrs, pack_len_ptrs);
+      RPlaunchCudaKernel( (haloexchange_fused_pack<block_size>),
+                          pack_nblocks, pack_nthreads_per_block,
+                          shmem, res.get_stream(),
+                          pack_buffer_ptrs,
+                          pack_list_ptrs,
+                          pack_var_ptrs,
+                          pack_len_ptrs );
       cudaErrchk( cudaGetLastError() );
       cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
 
@@ -150,11 +159,18 @@ void HALOEXCHANGE_FUSED::runCudaVariantDirect(VariantID vid)
           buffer += len;
         }
       }
-      Index_type unpack_len_ave = (unpack_len_sum + unpack_index-1) / unpack_index;
+      Index_type unpack_len_ave = (unpack_len_sum + unpack_index-1) /
+                                  unpack_index;
       dim3 unpack_nthreads_per_block(block_size);
-      dim3 unpack_nblocks((unpack_len_ave + block_size-1) / block_size, unpack_index);
-      haloexchange_fused_unpack<block_size><<<unpack_nblocks, unpack_nthreads_per_block, shmem, res.get_stream()>>>(
-          unpack_buffer_ptrs, unpack_list_ptrs, unpack_var_ptrs, unpack_len_ptrs);
+      dim3 unpack_nblocks((unpack_len_ave + block_size-1) / block_size,
+                          unpack_index);
+      RPlaunchCudaKernel( (haloexchange_fused_unpack<block_size>),
+                          unpack_nblocks, unpack_nthreads_per_block,
+                          shmem, res.get_stream(),
+                          unpack_buffer_ptrs,
+                          unpack_list_ptrs,
+                          unpack_var_ptrs, 
+                          unpack_len_ptrs ); 
       cudaErrchk( cudaGetLastError() );
       cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
 

--- a/src/apps/HALOEXCHANGE_FUSED-Hip.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED-Hip.cpp
@@ -51,8 +51,10 @@ namespace apps
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void haloexchange_fused_pack(Real_ptr* pack_buffer_ptrs, Int_ptr* pack_list_ptrs,
-                                        Real_ptr* pack_var_ptrs, Index_type* pack_len_ptrs)
+__global__ void haloexchange_fused_pack(Real_ptr* pack_buffer_ptrs,
+                                        Int_ptr* pack_list_ptrs,
+                                        Real_ptr* pack_var_ptrs,
+                                        Index_type* pack_len_ptrs)
 {
   Index_type j = blockIdx.y;
 
@@ -70,8 +72,10 @@ __global__ void haloexchange_fused_pack(Real_ptr* pack_buffer_ptrs, Int_ptr* pac
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void haloexchange_fused_unpack(Real_ptr* unpack_buffer_ptrs, Int_ptr* unpack_list_ptrs,
-                                          Real_ptr* unpack_var_ptrs, Index_type* unpack_len_ptrs)
+__global__ void haloexchange_fused_unpack(Real_ptr* unpack_buffer_ptrs,
+                                          Int_ptr* unpack_list_ptrs,
+                                          Real_ptr* unpack_var_ptrs,
+                                          Index_type* unpack_len_ptrs)
 {
   Index_type j = blockIdx.y;
 
@@ -127,8 +131,13 @@ void HALOEXCHANGE_FUSED::runHipVariantDirect(VariantID vid)
       Index_type pack_len_ave = (pack_len_sum + pack_index-1) / pack_index;
       dim3 pack_nthreads_per_block(block_size);
       dim3 pack_nblocks((pack_len_ave + block_size-1) / block_size, pack_index);
-      hipLaunchKernelGGL((haloexchange_fused_pack<block_size>), pack_nblocks, pack_nthreads_per_block, shmem, res.get_stream(),
-          pack_buffer_ptrs, pack_list_ptrs, pack_var_ptrs, pack_len_ptrs);
+      RPlaunchHipKernel( (haloexchange_fused_pack<block_size>),
+                         pack_nblocks, pack_nthreads_per_block,
+                         shmem, res.get_stream(),
+                         pack_buffer_ptrs, 
+                         pack_list_ptrs,
+                         pack_var_ptrs, 
+                         pack_len_ptrs );
       hipErrchk( hipGetLastError() );
       hipErrchk( hipStreamSynchronize( res.get_stream() ) );
 
@@ -150,11 +159,18 @@ void HALOEXCHANGE_FUSED::runHipVariantDirect(VariantID vid)
           buffer += len;
         }
       }
-      Index_type unpack_len_ave = (unpack_len_sum + unpack_index-1) / unpack_index;
+      Index_type unpack_len_ave = (unpack_len_sum + unpack_index-1) /
+                                  unpack_index;
       dim3 unpack_nthreads_per_block(block_size);
-      dim3 unpack_nblocks((unpack_len_ave + block_size-1) / block_size, unpack_index);
-      hipLaunchKernelGGL((haloexchange_fused_unpack<block_size>), unpack_nblocks, unpack_nthreads_per_block, shmem, res.get_stream(),
-          unpack_buffer_ptrs, unpack_list_ptrs, unpack_var_ptrs, unpack_len_ptrs);
+      dim3 unpack_nblocks((unpack_len_ave + block_size-1) / block_size,
+                          unpack_index);
+      RPlaunchHipKernel( (haloexchange_fused_unpack<block_size>),
+                         unpack_nblocks, unpack_nthreads_per_block,
+                         shmem, res.get_stream(),
+                         unpack_buffer_ptrs,
+                         unpack_list_ptrs,
+                         unpack_var_ptrs,
+                         unpack_len_ptrs );
       hipErrchk( hipGetLastError() );
       hipErrchk( hipStreamSynchronize( res.get_stream() ) );
 

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -152,14 +152,16 @@ void LTIMES::runCudaVariantImpl(VariantID vid)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, num_d),
-                                                 IZRange(0, num_z),
-                                                 IGRange(0, num_g),
-                                                 IMRange(0, num_m)),
-                                         res,
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(IDRange(0, num_d),
+                           IZRange(0, num_z),
+                           IGRange(0, num_g),
+                           IMRange(0, num_m)),
+          res,
           [=] __device__ (ID d, IZ z, IG g, IM m) {
-          LTIMES_BODY_RAJA;
-        });
+            LTIMES_BODY_RAJA;
+          }
+        );
 
       }
       stopTimer();

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -91,10 +91,12 @@ void LTIMES::runCudaVariantImpl(VariantID vid)
       LTIMES_NBLOCKS_CUDA;
       constexpr size_t shmem = 0;
 
-      ltimes<LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-            <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(phidat, elldat, psidat,
-                                              num_d,
-                                              num_m, num_g, num_z);
+      RPlaunchCudaKernel(
+        (ltimes<LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        phidat, elldat, psidat,
+        num_d, num_m, num_g, num_z );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -105,18 +107,24 @@ void LTIMES::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      auto ltimes_lambda = [=] __device__ (Index_type z, Index_type g, 
+                                           Index_type m) {
+        for (Index_type d = 0; d < num_d; ++d ) {
+          LTIMES_BODY;
+        }
+      };
+
       LTIMES_THREADS_PER_BLOCK_CUDA;
       LTIMES_NBLOCKS_CUDA;
       constexpr size_t shmem = 0;
 
-      ltimes_lam<LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(num_m, num_g, num_z,
-        [=] __device__ (Index_type z, Index_type g, Index_type m) {
-          for (Index_type d = 0; d < num_d; ++d ) {
-            LTIMES_BODY;
-          }
-        }
-      );
+      RPlaunchCudaKernel(
+        (ltimes_lam<LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                    decltype(ltimes_lambda)>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        num_m, num_g, num_z,
+        ltimes_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/apps/LTIMES-Hip.cpp
+++ b/src/apps/LTIMES-Hip.cpp
@@ -151,14 +151,16 @@ void LTIMES::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, num_d),
-                                               IZRange(0, num_z),
-                                               IGRange(0, num_g),
-                                               IMRange(0, num_m)),
-                                       res,
+      RAJA::kernel_resource<EXEC_POL>(
+        RAJA::make_tuple(IDRange(0, num_d),
+                         IZRange(0, num_z),
+                         IGRange(0, num_g),
+                         IMRange(0, num_m)),
+        res,
         [=] __device__ (ID d, IZ z, IG g, IM m) {
-        LTIMES_BODY_RAJA;
-      });
+          LTIMES_BODY_RAJA;
+        }
+      );
 
     }
     stopTimer();

--- a/src/apps/LTIMES-Hip.cpp
+++ b/src/apps/LTIMES-Hip.cpp
@@ -90,11 +90,12 @@ void LTIMES::runHipVariantImpl(VariantID vid)
       LTIMES_NBLOCKS_HIP;
       constexpr size_t shmem = 0;
 
-      hipLaunchKernelGGL((ltimes<LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                         dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         phidat, elldat, psidat,
-                         num_d,
-                         num_m, num_g, num_z);
+      RPlaunchHipKernel(
+        (ltimes<LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        phidat, elldat, psidat,
+        num_d, num_m, num_g, num_z );
       hipErrchk( hipGetLastError() );
 
     }
@@ -105,20 +106,24 @@ void LTIMES::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      auto ltimes_lambda = [=] __device__ (Index_type z, Index_type g, 
+                                           Index_type m) {
+       for (Index_type d = 0; d < num_d; ++d ) {
+         LTIMES_BODY;
+       }
+      };
+
       LTIMES_THREADS_PER_BLOCK_HIP;
       LTIMES_NBLOCKS_HIP;
       constexpr size_t shmem = 0;
 
-      auto ltimes_lambda =
-        [=] __device__ (Index_type z, Index_type g, Index_type m) {
-          for (Index_type d = 0; d < num_d; ++d ) {
-            LTIMES_BODY;
-          }
-        };
-
-      hipLaunchKernelGGL((ltimes_lam<LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(ltimes_lambda)>),
-                         dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         num_m, num_g, num_z, ltimes_lambda);
+      RPlaunchHipKernel(
+        (ltimes_lam<LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                    decltype(ltimes_lambda)>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        num_m, num_g, num_z,
+        ltimes_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -149,14 +149,17 @@ void LTIMES_NOVIEW::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
-                                               RAJA::RangeSegment(0, num_z),
-                                               RAJA::RangeSegment(0, num_g),
-                                               RAJA::RangeSegment(0, num_m)),
-                                       res,
-        [=] __device__ (Index_type d, Index_type z, Index_type g, Index_type m) {
-        LTIMES_NOVIEW_BODY;
-      });
+      RAJA::kernel_resource<EXEC_POL>(
+        RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
+                         RAJA::RangeSegment(0, num_z),
+                         RAJA::RangeSegment(0, num_g),
+                         RAJA::RangeSegment(0, num_m)),
+        res,
+        [=] __device__ (Index_type d, Index_type z,
+                        Index_type g, Index_type m) {
+          LTIMES_NOVIEW_BODY;
+        }
+      );
 
     }
     stopTimer();

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -90,10 +90,12 @@ void LTIMES_NOVIEW::runCudaVariantImpl(VariantID vid)
       LTIMES_NOVIEW_NBLOCKS_CUDA;
       constexpr size_t shmem = 0;
 
-      ltimes_noview<LTIMES_NOVIEW_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                   <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(phidat, elldat, psidat,
-                                                     num_d,
-                                                     num_m, num_g, num_z);
+      RPlaunchCudaKernel( 
+        (ltimes_noview<LTIMES_NOVIEW_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        phidat, elldat, psidat,
+        num_d, num_m, num_g, num_z );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -104,18 +106,24 @@ void LTIMES_NOVIEW::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      LTIMES_NOVIEW_THREADS_PER_BLOCK_CUDA;
-      LTIMES_NOVIEW_NBLOCKS_CUDA;
-      constexpr size_t shmem = 0;
-
-      ltimes_noview_lam<LTIMES_NOVIEW_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                       <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(num_m, num_g, num_z,
+      auto ltimes_noview_lambda = 
         [=] __device__ (Index_type z, Index_type g, Index_type m) {
           for (Index_type d = 0; d < num_d; ++d ) {
             LTIMES_NOVIEW_BODY;
           }
-        }
-      );
+        }; 
+
+      LTIMES_NOVIEW_THREADS_PER_BLOCK_CUDA;
+      LTIMES_NOVIEW_NBLOCKS_CUDA;
+      constexpr size_t shmem = 0;
+
+      RPlaunchCudaKernel( 
+        (ltimes_noview_lam<LTIMES_NOVIEW_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                           decltype(ltimes_noview_lambda)>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        num_m, num_g, num_z,
+        ltimes_noview_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/apps/LTIMES_NOVIEW-Hip.cpp
+++ b/src/apps/LTIMES_NOVIEW-Hip.cpp
@@ -149,14 +149,17 @@ void LTIMES_NOVIEW::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
-                                               RAJA::RangeSegment(0, num_z),
-                                               RAJA::RangeSegment(0, num_g),
-                                               RAJA::RangeSegment(0, num_m)),
-                                       res,
-        [=] __device__ (Index_type d, Index_type z, Index_type g, Index_type m) {
+      RAJA::kernel_resource<EXEC_POL>(
+        RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
+                         RAJA::RangeSegment(0, num_z),
+                         RAJA::RangeSegment(0, num_g),
+                         RAJA::RangeSegment(0, num_m)),
+        res,
+        [=] __device__ (Index_type d, Index_type z,
+                        Index_type g, Index_type m) {
           LTIMES_NOVIEW_BODY;
-      });
+        }
+      );
 
     }
     stopTimer();

--- a/src/apps/LTIMES_NOVIEW-Hip.cpp
+++ b/src/apps/LTIMES_NOVIEW-Hip.cpp
@@ -90,11 +90,12 @@ void LTIMES_NOVIEW::runHipVariantImpl(VariantID vid)
       LTIMES_NOVIEW_NBLOCKS_HIP;
       constexpr size_t shmem = 0;
 
-      hipLaunchKernelGGL((ltimes_noview<LTIMES_NOVIEW_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                         dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         phidat, elldat, psidat,
-                         num_d,
-                         num_m, num_g, num_z);
+      RPlaunchHipKernel(
+        (ltimes_noview<LTIMES_NOVIEW_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        phidat, elldat, psidat,
+        num_d, num_m, num_g, num_z );
       hipErrchk( hipGetLastError() );
 
     }
@@ -105,21 +106,24 @@ void LTIMES_NOVIEW::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      LTIMES_NOVIEW_THREADS_PER_BLOCK_HIP;
-      LTIMES_NOVIEW_NBLOCKS_HIP;
-      constexpr size_t shmem = 0;
-
-      auto ltimes_noview_lambda =
+      auto ltimes_noview_lambda = 
         [=] __device__ (Index_type z, Index_type g, Index_type m) {
           for (Index_type d = 0; d < num_d; ++d ) {
             LTIMES_NOVIEW_BODY;
           }
-      };
+        };
 
-      hipLaunchKernelGGL((ltimes_noview_lam<LTIMES_NOVIEW_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(ltimes_noview_lambda)>),
-                         dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         num_m, num_g, num_z,
-                         ltimes_noview_lambda);
+      LTIMES_NOVIEW_THREADS_PER_BLOCK_HIP;
+      LTIMES_NOVIEW_NBLOCKS_HIP;
+      constexpr size_t shmem = 0;
+
+      RPlaunchHipKernel(
+        (ltimes_noview_lam<LTIMES_NOVIEW_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                           decltype(ltimes_noview_lambda)>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        num_m, num_g, num_z,
+        ltimes_noview_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/apps/MASS3DEA-Cuda.cpp
+++ b/src/apps/MASS3DEA-Cuda.cpp
@@ -69,14 +69,16 @@ void MASS3DEA::runCudaVariantImpl(VariantID vid) {
 
   case Base_CUDA: {
 
-    dim3 nthreads_per_block(MEA_D1D, MEA_D1D, MEA_D1D);
-    constexpr size_t shmem = 0;
-
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      Mass3DEA<block_size><<<NE, nthreads_per_block, shmem, res.get_stream()>>>(B, D, M);
+      dim3 nthreads_per_block(MEA_D1D, MEA_D1D, MEA_D1D);
+      constexpr size_t shmem = 0;
 
+      RPlaunchCudaKernel( (Mass3DEA<block_size>),
+                          NE, nthreads_per_block,
+                          shmem, res.get_stream(),
+                          B, D, M );
       cudaErrchk( cudaGetLastError() );
     }
     stopTimer();

--- a/src/apps/MASS3DEA-Hip.cpp
+++ b/src/apps/MASS3DEA-Hip.cpp
@@ -69,16 +69,16 @@ void MASS3DEA::runHipVariantImpl(VariantID vid) {
 
   case Base_HIP: {
 
-    dim3 nblocks(NE);
-    dim3 nthreads_per_block(MEA_D1D, MEA_D1D, MEA_D1D);
-    constexpr size_t shmem = 0;
-
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      hipLaunchKernelGGL((Mass3DEA<block_size>), dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         B, D, M);
+      dim3 nthreads_per_block(MEA_D1D, MEA_D1D, MEA_D1D);
+      constexpr size_t shmem = 0;
 
+      RPlaunchHipKernel( (Mass3DEA<block_size>),
+                         NE, nthreads_per_block,
+                         shmem, res.get_stream(),
+                         B, D, M );
       hipErrchk( hipGetLastError() );
     }
     stopTimer();

--- a/src/apps/MASS3DPA-Cuda.cpp
+++ b/src/apps/MASS3DPA-Cuda.cpp
@@ -99,14 +99,16 @@ void MASS3DPA::runCudaVariantImpl(VariantID vid) {
 
   case Base_CUDA: {
 
-    dim3 nthreads_per_block(MPA_Q1D, MPA_Q1D, 1);
-    constexpr size_t shmem = 0;
-
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      Mass3DPA<block_size><<<NE, nthreads_per_block, shmem, res.get_stream()>>>(B, Bt, D, X, Y);
+      dim3 nthreads_per_block(MPA_Q1D, MPA_Q1D, 1);
+      constexpr size_t shmem = 0;
 
+      RPlaunchCudaKernel( (Mass3DPA<block_size>),
+                          NE, nthreads_per_block,
+                          shmem, res.get_stream(),
+                          B, Bt, D, X, Y );
       cudaErrchk( cudaGetLastError() );
     }
     stopTimer();

--- a/src/apps/MASS3DPA-Hip.cpp
+++ b/src/apps/MASS3DPA-Hip.cpp
@@ -99,16 +99,16 @@ void MASS3DPA::runHipVariantImpl(VariantID vid) {
 
   case Base_HIP: {
 
-    dim3 nblocks(NE);
-    dim3 nthreads_per_block(MPA_Q1D, MPA_Q1D, 1);
-    constexpr size_t shmem = 0;
-
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      hipLaunchKernelGGL((Mass3DPA<block_size>), dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         B, Bt, D, X, Y);
+      dim3 nthreads_per_block(MPA_Q1D, MPA_Q1D, 1);
+      constexpr size_t shmem = 0;
 
+      RPlaunchHipKernel( (Mass3DPA<block_size>),
+                         NE, nthreads_per_block,
+                         shmem, res.get_stream(),
+                         B, Bt, D, X, Y );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/apps/NODAL_ACCUMULATION_3D-Cuda.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D-Cuda.cpp
@@ -61,10 +61,13 @@ void NODAL_ACCUMULATION_3D::runCudaVariantImpl(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
 
-      nodal_accumulation_3d<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(vol,
-                                       x0, x1, x2, x3, x4, x5, x6, x7,
-                                       real_zones,
-                                       ibegin, iend);
+      RPlaunchCudaKernel( (nodal_accumulation_3d<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          vol,
+                          x0, x1, x2, x3, x4, x5, x6, x7,
+                          real_zones,
+                          ibegin, iend );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/apps/NODAL_ACCUMULATION_3D-Hip.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D-Hip.cpp
@@ -61,10 +61,13 @@ void NODAL_ACCUMULATION_3D::runHipVariantImpl(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
 
-      hipLaunchKernelGGL((nodal_accumulation_3d<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(), vol,
-                                       x0, x1, x2, x3, x4, x5, x6, x7,
-                                       real_zones,
-                                       ibegin, iend);
+      RPlaunchHipKernel( (nodal_accumulation_3d<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         vol,
+                         x0, x1, x2, x3, x4, x5, x6, x7,
+                         real_zones,
+                         ibegin, iend );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/apps/PRESSURE-Cuda.cpp
+++ b/src/apps/PRESSURE-Cuda.cpp
@@ -64,19 +64,24 @@ void PRESSURE::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       constexpr size_t shmem = 0;
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
 
-       pressurecalc1<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( bvc, compression,
-                                                 cls,
-                                                 iend );
-       cudaErrchk( cudaGetLastError() );
+      RPlaunchCudaKernel( (pressurecalc1<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          bvc, compression, cls,
+                          iend );
+      cudaErrchk( cudaGetLastError() );
 
-       pressurecalc2<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( p_new, bvc, e_old,
-                                                 vnewc,
-                                                 p_cut, eosvmax, pmin,
-                                                 iend );
-       cudaErrchk( cudaGetLastError() );
+      RPlaunchCudaKernel( (pressurecalc2<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          p_new, bvc, e_old,
+                          vnewc,
+                          p_cut, eosvmax, pmin,
+                          iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/PRESSURE-Hip.cpp
+++ b/src/apps/PRESSURE-Hip.cpp
@@ -64,19 +64,24 @@ void PRESSURE::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       constexpr size_t shmem = 0;
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
 
-       hipLaunchKernelGGL((pressurecalc1<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  bvc, compression,
-                                                 cls,
-                                                 iend );
-       hipErrchk( hipGetLastError() );
+      RPlaunchHipKernel( (pressurecalc1<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         bvc, compression, cls, 
+                         iend );
+      hipErrchk( hipGetLastError() );
 
-       hipLaunchKernelGGL((pressurecalc2<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  p_new, bvc, e_old,
-                                                 vnewc,
-                                                 p_cut, eosvmax, pmin,
-                                                 iend );
-       hipErrchk( hipGetLastError() );
+      RPlaunchHipKernel( (pressurecalc2<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         p_new, bvc, e_old,
+                         vnewc,
+                         p_cut, eosvmax, pmin,
+                         iend );
+      hipErrchk( hipGetLastError() );
 
     }
     stopTimer();

--- a/src/apps/VOL3D-Cuda.cpp
+++ b/src/apps/VOL3D-Cuda.cpp
@@ -68,12 +68,15 @@ void VOL3D::runCudaVariantImpl(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
 
-      vol3d<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(vol,
-                                       x0, x1, x2, x3, x4, x5, x6, x7,
-                                       y0, y1, y2, y3, y4, y5, y6, y7,
-                                       z0, z1, z2, z3, z4, z5, z6, z7,
-                                       vnormq,
-                                       ibegin, iend);
+      RPlaunchCudaKernel( (vol3d<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          vol, 
+                          x0, x1, x2, x3, x4, x5, x6, x7,
+                          y0, y1, y2, y3, y4, y5, y6, y7,
+                          z0, z1, z2, z3, z4, z5, z6, z7,
+                          vnormq,
+                          ibegin, iend );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/apps/VOL3D-Hip.cpp
+++ b/src/apps/VOL3D-Hip.cpp
@@ -68,12 +68,15 @@ void VOL3D::runHipVariantImpl(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
 
-      hipLaunchKernelGGL((vol3d<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(), vol,
-                                       x0, x1, x2, x3, x4, x5, x6, x7,
-                                       y0, y1, y2, y3, y4, y5, y6, y7,
-                                       z0, z1, z2, z3, z4, z5, z6, z7,
-                                       vnormq,
-                                       ibegin, iend);
+      RPlaunchHipKernel( (vol3d<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         vol,
+                         x0, x1, x2, x3, x4, x5, x6, x7,
+                         y0, y1, y2, y3, y4, y5, y6, y7,
+                         z0, z1, z2, z3, z4, z5, z6, z7,
+                         vnormq,
+                         ibegin, iend );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/apps/ZONAL_ACCUMULATION_3D-Cuda.cpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D-Cuda.cpp
@@ -61,10 +61,13 @@ void ZONAL_ACCUMULATION_3D::runCudaVariantImpl(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
 
-      zonal_accumulation_3d<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(vol,
-                                       x0, x1, x2, x3, x4, x5, x6, x7,
-                                       real_zones,
-                                       ibegin, iend);
+      RPlaunchCudaKernel( (zonal_accumulation_3d<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          vol,
+                          x0, x1, x2, x3, x4, x5, x6, x7,
+                          real_zones,
+                          ibegin, iend );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/apps/ZONAL_ACCUMULATION_3D-Hip.cpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D-Hip.cpp
@@ -61,10 +61,13 @@ void ZONAL_ACCUMULATION_3D::runHipVariantImpl(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
 
-      hipLaunchKernelGGL((zonal_accumulation_3d<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(), vol,
-                                       x0, x1, x2, x3, x4, x5, x6, x7,
-                                       real_zones,
-                                       ibegin, iend);
+      RPlaunchHipKernel( (zonal_accumulation_3d<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         vol,
+                         x0, x1, x2, x3, x4, x5, x6, x7,
+                         real_zones,
+                         ibegin, iend );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/basic/ARRAY_OF_PTRS-Cuda.cpp
+++ b/src/basic/ARRAY_OF_PTRS-Cuda.cpp
@@ -54,8 +54,11 @@ void ARRAY_OF_PTRS::runCudaVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      array_of_ptrs<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-          y, x_array, array_size, iend );
+
+      RPlaunchCudaKernel( (array_of_ptrs<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          y, x_array, array_size, iend );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -66,12 +69,18 @@ void ARRAY_OF_PTRS::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      auto array_of_ptrs_lambda = [=] __device__ (Index_type i) {
+        ARRAY_OF_PTRS_BODY(x);
+      };
+
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      lambda_cuda_forall<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-        ibegin, iend, [=] __device__ (Index_type i) {
-        ARRAY_OF_PTRS_BODY(x);
-      });
+
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size, 
+                                              decltype(array_of_ptrs_lambda)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend, array_of_ptrs_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/basic/ARRAY_OF_PTRS-Hip.cpp
+++ b/src/basic/ARRAY_OF_PTRS-Hip.cpp
@@ -54,8 +54,11 @@ void ARRAY_OF_PTRS::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((array_of_ptrs<block_size>),dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-          y, x_array, array_size, iend );
+  
+      RPlaunchHipKernel( (array_of_ptrs<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         y, x_array, array_size, iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -72,8 +75,12 @@ void ARRAY_OF_PTRS::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(array_of_ptrs_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, array_of_ptrs_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(array_of_ptrs_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, array_of_ptrs_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/basic/COPY8-Cuda.cpp
+++ b/src/basic/COPY8-Cuda.cpp
@@ -23,8 +23,10 @@ namespace basic
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void copy8(Real_ptr y0, Real_ptr y1, Real_ptr y2, Real_ptr y3, Real_ptr y4, Real_ptr y5, Real_ptr y6, Real_ptr y7,
-                      Real_ptr x0, Real_ptr x1, Real_ptr x2, Real_ptr x3, Real_ptr x4, Real_ptr x5, Real_ptr x6, Real_ptr x7,
+__global__ void copy8(Real_ptr y0, Real_ptr y1, Real_ptr y2, Real_ptr y3,
+                      Real_ptr y4, Real_ptr y5, Real_ptr y6, Real_ptr y7,
+                      Real_ptr x0, Real_ptr x1, Real_ptr x2, Real_ptr x3,
+                      Real_ptr x4, Real_ptr x5, Real_ptr x6, Real_ptr x7,
                       Index_type iend)
 {
    Index_type i = blockIdx.x * block_size + threadIdx.x;
@@ -52,10 +54,13 @@ void COPY8::runCudaVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      copy8<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-          y0, y1, y2, y3, y4, y5, y6, y7,
-          x0, x1, x2, x3, x4, x5, x6, x7,
-          iend );
+
+      RPlaunchCudaKernel( (copy8<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          y0, y1, y2, y3, y4, y5, y6, y7,
+                          x0, x1, x2, x3, x4, x5, x6, x7,
+                          iend );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -66,12 +71,18 @@ void COPY8::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      auto copy8_lambda = [=] __device__ (Index_type i) {
+        COPY8_BODY;
+      }; 
+
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      lambda_cuda_forall<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-        ibegin, iend, [=] __device__ (Index_type i) {
-        COPY8_BODY;
-      });
+
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size,
+                                              decltype(copy8_lambda)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend, copy8_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/basic/COPY8-Hip.cpp
+++ b/src/basic/COPY8-Hip.cpp
@@ -23,8 +23,10 @@ namespace basic
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void copy8(Real_ptr y0, Real_ptr y1, Real_ptr y2, Real_ptr y3, Real_ptr y4, Real_ptr y5, Real_ptr y6, Real_ptr y7,
-                      Real_ptr x0, Real_ptr x1, Real_ptr x2, Real_ptr x3, Real_ptr x4, Real_ptr x5, Real_ptr x6, Real_ptr x7,
+__global__ void copy8(Real_ptr y0, Real_ptr y1, Real_ptr y2, Real_ptr y3,
+                      Real_ptr y4, Real_ptr y5, Real_ptr y6, Real_ptr y7,
+                      Real_ptr x0, Real_ptr x1, Real_ptr x2, Real_ptr x3,
+                      Real_ptr x4, Real_ptr x5, Real_ptr x6, Real_ptr x7,
                       Index_type iend)
 {
    Index_type i = blockIdx.x * block_size + threadIdx.x;
@@ -53,10 +55,13 @@ void COPY8::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((copy8<block_size>),dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-          y0, y1, y2, y3, y4, y5, y6, y7,
-          x0, x1, x2, x3, x4, x5, x6, x7,
-          iend );
+
+      RPlaunchHipKernel( (copy8<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         y0, y1, y2, y3, y4, y5, y6, y7,
+                         x0, x1, x2, x3, x4, x5, x6, x7,
+                         iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -73,8 +78,12 @@ void COPY8::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(copy8_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, copy8_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(copy8_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, copy8_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/basic/DAXPY-Cuda.cpp
+++ b/src/basic/DAXPY-Cuda.cpp
@@ -67,12 +67,12 @@ void DAXPY::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      constexpr size_t shmem = 0;
-
       auto daxpy_lambda = [=] __device__ (Index_type i) {
         DAXPY_BODY;
       };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
 
       RPlaunchCudaKernel( (lambda_cuda_forall<block_size, 
                                               decltype(daxpy_lambda)>),

--- a/src/basic/DAXPY-Hip.cpp
+++ b/src/basic/DAXPY-Hip.cpp
@@ -53,8 +53,15 @@ void DAXPY::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
+#if 0
       hipLaunchKernelGGL((daxpy<block_size>),dim3(grid_size), dim3(block_size), shmem, res.get_stream(), y, x, a,
                                         iend );
+#else
+      RPlaunchHipKernel( (daxpy<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         y, x, a, iend );
+#endif
       hipErrchk( hipGetLastError() );
 
     }
@@ -71,8 +78,16 @@ void DAXPY::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
+#if 0
       hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(daxpy_lambda)>),
         grid_size, block_size, shmem, res.get_stream(), ibegin, iend, daxpy_lambda);
+#else
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(daxpy_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, daxpy_lambda );
+#endif
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/basic/DAXPY-Hip.cpp
+++ b/src/basic/DAXPY-Hip.cpp
@@ -53,15 +53,11 @@ void DAXPY::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-#if 0
-      hipLaunchKernelGGL((daxpy<block_size>),dim3(grid_size), dim3(block_size), shmem, res.get_stream(), y, x, a,
-                                        iend );
-#else
+
       RPlaunchHipKernel( (daxpy<block_size>),
                          grid_size, block_size,
                          shmem, res.get_stream(),
                          y, x, a, iend );
-#endif
       hipErrchk( hipGetLastError() );
 
     }
@@ -78,16 +74,12 @@ void DAXPY::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-#if 0
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(daxpy_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, daxpy_lambda);
-#else
+
       RPlaunchHipKernel( (lambda_hip_forall<block_size,
                                             decltype(daxpy_lambda)>),
                          grid_size, block_size,
                          shmem, res.get_stream(),
                          ibegin, iend, daxpy_lambda );
-#endif
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/basic/IF_QUAD-Cuda.cpp
+++ b/src/basic/IF_QUAD-Cuda.cpp
@@ -53,7 +53,13 @@ void IF_QUAD::runCudaVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      ifquad<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( x1, x2, a, b, c, iend );
+
+      RPlaunchCudaKernel( (ifquad<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x1, x2,
+                          a, b, c,
+                          iend );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -63,12 +69,18 @@ void IF_QUAD::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      auto ifquad_lambda = [=] __device__ (Index_type i) {
+        IF_QUAD_BODY;
+      };
+
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      lambda_cuda_forall<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-        ibegin, iend, [=] __device__ (Index_type i) {
-        IF_QUAD_BODY;
-      });
+
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size,
+                                              decltype(ifquad_lambda)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend, ifquad_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/basic/IF_QUAD-Hip.cpp
+++ b/src/basic/IF_QUAD-Hip.cpp
@@ -53,8 +53,13 @@ void IF_QUAD::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((ifquad<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  x1, x2, a, b, c,
-                                          iend );
+
+      RPlaunchHipKernel( (ifquad<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         x1, x2,
+                         a, b, c,
+                         iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -71,8 +76,12 @@ void IF_QUAD::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(ifquad_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, ifquad_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(ifquad_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, ifquad_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/basic/INDEXLIST-Cuda.cpp
+++ b/src/basic/INDEXLIST-Cuda.cpp
@@ -268,12 +268,14 @@ void INDEXLIST::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      cudaErrchk( cudaMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size, res.get_stream()) );
-      indexlist<block_size, items_per_thread>
-          <<<grid_size, block_size, shmem_size, res.get_stream()>>>(
-          x+ibegin, list+ibegin,
-          block_counts, grid_counts, block_readys,
-          len, iend-ibegin );
+      cudaErrchk( cudaMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size, 
+                                  res.get_stream()) );
+      RPlaunchCudaKernel( (indexlist<block_size, items_per_thread>),
+                          grid_size, block_size,
+                          shmem_size, res.get_stream(),
+                          x+ibegin, list+ibegin,
+                          block_counts, grid_counts, block_readys,
+                          len, iend-ibegin );
       cudaErrchk( cudaGetLastError() );
 
       cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );

--- a/src/basic/INDEXLIST-Hip.cpp
+++ b/src/basic/INDEXLIST-Hip.cpp
@@ -268,12 +268,15 @@ void INDEXLIST::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      hipErrchk( hipMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size, res.get_stream()) );
-      indexlist<block_size, items_per_thread>
-          <<<grid_size, block_size, shmem_size, res.get_stream()>>>(
-          x+ibegin, list+ibegin,
-          block_counts, grid_counts, block_readys,
-          len, iend-ibegin );
+      hipErrchk( hipMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size,
+                                res.get_stream()) );
+
+      RPlaunchHipKernel( (indexlist<block_size, items_per_thread>),
+                         grid_size, block_size,
+                         shmem_size, res.get_stream(),
+                         x+ibegin, list+ibegin,
+                         block_counts, grid_counts, block_readys,
+                         len, iend-ibegin );
       hipErrchk( hipGetLastError() );
 
       hipErrchk( hipStreamSynchronize( res.get_stream() ) );

--- a/src/basic/INDEXLIST_3LOOP-Cuda.cpp
+++ b/src/basic/INDEXLIST_3LOOP-Cuda.cpp
@@ -150,8 +150,10 @@ void INDEXLIST_3LOOP::runCudaVariantImpl(VariantID vid)
         counts[i] = (INDEXLIST_3LOOP_CONDITIONAL) ? 1 : 0;
       });
 
-      RAJA::exclusive_scan_inplace< RAJA::cuda_exec<block_size, true /*async*/> >( res,
-          RAJA::make_span(counts+ibegin, iend+1-ibegin));
+      RAJA::exclusive_scan_inplace<
+        RAJA::cuda_exec<block_size, true /*async*/> >(
+          res,
+          RAJA::make_span(counts+ibegin, iend+1-ibegin) );
 
       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >( res,
         RAJA::RangeSegment(ibegin, iend),

--- a/src/basic/INDEXLIST_3LOOP-Cuda.cpp
+++ b/src/basic/INDEXLIST_3LOOP-Cuda.cpp
@@ -101,8 +101,11 @@ void INDEXLIST_3LOOP::runCudaVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      indexlist_conditional<block_size><<<grid_size, block_size, shmem, stream>>>(
-          x, counts, iend );
+
+      RPlaunchCudaKernel( (indexlist_conditional<block_size>),
+                          grid_size, block_size,
+                          shmem, stream,
+                          x, counts, iend );
       cudaErrchk( cudaGetLastError() );
 
       cudaErrchk(::cub::DeviceScan::ExclusiveScan(d_temp_storage,
@@ -114,8 +117,10 @@ void INDEXLIST_3LOOP::runCudaVariantImpl(VariantID vid)
                                                   scan_size,
                                                   stream));
 
-      indexlist_make_list<block_size><<<grid_size, block_size, shmem, stream>>>(
-          list, counts, len, iend );
+      RPlaunchCudaKernel( (indexlist_make_list<block_size>),
+                          grid_size, block_size,
+                          shmem, stream,
+                          list, counts, len, iend );
       cudaErrchk( cudaGetLastError() );
 
       cudaErrchk( cudaStreamSynchronize(stream) );

--- a/src/basic/INDEXLIST_3LOOP-Hip.cpp
+++ b/src/basic/INDEXLIST_3LOOP-Hip.cpp
@@ -112,8 +112,11 @@ void INDEXLIST_3LOOP::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((indexlist_conditional<block_size>), grid_size, block_size, shmem, stream,
-          x, counts, iend );
+
+      RPlaunchHipKernel( (indexlist_conditional<block_size>),
+                         grid_size, block_size,
+                         shmem, stream,
+                         x, counts, iend );
       hipErrchk( hipGetLastError() );
 
 #if defined(__HIPCC__)
@@ -136,8 +139,10 @@ void INDEXLIST_3LOOP::runHipVariantImpl(VariantID vid)
                                                  stream));
 #endif
 
-      hipLaunchKernelGGL((indexlist_make_list<block_size>), grid_size, block_size, shmem, stream,
-          list, counts, len, iend );
+      RPlaunchHipKernel( (indexlist_make_list<block_size>),
+                         grid_size, block_size,
+                         shmem, stream,
+                         list, counts, len, iend );
       hipErrchk( hipGetLastError() );
 
       hipErrchk( hipStreamSynchronize(stream) );

--- a/src/basic/INDEXLIST_3LOOP-Hip.cpp
+++ b/src/basic/INDEXLIST_3LOOP-Hip.cpp
@@ -172,8 +172,10 @@ void INDEXLIST_3LOOP::runHipVariantImpl(VariantID vid)
         counts[i] = (INDEXLIST_3LOOP_CONDITIONAL) ? 1 : 0;
       });
 
-      RAJA::exclusive_scan_inplace< RAJA::hip_exec<block_size, true /*async*/> >( res,
-          RAJA::make_span(counts+ibegin, iend+1-ibegin));
+      RAJA::exclusive_scan_inplace<
+        RAJA::hip_exec<block_size, true /*async*/> >(
+          res,
+          RAJA::make_span(counts+ibegin, iend+1-ibegin) );
 
       RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >( res,
         RAJA::RangeSegment(ibegin, iend),

--- a/src/basic/INIT3-Hip.cpp
+++ b/src/basic/INIT3-Hip.cpp
@@ -53,8 +53,13 @@ void INIT3::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((init3<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  out1, out2, out3, in1, in2,
-                                        iend );
+
+      RPlaunchHipKernel( (init3<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         out1, out2, out3,
+                         in1, in2,
+                         iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -71,8 +76,12 @@ void INIT3::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(init3_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, init3_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(init3_lambda)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend, init3_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/basic/INIT_VIEW1D-Hip.cpp
+++ b/src/basic/INIT_VIEW1D-Hip.cpp
@@ -53,8 +53,11 @@ void INIT_VIEW1D::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((initview1d<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-          a, v, iend );
+
+      RPlaunchHipKernel( (initview1d<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         a, v, iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -71,8 +74,12 @@ void INIT_VIEW1D::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(initview1d_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, initview1d_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(initview1d_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, initview1d_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/basic/INIT_VIEW1D_OFFSET-Hip.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Hip.cpp
@@ -54,8 +54,12 @@ void INIT_VIEW1D_OFFSET::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend-ibegin, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((initview1d_offset<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-          a, v, ibegin, iend );
+
+      RPlaunchHipKernel( (initview1d_offset<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         a, v,
+                         ibegin, iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -72,8 +76,12 @@ void INIT_VIEW1D_OFFSET::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend-ibegin, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(initview1d_offset_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, initview1d_offset_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(initview1d_offset_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, initview1d_offset_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/basic/MAT_MAT_SHARED-Hip.cpp
+++ b/src/basic/MAT_MAT_SHARED-Hip.cpp
@@ -73,9 +73,10 @@ void MAT_MAT_SHARED::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      hipLaunchKernelGGL((mat_mat_shared<tile_size>), dim3(gridDim), dim3(blockDim), shmem, res.get_stream(),
-                         N, C, A, B);
-
+      RPlaunchHipKernel( (mat_mat_shared<tile_size>),
+                         gridDim, blockDim,
+                         shmem, res.get_stream(),
+                         N, C, A, B );
       hipErrchk( hipGetLastError() );
     }
     stopTimer();
@@ -85,7 +86,7 @@ void MAT_MAT_SHARED::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      auto mat_mat_shared_lam = [=] __device__() {
+      auto mat_mat_shared_lambda = [=] __device__() {
 
         auto outer_y = [&](Index_type by) {
           auto outer_x = [&](Index_type bx) {
@@ -175,9 +176,11 @@ void MAT_MAT_SHARED::runHipVariantImpl(VariantID vid)
         }
       };
 
-      hipLaunchKernelGGL((lambda_hip<tile_size*tile_size, decltype(mat_mat_shared_lam)>),
-        gridDim, blockDim, shmem, res.get_stream(), mat_mat_shared_lam);
-
+      RPlaunchHipKernel( (lambda_hip<tile_size*tile_size,
+                                     decltype(mat_mat_shared_lambda)>),
+                         gridDim, blockDim,
+                         shmem, res.get_stream(),
+                         mat_mat_shared_lambda );
       hipErrchk( hipGetLastError() );
     }
     stopTimer();

--- a/src/basic/MULADDSUB-Cuda.cpp
+++ b/src/basic/MULADDSUB-Cuda.cpp
@@ -53,8 +53,13 @@ void MULADDSUB::runCudaVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      muladdsub<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( out1, out2, out3, in1, in2,
-                                            iend );
+
+      RPlaunchCudaKernel( (muladdsub<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          out1, out2, out3,
+                          in1, in2,
+                          iend );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -65,12 +70,18 @@ void MULADDSUB::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      auto muladdsub_lambda = [=] __device__ (Index_type i) {
+        MULADDSUB_BODY;
+      };
+
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      lambda_cuda_forall<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-        ibegin, iend, [=] __device__ (Index_type i) {
-        MULADDSUB_BODY;
-      });
+
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size,
+                                              decltype(muladdsub_lambda)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend, muladdsub_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/basic/MULADDSUB-Hip.cpp
+++ b/src/basic/MULADDSUB-Hip.cpp
@@ -53,8 +53,13 @@ void MULADDSUB::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((muladdsub<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-          out1, out2, out3, in1, in2, iend );
+
+      RPlaunchHipKernel( (muladdsub<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         out1, out2, out3,
+                         in1, in2,
+                         iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -71,8 +76,12 @@ void MULADDSUB::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(muladdsub_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, muladdsub_lambda );
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(muladdsub_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, muladdsub_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -89,9 +89,11 @@ void NESTED_INIT::runCudaVariantImpl(VariantID vid)
       NESTED_INIT_NBLOCKS_CUDA;
       constexpr size_t shmem = 0;
 
-      nested_init<NESTED_INIT_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                 <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(array,
-                                                   ni, nj, nk);
+      RPlaunchCudaKernel(
+        (nested_init<NESTED_INIT_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        array, ni, nj, nk );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -102,16 +104,23 @@ void NESTED_INIT::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      auto nested_init_lambda = [=] __device__ (Index_type i, 
+                                                Index_type j, 
+                                                Index_type k) {
+          NESTED_INIT_BODY;
+      };
+
       NESTED_INIT_THREADS_PER_BLOCK_CUDA;
       NESTED_INIT_NBLOCKS_CUDA;
       constexpr size_t shmem = 0;
 
-      nested_init_lam<NESTED_INIT_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                     <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(ni, nj, nk,
-        [=] __device__ (Index_type i, Index_type j, Index_type k) {
-          NESTED_INIT_BODY;
-        }
-      );
+      RPlaunchCudaKernel(
+        (nested_init_lam<NESTED_INIT_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                         decltype(nested_init_lambda)>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        ni, nj, nk,
+        nested_init_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -145,10 +145,11 @@ void NESTED_INIT::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment(0, ni),
-                                               RAJA::RangeSegment(0, nj),
-                                               RAJA::RangeSegment(0, nk)),
-                                       res,
+      RAJA::kernel_resource<EXEC_POL>(
+        RAJA::make_tuple(RAJA::RangeSegment(0, ni),
+                         RAJA::RangeSegment(0, nj),
+                         RAJA::RangeSegment(0, nk)),
+        res,
         [=] __device__ (Index_type i, Index_type j, Index_type k) {
         NESTED_INIT_BODY;
       });

--- a/src/basic/NESTED_INIT-Hip.cpp
+++ b/src/basic/NESTED_INIT-Hip.cpp
@@ -145,10 +145,11 @@ void NESTED_INIT::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment(0, ni),
-                                               RAJA::RangeSegment(0, nj),
-                                               RAJA::RangeSegment(0, nk)),
-                                       res,
+      RAJA::kernel_resource<EXEC_POL>(
+        RAJA::make_tuple(RAJA::RangeSegment(0, ni),
+                         RAJA::RangeSegment(0, nj),
+                         RAJA::RangeSegment(0, nk)),
+        res,
         [=] __device__ (Index_type i, Index_type j, Index_type k) {
         NESTED_INIT_BODY;
       });

--- a/src/basic/NESTED_INIT-Hip.cpp
+++ b/src/basic/NESTED_INIT-Hip.cpp
@@ -89,9 +89,11 @@ void NESTED_INIT::runHipVariantImpl(VariantID vid)
       NESTED_INIT_NBLOCKS_HIP;
       constexpr size_t shmem = 0;
 
-      hipLaunchKernelGGL((nested_init<NESTED_INIT_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                         dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         array, ni, nj, nk);
+      RPlaunchHipKernel(
+        (nested_init<NESTED_INIT_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        array, ni, nj, nk );
       hipErrchk( hipGetLastError() );
 
     }
@@ -102,18 +104,23 @@ void NESTED_INIT::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      NESTED_INIT_THREADS_PER_BLOCK_HIP;
-      NESTED_INIT_NBLOCKS_HIP;
-      constexpr size_t shmem = 0;
-
-      auto nested_init_lambda = [=] __device__ (Index_type i, Index_type j,
+      auto nested_init_lambda = [=] __device__ (Index_type i, 
+                                                Index_type j,
                                                 Index_type k) {
         NESTED_INIT_BODY;
       };
 
-      hipLaunchKernelGGL((nested_init_lam<NESTED_INIT_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(nested_init_lambda) >),
-                         dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         ni, nj, nk, nested_init_lambda);
+      NESTED_INIT_THREADS_PER_BLOCK_HIP;
+      NESTED_INIT_NBLOCKS_HIP;
+      constexpr size_t shmem = 0;
+
+      RPlaunchHipKernel(
+        (nested_init_lam<NESTED_INIT_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                         decltype(nested_init_lambda)>),
+        nblocks, nthreads_per_block,
+        shmem, res.get_stream(),
+        ni, nj, nk,
+        nested_init_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/basic/PI_ATOMIC-Hip.cpp
+++ b/src/basic/PI_ATOMIC-Hip.cpp
@@ -58,7 +58,13 @@ void PI_ATOMIC::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((atomic_pi<block_size>),grid_size, block_size, shmem, res.get_stream(), pi, dx, iend );
+
+      RPlaunchHipKernel( (pi_atomic<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         pi,
+                         dx,
+                         iend );
       hipErrchk( hipGetLastError() );
 
       Real_type rpi;
@@ -75,16 +81,19 @@ void PI_ATOMIC::runHipVariantImpl(VariantID vid)
 
       RAJAPERF_HIP_REDUCER_INITIALIZE(&m_pi_init, pi, hpi, 1);
 
-      auto atomic_pi_lambda = [=] __device__ (Index_type i) {
+      auto pi_atomic_lambda = [=] __device__ (Index_type i) {
           double x = (double(i) + 0.5) * dx;
           RAJA::atomicAdd<RAJA::hip_atomic>(pi, dx / (1.0 + x * x));
       };
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(atomic_pi_lambda)>),
-          grid_size, block_size, shmem, res.get_stream(), ibegin, iend, atomic_pi_lambda);
-      hipErrchk( hipGetLastError() );
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(pi_atomic_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, pi_atomic_lambda );
 
       Real_type rpi;
       RAJAPERF_HIP_REDUCER_COPY_BACK(&rpi, pi, hpi, 1);

--- a/src/basic/PI_ATOMIC-Hip.cpp
+++ b/src/basic/PI_ATOMIC-Hip.cpp
@@ -23,7 +23,7 @@ namespace basic
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void atomic_pi(Real_ptr pi,
+__global__ void pi_atomic(Real_ptr pi,
                           Real_type dx,
                           Index_type iend)
 {

--- a/src/basic/PI_REDUCE-Cuda.cpp
+++ b/src/basic/PI_REDUCE-Cuda.cpp
@@ -76,10 +76,13 @@ void PI_REDUCE::runCudaVariantBlockAtomic(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = sizeof(Real_type)*block_size;
-      pi_reduce<block_size><<<grid_size, block_size,
-                  shmem, res.get_stream()>>>( dx,
-                                                   pi, m_pi_init,
-                                                   iend );
+
+      RPlaunchCudaKernel( (pi_reduce<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          dx,
+                          pi, m_pi_init,
+                          iend );
       cudaErrchk( cudaGetLastError() );
 
       Real_type rpi;
@@ -139,10 +142,13 @@ void PI_REDUCE::runCudaVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      pi_reduce<block_size><<<grid_size, block_size,
-                              shmem, res.get_stream()>>>( dx,
-                                                   pi, m_pi_init,
-                                                   iend );
+
+      RPlaunchCudaKernel( (pi_reduce<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          dx,
+                          pi, m_pi_init,
+                          iend );
       cudaErrchk( cudaGetLastError() );
 
       Real_type rpi;

--- a/src/basic/PI_REDUCE-Hip.cpp
+++ b/src/basic/PI_REDUCE-Hip.cpp
@@ -76,9 +76,13 @@ void PI_REDUCE::runHipVariantBlockAtomic(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = sizeof(Real_type)*block_size;
-      hipLaunchKernelGGL( (pi_reduce<block_size>), dim3(grid_size), dim3(block_size),
-                          shmem, res.get_stream(),
-                          dx, pi, m_pi_init, iend );
+
+      RPlaunchHipKernel( (pi_reduce<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         dx,
+                         pi, m_pi_init,
+                         iend );
       hipErrchk( hipGetLastError() );
 
       Real_type rpi;
@@ -138,9 +142,13 @@ void PI_REDUCE::runHipVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      hipLaunchKernelGGL( (pi_reduce<block_size>), dim3(grid_size), dim3(block_size),
-                          shmem, res.get_stream(),
-                          dx, pi, m_pi_init, iend );
+
+      RPlaunchHipKernel( (pi_reduce<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         dx,
+                         pi, m_pi_init,
+                         iend );
       hipErrchk( hipGetLastError() );
 
       Real_type rpi;

--- a/src/basic/REDUCE3_INT-Cuda.cpp
+++ b/src/basic/REDUCE3_INT-Cuda.cpp
@@ -90,12 +90,15 @@ void REDUCE3_INT::runCudaVariantBlockAtomic(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 3*sizeof(Int_type)*block_size;
-      reduce3int<block_size><<<grid_size, block_size,
-                   shmem, res.get_stream()>>>(vec,
-                                                    vmem + 0, m_vsum_init,
-                                                    vmem + 1, m_vmin_init,
-                                                    vmem + 2, m_vmax_init,
-                                                    iend );
+
+      RPlaunchCudaKernel( (reduce3int<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          vec,
+                          vmem + 0, m_vsum_init,
+                          vmem + 1, m_vmin_init,
+                          vmem + 2, m_vmax_init,
+                          iend );
       cudaErrchk( cudaGetLastError() );
 
       Int_type rvmem[3];
@@ -162,12 +165,15 @@ void REDUCE3_INT::runCudaVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      reduce3int<block_size><<<grid_size, block_size,
-                               shmem, res.get_stream()>>>(vec,
-                                                    vmem + 0, m_vsum_init,
-                                                    vmem + 1, m_vmin_init,
-                                                    vmem + 2, m_vmax_init,
-                                                    iend );
+
+      RPlaunchCudaKernel( (reduce3int<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          vec,
+                          vmem + 0, m_vsum_init,
+                          vmem + 1, m_vmin_init,
+                          vmem + 2, m_vmax_init,
+                          iend );
       cudaErrchk( cudaGetLastError() );
 
       Int_type rvmem[3];

--- a/src/basic/REDUCE3_INT-Hip.cpp
+++ b/src/basic/REDUCE3_INT-Hip.cpp
@@ -90,12 +90,15 @@ void REDUCE3_INT::runHipVariantBlockAtomic(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 3*sizeof(Int_type)*block_size;
-      hipLaunchKernelGGL((reduce3int<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                                                    vec,
-                                                    vmem + 0, m_vsum_init,
-                                                    vmem + 1, m_vmin_init,
-                                                    vmem + 2, m_vmax_init,
-                                                    iend );
+
+      RPlaunchHipKernel( (reduce3int<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         vec,
+                         vmem + 0, m_vsum_init,
+                         vmem + 1, m_vmin_init,
+                         vmem + 2, m_vmax_init,
+                         iend );
       hipErrchk( hipGetLastError() );
 
       Int_type rvmem[3];
@@ -162,13 +165,15 @@ void REDUCE3_INT::runHipVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      hipLaunchKernelGGL((reduce3int<block_size>), dim3(grid_size), dim3(block_size),
-                                                   shmem, res.get_stream(),
-                                                    vec,
-                                                    vmem + 0, m_vsum_init,
-                                                    vmem + 1, m_vmin_init,
-                                                    vmem + 2, m_vmax_init,
-                                                    iend );
+
+      RPlaunchHipKernel( (reduce3int<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         vec,
+                         vmem + 0, m_vsum_init,
+                         vmem + 1, m_vmin_init,
+                         vmem + 2, m_vmax_init,
+                         iend );
       hipErrchk( hipGetLastError() );
 
       Int_type rvmem[3];

--- a/src/basic/REDUCE_STRUCT-Cuda.cpp
+++ b/src/basic/REDUCE_STRUCT-Cuda.cpp
@@ -121,13 +121,15 @@ void REDUCE_STRUCT::runCudaVariantBlockAtomic(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 6*sizeof(Real_type)*block_size;
-      reduce_struct<block_size><<<grid_size, block_size,
-                                  shmem, res.get_stream()>>>(
-        points.x, points.y,
-        mem, mem+1, mem+2,    // xcenter,xmin,xmax
-        mem+3, mem+4, mem+5,  // ycenter,ymin,ymax
-        m_init_sum, m_init_min, m_init_max,
-        points.N);
+
+      RPlaunchCudaKernel( (reduce_struct<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          points.x, points.y,
+                          mem, mem+1, mem+2,    // xcenter,xmin,xmax
+                          mem+3, mem+4, mem+5,  // ycenter,ymin,ymax
+                          m_init_sum, m_init_min, m_init_max,
+                          points.N );
       cudaErrchk( cudaGetLastError() );
 
       Real_type rmem[6];
@@ -205,13 +207,15 @@ void REDUCE_STRUCT::runCudaVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      reduce_struct<block_size><<<grid_size, block_size,
-                                  shmem, res.get_stream()>>>(
-        points.x, points.y,
-        mem, mem+1, mem+2,    // xcenter,xmin,xmax
-        mem+3, mem+4, mem+5,  // ycenter,ymin,ymax
-        m_init_sum, m_init_min, m_init_max,
-        points.N);
+
+      RPlaunchCudaKernel( (reduce_struct<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          points.x, points.y,
+                          mem, mem+1, mem+2,    // xcenter,xmin,xmax
+                          mem+3, mem+4, mem+5,  // ycenter,ymin,ymax
+                          m_init_sum, m_init_min, m_init_max,
+                          points.N );
       cudaErrchk( cudaGetLastError() );
 
       Real_type rmem[6];

--- a/src/basic/REDUCE_STRUCT-Hip.cpp
+++ b/src/basic/REDUCE_STRUCT-Hip.cpp
@@ -123,14 +123,14 @@ void REDUCE_STRUCT::runHipVariantBlockAtomic(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 6*sizeof(Real_type)*block_size;
 
-      hipLaunchKernelGGL((reduce_struct<block_size>), 
-                         dim3(grid_size), dim3(block_size), 
+      RPlaunchHipKernel( (reduce_struct<block_size>),
+                         grid_size, block_size,
                          shmem, res.get_stream(),
-	                 points.x, points.y,
+                         points.x, points.y,
                          mem, mem+1, mem+2,    // xcenter,xmin,xmax
                          mem+3, mem+4, mem+5,  // ycenter,ymin,ymax
                          m_init_sum, m_init_min, m_init_max,
-                         points.N);
+                         points.N );
       hipErrchk( hipGetLastError() );
 
       Real_type rmem[6];
@@ -207,14 +207,15 @@ void REDUCE_STRUCT::runHipVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      hipLaunchKernelGGL((reduce_struct<block_size>),
-                         dim3(grid_size), dim3(block_size),
+
+      RPlaunchHipKernel( (reduce_struct<block_size>),
+                         grid_size, block_size,
                          shmem, res.get_stream(),
                          points.x, points.y,
                          mem, mem+1, mem+2,    // xcenter,xmin,xmax
                          mem+3, mem+4, mem+5,  // ycenter,ymin,ymax
                          m_init_sum, m_init_min, m_init_max,
-                         points.N);
+                         points.N ); 
       hipErrchk( hipGetLastError() );
 
       Real_type rmem[6];

--- a/src/basic/REDUCE_STRUCT.hpp
+++ b/src/basic/REDUCE_STRUCT.hpp
@@ -107,7 +107,7 @@ public:
   void runHipVariantBlockDeviceOccGS(VariantID vid);
 
   struct PointsType {
-    Int_type N;
+    Index_type N;
     Real_ptr x, y;
 
     Real_ptr GetCenter(){return &center[0];};

--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -95,12 +95,15 @@ void TRAP_INT::runCudaVariantBlockAtomic(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = sizeof(Real_type)*block_size;
-      trapint<block_size><<<grid_size, block_size,
-                shmem, res.get_stream()>>>(x0, xp,
-                                                y, yp,
-                                                h,
-                                                sumx,
-                                                iend);
+
+      RPlaunchCudaKernel( (trapint<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x0, xp,
+                          y, yp,
+                          h,
+                          sumx,
+                          iend);
       cudaErrchk( cudaGetLastError() );
 
       Real_type rsumx;
@@ -160,12 +163,15 @@ void TRAP_INT::runCudaVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      trapint<block_size><<<grid_size, block_size,
-                            shmem, res.get_stream()>>>(x0, xp,
-                                                y, yp,
-                                                h,
-                                                sumx,
-                                                iend);
+
+      RPlaunchCudaKernel( (trapint<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x0, xp,
+                          y, yp,
+                          h,
+                          sumx,
+                          iend);
       cudaErrchk( cudaGetLastError() );
 
       Real_type rsumx;

--- a/src/basic/TRAP_INT-Hip.cpp
+++ b/src/basic/TRAP_INT-Hip.cpp
@@ -95,11 +95,15 @@ void TRAP_INT::runHipVariantBlockAtomic(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = sizeof(Real_type)*block_size;
-      hipLaunchKernelGGL((trapint<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(), x0, xp,
-                                                y, yp,
-                                                h,
-                                                sumx,
-                                                iend);
+
+      RPlaunchHipKernel( (trapint<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         x0, xp,
+                         y, yp,
+                         h,
+                         sumx,
+                         iend);
       hipErrchk( hipGetLastError() );
 
       Real_type rsumx;
@@ -159,12 +163,15 @@ void TRAP_INT::runHipVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      hipLaunchKernelGGL((trapint<block_size>), dim3(grid_size), dim3(block_size),
-                                                shmem, res.get_stream(), x0, xp,
-                                                y, yp,
-                                                h,
-                                                sumx,
-                                                iend);
+
+      RPlaunchHipKernel( (trapint<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         x0, xp,
+                         y, yp,
+                         h,
+                         sumx,
+                         iend);
       hipErrchk( hipGetLastError() );
 
       Real_type rsumx;

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -49,14 +49,16 @@ __device__ __forceinline__ unsigned long long device_timer()
  *              in kernel signature matches number of args passed to this 
  *              method.
  */
-template <typename... Args, typename F = void (*)(Args...)>
-void RPlaunchCudaKernel(F kernel,
+template <typename... Args, typename...KernArgs>
+void RPlaunchCudaKernel(void (*kernel)(KernArgs...),
                         const dim3& numBlocks, const dim3& dimBlocks,
                         std::uint32_t sharedMemBytes, cudaStream_t stream,
-                        Args const&... args) 
+                        Args const&... args)
 {
+  static_assert(sizeof...(KernArgs) == sizeof...(Args),
+                "Argument count mismatch between kernel and call to this method");
+
   constexpr size_t count = sizeof...(Args);
-  checkArgsCount(kernel, args...);
   void* arg_arr[count]{(void*)&args...};
 
   auto k = reinterpret_cast<const void*>(kernel);

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -57,8 +57,7 @@ void RPlaunchCudaKernel(void (*kernel)(KernArgs...),
   static_assert(sizeof...(KernArgs) == sizeof...(Args),
                 "Number of kernel args doesn't match what's passed to method");
 
-  using int_array = int[];
-  int_array ia = {[](...){
+  int ia[] = {[](){
     static_assert(std::is_same<std::decay_t<KernArgs>, std::decay_t<Args>>::value, "Kernel arg types don't match what's passed to method");
     return 0;
   }()...};

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -58,7 +58,7 @@ void RPlaunchCudaKernel(void (*kernel)(KernArgs...),
                 "Number of kernel args doesn't match what's passed to method");
 
   using int_array = int[];
-  int_array ia = {[](){
+  int_array ia = {[](...){
     static_assert(std::is_same<std::decay_t<KernArgs>, std::decay_t<Args>>::value, "Kernel arg types don't match what's passed to method");
     return 0;
   }()...};

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -51,17 +51,15 @@ __device__ __forceinline__ unsigned long long device_timer()
  */
 template <typename... Args, typename F = void (*)(Args...)>
 void RPlaunchCudaKernel(F kernel,
-                        const size_t& numBlocks, const size_t& dimBlocks,
+                        const dim3& numBlocks, const dim3& dimBlocks,
                         std::uint32_t sharedMemBytes, cudaStream_t stream,
-                        Args... args) 
+                        Args const&... args) 
 {
   constexpr size_t count = sizeof...(Args);
-  auto tup = std::tuple<Args...>{args...};
-  auto chk_tup = checkArgsCount(kernel, tup);
-  void* arg_arr[count];
-  packArgs<0>(chk_tup, arg_arr);
+  checkArgsCount(kernel, args...);
+  void* arg_arr[count]{(void*)&args...};
 
-  auto k = reinterpret_cast<void*>(kernel);
+  auto k = reinterpret_cast<const void*>(kernel);
   cudaLaunchKernel(k, numBlocks, dimBlocks,
                    arg_arr,
                    sharedMemBytes, stream);

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -45,7 +45,7 @@ __device__ __forceinline__ unsigned long long device_timer()
 /*!
  * \brief Method for launching a CUDA kernel with given configuration.
  *
- *        Note: method checks whether number of args and their types in 
+ *        Note: method checks whether number of args and their types in
  *              kernel signature matches args passed to this method.
  */
 template <typename... Args, typename...KernArgs>
@@ -57,11 +57,8 @@ void RPlaunchCudaKernel(void (*kernel)(KernArgs...),
   static_assert(sizeof...(KernArgs) == sizeof...(Args),
                 "Number of kernel args doesn't match what's passed to method");
 
-  int ia[] = {[](){
-    static_assert(std::is_same<std::decay_t<KernArgs>, std::decay_t<Args>>::value, "Kernel arg types don't match what's passed to method");
-    return 0;
-  }()...};
-  RAJA_UNUSED_VAR(ia);
+  static_assert(conjunction<std::is_same<std::decay_t<KernArgs>, std::decay_t<Args>>...>::value,
+                "Kernel arg types don't match what's passed to method");
 
   constexpr size_t count = sizeof...(Args);
   void* arg_arr[count]{(void*)&args...};

--- a/src/common/GPUUtils.hpp
+++ b/src/common/GPUUtils.hpp
@@ -19,19 +19,6 @@
 namespace rajaperf
 {
 
-/*!
- * \brief Routine to check whether number of args in signature of the
- *        given kernel matches the number of items in the given tuple.
- */
-template <typename... Formals, typename... Actuals>
-void checkArgsCount(void (*kernel)(Formals...),
-                    Actuals...)
-{
-  (void) kernel; // to prevent compiler warning
-  static_assert(sizeof...(Formals) == sizeof...(Actuals),
-                "Argument Count Mismatch");
-}
-
 namespace gpu_block_size
 {
 

--- a/src/common/GPUUtils.hpp
+++ b/src/common/GPUUtils.hpp
@@ -19,6 +19,53 @@
 namespace rajaperf
 {
 
+/*!
+ * \brief Routine to check whether number of args in signature of the
+ *        given kernel matches the number of items in the given tuple.
+ */
+template <typename... Formals, typename... Actuals>
+std::tuple<Formals...> checkArgsCount(void (*kernel)(Formals...),
+                                      std::tuple<Actuals...>(actuals))
+{
+  (void) kernel; // to prevent compiler warning
+  static_assert(sizeof...(Formals) == sizeof...(Actuals),
+                "Argument Count Mismatch");
+  std::tuple<Formals...> to_formals{std::move(actuals)};
+  return to_formals;
+}
+
+/*!
+ * \brief Stopping case for recursive method below.
+ */
+template <std::size_t n, typename... Ts,
+          typename std::enable_if<n == sizeof...(Ts)>::type* = nullptr>
+void packArgs(const std::tuple<Ts...>&, void*) {}
+
+/*!
+ * \brief Recursive method to copy items from given tuple to an array
+ *        of void* pointers, which is what CUDA and HIP kernel launch
+ *        methods want for kernel arguments.
+ *
+ *        Note: method contains a static assert check for whether any
+ *              item in the given tuple is a reference type, which
+ *              doesn't work for passing args to a GPU kernel.
+ */
+template <std::size_t n, typename... Ts,
+          typename std::enable_if<n != sizeof...(Ts)>::type* = nullptr>
+void packArgs(const std::tuple<Ts...>& formals, void** vargs)
+{
+  using T = typename std::tuple_element<n, std::tuple<Ts...> >::type;
+
+  static_assert(!std::is_reference<T>{},
+                "A __global__ function cannot have a reference as one of its "
+                "arguments.");
+
+  vargs[n] = const_cast<void*>(
+               reinterpret_cast<const void*>(&std::get<n>(formals)) );
+
+  return packArgs<n + 1>(formals, vargs);
+}
+
 namespace gpu_block_size
 {
 

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -45,7 +45,7 @@ void RPlaunchHipKernel(void (*kernel)(KernArgs...),
                 "Number of kernel args doesn't match what's passed to method");
 
   using int_array = int[];
-  int_array ia = {[](){
+  int_array ia = {[](...){
     static_assert(std::is_same<std::decay_t<KernArgs>, std::decay_t<Args>>::value, 
                   "Kernel arg types don't match what's passed to method");
     return 0;

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -40,15 +40,13 @@ template <typename... Args, typename F = void (*)(Args...)>
 void RPlaunchHipKernel(F kernel,
                        const size_t& numBlocks, const size_t& dimBlocks,
                        std::uint32_t sharedMemBytes, hipStream_t stream,
-                       Args... args)
+                       Args const&... args)
 {
   constexpr size_t count = sizeof...(Args);
-  auto tup = std::tuple<Args...>{args...};
-  auto chk_tup = checkArgsCount(kernel, tup);
-  void* arg_arr[count];
-  packArgs<0>(chk_tup, arg_arr);
+  checkArgsCount(kernel, args...);
+  void* arg_arr[count]{(void*)&args...};
 
-  auto k = reinterpret_cast<void*>(kernel);
+  auto k = reinterpret_cast<const void*>(kernel);
   hipLaunchKernel(k, numBlocks, dimBlocks,
                   arg_arr,
                   sharedMemBytes, stream);

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -32,9 +32,8 @@ namespace rajaperf
 /*!
  * \brief Method for launching a HIP kernel with given configuration.
  *
- *        Note: method includes a call to check whether number of args
- *              in kernel signature matches number of args passed to this 
- *              method.
+ *        Note: method checks whether number of args and their types in 
+ *              kernel signature matches args passed to this method.
  */
 template <typename... Args, typename...KernArgs>
 void RPlaunchHipKernel(void (*kernel)(KernArgs...),
@@ -43,7 +42,15 @@ void RPlaunchHipKernel(void (*kernel)(KernArgs...),
                        Args const&... args)
 {
   static_assert(sizeof...(KernArgs) == sizeof...(Args),
-                "Argument count mismatch between kernel and call to this method");
+                "Number of kernel args doesn't match what's passed to method");
+
+  using int_array = int[];
+  int_array ia = {[](){
+    static_assert(std::is_same<std::decay_t<KernArgs>, std::decay_t<Args>>::value, 
+                  "Kernel arg types don't match what's passed to method");
+    return 0;
+  }()...};
+  RAJA_UNUSED_VAR(ia);
 
   constexpr size_t count = sizeof...(Args);
   void* arg_arr[count]{(void*)&args...};

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -36,14 +36,16 @@ namespace rajaperf
  *              in kernel signature matches number of args passed to this 
  *              method.
  */
-template <typename... Args, typename F = void (*)(Args...)>
-void RPlaunchHipKernel(F kernel,
+template <typename... Args, typename...KernArgs>
+void RPlaunchHipKernel(void (*kernel)(KernArgs...),
                        const dim3& numBlocks, const dim3& dimBlocks,
                        std::uint32_t sharedMemBytes, hipStream_t stream,
                        Args const&... args)
 {
+  static_assert(sizeof...(KernArgs) == sizeof...(Args),
+                "Argument count mismatch between kernel and call to this method");
+
   constexpr size_t count = sizeof...(Args);
-  checkArgsCount(kernel, args...);
   void* arg_arr[count]{(void*)&args...};
 
   auto k = reinterpret_cast<const void*>(kernel);

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -32,7 +32,7 @@ namespace rajaperf
 /*!
  * \brief Method for launching a HIP kernel with given configuration.
  *
- *        Note: method checks whether number of args and their types in 
+ *        Note: method checks whether number of args and their types in
  *              kernel signature matches args passed to this method.
  */
 template <typename... Args, typename...KernArgs>
@@ -44,12 +44,8 @@ void RPlaunchHipKernel(void (*kernel)(KernArgs...),
   static_assert(sizeof...(KernArgs) == sizeof...(Args),
                 "Number of kernel args doesn't match what's passed to method");
 
-  int ia[] = {[](){
-    static_assert(std::is_same<std::decay_t<KernArgs>, std::decay_t<Args>>::value, 
-                  "Kernel arg types don't match what's passed to method");
-    return 0;
-  }()...};
-  RAJA_UNUSED_VAR(ia);
+  static_assert(conjunction<std::is_same<std::decay_t<KernArgs>, std::decay_t<Args>>...>::value,
+                "Kernel arg types don't match what's passed to method");
 
   constexpr size_t count = sizeof...(Args);
   void* arg_arr[count]{(void*)&args...};

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -44,8 +44,7 @@ void RPlaunchHipKernel(void (*kernel)(KernArgs...),
   static_assert(sizeof...(KernArgs) == sizeof...(Args),
                 "Number of kernel args doesn't match what's passed to method");
 
-  using int_array = int[];
-  int_array ia = {[](...){
+  int ia[] = {[](){
     static_assert(std::is_same<std::decay_t<KernArgs>, std::decay_t<Args>>::value, 
                   "Kernel arg types don't match what's passed to method");
     return 0;

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -38,7 +38,7 @@ namespace rajaperf
  */
 template <typename... Args, typename F = void (*)(Args...)>
 void RPlaunchHipKernel(F kernel,
-                       const size_t& numBlocks, const size_t& dimBlocks,
+                       const dim3& numBlocks, const dim3& dimBlocks,
                        std::uint32_t sharedMemBytes, hipStream_t stream,
                        Args const&... args)
 {

--- a/src/lcals/DIFF_PREDICT-Cuda.cpp
+++ b/src/lcals/DIFF_PREDICT-Cuda.cpp
@@ -52,9 +52,11 @@ void DIFF_PREDICT::runCudaVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       diff_predict<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( px, cx,
-                                                offset,
-                                                iend );
+   
+       RPlaunchCudaKernel( (diff_predict<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           px, cx, offset, iend );
        cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/lcals/DIFF_PREDICT-Hip.cpp
+++ b/src/lcals/DIFF_PREDICT-Hip.cpp
@@ -53,9 +53,11 @@ void DIFF_PREDICT::runHipVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       hipLaunchKernelGGL((diff_predict<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  px, cx,
-                                                offset,
-                                                iend );
+
+       RPlaunchHipKernel( (diff_predict<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          px, cx, offset, iend );
        hipErrchk( hipGetLastError() );
 
     }

--- a/src/lcals/EOS-Cuda.cpp
+++ b/src/lcals/EOS-Cuda.cpp
@@ -52,9 +52,13 @@ void EOS::runCudaVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       eos<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( x, y, z, u,
-                                       q, r, t,
-                                       iend );
+
+       RPlaunchCudaKernel( (eos<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           x, y, z, u,
+                           q, r, t, 
+                           iend );
        cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/lcals/EOS-Hip.cpp
+++ b/src/lcals/EOS-Hip.cpp
@@ -52,9 +52,13 @@ void EOS::runHipVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       hipLaunchKernelGGL((eos<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  x, y, z, u,
-                                       q, r, t,
-                                       iend );
+
+       RPlaunchHipKernel( (eos<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x, y, z, u,
+                          q, r, t, 
+                          iend );
        hipErrchk( hipGetLastError() );
 
     }

--- a/src/lcals/FIRST_DIFF-Cuda.cpp
+++ b/src/lcals/FIRST_DIFF-Cuda.cpp
@@ -51,8 +51,12 @@ void FIRST_DIFF::runCudaVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       first_diff<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( x, y,
-                                              iend );
+
+       RPlaunchCudaKernel( (first_diff<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           x, y,
+                           iend );
        cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/lcals/FIRST_DIFF-Hip.cpp
+++ b/src/lcals/FIRST_DIFF-Hip.cpp
@@ -51,8 +51,12 @@ void FIRST_DIFF::runHipVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       hipLaunchKernelGGL((first_diff<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  x, y,
-                                              iend );
+
+       RPlaunchHipKernel( (first_diff<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x, y, 
+                          iend );
        hipErrchk( hipGetLastError() );
 
     }

--- a/src/lcals/FIRST_MIN-Cuda.cpp
+++ b/src/lcals/FIRST_MIN-Cuda.cpp
@@ -81,8 +81,12 @@ void FIRST_MIN::runCudaVariantBlockHost(VariantID vid)
       RAJAPERF_CUDA_REDUCER_INITIALIZE_VALUE(mymin, dminloc, mymin_block, grid_size);
 
       constexpr size_t shmem = sizeof(MyMinLoc)*block_size;
-      first_min<block_size><<<grid_size, block_size,
-                              shmem, res.get_stream()>>>(x, dminloc, mymin, iend);
+
+      RPlaunchCudaKernel( (first_min<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           x, dminloc, mymin, 
+                           iend );
       cudaErrchk( cudaGetLastError() );
 
       RAJAPERF_CUDA_REDUCER_COPY_BACK_NOFINAL(dminloc, mymin_block, grid_size);
@@ -164,8 +168,11 @@ void FIRST_MIN::runCudaVariantBlockHostOccGS(VariantID vid)
       FIRST_MIN_MINLOC_INIT;
       RAJAPERF_CUDA_REDUCER_INITIALIZE_VALUE(mymin, dminloc, mymin_block, grid_size);
 
-      first_min<block_size><<<grid_size, block_size,
-                              shmem, res.get_stream()>>>(x, dminloc, mymin, iend);
+      RPlaunchCudaKernel( (first_min<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           x, dminloc, mymin, 
+                           iend );
       cudaErrchk( cudaGetLastError() );
 
       RAJAPERF_CUDA_REDUCER_COPY_BACK_NOFINAL(dminloc, mymin_block, grid_size);

--- a/src/lcals/FIRST_MIN-Hip.cpp
+++ b/src/lcals/FIRST_MIN-Hip.cpp
@@ -81,11 +81,12 @@ void FIRST_MIN::runHipVariantBlockHost(VariantID vid)
       RAJAPERF_HIP_REDUCER_INITIALIZE_VALUE(mymin, dminloc, mymin_block, grid_size);
 
       constexpr size_t shmem = sizeof(MyMinLoc)*block_size;
-      hipLaunchKernelGGL( (first_min<block_size>), grid_size, block_size,
-                           shmem, res.get_stream(), x,
-                           dminloc,
-                           mymin,
-                           iend );
+
+      RPlaunchHipKernel( (first_min<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         x, dminloc, mymin,
+                         iend );
       hipErrchk( hipGetLastError() );
 
       RAJAPERF_HIP_REDUCER_COPY_BACK_NOFINAL(dminloc, mymin_block, grid_size);
@@ -167,11 +168,11 @@ void FIRST_MIN::runHipVariantBlockHostOccGS(VariantID vid)
       FIRST_MIN_MINLOC_INIT;
       RAJAPERF_HIP_REDUCER_INITIALIZE_VALUE(mymin, dminloc, mymin_block, grid_size);
 
-      hipLaunchKernelGGL( (first_min<block_size>), grid_size, block_size,
-                           shmem, res.get_stream(), x,
-                           dminloc,
-                           mymin,
-                           iend );
+      RPlaunchHipKernel( (first_min<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         x, dminloc, mymin,
+                         iend );
       hipErrchk( hipGetLastError() );
 
       RAJAPERF_HIP_REDUCER_COPY_BACK_NOFINAL(dminloc, mymin_block, grid_size);

--- a/src/lcals/FIRST_SUM-Cuda.cpp
+++ b/src/lcals/FIRST_SUM-Cuda.cpp
@@ -49,11 +49,15 @@ void FIRST_SUM::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-       constexpr size_t shmem = 0;
-       first_sum<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( x, y,
-                                              iend );
-       cudaErrchk( cudaGetLastError() );
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchCudaKernel( (first_sum<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           x, y,
+                           iend );
+      cudaErrchk( cudaGetLastError() );
 
     }
     stopTimer();

--- a/src/lcals/FIRST_SUM-Hip.cpp
+++ b/src/lcals/FIRST_SUM-Hip.cpp
@@ -51,8 +51,12 @@ void FIRST_SUM::runHipVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       hipLaunchKernelGGL((first_sum<block_size>),grid_size, block_size, shmem, res.get_stream(), x, y,
-                                              iend );
+
+       RPlaunchCudaKernel( (first_sum<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           x, y,
+                           iend );
        hipErrchk( hipGetLastError() );
 
     }

--- a/src/lcals/FIRST_SUM-Hip.cpp
+++ b/src/lcals/FIRST_SUM-Hip.cpp
@@ -52,11 +52,11 @@ void FIRST_SUM::runHipVariantImpl(VariantID vid)
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
 
-       RPlaunchCudaKernel( (first_sum<block_size>),
-                           grid_size, block_size,
-                           shmem, res.get_stream(),
-                           x, y,
-                           iend );
+       RPlaunchHipKernel( (first_sum<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x, y,
+                          iend );
        hipErrchk( hipGetLastError() );
 
     }

--- a/src/lcals/GEN_LIN_RECUR-Cuda.cpp
+++ b/src/lcals/GEN_LIN_RECUR-Cuda.cpp
@@ -65,15 +65,25 @@ void GEN_LIN_RECUR::runCudaVariantImpl(VariantID vid)
        constexpr size_t shmem = 0;
 
        const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(N, block_size);
-       genlinrecur1<block_size><<<grid_size1, block_size, shmem, res.get_stream()>>>( b5, stb5, sa, sb,
-                                                 kb5i,
-                                                 N );
+
+       RPlaunchCudaKernel( (genlinrecur1<block_size>),
+                           grid_size1, block_size,
+                           shmem, res.get_stream(),
+                           b5, stb5,
+                           sa, sb,
+                           kb5i,
+                           N );
        cudaErrchk( cudaGetLastError() );
 
        const size_t grid_size2 = RAJA_DIVIDE_CEILING_INT(N+1, block_size);
-       genlinrecur2<block_size><<<grid_size2, block_size, shmem, res.get_stream()>>>( b5, stb5, sa, sb,
-                                                 kb5i,
-                                                 N );
+
+       RPlaunchCudaKernel( (genlinrecur2<block_size>),
+                           grid_size2, block_size,
+                           shmem, res.get_stream(),
+                           b5, stb5,
+                           sa, sb,
+                           kb5i,
+                           N );
        cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/lcals/GEN_LIN_RECUR-Hip.cpp
+++ b/src/lcals/GEN_LIN_RECUR-Hip.cpp
@@ -65,17 +65,25 @@ void GEN_LIN_RECUR::runHipVariantImpl(VariantID vid)
        constexpr size_t shmem = 0;
 
        const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(N, block_size);
-       hipLaunchKernelGGL((genlinrecur1<block_size>), grid_size1, block_size, shmem, res.get_stream(),
-                                                 b5, stb5, sa, sb,
-                                                 kb5i,
-                                                 N );
-       hipErrchk( hipGetLastError() );
+
+       RPlaunchHipKernel( (genlinrecur1<block_size>),
+                          grid_size1, block_size,
+                          shmem, res.get_stream(),
+                          b5, stb5,
+                          sa, sb,
+                          kb5i,
+                          N );
+       cudaErrchk( hipGetLastError() );
 
        const size_t grid_size2 = RAJA_DIVIDE_CEILING_INT(N+1, block_size);
-       hipLaunchKernelGGL((genlinrecur2<block_size>), grid_size2, block_size, shmem, res.get_stream(),
-                                                 b5, stb5, sa, sb,
-                                                 kb5i,
-                                                 N );
+
+       RPlaunchHipKernel( (genlinrecur2<block_size>),
+                          grid_size2, block_size,
+                          shmem, res.get_stream(),
+                          b5, stb5,
+                          sa, sb,
+                          kb5i,
+                          N );
        hipErrchk( hipGetLastError() );
 
     }

--- a/src/lcals/GEN_LIN_RECUR-Hip.cpp
+++ b/src/lcals/GEN_LIN_RECUR-Hip.cpp
@@ -73,7 +73,7 @@ void GEN_LIN_RECUR::runHipVariantImpl(VariantID vid)
                           sa, sb,
                           kb5i,
                           N );
-       cudaErrchk( hipGetLastError() );
+       hipErrchk( hipGetLastError() );
 
        const size_t grid_size2 = RAJA_DIVIDE_CEILING_INT(N+1, block_size);
 

--- a/src/lcals/HYDRO_1D-Cuda.cpp
+++ b/src/lcals/HYDRO_1D-Cuda.cpp
@@ -52,9 +52,13 @@ void HYDRO_1D::runCudaVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       hydro_1d<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( x, y, z,
-                                            q, r, t,
-                                            iend );
+
+       RPlaunchCudaKernel( (hydro_1d<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           x, y, z,
+                           q, r, t,
+                           iend );
        cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/lcals/HYDRO_1D-Hip.cpp
+++ b/src/lcals/HYDRO_1D-Hip.cpp
@@ -52,9 +52,13 @@ void HYDRO_1D::runHipVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       hipLaunchKernelGGL((hydro_1d<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  x, y, z,
-                                            q, r, t,
-                                            iend );
+
+       RPlaunchHipKernel( (hydro_1d<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x, y, z,
+                          q, r, t,
+                          iend );
        hipErrchk( hipGetLastError() );
 
     }

--- a/src/lcals/HYDRO_2D-Cuda.cpp
+++ b/src/lcals/HYDRO_2D-Cuda.cpp
@@ -111,24 +111,33 @@ void HYDRO_2D::runCudaVariantImpl(VariantID vid)
       HYDRO_2D_THREADS_PER_BLOCK_CUDA;
       HYDRO_2D_NBLOCKS_CUDA;
 
-      hydro_2d1<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-               <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(zadat, zbdat,
-                                                 zpdat, zqdat, zrdat, zmdat,
-                                                 jn, kn);
+      RPlaunchCudaKernel( (hydro_2d1<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+                          nblocks, nthreads_per_block,
+                          shmem, res.get_stream(),
+                          zadat, zbdat,
+                          zpdat, zqdat,
+                          zrdat, zmdat,
+                          jn, kn);
       cudaErrchk( cudaGetLastError() );
 
-      hydro_2d2<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-               <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(zudat, zvdat,
-                                                 zadat, zbdat, zzdat, zrdat,
-                                                 s,
-                                                 jn, kn);
+      RPlaunchCudaKernel( (hydro_2d2<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+                          nblocks, nthreads_per_block,
+                          shmem, res.get_stream(),
+                          zudat, zvdat,
+                          zadat, zbdat,
+                          zzdat, zrdat,
+                          s,
+                          jn, kn);
       cudaErrchk( cudaGetLastError() );
 
-      hydro_2d3<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-               <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(zroutdat, zzoutdat,
-                                                 zrdat, zudat, zzdat, zvdat,
-                                                 t,
-                                                 jn, kn);
+      RPlaunchCudaKernel( (hydro_2d3<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+                          nblocks, nthreads_per_block,
+                          shmem, res.get_stream(),
+                          zroutdat, zzoutdat,
+                          zrdat, zudat,
+                          zzdat, zvdat,
+                          t,
+                          jn, kn);
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/lcals/HYDRO_2D-Hip.cpp
+++ b/src/lcals/HYDRO_2D-Hip.cpp
@@ -111,25 +111,31 @@ void HYDRO_2D::runHipVariantImpl(VariantID vid)
       HYDRO_2D_THREADS_PER_BLOCK_HIP;
       HYDRO_2D_NBLOCKS_HIP;
 
-      hipLaunchKernelGGL((hydro_2d1<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                         dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
+      RPlaunchHipKernel( (hydro_2d1<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+                         nblocks, nthreads_per_block,
+                         shmem, res.get_stream(),
                          zadat, zbdat,
-                         zpdat, zqdat, zrdat, zmdat,
+                         zpdat, zqdat,
+                         zrdat, zmdat,
                          jn, kn);
        hipErrchk( hipGetLastError() );
 
-       hipLaunchKernelGGL((hydro_2d2<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                          dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
+       RPlaunchHipKernel( (hydro_2d2<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+                          nblocks, nthreads_per_block,
+                          shmem, res.get_stream(),
                           zudat, zvdat,
-                          zadat, zbdat, zzdat, zrdat,
+                          zadat, zbdat,
+                          zzdat, zrdat,
                           s,
                           jn, kn);
        hipErrchk( hipGetLastError() );
 
-       hipLaunchKernelGGL((hydro_2d3<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                          dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
+       RPlaunchHipKernel( (hydro_2d3<HYDRO_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+                          nblocks, nthreads_per_block,
+                          shmem, res.get_stream(),
                           zroutdat, zzoutdat,
-                          zrdat, zudat, zzdat, zvdat,
+                          zrdat, zudat,
+                          zzdat, zvdat,
                           t,
                           jn, kn);
        hipErrchk( hipGetLastError() );

--- a/src/lcals/INT_PREDICT-Cuda.cpp
+++ b/src/lcals/INT_PREDICT-Cuda.cpp
@@ -55,11 +55,16 @@ void INT_PREDICT::runCudaVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       int_predict<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( px,
-                                               dm22, dm23, dm24, dm25,
-                                               dm26, dm27, dm28, c0,
-                                               offset,
-                                               iend );
+      
+       RPlaunchCudaKernel( (int_predict<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           px,
+                           dm22, dm23, dm24,
+                           dm25, dm26, dm27,
+                           dm28, c0,
+                           offset,
+                           iend );
        cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/lcals/INT_PREDICT-Hip.cpp
+++ b/src/lcals/INT_PREDICT-Hip.cpp
@@ -55,11 +55,16 @@ void INT_PREDICT::runHipVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       hipLaunchKernelGGL((int_predict<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  px,
-                                               dm22, dm23, dm24, dm25,
-                                               dm26, dm27, dm28, c0,
-                                               offset,
-                                               iend );
+
+       RPlaunchHipKernel( (int_predict<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          px,
+                          dm22, dm23, dm24,
+                          dm25, dm26, dm27,
+                          dm28, c0,
+                          offset,
+                          iend );
        hipErrchk( hipGetLastError() );
 
     }

--- a/src/lcals/PLANCKIAN-Cuda.cpp
+++ b/src/lcals/PLANCKIAN-Cuda.cpp
@@ -53,9 +53,13 @@ void PLANCKIAN::runCudaVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       planckian<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( x, y,
-                                             u, v, w,
-                                             iend );
+
+       RPlaunchCudaKernel( (planckian<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           x, y,
+                           u, v, w,
+                           iend );
        cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/lcals/PLANCKIAN-Hip.cpp
+++ b/src/lcals/PLANCKIAN-Hip.cpp
@@ -53,9 +53,13 @@ void PLANCKIAN::runHipVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       hipLaunchKernelGGL((planckian<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  x, y,
-                                             u, v, w,
-                                             iend );
+
+       RPlaunchHipKernel( (planckian<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x, y,
+                          u, v, w,
+                          iend );
        hipErrchk( hipGetLastError() );
 
     }

--- a/src/lcals/TRIDIAG_ELIM-Hip.cpp
+++ b/src/lcals/TRIDIAG_ELIM-Hip.cpp
@@ -23,8 +23,9 @@ namespace lcals
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void eos(Real_ptr xout, Real_ptr xin, Real_ptr y, Real_ptr z,
-                    Index_type N)
+__global__ void tridiag_elim(Real_ptr xout, Real_ptr xin,
+                             Real_ptr y, Real_ptr z,
+                             Index_type N)
 {
    Index_type i = blockIdx.x * block_size + threadIdx.x;
    if (i > 0 && i < N) {
@@ -51,8 +52,13 @@ void TRIDIAG_ELIM::runHipVariantImpl(VariantID vid)
 
        const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
        constexpr size_t shmem = 0;
-       hipLaunchKernelGGL((eos<block_size>), grid_size, block_size, shmem, res.get_stream(), xout, xin, y, z,
-                                       iend );
+
+       RPlaunchHipKernel( (tridiag_elim<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          xout, xin,
+                          y, z,
+                          iend );
        hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_2MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_2MM-Cuda.cpp
@@ -125,15 +125,25 @@ void POLYBENCH_2MM::runCudaVariantImpl(VariantID vid)
       constexpr size_t shmem = 0;
 
       POLY_2MM_1_NBLOCKS_CUDA;
-      poly_2mm_1<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                <<<nblocks1, nthreads_per_block, shmem, res.get_stream()>>>(tmp, A, B, alpha,
-                                                   ni, nj, nk);
+      
+      RPlaunchCudaKernel(
+        (poly_2mm_1<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+        nblocks1, nthreads_per_block,
+        shmem, res.get_stream(),
+        tmp, A, B,
+        alpha,
+        ni, nj, nk );
       cudaErrchk( cudaGetLastError() );
 
       POLY_2MM_2_NBLOCKS_CUDA;
-      poly_2mm_2<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                <<<nblocks2, nthreads_per_block, shmem, res.get_stream()>>>(tmp, C, D, beta,
-                                                   ni, nl, nj);
+
+      RPlaunchCudaKernel(
+        (poly_2mm_2<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+        nblocks2, nthreads_per_block,
+        shmem, res.get_stream(),
+        tmp, C, D,
+        beta,
+        ni, nl, nj );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -148,29 +158,39 @@ void POLYBENCH_2MM::runCudaVariantImpl(VariantID vid)
       constexpr size_t shmem = 0;
 
       POLY_2MM_1_NBLOCKS_CUDA;
-      poly_2mm_1_lam<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                    <<<nblocks1, nthreads_per_block, shmem, res.get_stream()>>>(ni, nj,
-        [=] __device__ (Index_type i, Index_type j) {
-          POLYBENCH_2MM_BODY1;
-          for (Index_type k=0; k < nk; ++k) {
-            POLYBENCH_2MM_BODY2;
-          }
-          POLYBENCH_2MM_BODY3;
+
+      auto poly_2mm_1_lambda = [=] __device__ (Index_type i, Index_type j) {
+        POLYBENCH_2MM_BODY1;
+        for (Index_type k=0; k < nk; ++k) {
+          POLYBENCH_2MM_BODY2;
         }
-      );
+        POLYBENCH_2MM_BODY3;
+      };
+
+      RPlaunchCudaKernel(
+        (poly_2mm_1_lam<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                        decltype(poly_2mm_1_lambda)>),
+        nblocks1, nthreads_per_block,
+        shmem, res.get_stream(),
+        ni, nj, poly_2mm_1_lambda );
       cudaErrchk( cudaGetLastError() );
 
       POLY_2MM_2_NBLOCKS_CUDA;
-      poly_2mm_2_lam<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                    <<<nblocks2, nthreads_per_block, shmem, res.get_stream()>>>(ni, nl,
-        [=] __device__ (Index_type i, Index_type l) {
-          POLYBENCH_2MM_BODY4;
-          for (Index_type j=0; j < nj; ++j) {
-            POLYBENCH_2MM_BODY5;
-          }
-          POLYBENCH_2MM_BODY6;
+
+      auto poly_2mm_2_lambda = [=] __device__ (Index_type i, Index_type l) {
+        POLYBENCH_2MM_BODY4;
+        for (Index_type j=0; j < nj; ++j) {
+          POLYBENCH_2MM_BODY5;
         }
-      );
+        POLYBENCH_2MM_BODY6;
+      };
+     
+      RPlaunchCudaKernel( 
+        (poly_2mm_2_lam<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                        decltype(poly_2mm_2_lambda)>),
+        nblocks2, nthreads_per_block,
+        shmem, res.get_stream(),
+        ni, nl, poly_2mm_2_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_2MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_2MM-Hip.cpp
@@ -125,17 +125,25 @@ void POLYBENCH_2MM::runHipVariantImpl(VariantID vid)
       constexpr size_t shmem = 0;
 
       POLY_2MM_1_NBLOCKS_HIP;
-      hipLaunchKernelGGL((poly_2mm_1<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                         dim3(nblocks1), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         tmp, A, B, alpha,
-                         ni, nj, nk);
+
+      RPlaunchHipKernel(
+        (poly_2mm_1<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+        nblocks1, nthreads_per_block,
+        shmem, res.get_stream(),
+        tmp, A, B,
+        alpha,
+        ni, nj, nk );
       hipErrchk( hipGetLastError() );
 
       POLY_2MM_2_NBLOCKS_HIP;
-      hipLaunchKernelGGL((poly_2mm_2<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                         dim3(nblocks2), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         tmp, C, D, beta,
-                         ni, nl, nj);
+
+      RPlaunchHipKernel(
+        (poly_2mm_2<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+        nblocks2, nthreads_per_block,
+        shmem, res.get_stream(),
+        tmp, C, D,
+        beta,
+        ni, nl, nj );
       hipErrchk( hipGetLastError() );
 
     }
@@ -149,6 +157,8 @@ void POLYBENCH_2MM::runHipVariantImpl(VariantID vid)
       POLY_2MM_THREADS_PER_BLOCK_HIP;
       constexpr size_t shmem = 0;
 
+      POLY_2MM_1_NBLOCKS_HIP;
+
       auto poly_2mm_1_lambda = [=] __device__ (Index_type i, Index_type j) {
         POLYBENCH_2MM_BODY1;
         for (Index_type k=0; k < nk; ++k) {
@@ -157,11 +167,15 @@ void POLYBENCH_2MM::runHipVariantImpl(VariantID vid)
         POLYBENCH_2MM_BODY3;
       };
 
-      POLY_2MM_1_NBLOCKS_HIP;
-      hipLaunchKernelGGL((poly_2mm_1_lam<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_2mm_1_lambda)>),
-                         dim3(nblocks1), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         ni, nj, poly_2mm_1_lambda);
+      RPlaunchHipKernel(
+        (poly_2mm_1_lam<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP
+                        decltype(poly_2mm_1_lambda)>),
+        nblocks1, nthreads_per_block,
+        shmem, res.get_stream(),
+        ni, nj, poly_2mm_1_lambda );
       hipErrchk( hipGetLastError() );
+
+      POLY_2MM_2_NBLOCKS_HIP;
 
       auto poly_2mm_2_lambda = [=] __device__ (Index_type i, Index_type l) {
         POLYBENCH_2MM_BODY4;
@@ -171,10 +185,12 @@ void POLYBENCH_2MM::runHipVariantImpl(VariantID vid)
         POLYBENCH_2MM_BODY6;
       };
 
-      POLY_2MM_2_NBLOCKS_HIP;
-      hipLaunchKernelGGL((poly_2mm_2_lam<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_2mm_2_lambda)>),
-                         dim3(nblocks2), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         ni, nl, poly_2mm_2_lambda);
+      RPlaunchHipKernel(
+        (poly_2mm_2_lam<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                        decltype(poly_2mm_2_lambda)>),
+        nblocks2, nthreads_per_block,
+        shmem, res.get_stream(),
+        ni, nl, poly_2mm_2_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_2MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_2MM-Hip.cpp
@@ -168,7 +168,7 @@ void POLYBENCH_2MM::runHipVariantImpl(VariantID vid)
       };
 
       RPlaunchHipKernel(
-        (poly_2mm_1_lam<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP
+        (poly_2mm_1_lam<POLY_2MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
                         decltype(poly_2mm_1_lambda)>),
         nblocks1, nthreads_per_block,
         shmem, res.get_stream(),

--- a/src/polybench/POLYBENCH_3MM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_3MM-Cuda.cpp
@@ -159,21 +159,33 @@ void POLYBENCH_3MM::runCudaVariantImpl(VariantID vid)
       constexpr size_t shmem = 0;
 
       POLY_3MM_1_NBLOCKS_CUDA;
-      poly_3mm_1<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                <<<nblocks1, nthreads_per_block, shmem, res.get_stream()>>>(E, A, B,
-                                                   ni, nj, nk);
+
+      RPlaunchCudaKernel(
+        (poly_3mm_1<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+        nblocks1, nthreads_per_block,
+        shmem, res.get_stream(),
+        E, A, B,
+        ni, nj, nk );
       cudaErrchk( cudaGetLastError() );
 
       POLY_3MM_2_NBLOCKS_CUDA;
-      poly_3mm_2<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                <<<nblocks2, nthreads_per_block, shmem, res.get_stream()>>>(F, C, D,
-                                                   nj, nl, nm);
+
+      RPlaunchCudaKernel(
+        (poly_3mm_2<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+        nblocks2, nthreads_per_block,
+        shmem, res.get_stream(),
+        F, C, D,
+        nj, nl, nm );
       cudaErrchk( cudaGetLastError() );
 
       POLY_3MM_3_NBLOCKS_CUDA;
-      poly_3mm_3<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                <<<nblocks3, nthreads_per_block, shmem, res.get_stream()>>>(G, E, F,
-                                                   ni, nl, nj);
+
+      RPlaunchCudaKernel(
+        (poly_3mm_3<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+        nblocks3, nthreads_per_block,
+        shmem, res.get_stream(),
+        G, E, F,
+        ni, nl, nj );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -188,42 +200,57 @@ void POLYBENCH_3MM::runCudaVariantImpl(VariantID vid)
       constexpr size_t shmem = 0;
 
       POLY_3MM_1_NBLOCKS_CUDA;
-      poly_3mm_1_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                    <<<nblocks1, nthreads_per_block, shmem, res.get_stream()>>>(ni, nj,
-        [=] __device__ (Index_type i, Index_type j) {
-          POLYBENCH_3MM_BODY1;
-          for (Index_type k=0; k < nk; ++k) {
-            POLYBENCH_3MM_BODY2;
-          }
-          POLYBENCH_3MM_BODY3;
+
+      auto poly_3mm_1_lambda = [=] __device__ (Index_type i, Index_type j) {
+        POLYBENCH_3MM_BODY1;
+        for (Index_type k=0; k < nk; ++k) {
+          POLYBENCH_3MM_BODY2;
         }
-      );
+        POLYBENCH_3MM_BODY3;
+      };
+
+      RPlaunchCudaKernel(
+        (poly_3mm_1_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                        decltype(poly_3mm_1_lambda)>),
+        nblocks1, nthreads_per_block,
+        shmem, res.get_stream(),
+        ni, nj, poly_3mm_1_lambda );
       cudaErrchk( cudaGetLastError() );
 
       POLY_3MM_2_NBLOCKS_CUDA;
-      poly_3mm_2_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                    <<<nblocks2, nthreads_per_block, shmem, res.get_stream()>>>(nj, nl,
-        [=] __device__ (Index_type j, Index_type l) {
-          POLYBENCH_3MM_BODY4;
-          for (Index_type m=0; m < nm; ++m) {
-            POLYBENCH_3MM_BODY5;
-          }
-          POLYBENCH_3MM_BODY6;
-        }
-      );
+
+      auto poly_3mm_2_lambda = [=] __device__ (Index_type j, Index_type l) {
+        POLYBENCH_3MM_BODY4;
+        for (Index_type m=0; m < nm; ++m) { 
+          POLYBENCH_3MM_BODY5;
+        } 
+        POLYBENCH_3MM_BODY6;
+      };
+
+      RPlaunchCudaKernel(
+        (poly_3mm_2_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                        decltype(poly_3mm_2_lambda)>),
+        nblocks2, nthreads_per_block,
+        shmem, res.get_stream(),
+        nj, nl, poly_3mm_2_lambda );
       cudaErrchk( cudaGetLastError() );
 
       POLY_3MM_3_NBLOCKS_CUDA;
-      poly_3mm_3_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                    <<<nblocks3, nthreads_per_block, shmem, res.get_stream()>>>(ni, nl,
-        [=] __device__ (Index_type i, Index_type l) {
-          POLYBENCH_3MM_BODY7;
-          for (Index_type j=0; j < nj; ++j) {
-            POLYBENCH_3MM_BODY8;
-          }
-          POLYBENCH_3MM_BODY9;
+
+      auto poly_3mm_3_lambda = [=] __device__ (Index_type i, Index_type l) {
+        POLYBENCH_3MM_BODY7;
+        for (Index_type j=0; j < nj; ++j) {
+          POLYBENCH_3MM_BODY8;
         }
-      );
+        POLYBENCH_3MM_BODY9;
+      };
+
+      RPlaunchCudaKernel(
+        (poly_3mm_3_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                        decltype(poly_3mm_3_lambda)>),
+        nblocks3, nthreads_per_block,
+        shmem, res.get_stream(),
+        ni, nl, poly_3mm_3_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_3MM-Hip.cpp
+++ b/src/polybench/POLYBENCH_3MM-Hip.cpp
@@ -158,24 +158,33 @@ void POLYBENCH_3MM::runHipVariantImpl(VariantID vid)
       constexpr size_t shmem = 0;
 
       POLY_3MM_1_NBLOCKS_HIP;
-      hipLaunchKernelGGL((poly_3mm_1<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                         dim3(nblocks1) , dim3(nthreads_per_block), shmem, res.get_stream(),
-                         E, A, B,
-                         ni, nj, nk);
+
+      RPlaunchHipKernel(
+        (poly_3mm_1<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+        nblocks1, nthreads_per_block,
+        shmem, res.get_stream(),
+        E, A, B,
+        ni, nj, nk );
       hipErrchk( hipGetLastError() );
 
       POLY_3MM_2_NBLOCKS_HIP;
-      hipLaunchKernelGGL((poly_3mm_2<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                         dim3(nblocks2), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         F, C, D,
-                         nj, nl, nm);
+
+      RPlaunchHipKernel(
+        (poly_3mm_2<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+        nblocks2, nthreads_per_block,
+        shmem, res.get_stream(),
+        F, C, D,
+        nj, nl, nm );
       hipErrchk( hipGetLastError() );
 
       POLY_3MM_3_NBLOCKS_HIP;
-      hipLaunchKernelGGL((poly_3mm_3<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                         dim3(nblocks3), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         G, E, F,
-                         ni, nl, nj);
+
+      RPlaunchHipKernel(
+        (poly_3mm_3<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+        nblocks3, nthreads_per_block,
+        shmem, res.get_stream(),
+        G, E, F,
+        ni, nl, nj );
       hipErrchk( hipGetLastError() );
 
     }
@@ -189,6 +198,8 @@ void POLYBENCH_3MM::runHipVariantImpl(VariantID vid)
       POLY_3MM_THREADS_PER_BLOCK_HIP;
       constexpr size_t shmem = 0;
 
+      POLY_3MM_1_NBLOCKS_HIP;
+
       auto poly_3mm_1_lambda = [=] __device__ (Index_type i, Index_type j) {
         POLYBENCH_3MM_BODY1;
         for (Index_type k=0; k < nk; ++k) {
@@ -197,11 +208,15 @@ void POLYBENCH_3MM::runHipVariantImpl(VariantID vid)
         POLYBENCH_3MM_BODY3;
       };
 
-      POLY_3MM_1_NBLOCKS_HIP;
-      hipLaunchKernelGGL((poly_3mm_1_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_3mm_1_lambda)>),
-                         dim3(nblocks1), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         ni, nj, poly_3mm_1_lambda);
+      RPlaunchHipKernel(
+        (poly_3mm_1_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                        decltype(poly_3mm_1_lambda)>),
+        nblocks1, nthreads_per_block,
+        shmem, res.get_stream(),
+        ni, nj, poly_3mm_1_lambda );
       hipErrchk( hipGetLastError() );
+
+      POLY_3MM_2_NBLOCKS_HIP;
 
       auto poly_3mm_2_lambda = [=] __device__ (Index_type j, Index_type l) {
         POLYBENCH_3MM_BODY4;
@@ -211,11 +226,15 @@ void POLYBENCH_3MM::runHipVariantImpl(VariantID vid)
         POLYBENCH_3MM_BODY6;
       };
 
-      POLY_3MM_2_NBLOCKS_HIP;
-      hipLaunchKernelGGL((poly_3mm_2_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_3mm_2_lambda)>),
-                         dim3(nblocks2), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         nj, nl, poly_3mm_2_lambda);
+      RPlaunchHipKernel(
+        (poly_3mm_2_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                        decltype(poly_3mm_2_lambda)>),
+        nblocks2, nthreads_per_block,
+        shmem, res.get_stream(),
+        nj, nl, poly_3mm_2_lambda );
       hipErrchk( hipGetLastError() );
+
+      POLY_3MM_3_NBLOCKS_HIP;
 
       auto poly_3mm_3_lambda = [=] __device__ (Index_type i, Index_type l) {
         POLYBENCH_3MM_BODY7;
@@ -225,10 +244,12 @@ void POLYBENCH_3MM::runHipVariantImpl(VariantID vid)
         POLYBENCH_3MM_BODY9;
       };
 
-      POLY_3MM_3_NBLOCKS_HIP;
-      hipLaunchKernelGGL((poly_3mm_3_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_3mm_3_lambda)>),
-                         dim3(nblocks3), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         ni, nl, poly_3mm_3_lambda);
+      RPlaunchHipKernel(
+        (poly_3mm_3_lam<POLY_3MM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                        decltype(poly_3mm_3_lambda)>),
+        nblocks3, nthreads_per_block,
+        shmem, res.get_stream(),
+        ni, nl, poly_3mm_3_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_ADI-Cuda.cpp
+++ b/src/polybench/POLYBENCH_ADI-Cuda.cpp
@@ -23,7 +23,7 @@ namespace polybench
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void adi1(const Index_type n,
+__global__ void poly_adi1(const Index_type n,
                      const Real_type a, const Real_type b, const Real_type c,
                      const Real_type d, const Real_type f,
                      Real_ptr P, Real_ptr Q, Real_ptr U, Real_ptr V)
@@ -43,7 +43,7 @@ __global__ void adi1(const Index_type n,
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void adi2(const Index_type n,
+__global__ void poly_adi2(const Index_type n,
                      const Real_type a, const Real_type c, const Real_type d,
                      const Real_type e, const Real_type f,
                      Real_ptr P, Real_ptr Q, Real_ptr U, Real_ptr V)
@@ -63,7 +63,7 @@ __global__ void adi2(const Index_type n,
 
 template < size_t block_size, typename Lambda >
 __launch_bounds__(block_size)
-__global__ void adi_lam(const Index_type n,
+__global__ void poly_adi_lam(const Index_type n,
                         Lambda body)
 {
   Index_type i = 1 + blockIdx.x * block_size + threadIdx.x;
@@ -92,14 +92,22 @@ void POLYBENCH_ADI::runCudaVariantImpl(VariantID vid)
         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(n-2, block_size);
         constexpr size_t shmem = 0;
 
-        adi1<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(n,
-                                        a, b, c, d, f,
-                                        P, Q, U, V);
+        RPlaunchCudaKernel( (poly_adi1<block_size>),
+                            grid_size, block_size,
+                            shmem, res.get_stream(),
+                            n,
+                            a, b, c,
+                            d, f,
+                            P, Q, U, V ); 
         cudaErrchk( cudaGetLastError() );
 
-        adi2<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(n,
-                                        a, c, d, e, f,
-                                        P, Q, U, V);
+        RPlaunchCudaKernel( (poly_adi2<block_size>),
+                            grid_size, block_size,
+                            shmem, res.get_stream(),
+                            n,
+                            a, c, d,
+                            e, f,
+                            P, Q, U, V ); 
         cudaErrchk( cudaGetLastError() );
 
       }  // tstep loop
@@ -117,32 +125,40 @@ void POLYBENCH_ADI::runCudaVariantImpl(VariantID vid)
         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(n-2, block_size);
         constexpr size_t shmem = 0;
 
-        adi_lam<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(n,
-          [=] __device__ (Index_type i) {
-            POLYBENCH_ADI_BODY2;
-            for (Index_type j = 1; j < n-1; ++j) {
-              POLYBENCH_ADI_BODY3;
-            }
-            POLYBENCH_ADI_BODY4;
-            for (Index_type k = n-2; k >= 1; --k) {
-              POLYBENCH_ADI_BODY5;
-            }
+        auto poly_adi1_lambda = [=] __device__ (Index_type i) {
+          POLYBENCH_ADI_BODY2;
+          for (Index_type j = 1; j < n-1; ++j) {
+            POLYBENCH_ADI_BODY3;
           }
-        );
+          POLYBENCH_ADI_BODY4;
+          for (Index_type k = n-2; k >= 1; --k) {
+            POLYBENCH_ADI_BODY5;
+          }
+        };
+
+        RPlaunchCudaKernel( (poly_adi_lam<block_size,
+                                          decltype(poly_adi1_lambda)>),
+                            grid_size, block_size,
+                            shmem, res.get_stream(),
+                            n, poly_adi1_lambda );
         cudaErrchk( cudaGetLastError() );
 
-        adi_lam<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(n,
-          [=] __device__ (Index_type i) {
-            POLYBENCH_ADI_BODY6;
-            for (Index_type j = 1; j < n-1; ++j) {
-              POLYBENCH_ADI_BODY7;
-            }
-            POLYBENCH_ADI_BODY8;
-            for (Index_type k = n-2; k >= 1; --k) {
-              POLYBENCH_ADI_BODY9;
-            }
+        auto poly_adi2_lambda = [=] __device__ (Index_type i) {
+          POLYBENCH_ADI_BODY6;
+          for (Index_type j = 1; j < n-1; ++j) {
+            POLYBENCH_ADI_BODY7;
           }
-        );
+          POLYBENCH_ADI_BODY8;
+          for (Index_type k = n-2; k >= 1; --k) {
+            POLYBENCH_ADI_BODY9;
+          }
+        };
+
+        RPlaunchCudaKernel( (poly_adi_lam<block_size,
+                                          decltype(poly_adi2_lambda)>),
+                            grid_size, block_size, 
+                            shmem, res.get_stream(),
+                            n, poly_adi2_lambda );
         cudaErrchk( cudaGetLastError() );
 
       }  // tstep loop

--- a/src/polybench/POLYBENCH_ADI-Hip.cpp
+++ b/src/polybench/POLYBENCH_ADI-Hip.cpp
@@ -23,7 +23,7 @@ namespace polybench
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void adi1(const Index_type n,
+__global__ void poly_adi1(const Index_type n,
                      const Real_type a, const Real_type b, const Real_type c,
                      const Real_type d, const Real_type f,
                      Real_ptr P, Real_ptr Q, Real_ptr U, Real_ptr V)
@@ -43,7 +43,7 @@ __global__ void adi1(const Index_type n,
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void adi2(const Index_type n,
+__global__ void poly_adi2(const Index_type n,
                      const Real_type a, const Real_type c, const Real_type d,
                      const Real_type e, const Real_type f,
                      Real_ptr P, Real_ptr Q, Real_ptr U, Real_ptr V)
@@ -63,7 +63,7 @@ __global__ void adi2(const Index_type n,
 
 template < size_t block_size, typename Lambda >
 __launch_bounds__(block_size)
-__global__ void adi_lam(const Index_type n,
+__global__ void poly_adi_lam(const Index_type n,
                         Lambda body)
 {
   Index_type i = 1 + blockIdx.x * block_size + threadIdx.x;
@@ -92,18 +92,22 @@ void POLYBENCH_ADI::runHipVariantImpl(VariantID vid)
         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(n-2, block_size);
         constexpr size_t shmem = 0;
 
-        hipLaunchKernelGGL((adi1<block_size>),
-                           dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
+        RPlaunchHipKernel( (poly_adi1<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
                            n,
-                           a, b, c, d, f,
-                           P, Q, U, V);
+                           a, b, c,
+                           d, f,
+                           P, Q, U, V );
         hipErrchk( hipGetLastError() );
 
-        hipLaunchKernelGGL((adi2<block_size>),
-                           dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
+        RPlaunchHipKernel( (poly_adi2<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
                            n,
-                           a, c, d, e, f,
-                           P, Q, U, V);
+                           a, c, d,
+                           e, f,
+                           P, Q, U, V );
         hipErrchk( hipGetLastError() );
 
       }  // tstep loop
@@ -121,7 +125,7 @@ void POLYBENCH_ADI::runHipVariantImpl(VariantID vid)
         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(n-2, block_size);
         constexpr size_t shmem = 0;
 
-        auto adi1_lamda = [=] __device__ (Index_type i) {
+        auto poly_adi1_lambda = [=] __device__ (Index_type i) {
           POLYBENCH_ADI_BODY2;
           for (Index_type j = 1; j < n-1; ++j) {
              POLYBENCH_ADI_BODY3;
@@ -132,12 +136,14 @@ void POLYBENCH_ADI::runHipVariantImpl(VariantID vid)
           }
         };
 
-        hipLaunchKernelGGL((adi_lam<block_size, decltype(adi1_lamda)>),
-                           dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                           n, adi1_lamda);
+        RPlaunchHipKernel( (poly_adi_lam<block_size,
+                                         decltype(poly_adi1_lambda)>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           n, poly_adi1_lambda );
         hipErrchk( hipGetLastError() );
 
-        auto adi2_lamda = [=] __device__ (Index_type i) {
+        auto poly_adi2_lambda = [=] __device__ (Index_type i) {
           POLYBENCH_ADI_BODY6;
           for (Index_type j = 1; j < n-1; ++j) {
             POLYBENCH_ADI_BODY7;
@@ -148,9 +154,11 @@ void POLYBENCH_ADI::runHipVariantImpl(VariantID vid)
           }
         };
 
-        hipLaunchKernelGGL((adi_lam<block_size, decltype(adi2_lamda)>),
-                           dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                           n, adi2_lamda);
+        RPlaunchHipKernel( (poly_adi_lam<block_size,
+                                         decltype(poly_adi2_lambda)>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           n, poly_adi2_lambda );
         hipErrchk( hipGetLastError() );
 
       }  // tstep loop

--- a/src/polybench/POLYBENCH_ATAX-Hip.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Hip.cpp
@@ -83,14 +83,18 @@ void POLYBENCH_ATAX::runHipVariantImpl(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
       constexpr size_t shmem = 0;
 
-      hipLaunchKernelGGL((poly_atax_1<block_size>),
-                         dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                         A, x, y, tmp, N);
+     RPlaunchHipKernel( (poly_atax_1<block_size>),
+                        grid_size, block_size,
+                        shmem, res.get_stream(),
+                        A, x, y, tmp,
+                        N );
       hipErrchk( hipGetLastError() );
 
-      hipLaunchKernelGGL((poly_atax_2<block_size>),
-                         dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                         A, tmp, y, N);
+      RPlaunchHipKernel( (poly_atax_2<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         A, tmp, y,
+                         N );
       hipErrchk( hipGetLastError() );
 
     }
@@ -104,7 +108,7 @@ void POLYBENCH_ATAX::runHipVariantImpl(VariantID vid)
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
       constexpr size_t shmem = 0;
 
-      auto poly_atax_1_lambda = [=] __device__ (Index_type i) {
+      auto poly_atax1_lambda = [=] __device__ (Index_type i) {
         POLYBENCH_ATAX_BODY1;
         for (Index_type j = 0; j < N; ++j ) {
           POLYBENCH_ATAX_BODY2;
@@ -112,12 +116,14 @@ void POLYBENCH_ATAX::runHipVariantImpl(VariantID vid)
         POLYBENCH_ATAX_BODY3;
       };
 
-      hipLaunchKernelGGL((poly_atax_lam<block_size, decltype(poly_atax_1_lambda)>),
-        dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-        N, poly_atax_1_lambda);
+      RPlaunchHipKernel( (poly_atax_lam<block_size,
+                                        decltype(poly_atax1_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         N, poly_atax1_lambda );
       hipErrchk( hipGetLastError() );
 
-      auto poly_atax_2_lambda = [=] __device__ (Index_type j) {
+      auto poly_atax2_lambda = [=] __device__ (Index_type j) {
         POLYBENCH_ATAX_BODY4;
         for (Index_type i = 0; i < N; ++i ) {
           POLYBENCH_ATAX_BODY5;
@@ -125,9 +131,11 @@ void POLYBENCH_ATAX::runHipVariantImpl(VariantID vid)
         POLYBENCH_ATAX_BODY6;
       };
 
-      hipLaunchKernelGGL((poly_atax_lam<block_size, decltype(poly_atax_2_lambda)>),
-        dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-        N, poly_atax_2_lambda);
+      RPlaunchHipKernel( (poly_atax_lam<block_size,
+                                        decltype(poly_atax2_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         N, poly_atax2_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Cuda.cpp
@@ -160,22 +160,35 @@ void POLYBENCH_FDTD_2D::runCudaVariantImpl(VariantID vid)
         constexpr size_t shmem = 0;
 
         const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
-        poly_fdtd2d_1<block_size><<<grid_size1, block_size, shmem, res.get_stream()>>>(ey, fict, ny, t);
+
+        RPlaunchCudaKernel( (poly_fdtd2d_1<block_size>),
+                            grid_size1, block_size,
+                            shmem, res.get_stream(),
+                            ey, fict, ny, t );
         cudaErrchk( cudaGetLastError() );
 
         FDTD_2D_THREADS_PER_BLOCK_CUDA;
         FDTD_2D_NBLOCKS_CUDA;
 
-        poly_fdtd2d_2<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                     <<<nblocks234, nthreads_per_block234, shmem, res.get_stream()>>>(ey, hz, nx, ny);
+        RPlaunchCudaKernel(
+          (poly_fdtd2d_2<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          ey, hz, nx, ny );
         cudaErrchk( cudaGetLastError() );
 
-        poly_fdtd2d_3<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                     <<<nblocks234, nthreads_per_block234, shmem, res.get_stream()>>>(ex, hz, nx, ny);
+        RPlaunchCudaKernel( 
+          (poly_fdtd2d_3<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          ex, hz, nx, ny );
         cudaErrchk( cudaGetLastError() );
 
-        poly_fdtd2d_4<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                     <<<nblocks234, nthreads_per_block234, shmem, res.get_stream()>>>(hz, ex, ey, nx, ny);
+        RPlaunchCudaKernel(
+          (poly_fdtd2d_4<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          hz, ex, ey, nx, ny );
         cudaErrchk( cudaGetLastError() );
 
       } // tstep loop
@@ -193,37 +206,58 @@ void POLYBENCH_FDTD_2D::runCudaVariantImpl(VariantID vid)
         constexpr size_t shmem = 0;
 
         const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
-        poly_fdtd2d_1_lam<block_size><<<grid_size1, block_size, shmem, res.get_stream()>>>(ny,
-          [=] __device__ (Index_type j) {
-            POLYBENCH_FDTD_2D_BODY1;
-          }
-        );
+
+        auto poly_fdtd2d_1_lambda = [=] __device__ (Index_type j) {
+          POLYBENCH_FDTD_2D_BODY1;
+        };
+
+        RPlaunchCudaKernel( (poly_fdtd2d_1_lam<block_size,
+                                               decltype(poly_fdtd2d_1_lambda)>),
+                            grid_size1, block_size,
+                            shmem, res.get_stream(),
+                            ny, poly_fdtd2d_1_lambda );
+        cudaErrchk( cudaGetLastError() );
 
         FDTD_2D_THREADS_PER_BLOCK_CUDA;
         FDTD_2D_NBLOCKS_CUDA;
 
-        poly_fdtd2d_2_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                         <<<nblocks234, nthreads_per_block234, shmem, res.get_stream()>>>(nx, ny,
-          [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_FDTD_2D_BODY2;
-          }
-        );
+        auto poly_fdtd2d_2_lambda = [=] __device__ (Index_type i, 
+                                                    Index_type j) {
+          POLYBENCH_FDTD_2D_BODY2;
+        };
+        
+        RPlaunchCudaKernel( 
+          (poly_fdtd2d_2_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                             decltype(poly_fdtd2d_2_lambda)>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          nx, ny, poly_fdtd2d_2_lambda );
         cudaErrchk( cudaGetLastError() );
 
-        poly_fdtd2d_3_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                         <<<nblocks234, nthreads_per_block234, shmem, res.get_stream()>>>(nx, ny,
-          [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_FDTD_2D_BODY3;
-          }
-        );
+        auto poly_fdtd2d_3_lambda = [=] __device__ (Index_type i, 
+                                                    Index_type j) {
+          POLYBENCH_FDTD_2D_BODY3;
+        };
+
+        RPlaunchCudaKernel( 
+          (poly_fdtd2d_3_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                             decltype(poly_fdtd2d_3_lambda)>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          nx, ny, poly_fdtd2d_3_lambda );
         cudaErrchk( cudaGetLastError() );
 
-        poly_fdtd2d_4_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                         <<<nblocks234, nthreads_per_block234, shmem, res.get_stream()>>>(nx, ny,
-          [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_FDTD_2D_BODY4;
-          }
-        );
+        auto poly_fdtd2d_4_lambda = [=] __device__ (Index_type i,
+                                                    Index_type j) {
+          POLYBENCH_FDTD_2D_BODY4;
+        };
+
+        RPlaunchCudaKernel(
+          (poly_fdtd2d_4_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                             decltype(poly_fdtd2d_4_lambda)>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          nx, ny, poly_fdtd2d_4_lambda );
         cudaErrchk( cudaGetLastError() );
 
       } // tstep loop

--- a/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Hip.cpp
@@ -159,27 +159,35 @@ void POLYBENCH_FDTD_2D::runHipVariantImpl(VariantID vid)
         constexpr size_t shmem = 0;
 
         const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
-        hipLaunchKernelGGL((poly_fdtd2d_1<block_size>),
-                           dim3(grid_size1), dim3(block_size), shmem, res.get_stream(),
-                           ey, fict, ny, t);
+
+        RPlaunchHipKernel( (poly_fdtd2d_1<block_size>),
+                           grid_size1, block_size,
+                           shmem, res.get_stream(),
+                           ey, fict, ny, t );
         hipErrchk( hipGetLastError() );
 
         FDTD_2D_THREADS_PER_BLOCK_HIP;
         FDTD_2D_NBLOCKS_HIP;
 
-        hipLaunchKernelGGL((poly_fdtd2d_2<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                           dim3(nblocks234), dim3(nthreads_per_block234), shmem, res.get_stream(),
-                           ey, hz, nx, ny);
+        RPlaunchHipKernel(
+          (poly_fdtd2d_2<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          ey, hz, nx, ny );
         hipErrchk( hipGetLastError() );
 
-        hipLaunchKernelGGL((poly_fdtd2d_3<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                           dim3(nblocks234), dim3(nthreads_per_block234), shmem, res.get_stream(),
-                           ex, hz, nx, ny);
+        RPlaunchHipKernel(
+          (poly_fdtd2d_3<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          ex, hz, nx, ny );
         hipErrchk( hipGetLastError() );
 
-        hipLaunchKernelGGL((poly_fdtd2d_4<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                           dim3(nblocks234), dim3(nthreads_per_block234), shmem, res.get_stream(),
-                           hz, ex, ey, nx, ny);
+        RPlaunchHipKernel(
+          (poly_fdtd2d_4<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          hz, ex, ey, nx, ny );
         hipErrchk( hipGetLastError() );
 
       } // tstep loop
@@ -196,47 +204,59 @@ void POLYBENCH_FDTD_2D::runHipVariantImpl(VariantID vid)
 
         constexpr size_t shmem = 0;
 
+        const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
+
         auto poly_fdtd2d_1_lambda = [=] __device__ (Index_type j) {
           POLYBENCH_FDTD_2D_BODY1;
         };
 
-        const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(ny, block_size);
-        hipLaunchKernelGGL((poly_fdtd2d_1_lam<block_size, decltype(poly_fdtd2d_1_lambda)>),
-          dim3(grid_size1), dim3(block_size), shmem, res.get_stream(),
-          ny, poly_fdtd2d_1_lambda);
+        RPlaunchHipKernel( (poly_fdtd2d_1_lam<block_size,
+                                              decltype(poly_fdtd2d_1_lambda)>),
+                           grid_size1, block_size,
+                           shmem, res.get_stream(),
+                           ny, poly_fdtd2d_1_lambda );
         hipErrchk( hipGetLastError() );
 
         FDTD_2D_THREADS_PER_BLOCK_HIP;
         FDTD_2D_NBLOCKS_HIP;
 
-        auto poly_fdtd2d_2_lambda =
-          [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_FDTD_2D_BODY2;
-          };
+        auto poly_fdtd2d_2_lambda = [=] __device__ (Index_type i,
+                                                    Index_type j) {
+          POLYBENCH_FDTD_2D_BODY2;
+        };
 
-        hipLaunchKernelGGL((poly_fdtd2d_2_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_fdtd2d_2_lambda)>),
-                           dim3(nblocks234), dim3(nthreads_per_block234), shmem, res.get_stream(),
-                           nx, ny, poly_fdtd2d_2_lambda);
+        RPlaunchHipKernel(
+          (poly_fdtd2d_2_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                             decltype(poly_fdtd2d_2_lambda)>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          nx, ny, poly_fdtd2d_2_lambda );
         hipErrchk( hipGetLastError() );
 
-        auto poly_fdtd2d_3_lambda =
-          [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_FDTD_2D_BODY3;
-          };
+        auto poly_fdtd2d_3_lambda = [=] __device__ (Index_type i,
+                                                    Index_type j) {
+          POLYBENCH_FDTD_2D_BODY3;
+        };
 
-        hipLaunchKernelGGL((poly_fdtd2d_3_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_fdtd2d_3_lambda)>),
-                           dim3(nblocks234), dim3(nthreads_per_block234), shmem, res.get_stream(),
-                           nx, ny, poly_fdtd2d_3_lambda);
+        RPlaunchHipKernel(
+          (poly_fdtd2d_3_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                             decltype(poly_fdtd2d_3_lambda)>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          nx, ny, poly_fdtd2d_3_lambda );
         hipErrchk( hipGetLastError() );
 
-        auto poly_fdtd2d_4_lambda =
-          [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_FDTD_2D_BODY4;
-          };
+        auto poly_fdtd2d_4_lambda = [=] __device__ (Index_type i,
+                                                    Index_type j) {
+          POLYBENCH_FDTD_2D_BODY4;
+        };
 
-        hipLaunchKernelGGL((poly_fdtd2d_4_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_fdtd2d_4_lambda)>),
-                           dim3(nblocks234), dim3(nthreads_per_block234), shmem, res.get_stream(),
-                           nx, ny, poly_fdtd2d_4_lambda);
+        RPlaunchHipKernel(
+          (poly_fdtd2d_4_lam<FDTD_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                             decltype(poly_fdtd2d_4_lambda)>),
+          nblocks234, nthreads_per_block234,
+          shmem, res.get_stream(),
+          nx, ny, poly_fdtd2d_4_lambda );
         hipErrchk( hipGetLastError() );
 
       } // tstep loop

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
@@ -85,9 +85,11 @@ void POLYBENCH_FLOYD_WARSHALL::runCudaVariantImpl(VariantID vid)
         POLY_FLOYD_WARSHALL_NBLOCKS_CUDA;
         constexpr size_t shmem = 0;
 
-        poly_floyd_warshall<POLY_FLOYD_WARSHALL_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                           <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(pout, pin,
-                                                             k, N);
+        RPlaunchCudaKernel(
+          (poly_floyd_warshall<POLY_FLOYD_WARSHALL_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          pout, pin, k, N );
         cudaErrchk( cudaGetLastError() );
 
       }
@@ -106,12 +108,18 @@ void POLYBENCH_FLOYD_WARSHALL::runCudaVariantImpl(VariantID vid)
         POLY_FLOYD_WARSHALL_NBLOCKS_CUDA;
         constexpr size_t shmem = 0;
 
-        poly_floyd_warshall_lam<POLY_FLOYD_WARSHALL_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                               <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(N,
-          [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_FLOYD_WARSHALL_BODY;
-          }
-        );
+        auto poly_floyd_warshall_lambda = [=] __device__ (Index_type i,
+                                                          Index_type j) {
+          POLYBENCH_FLOYD_WARSHALL_BODY;
+        }; 
+ 
+        RPlaunchCudaKernel(
+          (poly_floyd_warshall_lam<POLY_FLOYD_WARSHALL_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA, 
+                                   decltype(poly_floyd_warshall_lambda)>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          N, poly_floyd_warshall_lambda );
+        cudaErrchk( cudaGetLastError() );
 
       }
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Cuda.cpp
@@ -146,10 +146,11 @@ void POLYBENCH_FLOYD_WARSHALL::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{0, N},
-                                               RAJA::RangeSegment{0, N},
-                                               RAJA::RangeSegment{0, N}),
-                                       res,
+      RAJA::kernel_resource<EXEC_POL>(
+        RAJA::make_tuple(RAJA::RangeSegment{0, N},
+                         RAJA::RangeSegment{0, N},
+                         RAJA::RangeSegment{0, N}),
+        res,
         [=] __device__ (Index_type k, Index_type i, Index_type j) {
           POLYBENCH_FLOYD_WARSHALL_BODY_RAJA;
         }

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Hip.cpp
@@ -146,10 +146,11 @@ void POLYBENCH_FLOYD_WARSHALL::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{0, N},
-                                               RAJA::RangeSegment{0, N},
-                                               RAJA::RangeSegment{0, N}),
-                                       res,
+      RAJA::kernel_resource<EXEC_POL>(
+        RAJA::make_tuple(RAJA::RangeSegment{0, N},
+                         RAJA::RangeSegment{0, N},
+                         RAJA::RangeSegment{0, N}),
+        res,
         [=] __device__ (Index_type k, Index_type i, Index_type j) {
           POLYBENCH_FLOYD_WARSHALL_BODY_RAJA;
         }

--- a/src/polybench/POLYBENCH_GEMM-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Cuda.cpp
@@ -90,10 +90,13 @@ void POLYBENCH_GEMM::runCudaVariantImpl(VariantID vid)
       POLY_GEMM_NBLOCKS_CUDA;
       constexpr size_t shmem = 0;
 
-      poly_gemm<POLY_GEMM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-               <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(C, A, B,
-                                                 alpha, beta,
-                                                 ni, nj, nk);
+      RPlaunchCudaKernel(
+          (poly_gemm<POLY_GEMM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          C, A, B,
+          alpha, beta,
+          ni, nj, nk );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -108,17 +111,21 @@ void POLYBENCH_GEMM::runCudaVariantImpl(VariantID vid)
       POLY_GEMM_NBLOCKS_CUDA;
       constexpr size_t shmem = 0;
 
-      poly_gemm_lam<POLY_GEMM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                   <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(ni, nj,
-        [=] __device__ (Index_type i, Index_type j) {
-          POLYBENCH_GEMM_BODY1;
-          POLYBENCH_GEMM_BODY2;
-          for (Index_type k = 0; k < nk; ++k ) {
-            POLYBENCH_GEMM_BODY3;
-          }
-          POLYBENCH_GEMM_BODY4;
+      auto poly_gemm_lambda = [=] __device__ (Index_type i, Index_type j) {
+        POLYBENCH_GEMM_BODY1;
+        POLYBENCH_GEMM_BODY2;
+        for (Index_type k = 0; k < nk; ++k ) {
+          POLYBENCH_GEMM_BODY3;
         }
-      );
+        POLYBENCH_GEMM_BODY4;
+      };
+
+      RPlaunchCudaKernel(
+       (poly_gemm_lam<POLY_GEMM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                      decltype(poly_gemm_lambda)>),
+       nblocks, nthreads_per_block,
+       shmem, res.get_stream(),
+       ni, nj, poly_gemm_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_GEMM-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Hip.cpp
@@ -90,10 +90,13 @@ void POLYBENCH_GEMM::runHipVariantImpl(VariantID vid)
       POLY_GEMM_NBLOCKS_HIP;
       constexpr size_t shmem = 0;
 
-      hipLaunchKernelGGL((poly_gemm<POLY_GEMM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                         dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                         C, A, B, alpha, beta,
-                         ni, nj, nk);
+      RPlaunchHipKernel(
+          (poly_gemm<POLY_GEMM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          C, A, B,
+          alpha, beta,
+          ni, nj, nk );
       hipErrchk( hipGetLastError() );
 
     }
@@ -117,9 +120,12 @@ void POLYBENCH_GEMM::runHipVariantImpl(VariantID vid)
         POLYBENCH_GEMM_BODY4;
       };
 
-      hipLaunchKernelGGL((poly_gemm_lam<POLY_GEMM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_gemm_lambda)>),
-        dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-        ni, nj, poly_gemm_lambda);
+      RPlaunchHipKernel(
+       (poly_gemm_lam<POLY_GEMM_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                      decltype(poly_gemm_lambda)>),
+       nblocks, nthreads_per_block,
+       shmem, res.get_stream(),
+       ni, nj, poly_gemm_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Cuda.cpp
@@ -270,9 +270,10 @@ void POLYBENCH_GEMVER::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL1>( RAJA::make_tuple(RAJA::RangeSegment{0, n},
-                                                RAJA::RangeSegment{0, n}),
-                                        res,
+      RAJA::kernel_resource<EXEC_POL1>(
+        RAJA::make_tuple(RAJA::RangeSegment{0, n},
+                         RAJA::RangeSegment{0, n}),
+        res,
         [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_GEMVER_BODY1_RAJA;
         }

--- a/src/polybench/POLYBENCH_GEMVER-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Hip.cpp
@@ -270,9 +270,10 @@ void POLYBENCH_GEMVER::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL1>( RAJA::make_tuple(RAJA::RangeSegment{0, n},
-                                                RAJA::RangeSegment{0, n}),
-                                        res,
+      RAJA::kernel_resource<EXEC_POL1>(
+        RAJA::make_tuple(RAJA::RangeSegment{0, n},
+                         RAJA::RangeSegment{0, n}),
+        res,
         [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_GEMVER_BODY1_RAJA;
         }

--- a/src/polybench/POLYBENCH_GEMVER-Hip.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Hip.cpp
@@ -41,10 +41,10 @@ namespace polybench
 
 template < size_t j_block_size, size_t i_block_size >
 __launch_bounds__(j_block_size*i_block_size)
-__global__ void poly_gemmver_1(Real_ptr A,
-                               Real_ptr u1, Real_ptr v1,
-                               Real_ptr u2, Real_ptr v2,
-                               Index_type n)
+__global__ void poly_gemver_1(Real_ptr A,
+                              Real_ptr u1, Real_ptr v1,
+                              Real_ptr u2, Real_ptr v2,
+                              Index_type n)
 {
   Index_type i = blockIdx.y * i_block_size + threadIdx.y;
   Index_type j = blockIdx.x * j_block_size + threadIdx.x;
@@ -56,7 +56,7 @@ __global__ void poly_gemmver_1(Real_ptr A,
 
 template < size_t j_block_size, size_t i_block_size, typename Lambda >
 __launch_bounds__(j_block_size*i_block_size)
-__global__ void poly_gemmver_1_lam(Index_type n, Lambda body)
+__global__ void poly_gemver_1_lam(Index_type n, Lambda body)
 {
   Index_type i = blockIdx.y * i_block_size + threadIdx.y;
   Index_type j = blockIdx.x * j_block_size + threadIdx.x;
@@ -68,10 +68,10 @@ __global__ void poly_gemmver_1_lam(Index_type n, Lambda body)
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void poly_gemmver_2(Real_ptr A,
-                               Real_ptr x, Real_ptr y,
-                               Real_type beta,
-                               Index_type n)
+__global__ void poly_gemver_2(Real_ptr A,
+                              Real_ptr x, Real_ptr y,
+                              Real_type beta,
+                              Index_type n)
 {
   Index_type i = blockIdx.x * block_size + threadIdx.x;
   if (i < n) {
@@ -85,8 +85,8 @@ __global__ void poly_gemmver_2(Real_ptr A,
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void poly_gemmver_3(Real_ptr x, Real_ptr z,
-                               Index_type n)
+__global__ void poly_gemver_3(Real_ptr x, Real_ptr z,
+                              Index_type n)
 {
   Index_type i = blockIdx.x * block_size + threadIdx.x;
   if (i < n) {
@@ -96,10 +96,10 @@ __global__ void poly_gemmver_3(Real_ptr x, Real_ptr z,
 
 template < size_t block_size >
 __launch_bounds__(block_size)
-__global__ void poly_gemmver_4(Real_ptr A,
-                               Real_ptr x, Real_ptr w,
-                               Real_type alpha,
-                               Index_type n)
+__global__ void poly_gemver_4(Real_ptr A,
+                              Real_ptr x, Real_ptr w,
+                              Real_type alpha,
+                              Index_type n)
 {
   Index_type i = blockIdx.x * block_size + threadIdx.x;
   if (i < n) {
@@ -113,7 +113,7 @@ __global__ void poly_gemmver_4(Real_ptr A,
 
 template < size_t block_size, typename Lambda >
 __launch_bounds__(block_size)
-__global__ void poly_gemmver_234_lam(Index_type n, Lambda body)
+__global__ void poly_gemver_234_lam(Index_type n, Lambda body)
 {
   Index_type i = blockIdx.x * block_size + threadIdx.x;
   if (i < n) {
@@ -140,26 +140,31 @@ void POLYBENCH_GEMVER::runHipVariantImpl(VariantID vid)
       GEMVER_NBLOCKS_HIP;
       constexpr size_t shmem = 0;
 
-      hipLaunchKernelGGL((poly_gemmver_1<GEMVER_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                         dim3(nblocks1), dim3(nthreads_per_block1), shmem, res.get_stream(),
-                         A, u1, v1, u2, v2, n);
+      RPlaunchHipKernel(
+        (poly_gemver_1<GEMVER_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+        nblocks1, nthreads_per_block1,
+        shmem, res.get_stream(),
+        A, u1, v1, u2, v2, n );
       hipErrchk( hipGetLastError() );
 
       size_t grid_size = RAJA_DIVIDE_CEILING_INT(m_n, block_size);
 
-      hipLaunchKernelGGL((poly_gemmver_2<block_size>),
-                         dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                         A, x, y, beta, n);
+      RPlaunchHipKernel( (poly_gemver_2<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         A, x, y, beta, n );
       hipErrchk( hipGetLastError() );
 
-      hipLaunchKernelGGL((poly_gemmver_3<block_size>),
-                         dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                         x, z, n);
+      RPlaunchHipKernel( (poly_gemver_3<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         x, z, n );
       hipErrchk( hipGetLastError() );
 
-      hipLaunchKernelGGL((poly_gemmver_4<block_size>),
-                         dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                         A, x, w, alpha, n);
+      RPlaunchHipKernel( (poly_gemver_4<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         A, x, w, alpha, n );
       hipErrchk( hipGetLastError() );
 
     }
@@ -174,50 +179,59 @@ void POLYBENCH_GEMVER::runHipVariantImpl(VariantID vid)
       GEMVER_NBLOCKS_HIP;
       constexpr size_t shmem = 0;
 
-      auto poly_gemmver_1_lambda = [=] __device__ (Index_type i, Index_type j) {
-          POLYBENCH_GEMVER_BODY1;
+      auto poly_gemver1_lambda = [=] __device__ (Index_type i, Index_type j) {
+        POLYBENCH_GEMVER_BODY1;
       };
 
-      hipLaunchKernelGGL((poly_gemmver_1_lam<GEMVER_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_gemmver_1_lambda)>),
-                         dim3(nblocks1), dim3(nthreads_per_block1), shmem, res.get_stream(),
-                         n, poly_gemmver_1_lambda);
+      RPlaunchHipKernel(
+       (poly_gemver_1_lam<GEMVER_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                          decltype(poly_gemver1_lambda)>),
+       nblocks1, nthreads_per_block1,
+       shmem, res.get_stream(),
+       n, poly_gemver1_lambda );
       hipErrchk( hipGetLastError() );
 
       size_t grid_size = RAJA_DIVIDE_CEILING_INT(n, block_size);
 
-      auto poly_gemmver_2_lambda = [=] __device__ (Index_type i) {
-          POLYBENCH_GEMVER_BODY2;
-          for (Index_type j = 0; j < n; ++j) {
-            POLYBENCH_GEMVER_BODY3;
-          }
-          POLYBENCH_GEMVER_BODY4;
+      auto poly_gemver2_lambda = [=] __device__ (Index_type i) {
+        POLYBENCH_GEMVER_BODY2;
+        for (Index_type j = 0; j < n; ++j) {
+          POLYBENCH_GEMVER_BODY3;
+        }
+        POLYBENCH_GEMVER_BODY4;
       };
 
-      hipLaunchKernelGGL((poly_gemmver_234_lam<block_size, decltype(poly_gemmver_2_lambda)>),
-        dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-        n, poly_gemmver_2_lambda);
+      RPlaunchHipKernel( (poly_gemver_234_lam<block_size,
+                                              decltype(poly_gemver2_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         n, poly_gemver2_lambda );
       hipErrchk( hipGetLastError() );
 
-      auto poly_gemmver_3_lambda = [=] __device__ (Index_type i) {
-          POLYBENCH_GEMVER_BODY5;
+      auto poly_gemver3_lambda = [=] __device__ (Index_type i) {
+        POLYBENCH_GEMVER_BODY5;
       };
 
-      hipLaunchKernelGGL((poly_gemmver_234_lam<block_size, decltype(poly_gemmver_3_lambda)>),
-        dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-        n, poly_gemmver_3_lambda);
+      RPlaunchHipKernel( (poly_gemver_234_lam<block_size,
+                                              decltype(poly_gemver3_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         n, poly_gemver3_lambda );
       hipErrchk( hipGetLastError() );
 
-      auto poly_gemmver_4_lambda = [=] __device__ (Index_type i) {
-          POLYBENCH_GEMVER_BODY6;
-          for (Index_type j = 0; j < n; ++j) {
-            POLYBENCH_GEMVER_BODY7;
-          }
-          POLYBENCH_GEMVER_BODY8;
+      auto poly_gemver4_lambda = [=] __device__ (Index_type i) {
+        POLYBENCH_GEMVER_BODY6;
+        for (Index_type j = 0; j < n; ++j) {
+          POLYBENCH_GEMVER_BODY7;
+        }
+        POLYBENCH_GEMVER_BODY8;
       };
 
-      hipLaunchKernelGGL((poly_gemmver_234_lam<block_size, decltype(poly_gemmver_4_lambda)>),
-        dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-        n, poly_gemmver_4_lambda);
+      RPlaunchHipKernel( (poly_gemver_234_lam<block_size,
+                                              decltype(poly_gemver4_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         n, poly_gemver4_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Cuda.cpp
@@ -56,10 +56,14 @@ void POLYBENCH_GESUMMV::runCudaVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
       constexpr size_t shmem = 0;
-      poly_gesummv<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(x, y,
-                                              A, B,
-                                              alpha, beta,
-                                              N);
+
+      RPlaunchCudaKernel( (poly_gesummv<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          x, y,
+                          A, B, 
+                          alpha, beta,
+                          N );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_GESUMMV-Hip.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Hip.cpp
@@ -56,12 +56,14 @@ void POLYBENCH_GESUMMV::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((poly_gesummv<block_size>),
-                         dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
+    
+      RPlaunchHipKernel( (poly_gesummv<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
                          x, y,
-                         A, B,
+                         A, B, 
                          alpha, beta,
-                         N);
+                         N );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
@@ -100,12 +100,18 @@ void POLYBENCH_HEAT_3D::runCudaVariantImpl(VariantID vid)
         HEAT_3D_NBLOCKS_CUDA;
         constexpr size_t shmem = 0;
 
-        poly_heat_3D_1<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-            <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(A, B, N);
+        RPlaunchCudaKernel(
+          (poly_heat_3D_1<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          A, B, N );
         cudaErrchk( cudaGetLastError() );
 
-        poly_heat_3D_2<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-            <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(A, B, N);
+        RPlaunchCudaKernel(
+          (poly_heat_3D_2<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          A, B, N );
         cudaErrchk( cudaGetLastError() );
 
       }
@@ -124,20 +130,32 @@ void POLYBENCH_HEAT_3D::runCudaVariantImpl(VariantID vid)
         HEAT_3D_NBLOCKS_CUDA;
         constexpr size_t shmem = 0;
 
-        poly_heat_3D_lam<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-            <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(N,
-          [=] __device__ (Index_type i, Index_type j, Index_type k) {
-            POLYBENCH_HEAT_3D_BODY1;
-          }
-        );
+        auto poly_heat_3D_1_lambda = [=] __device__ (Index_type i,
+                                                     Index_type j,
+                                                     Index_type k) {
+          POLYBENCH_HEAT_3D_BODY1;
+        };
+
+        RPlaunchCudaKernel(
+          (poly_heat_3D_lam<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                            decltype(poly_heat_3D_1_lambda)>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          N, poly_heat_3D_1_lambda );
         cudaErrchk( cudaGetLastError() );
 
-        poly_heat_3D_lam<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-            <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(N,
-          [=] __device__ (Index_type i, Index_type j, Index_type k) {
-            POLYBENCH_HEAT_3D_BODY2;
-          }
-        );
+        auto poly_heat_3D_2_lambda = [=] __device__ (Index_type i,
+                                                     Index_type j,
+                                                     Index_type k) {
+          POLYBENCH_HEAT_3D_BODY2;
+        };
+
+        RPlaunchCudaKernel(
+          (poly_heat_3D_lam<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                            decltype(poly_heat_3D_2_lambda)>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          N, poly_heat_3D_2_lambda );
         cudaErrchk( cudaGetLastError() );
 
       }
@@ -168,19 +186,21 @@ void POLYBENCH_HEAT_3D::runCudaVariantImpl(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                                                 RAJA::RangeSegment{1, N-1},
-                                                 RAJA::RangeSegment{1, N-1}),
-                                         res,
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1}),
+          res,
           [=] __device__ (Index_type i, Index_type j, Index_type k) {
             POLYBENCH_HEAT_3D_BODY1_RAJA;
           }
         );
 
-        RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                                                 RAJA::RangeSegment{1, N-1},
-                                                 RAJA::RangeSegment{1, N-1}),
-                                         res,
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1}),
+          res,
           [=] __device__ (Index_type i, Index_type j, Index_type k) {
             POLYBENCH_HEAT_3D_BODY2_RAJA;
           }

--- a/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
@@ -100,14 +100,18 @@ void POLYBENCH_HEAT_3D::runHipVariantImpl(VariantID vid)
         HEAT_3D_NBLOCKS_HIP;
         constexpr size_t shmem = 0;
 
-        hipLaunchKernelGGL((poly_heat_3D_1<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                           dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                           A, B, N);
+        RPlaunchHipKernel(
+          (poly_heat_3D_1<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          A, B, N );
         hipErrchk( hipGetLastError() );
 
-        hipLaunchKernelGGL((poly_heat_3D_2<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                           dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                           A, B, N);
+        RPlaunchHipKernel(
+          (poly_heat_3D_2<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          A, B, N );
         hipErrchk( hipGetLastError() );
 
       }
@@ -126,25 +130,32 @@ void POLYBENCH_HEAT_3D::runHipVariantImpl(VariantID vid)
         HEAT_3D_NBLOCKS_HIP;
         constexpr size_t shmem = 0;
 
-        auto poly_heat_3D_1_lambda = [=] __device__ (Index_type i, Index_type j,
+        auto poly_heat_3D_1_lambda = [=] __device__ (Index_type i,
+                                                     Index_type j,
                                                      Index_type k) {
           POLYBENCH_HEAT_3D_BODY1;
         };
 
-        auto poly_heat_3D_2_lambda = [=] __device__ (Index_type i, Index_type j,                                                     Index_type k) {
+        RPlaunchHipKernel(
+          (poly_heat_3D_lam<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                            decltype(poly_heat_3D_1_lambda)>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          N, poly_heat_3D_1_lambda );
+        hipErrchk( hipGetLastError() );
+
+        auto poly_heat_3D_2_lambda = [=] __device__ (Index_type i,
+                                                     Index_type j,
+                                                     Index_type k) {
           POLYBENCH_HEAT_3D_BODY2;
         };
 
-        hipLaunchKernelGGL((poly_heat_3D_lam<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
-                                             decltype(poly_heat_3D_1_lambda)>),
-                           dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                           N, poly_heat_3D_1_lambda);
-        hipErrchk( hipGetLastError() );
-
-        hipLaunchKernelGGL((poly_heat_3D_lam<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
-                                             decltype(poly_heat_3D_2_lambda)>),
-                           dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                           N, poly_heat_3D_2_lambda);
+        RPlaunchHipKernel(
+          (poly_heat_3D_lam<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                            decltype(poly_heat_3D_2_lambda)>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          N, poly_heat_3D_2_lambda );
         hipErrchk( hipGetLastError() );
 
       }
@@ -174,19 +185,21 @@ void POLYBENCH_HEAT_3D::runHipVariantImpl(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                                                 RAJA::RangeSegment{1, N-1},
-                                                 RAJA::RangeSegment{1, N-1}),
-                                         res,
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1}),
+          res,
           [=] __device__ (Index_type i, Index_type j, Index_type k) {
             POLYBENCH_HEAT_3D_BODY1_RAJA;
           }
         );
 
-        RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                                                 RAJA::RangeSegment{1, N-1},
-                                                 RAJA::RangeSegment{1, N-1}),
-                                         res,
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1}),
+          res,
           [=] __device__ (Index_type i, Index_type j, Index_type k) {
             POLYBENCH_HEAT_3D_BODY2_RAJA;
           }

--- a/src/polybench/POLYBENCH_JACOBI_1D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-Cuda.cpp
@@ -63,10 +63,16 @@ void POLYBENCH_JACOBI_1D::runCudaVariantImpl(VariantID vid)
         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
         constexpr size_t shmem = 0;
 
-        poly_jacobi_1D_1<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(A, B, N);
+        RPlaunchCudaKernel( (poly_jacobi_1D_1<block_size>),
+                            grid_size, block_size,
+                            shmem, res.get_stream(),
+                            A, B, N );
         cudaErrchk( cudaGetLastError() );
 
-        poly_jacobi_1D_2<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(A, B, N);
+        RPlaunchCudaKernel( (poly_jacobi_1D_2<block_size>),
+                            grid_size, block_size,
+                            shmem, res.get_stream(),
+                            A, B, N );
         cudaErrchk( cudaGetLastError() );
 
       }

--- a/src/polybench/POLYBENCH_JACOBI_1D-Hip.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-Hip.cpp
@@ -63,12 +63,16 @@ void POLYBENCH_JACOBI_1D::runHipVariantImpl(VariantID vid)
         const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
         constexpr size_t shmem = 0;
 
-        hipLaunchKernelGGL((poly_jacobi_1D_1<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                                            A, B, N);
+        RPlaunchHipKernel( (poly_jacobi_1D_1<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           A, B, N );
         hipErrchk( hipGetLastError() );
 
-        hipLaunchKernelGGL((poly_jacobi_1D_2<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                                            A, B, N);
+        RPlaunchHipKernel( (poly_jacobi_1D_2<block_size>),
+                           grid_size, block_size,
+                           shmem, res.get_stream(),
+                           A, B, N );
         hipErrchk( hipGetLastError() );
 
       }

--- a/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
@@ -96,12 +96,18 @@ void POLYBENCH_JACOBI_2D::runCudaVariantImpl(VariantID vid)
         JACOBI_2D_NBLOCKS_CUDA;
         constexpr size_t shmem = 0;
 
-        poly_jacobi_2D_1<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                        <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(A, B, N);
+        RPlaunchCudaKernel( 
+          (poly_jacobi_2D_1<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          A, B, N );
         cudaErrchk( cudaGetLastError() );
 
-        poly_jacobi_2D_2<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                        <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(A, B, N);
+        RPlaunchCudaKernel( 
+          (poly_jacobi_2D_2<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          A, B, N );
         cudaErrchk( cudaGetLastError() );
 
       }
@@ -120,20 +126,30 @@ void POLYBENCH_JACOBI_2D::runCudaVariantImpl(VariantID vid)
         JACOBI_2D_NBLOCKS_CUDA;
         constexpr size_t shmem = 0;
 
-        poly_jacobi_2D_lam<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                          <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(N,
-          [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_JACOBI_2D_BODY1;
-          }
-        );
+        auto poly_jacobi_2D_1_lambda = [=] __device__ (Index_type i,
+                                                       Index_type j) {
+          POLYBENCH_JACOBI_2D_BODY1;
+        };
+
+        RPlaunchCudaKernel(
+          (poly_jacobi_2D_lam<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                              decltype(poly_jacobi_2D_1_lambda)>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          N, poly_jacobi_2D_1_lambda );
         cudaErrchk( cudaGetLastError() );
 
-        poly_jacobi_2D_lam<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>
-                          <<<nblocks, nthreads_per_block, shmem, res.get_stream()>>>(N,
-          [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_JACOBI_2D_BODY2;
-          }
-        );
+        auto poly_jacobi_2D_2_lambda = [=] __device__ (Index_type i,
+                                                       Index_type j) {
+          POLYBENCH_JACOBI_2D_BODY2;
+        };
+
+        RPlaunchCudaKernel(
+          (poly_jacobi_2D_lam<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA,
+                              decltype(poly_jacobi_2D_2_lambda)>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          N, poly_jacobi_2D_2_lambda );
         cudaErrchk( cudaGetLastError() );
 
       }
@@ -161,17 +177,19 @@ void POLYBENCH_JACOBI_2D::runCudaVariantImpl(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        RAJA::kernel_resource<EXEC_POL>(RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                                                RAJA::RangeSegment{1, N-1}),
-                                        res,
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1}),
+          res,
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_JACOBI_2D_BODY1_RAJA;
           }
         );
 
-         RAJA::kernel_resource<EXEC_POL>(RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                                                 RAJA::RangeSegment{1, N-1}),
-                                         res,
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1}),
+          res,
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_JACOBI_2D_BODY2_RAJA;
           }

--- a/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
@@ -96,14 +96,18 @@ void POLYBENCH_JACOBI_2D::runHipVariantImpl(VariantID vid)
         JACOBI_2D_NBLOCKS_HIP;
         constexpr size_t shmem = 0;
 
-        hipLaunchKernelGGL((poly_jacobi_2D_1<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                           dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                           A, B, N);
+        RPlaunchHipKernel(
+          (poly_jacobi_2D_1<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          A, B, N );
         hipErrchk( hipGetLastError() );
 
-        hipLaunchKernelGGL((poly_jacobi_2D_2<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
-                           dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                           A, B, N);
+        RPlaunchHipKernel(
+          (poly_jacobi_2D_2<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          A, B, N );
         hipErrchk( hipGetLastError() );
 
       }
@@ -122,24 +126,30 @@ void POLYBENCH_JACOBI_2D::runHipVariantImpl(VariantID vid)
         JACOBI_2D_NBLOCKS_HIP;
         constexpr size_t shmem = 0;
 
-        auto poly_jacobi_2D_1_lambda =
-          [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_JACOBI_2D_BODY1;
-          };
+        auto poly_jacobi_2D_1_lambda = [=] __device__ (Index_type i,
+                                                       Index_type j) {
+          POLYBENCH_JACOBI_2D_BODY1;
+        };
 
-        hipLaunchKernelGGL((poly_jacobi_2D_lam<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_jacobi_2D_1_lambda)>),
-                           dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                           N, poly_jacobi_2D_1_lambda);
+        RPlaunchHipKernel(
+          (poly_jacobi_2D_lam<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                              decltype(poly_jacobi_2D_1_lambda)>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          N, poly_jacobi_2D_1_lambda );
         hipErrchk( hipGetLastError() );
 
-        auto poly_jacobi_2D_2_lambda =
-          [=] __device__ (Index_type i, Index_type j) {
-            POLYBENCH_JACOBI_2D_BODY2;
-          };
+        auto poly_jacobi_2D_2_lambda = [=] __device__ (Index_type i,
+                                                       Index_type j) {
+          POLYBENCH_JACOBI_2D_BODY2;
+        };
 
-        hipLaunchKernelGGL((poly_jacobi_2D_lam<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, decltype(poly_jacobi_2D_2_lambda)>),
-                           dim3(nblocks), dim3(nthreads_per_block), shmem, res.get_stream(),
-                           N, poly_jacobi_2D_2_lambda);
+        RPlaunchHipKernel(
+          (poly_jacobi_2D_lam<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP,
+                              decltype(poly_jacobi_2D_2_lambda)>),
+          nblocks, nthreads_per_block,
+          shmem, res.get_stream(),
+          N, poly_jacobi_2D_2_lambda );
         hipErrchk( hipGetLastError() );
 
       }
@@ -167,17 +177,19 @@ void POLYBENCH_JACOBI_2D::runHipVariantImpl(VariantID vid)
 
       for (Index_type t = 0; t < tsteps; ++t) {
 
-        RAJA::kernel_resource<EXEC_POL>(RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                                                RAJA::RangeSegment{1, N-1}),
-                                        res,
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1}),
+          res,
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_JACOBI_2D_BODY1_RAJA;
           }
         );
 
-        RAJA::kernel_resource<EXEC_POL>(RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                                                RAJA::RangeSegment{1, N-1}),
-                                        res,
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1}),
+          res,
           [=] __device__ (Index_type i, Index_type j) {
             POLYBENCH_JACOBI_2D_BODY2_RAJA;
           }

--- a/src/polybench/POLYBENCH_MVT-Cuda.cpp
+++ b/src/polybench/POLYBENCH_MVT-Cuda.cpp
@@ -69,12 +69,18 @@ void POLYBENCH_MVT::runCudaVariantImpl(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
-        constexpr size_t shmem = 0;
+      constexpr size_t shmem = 0;
 
-      poly_mvt_1<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(A, x1, y1, N);
+      RPlaunchCudaKernel( (poly_mvt_1<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          A, x1, y1, N );
       cudaErrchk( cudaGetLastError() );
 
-      poly_mvt_2<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(A, x2, y2, N);
+      RPlaunchCudaKernel( (poly_mvt_2<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          A, x2, y2, N );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/polybench/POLYBENCH_MVT-Hip.cpp
+++ b/src/polybench/POLYBENCH_MVT-Hip.cpp
@@ -69,16 +69,18 @@ void POLYBENCH_MVT::runHipVariantImpl(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(N, block_size);
-        constexpr size_t shmem = 0;
+      constexpr size_t shmem = 0;
 
-      hipLaunchKernelGGL((poly_mvt_1<block_size>),
-                         dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                         A, x1, y1, N);
+      RPlaunchHipKernel( (poly_mvt_1<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         A, x1, y1, N );
       hipErrchk( hipGetLastError() );
 
-      hipLaunchKernelGGL((poly_mvt_2<block_size>),
-                         dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-                         A, x2, y2, N);
+      RPlaunchHipKernel( (poly_mvt_2<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         A, x2, y2, N );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/rajaperf_config.hpp.in
+++ b/src/rajaperf_config.hpp.in
@@ -23,6 +23,7 @@
 #include "RAJA/config.hpp"
 #include "camp/number.hpp"
 
+#include <type_traits>
 #include <string>
 
 #cmakedefine RAJA_PERFSUITE_ENABLE_MPI
@@ -109,6 +110,17 @@ std::string systype_run;
 std::string machine_run;
 
 };
+
+#if __cplusplus < 201703L
+// Implement std::conjunction from https://en.cppreference.com/w/cpp/types/conjunction
+template<class...> struct conjunction : std::true_type {};
+template<class B1> struct conjunction<B1> : B1 {};
+template<class B1, class... Bn>
+struct conjunction<B1, Bn...>
+  : std::conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
+#else
+using std::conjunction;
+#endif
 
 } // closing brace for rajaperf namespace
 

--- a/src/rajaperf_config.hpp.in
+++ b/src/rajaperf_config.hpp.in
@@ -124,6 +124,17 @@ std::string machine_run;
 
 };
 
+#if __cplusplus < 201703L
+// Implement std::conjunction from https://en.cppreference.com/w/cpp/types/conjunction
+template<class...> struct conjunction : std::true_type {};
+template<class B1> struct conjunction<B1> : B1 {};
+template<class B1, class... Bn>
+struct conjunction<B1, Bn...>
+  : std::conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
+#else
+using std::conjunction;
+#endif
+
 //compile time loop over an integer sequence
 //this allows for creating a loop over a compile time constant variable
 template <typename Func, typename... Ts>

--- a/src/stream/ADD-Hip.cpp
+++ b/src/stream/ADD-Hip.cpp
@@ -51,8 +51,11 @@ void ADD::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((add<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  c, a, b,
-                                      iend );
+
+      RPlaunchHipKernel( (add<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         c, a, b, iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -69,8 +72,12 @@ void ADD::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(add_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, add_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(add_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, add_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/stream/COPY-Cuda.cpp
+++ b/src/stream/COPY-Cuda.cpp
@@ -51,8 +51,11 @@ void COPY::runCudaVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      copy<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( c, a,
-                                       iend );
+
+      RPlaunchCudaKernel( (copy<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          c, a, iend );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -63,12 +66,18 @@ void COPY::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      auto copy_lambda = [=] __device__ (Index_type i) {
+        COPY_BODY;
+      };
+
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      lambda_cuda_forall<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-        ibegin, iend, [=] __device__ (Index_type i) {
-        COPY_BODY;
-      });
+
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size, 
+                                              decltype(copy_lambda)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend, copy_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/stream/COPY-Hip.cpp
+++ b/src/stream/COPY-Hip.cpp
@@ -51,8 +51,11 @@ void COPY::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((copy<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),
-          c, a, iend );
+
+      RPlaunchHipKernel( (copy<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         c, a, iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -69,8 +72,12 @@ void COPY::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(copy_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, copy_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(copy_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, copy_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/stream/DOT-Cuda.cpp
+++ b/src/stream/DOT-Cuda.cpp
@@ -75,8 +75,11 @@ void DOT::runCudaVariantBlockAtomic(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = sizeof(Real_type)*block_size;
-      dot<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-          a, b, dprod, m_dot_init, iend );
+
+      RPlaunchCudaKernel( (dot<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          a, b, dprod, m_dot_init, iend );
       cudaErrchk( cudaGetLastError() );
 
       Real_type rdprod;
@@ -136,8 +139,11 @@ void DOT::runCudaVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      dot<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-          a, b, dprod, m_dot_init, iend );
+
+      RPlaunchCudaKernel( (dot<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          a, b, dprod, m_dot_init, iend );
       cudaErrchk( cudaGetLastError() );
 
       Real_type rdprod;

--- a/src/stream/DOT-Hip.cpp
+++ b/src/stream/DOT-Hip.cpp
@@ -75,8 +75,10 @@ void DOT::runHipVariantBlockAtomic(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = sizeof(Real_type)*block_size;
-      hipLaunchKernelGGL((dot<block_size>), dim3(grid_size), dim3(block_size),
-                                            shmem, res.get_stream(),
+
+      RPlaunchHipKernel( (dot<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
                          a, b, dprod, m_dot_init, iend );
       hipErrchk( hipGetLastError() );
 
@@ -137,8 +139,10 @@ void DOT::runHipVariantBlockAtomicOccGS(VariantID vid)
 
       const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       const size_t grid_size = std::min(normal_grid_size, max_grid_size);
-      hipLaunchKernelGGL((dot<block_size>), dim3(grid_size), dim3(block_size),
-                                            shmem, res.get_stream(),
+
+      RPlaunchHipKernel( (dot<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
                          a, b, dprod, m_dot_init, iend );
       hipErrchk( hipGetLastError() );
 

--- a/src/stream/MUL-Hip.cpp
+++ b/src/stream/MUL-Hip.cpp
@@ -51,8 +51,11 @@ void MUL::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((mul<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  b, c, alpha,
-                                      iend );
+
+      RPlaunchHipKernel( (mul<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         b, c, alpha, iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -69,8 +72,12 @@ void MUL::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(mul_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, mul_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                             decltype(mul_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, mul_lambda );
       hipErrchk( hipGetLastError() );
 
     }

--- a/src/stream/TRIAD-Cuda.cpp
+++ b/src/stream/TRIAD-Cuda.cpp
@@ -51,8 +51,11 @@ void TRIAD::runCudaVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      triad<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>( a, b, c, alpha,
-                                        iend );
+
+      RPlaunchCudaKernel( (triad<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          a, b, c, alpha, iend );
       cudaErrchk( cudaGetLastError() );
 
     }
@@ -63,12 +66,18 @@ void TRIAD::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
+      auto triad_lambda = [=] __device__ (Index_type i) {
+        TRIAD_BODY;
+      }; 
+
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      lambda_cuda_forall<block_size><<<grid_size, block_size, shmem, res.get_stream()>>>(
-        ibegin, iend, [=] __device__ (Index_type i) {
-        TRIAD_BODY;
-      });
+
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size,
+                                              decltype(triad_lambda)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend, triad_lambda );
       cudaErrchk( cudaGetLastError() );
 
     }

--- a/src/stream/TRIAD-Hip.cpp
+++ b/src/stream/TRIAD-Hip.cpp
@@ -51,8 +51,11 @@ void TRIAD::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((triad<block_size>), dim3(grid_size), dim3(block_size), shmem, res.get_stream(),  a, b, c, alpha,
-                                        iend );
+
+      RPlaunchHipKernel( (triad<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          a, b, c, alpha, iend );
       hipErrchk( hipGetLastError() );
 
     }
@@ -69,8 +72,12 @@ void TRIAD::runHipVariantImpl(VariantID vid)
 
       const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
       constexpr size_t shmem = 0;
-      hipLaunchKernelGGL((lambda_hip_forall<block_size, decltype(triad_lambda)>),
-        grid_size, block_size, shmem, res.get_stream(), ibegin, iend, triad_lambda);
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                             decltype(triad_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, triad_lambda );
       hipErrchk( hipGetLastError() );
 
     }


### PR DESCRIPTION
# Summary 

- This PR converts non-RAJA base and lambda GPU kernel variants so that all GPU variants use the same methodology for kernel launches, specifically what is used inside RAJA.
- It introduces new methods to launch non-RAJA variants of GPU kernels and converts all such kernel implementations to use them.
- It also addresses function argument organization and alignment issues that have been discussed by the team.

Resolves https://github.com/LLNL/RAJAPerf/issues/385

Resolves https://github.com/LLNL/RAJAPerf/issues/371

**NOTE: This is a large PR touching many files. No functionality was changed. All of the changes are very similar acoss all of the kernels.** 
