### PR TITLE
Remove the allow problematic implementations flag

### DIFF
--- a/scripts/lc-builds/toss4_cray-mpich_amdclang.sh
+++ b/scripts/lc-builds/toss4_cray-mpich_amdclang.sh
@@ -104,11 +104,10 @@ echo
 echo "    module unload rocm"
 echo "    srun -n1 make"
 echo
-echo "  Please note that cray-mpich requires libmodules.so.1 from cce and"
-echo "  libpgmath.so from rocm/llvm to run."
+echo "  Please note that rocm requires libpgmath.so from rocm/llvm to run."
 echo "  Until this is handled transparently in the build system you may add "
-echo "  cce and rocm/llvm to your LD_LIBRARY_PATH."
+echo "  rocm/llvm to your LD_LIBRARY_PATH."
 echo
-echo "    export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/tce/packages/cce-tce/cce-13.0.2/cce/x86_64/lib/:/usr/rocm-5.7.0/llvm/lib"
+echo "    export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/opt/rocm-${COMP_VER}/llvm/lib"
 echo
 echo "***********************************************************************"

--- a/src/basic/INDEXLIST.cpp
+++ b/src/basic/INDEXLIST.cpp
@@ -46,13 +46,9 @@ INDEXLIST::INDEXLIST(const RunParams& params)
   setVariantDefined( Base_OpenMPTarget );
 #endif
 
-  if (params.getAllowProblematicImplementations()) {
-    // these may deadlock depending on the order that blocks are scheduled
+  setVariantDefined( Base_CUDA );
 
-    setVariantDefined( Base_CUDA );
-
-    setVariantDefined( Base_HIP );
-  }
+  setVariantDefined( Base_HIP );
 }
 
 INDEXLIST::~INDEXLIST()

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -71,7 +71,6 @@ RunParams::RunParams(int argc, char** argv)
    add_to_spot_config(),
 #endif
    disable_warmup(false),
-   allow_problematic_implementations(false),
    run_kernels(),
    run_variants()
 {
@@ -142,8 +141,6 @@ void RunParams::print(std::ostream& str) const
 #endif
 
   str << "\n disable_warmup = " << disable_warmup;
-  str << "\n allow_problematic_implementations = "
-      << allow_problematic_implementations;
 
   str << "\n seq data space = " << getDataSpaceName(seqDataSpace);
   str << "\n omp data space = " << getDataSpaceName(ompDataSpace);
@@ -799,11 +796,6 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
 
       disable_warmup = true;
 
-    } else if ( std::string(argv[i]) ==
-                std::string("--allow-problematic-implementations") ) {
-
-      allow_problematic_implementations = true;
-
     } else if ( std::string(argv[i]) == std::string("--checkrun") ) {
 
       input_state = CheckRun;
@@ -992,9 +984,6 @@ void RunParams::printHelpMessage(std::ostream& str) const
       << "\t ========================================\n\n";;
 
   str << "\t --disable-warmup (disable warmup kernels) [Default is run warmup kernels that are relevant to kernels selected to run]\n\n";
-
-  str << "\t --allow-problematic-implementations (allow problematic kernel implementations) [Default is to not allow problematic kernel implementations to run]\n"
-      << "\t      These implementations may deadlock causing the code to hang indefinitely.\n\n";
 
   str << "\t --kernels, -k <space-separated strings> [Default is run all]\n"
       << "\t      (names of individual kernels and/or groups of kernels to run)\n"

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -181,9 +181,6 @@ public:
 
   bool getDisableWarmup() const { return disable_warmup; }
 
-  bool getAllowProblematicImplementations() const
-  { return allow_problematic_implementations; }
-
   const std::set<KernelID>& getKernelIDsToRun() const { return run_kernels; }
   const std::set<VariantID>& getVariantIDsToRun() const { return run_variants; }
   VariantID getReferenceVariantID() const { return reference_vid; }
@@ -302,8 +299,6 @@ private:
 #endif
 
   bool disable_warmup;
-
-  bool allow_problematic_implementations;
 
   std::set<KernelID>  run_kernels;
   std::set<VariantID> run_variants;


### PR DESCRIPTION
# Remove the now unnecessary allow problematic implementations flag

The kernels with problematic implementations have been fixed.

- This PR is a feature
- It does the following (modify list as needed):
  - Adds it at the request of me
