### PR TITLE
Bugfix/omptarget things

### DIFF
--- a/src/apps/EDGE3D-OMPTarget.cpp
+++ b/src/apps/EDGE3D-OMPTarget.cpp
@@ -61,8 +61,6 @@ void EDGE3D::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    EDGE3D_DATA_SETUP_OMP_TARGET;
-
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 

--- a/src/apps/EDGE3D-Seq.cpp
+++ b/src/apps/EDGE3D-Seq.cpp
@@ -28,9 +28,11 @@ void EDGE3D::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 
   EDGE3D_DATA_SETUP;
 
+#if defined(RUN_RAJA_SEQ)
   auto edge3d_lam = [=](Index_type i) {
                      EDGE3D_BODY;
                    };
+#endif
 
   switch ( vid ) {
 

--- a/src/apps/HALOEXCHANGE_FUSED-OMPTarget.cpp
+++ b/src/apps/HALOEXCHANGE_FUSED-OMPTarget.cpp
@@ -237,8 +237,6 @@ void HALOEXCHANGE_FUSED::runOpenMPTargetVariantWorkGroup(VariantID vid)
     }
     stopTimer();
 
-    HALOEXCHANGE_FUSED_DATA_TEARDOWN_OMP_TARGET;
-
   } else {
      getCout() << "\n HALOEXCHANGE_FUSED : Unknown OMP Target variant id = " << vid << std::endl;
   }
@@ -248,7 +246,7 @@ void HALOEXCHANGE_FUSED::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
 
-  if (vid == Base_OpenMPTarget || vid == Lambda_OpenMPTarget) {
+  if (vid == Base_OpenMPTarget) {
 
     if (tune_idx == t) {
 
@@ -279,7 +277,7 @@ void HALOEXCHANGE_FUSED::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 
 void HALOEXCHANGE_FUSED::setOpenMPTargetTuningDefinitions(VariantID vid)
 {
-  if (vid == Base_OpenMPTarget || vid == Lambda_OpenMPTarget) {
+  if (vid == Base_OpenMPTarget) {
 
     addVariantTuningName(vid, "direct");
 


### PR DESCRIPTION
# Summary 

- This PR is a bugfix.
- It updates the RAJA submodule, which had broken namespaces on omp target exec policies
- Fixes compilation issues for openmp target variants in a couple of kernels.

**Note: All kernels and variants, except for edge3d, run correctly in an openmp target build using the clang/ibm-16.0.6-cuda-11.2.0-gcc-8.3.1 compiler on LC blueos machines. Even the Base_Seq variant of edge3d will not run in this build although all non-OpenMPTarget variants of edge3d run correctly for builds with other compilers on other platforms.**

So there is more to do here. Not sure what is going on.