### PR TITLE
[OpenMP] Fixed 'undeclared identifier' error in COPY8-OMPTarget.cpp

### DIFF
--- a/src/basic/COPY8-OMPTarget.cpp
+++ b/src/basic/COPY8-OMPTarget.cpp
@@ -40,7 +40,8 @@ void COPY8::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tun
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      #pragma omp target is_device_ptr(x, y) device( did )
+      #pragma omp target is_device_ptr(x0, x1, x2, x3, x4, x5, x6, x7, y0, y1, y2,   \
+                                 y3, y4, y5, y6, y7) device( did )
       #pragma omp teams distribute parallel for thread_limit(threads_per_team) schedule(static, 1)
       for (Index_type i = ibegin; i < iend; ++i ) {
         COPY8_BODY;
@@ -70,4 +71,4 @@ void COPY8::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tun
 } // end namespace basic
 } // end namespace rajaperf
 
-#endif  // RAJA_ENABLE_TARGET_OPENMP
+#endif // RAJA_ENABLE_TARGET_OPENMP


### PR DESCRIPTION
# Summary (Write a short headline summary of PR)

This PR is a bugfix for a compiler error in COPY8-OMPTarget.cpp (undeclared identifier x, y).
