### PR TITLE
Add ATOMIC kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ set(RAJA_USE_CHRONO On CACHE BOOL "")
 
 set(RAJA_PERFSUITE_GPU_BLOCKSIZES "" CACHE STRING "Comma separated list of GPU block sizes, ex '256,1024'")
 
+set(RAJA_PERFSUITE_ATOMIC_REPLICATIONS "" CACHE STRING "Comma separated list of atomic replications, ex '1,256,4096'")
+
 set(RAJA_RANGE_ALIGN 4)
 set(RAJA_RANGE_MIN_LENGTH 32)
 set(RAJA_DATA_ALIGN 64)
@@ -84,6 +86,13 @@ if (BLOCKSIZES_LENGTH GREATER 0)
   message(STATUS "Using gpu block size(s): ${RAJA_PERFSUITE_GPU_BLOCKSIZES}")
 else()
   message(STATUS "Using default gpu block size(s)")
+endif()
+
+string(LENGTH "${RAJA_PERFSUITE_ATOMIC_REPLICATIONS}" ATOMIC_REPLICATIONS_LENGTH)
+if (ATOMIC_REPLICATIONS_LENGTH GREATER 0)
+  message(STATUS "Using atomic replication(s): ${RAJA_PERFSUITE_ATOMIC_REPLICATIONS}")
+else()
+  message(STATUS "Using default atomic replication(s)")
 endif()
 
 # exclude RAJA make targets from top-level build...

--- a/docs/sphinx/user_guide/build.rst
+++ b/docs/sphinx/user_guide/build.rst
@@ -201,7 +201,7 @@ multiple versions of GPU kernels that will run with different GPU thread-block
 sizes. The CMake option for this is 
 ``-DRAJA_PERFSUITE_GPU_BLOCKSIZES=<list,of,block,sizes>``. For example::
 
-  $ mkdir my-gnu-build
+  $ mkdir my-gpu-build
   $ cd my-gpu-build
   $ cmake <cmake args> \
     -DRAJA_PERFSUITE_GPU_BLOCKSIZES=64,128,256,512,1024 \
@@ -210,6 +210,24 @@ sizes. The CMake option for this is
 
 will build versions of GPU kernels that use 64, 128, 256, 512, and 1024 threads
 per GPU thread-block.
+
+Building with specific GPU atomic replication tunings
+-----------------------------------------------------
+
+If desired, you can build a version of the RAJA Performance Suite code with
+multiple versions of GPU kernels that will run with different GPU atomic
+replication amounts. The CMake option for this is
+``-DRAJA_PERFSUITE_ATOMIC_REPLICATIONS=<list,of,atomic,replication,amounts>``. For example::
+
+  $ mkdir my-gpu-build
+  $ cd my-gpu-build
+  $ cmake <cmake args> \
+    -DRAJA_PERFSUITE_ATOMIC_REPLICATIONS=1,256,4096 \
+    ..
+  $ make -j
+
+will build versions of GPU kernels that use 1, 256, and 4096 atomic
+replications.
 
 Building with Caliper
 ---------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -244,6 +244,9 @@ blt_add_executable(
   algorithm/MEMCPY.cpp
   algorithm/MEMCPY-Seq.cpp
   algorithm/MEMCPY-OMPTarget.cpp
+  algorithm/ATOMIC.cpp
+  algorithm/ATOMIC-Seq.cpp
+  algorithm/ATOMIC-OMPTarget.cpp
   comm/HALO_base.cpp
   comm/HALO_PACKING.cpp
   comm/HALO_PACKING-Seq.cpp

--- a/src/algorithm/ATOMIC-Cuda.cpp
+++ b/src/algorithm/ATOMIC-Cuda.cpp
@@ -205,7 +205,7 @@ void ATOMIC::runCudaVariant(VariantID vid, size_t tune_idx)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        seq_for(atomic_replications_type{}, [&](auto replication) {
+        seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
           if (run_params.numValidAtomicReplication() == 0u ||
               run_params.validAtomicReplication(replication)) {
@@ -225,7 +225,7 @@ void ATOMIC::runCudaVariant(VariantID vid, size_t tune_idx)
 
         if ( vid == Base_CUDA ) {
 
-          seq_for(atomic_replications_type{}, [&](auto replication) {
+          seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
                 run_params.validAtomicReplication(replication)) {
@@ -243,7 +243,7 @@ void ATOMIC::runCudaVariant(VariantID vid, size_t tune_idx)
 
           });
 
-          seq_for(atomic_replications_type{}, [&](auto replication) {
+          seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
                 run_params.validAtomicReplication(replication)) {
@@ -284,7 +284,7 @@ void ATOMIC::setCudaTuningDefinitions(VariantID vid)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        seq_for(atomic_replications_type{}, [&](auto replication) {
+        seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
           if (run_params.numValidAtomicReplication() == 0u ||
               run_params.validAtomicReplication(replication)) {
@@ -298,7 +298,7 @@ void ATOMIC::setCudaTuningDefinitions(VariantID vid)
 
         if ( vid == Base_CUDA ) {
 
-          seq_for(atomic_replications_type{}, [&](auto replication) {
+          seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
                 run_params.validAtomicReplication(replication)) {
@@ -310,7 +310,7 @@ void ATOMIC::setCudaTuningDefinitions(VariantID vid)
 
           });
 
-          seq_for(atomic_replications_type{}, [&](auto replication) {
+          seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
                 run_params.validAtomicReplication(replication)) {

--- a/src/algorithm/ATOMIC-Cuda.cpp
+++ b/src/algorithm/ATOMIC-Cuda.cpp
@@ -1,0 +1,241 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ATOMIC.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+template < size_t block_size, size_t replication >
+__launch_bounds__(block_size)
+__global__ void atomic_replicate_thread(Real_ptr atomic,
+                          Index_type iend)
+{
+   Index_type i = blockIdx.x * block_size + threadIdx.x;
+   if (i < iend) {
+     ATOMIC_RAJA_BODY(RAJA::cuda_atomic, i);
+   }
+}
+
+template < size_t block_size, size_t replication >
+__launch_bounds__(block_size)
+__global__ void atomic_replicate_block(Real_ptr atomic,
+                          Index_type iend)
+{
+   Index_type i = blockIdx.x * block_size + threadIdx.x;
+   if (i < iend) {
+     ATOMIC_RAJA_BODY(RAJA::cuda_atomic, blockIdx.x);
+   }
+}
+
+
+template < size_t block_size, size_t replication >
+void ATOMIC::runCudaVariantReplicateGlobal(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  ATOMIC_DATA_SETUP(replication);
+
+  if ( vid == Base_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchCudaKernel( (atomic_replicate_thread<block_size, replication>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         atomic,
+                         iend );
+
+    }
+    stopTimer();
+
+  } else  if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::cuda_exec<block_size, true /*async*/>>(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          ATOMIC_RAJA_BODY(RAJA::cuda_atomic, i);
+      });
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  ATOMIC : Unknown Cuda variant id = " << vid << std::endl;
+  }
+
+  ATOMIC_DATA_TEARDOWN(replication);
+}
+
+template < size_t block_size, size_t replication >
+void ATOMIC::runCudaVariantReplicateBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  ATOMIC_DATA_SETUP(replication);
+
+  if ( vid == Base_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchCudaKernel( (atomic_replicate_block<block_size, replication>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         atomic,
+                         iend );
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  ATOMIC : Unknown Cuda variant id = " << vid << std::endl;
+  }
+
+  ATOMIC_DATA_TEARDOWN(replication);
+}
+
+void ATOMIC::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        seq_for(atomic_replications_type{}, [&](auto replication) {
+
+          if (run_params.numValidAtomicReplication() == 0u ||
+              run_params.validAtomicReplication(replication)) {
+
+            if (tune_idx == t) {
+
+              setBlockSize(block_size);
+              runCudaVariantReplicateGlobal<decltype(block_size)::value, replication>(vid);
+
+            }
+
+            t += 1;
+
+          }
+
+        });
+
+        if ( vid == Base_CUDA ) {
+
+          seq_for(atomic_replications_type{}, [&](auto replication) {
+
+            if (run_params.numValidAtomicReplication() == 0u ||
+                run_params.validAtomicReplication(replication)) {
+
+              if (tune_idx == t) {
+
+                setBlockSize(block_size);
+                runCudaVariantReplicateBlock<decltype(block_size)::value, replication>(vid);
+
+              }
+
+              t += 1;
+
+            }
+
+          });
+
+        }
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  ATOMIC : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void ATOMIC::setCudaTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        seq_for(atomic_replications_type{}, [&](auto replication) {
+
+          if (run_params.numValidAtomicReplication() == 0u ||
+              run_params.validAtomicReplication(replication)) {
+
+            addVariantTuningName(vid, "replicate_"+std::to_string(replication)+
+                                      "_global_"+std::to_string(block_size));
+
+          }
+
+        });
+
+        if ( vid == Base_CUDA ) {
+
+          seq_for(atomic_replications_type{}, [&](auto replication) {
+
+            if (run_params.numValidAtomicReplication() == 0u ||
+                run_params.validAtomicReplication(replication)) {
+
+              addVariantTuningName(vid, "replicate_"+std::to_string(replication)+
+                                        "_block_"+std::to_string(block_size));
+
+            }
+
+          });
+
+        }
+
+      }
+
+    });
+
+  }
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/algorithm/ATOMIC-Hip.cpp
+++ b/src/algorithm/ATOMIC-Hip.cpp
@@ -205,7 +205,7 @@ void ATOMIC::runHipVariant(VariantID vid, size_t tune_idx)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        seq_for(atomic_replications_type{}, [&](auto replication) {
+        seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
           if (run_params.numValidAtomicReplication() == 0u ||
               run_params.validAtomicReplication(replication)) {
@@ -225,7 +225,7 @@ void ATOMIC::runHipVariant(VariantID vid, size_t tune_idx)
 
         if ( vid == Base_HIP ) {
 
-          seq_for(atomic_replications_type{}, [&](auto replication) {
+          seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
                 run_params.validAtomicReplication(replication)) {
@@ -243,7 +243,7 @@ void ATOMIC::runHipVariant(VariantID vid, size_t tune_idx)
 
           });
 
-          seq_for(atomic_replications_type{}, [&](auto replication) {
+          seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
                 run_params.validAtomicReplication(replication)) {
@@ -284,7 +284,7 @@ void ATOMIC::setHipTuningDefinitions(VariantID vid)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        seq_for(atomic_replications_type{}, [&](auto replication) {
+        seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
           if (run_params.numValidAtomicReplication() == 0u ||
               run_params.validAtomicReplication(replication)) {
@@ -298,7 +298,7 @@ void ATOMIC::setHipTuningDefinitions(VariantID vid)
 
         if ( vid == Base_HIP ) {
 
-          seq_for(atomic_replications_type{}, [&](auto replication) {
+          seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
                 run_params.validAtomicReplication(replication)) {
@@ -310,7 +310,7 @@ void ATOMIC::setHipTuningDefinitions(VariantID vid)
 
           });
 
-          seq_for(atomic_replications_type{}, [&](auto replication) {
+          seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
                 run_params.validAtomicReplication(replication)) {

--- a/src/algorithm/ATOMIC-Hip.cpp
+++ b/src/algorithm/ATOMIC-Hip.cpp
@@ -1,0 +1,241 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ATOMIC.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+#include "common/HipDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+template < size_t block_size, size_t replication >
+__launch_bounds__(block_size)
+__global__ void atomic_replicate_thread(Real_ptr atomic,
+                          Index_type iend)
+{
+  Index_type i = blockIdx.x * block_size + threadIdx.x;
+  if (i < iend) {
+    ATOMIC_RAJA_BODY(RAJA::hip_atomic, i);
+  }
+}
+
+template < size_t block_size, size_t replication >
+__launch_bounds__(block_size)
+__global__ void atomic_replicate_block(Real_ptr atomic,
+                          Index_type iend)
+{
+  Index_type i = blockIdx.x * block_size + threadIdx.x;
+  if (i < iend) {
+    ATOMIC_RAJA_BODY(RAJA::hip_atomic, blockIdx.x);
+  }
+}
+
+
+template < size_t block_size, size_t replication >
+void ATOMIC::runHipVariantReplicateGlobal(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  ATOMIC_DATA_SETUP(replication);
+
+  if ( vid == Base_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchHipKernel( (atomic_replicate_thread<block_size, replication>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         atomic,
+                         iend );
+
+    }
+    stopTimer();
+
+  } else  if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::hip_exec<block_size, true /*async*/>>(
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
+          ATOMIC_RAJA_BODY(RAJA::hip_atomic, i);
+      });
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  ATOMIC : Unknown Hip variant id = " << vid << std::endl;
+  }
+
+  ATOMIC_DATA_TEARDOWN(replication);
+}
+
+template < size_t block_size, size_t replication >
+void ATOMIC::runHipVariantReplicateBlock(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  ATOMIC_DATA_SETUP(replication);
+
+  if ( vid == Base_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchHipKernel( (atomic_replicate_block<block_size, replication>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         atomic,
+                         iend );
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  ATOMIC : Unknown Hip variant id = " << vid << std::endl;
+  }
+
+  ATOMIC_DATA_TEARDOWN(replication);
+}
+
+void ATOMIC::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        seq_for(atomic_replications_type{}, [&](auto replication) {
+
+        if (run_params.numValidAtomicReplication() == 0u ||
+            run_params.validAtomicReplication(replication)) {
+
+            if (tune_idx == t) {
+
+              setBlockSize(block_size);
+              runHipVariantReplicateGlobal<block_size, replication>(vid);
+
+            }
+
+            t += 1;
+
+          }
+
+        });
+
+        if ( vid == Base_HIP ) {
+
+          seq_for(atomic_replications_type{}, [&](auto replication) {
+
+          if (run_params.numValidAtomicReplication() == 0u ||
+              run_params.validAtomicReplication(replication)) {
+
+              if (tune_idx == t) {
+
+                setBlockSize(block_size);
+                runHipVariantReplicateBlock<block_size, replication>(vid);
+
+              }
+
+              t += 1;
+
+            }
+
+          });
+
+        }
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  ATOMIC : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void ATOMIC::setHipTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        seq_for(atomic_replications_type{}, [&](auto replication) {
+
+          if (run_params.numValidAtomicReplication() == 0u ||
+              run_params.validAtomicReplication(replication)) {
+
+            addVariantTuningName(vid, "replicate_"+std::to_string(replication)+
+                                      "_global_"+std::to_string(block_size));
+
+          }
+
+        });
+
+        if ( vid == Base_HIP ) {
+
+          seq_for(atomic_replications_type{}, [&](auto replication) {
+
+          if (run_params.numValidAtomicReplication() == 0u ||
+              run_params.validAtomicReplication(replication)) {
+
+              addVariantTuningName(vid, "replicate_"+std::to_string(replication)+
+                                        "_block_"+std::to_string(block_size));
+
+            }
+
+          });
+
+        }
+
+      }
+
+    });
+
+  }
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_HIP

--- a/src/algorithm/ATOMIC-Hip.cpp
+++ b/src/algorithm/ATOMIC-Hip.cpp
@@ -14,12 +14,17 @@
 
 #include "common/HipDataUtils.hpp"
 
+#include <rocprim/block/block_reduce.hpp>
+#include <rocprim/warp/warp_reduce.hpp>
+
 #include <iostream>
 
 namespace rajaperf
 {
 namespace algorithm
 {
+
+const size_t warp_size = 64;
 
 template < size_t block_size, size_t replication >
 __launch_bounds__(block_size)
@@ -28,7 +33,27 @@ __global__ void atomic_replicate_thread(Real_ptr atomic,
 {
   Index_type i = blockIdx.x * block_size + threadIdx.x;
   if (i < iend) {
-    ATOMIC_RAJA_BODY(RAJA::hip_atomic, i);
+    ATOMIC_RAJA_BODY(RAJA::hip_atomic, i, ATOMIC_VALUE);
+  }
+}
+
+template < size_t block_size, size_t replication >
+__launch_bounds__(block_size)
+__global__ void atomic_replicate_warp(Real_ptr atomic,
+                          Index_type iend)
+{
+  Real_type val = 0;
+
+  Index_type i = blockIdx.x * block_size + threadIdx.x;
+  if (i < iend) {
+    val = ATOMIC_VALUE;
+  }
+
+  using WarpReduce = rocprim::warp_reduce<Real_type, warp_size>;
+  __shared__ typename WarpReduce::storage_type warp_reduce_storage;
+  WarpReduce().reduce(val, val, warp_reduce_storage);
+  if ((threadIdx.x % warp_size) == 0) {
+    ATOMIC_RAJA_BODY(RAJA::hip_atomic, i/warp_size, val);
   }
 }
 
@@ -37,9 +62,18 @@ __launch_bounds__(block_size)
 __global__ void atomic_replicate_block(Real_ptr atomic,
                           Index_type iend)
 {
+  Real_type val = 0;
+
   Index_type i = blockIdx.x * block_size + threadIdx.x;
   if (i < iend) {
-    ATOMIC_RAJA_BODY(RAJA::hip_atomic, blockIdx.x);
+    val = ATOMIC_VALUE;
+  }
+
+  using BlockReduce = rocprim::block_reduce<Real_type, block_size>;
+  __shared__ typename BlockReduce::storage_type block_reduce_storage;
+  BlockReduce().reduce(val, val, block_reduce_storage);
+  if (threadIdx.x == 0) {
+    ATOMIC_RAJA_BODY(RAJA::hip_atomic, blockIdx.x, val);
   }
 }
 
@@ -79,8 +113,42 @@ void ATOMIC::runHipVariantReplicateGlobal(VariantID vid)
 
       RAJA::forall<RAJA::hip_exec<block_size, true /*async*/>>(
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
-          ATOMIC_RAJA_BODY(RAJA::hip_atomic, i);
+          ATOMIC_RAJA_BODY(RAJA::hip_atomic, i, ATOMIC_VALUE);
       });
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  ATOMIC : Unknown Hip variant id = " << vid << std::endl;
+  }
+
+  ATOMIC_DATA_TEARDOWN(replication);
+}
+
+template < size_t block_size, size_t replication >
+void ATOMIC::runHipVariantReplicateWarp(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  ATOMIC_DATA_SETUP(replication);
+
+  if ( vid == Base_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchHipKernel( (atomic_replicate_warp<block_size, replication>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         atomic,
+                         iend );
 
     }
     stopTimer();
@@ -96,7 +164,6 @@ template < size_t block_size, size_t replication >
 void ATOMIC::runHipVariantReplicateBlock(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
-  const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
   auto res{getHipResource()};
@@ -140,8 +207,8 @@ void ATOMIC::runHipVariant(VariantID vid, size_t tune_idx)
 
         seq_for(atomic_replications_type{}, [&](auto replication) {
 
-        if (run_params.numValidAtomicReplication() == 0u ||
-            run_params.validAtomicReplication(replication)) {
+          if (run_params.numValidAtomicReplication() == 0u ||
+              run_params.validAtomicReplication(replication)) {
 
             if (tune_idx == t) {
 
@@ -160,8 +227,26 @@ void ATOMIC::runHipVariant(VariantID vid, size_t tune_idx)
 
           seq_for(atomic_replications_type{}, [&](auto replication) {
 
-          if (run_params.numValidAtomicReplication() == 0u ||
-              run_params.validAtomicReplication(replication)) {
+            if (run_params.numValidAtomicReplication() == 0u ||
+                run_params.validAtomicReplication(replication)) {
+
+              if (tune_idx == t) {
+
+                setBlockSize(block_size);
+                runHipVariantReplicateWarp<block_size, replication>(vid);
+
+              }
+
+              t += 1;
+
+            }
+
+          });
+
+          seq_for(atomic_replications_type{}, [&](auto replication) {
+
+            if (run_params.numValidAtomicReplication() == 0u ||
+                run_params.validAtomicReplication(replication)) {
 
               if (tune_idx == t) {
 
@@ -215,8 +300,20 @@ void ATOMIC::setHipTuningDefinitions(VariantID vid)
 
           seq_for(atomic_replications_type{}, [&](auto replication) {
 
-          if (run_params.numValidAtomicReplication() == 0u ||
-              run_params.validAtomicReplication(replication)) {
+            if (run_params.numValidAtomicReplication() == 0u ||
+                run_params.validAtomicReplication(replication)) {
+
+              addVariantTuningName(vid, "replicate_"+std::to_string(replication)+
+                                        "_warp_"+std::to_string(block_size));
+
+            }
+
+          });
+
+          seq_for(atomic_replications_type{}, [&](auto replication) {
+
+            if (run_params.numValidAtomicReplication() == 0u ||
+                run_params.validAtomicReplication(replication)) {
 
               addVariantTuningName(vid, "replicate_"+std::to_string(replication)+
                                         "_block_"+std::to_string(block_size));

--- a/src/algorithm/ATOMIC-OMP.cpp
+++ b/src/algorithm/ATOMIC-OMP.cpp
@@ -1,0 +1,153 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ATOMIC.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+template < size_t replication >
+void ATOMIC::runOpenMPVariantReplicate(VariantID vid)
+{
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  ATOMIC_DATA_SETUP(replication);
+
+  switch ( vid ) {
+
+    case Base_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          #pragma omp atomic
+          ATOMIC_BODY(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case Lambda_OpenMP : {
+
+      auto atomic_base_lam = [=](Index_type i) {
+                                 #pragma omp atomic
+                                 ATOMIC_BODY(i);
+                               };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          atomic_base_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::forall<RAJA::omp_parallel_for_exec>(
+          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+            ATOMIC_RAJA_BODY(RAJA::omp_atomic, i);
+        });
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    default : {
+      getCout() << "\n  ATOMIC : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+  ATOMIC_DATA_TEARDOWN(replication);
+
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+
+void ATOMIC::runOpenMPVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_OpenMP || vid == Lambda_OpenMP || vid == RAJA_OpenMP ) {
+
+    seq_for(cpu_atomic_replications_type{}, [&](auto replication) {
+
+      if (run_params.numValidAtomicReplication() == 0u ||
+          run_params.validAtomicReplication(replication)) {
+
+        if (tune_idx == t) {
+
+          runOpenMPVariantReplicate<replication>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  ATOMIC : Unknown OMP Target variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void ATOMIC::setOpenMPTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_OpenMP || vid == Lambda_OpenMP || vid == RAJA_OpenMP ) {
+
+    seq_for(cpu_atomic_replications_type{}, [&](auto replication) {
+
+      if (run_params.numValidAtomicReplication() == 0u ||
+          run_params.validAtomicReplication(replication)) {
+
+        addVariantTuningName(vid, "replicate_"+std::to_string(replication));
+
+      }
+
+    });
+
+  }
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/ATOMIC-OMP.cpp
+++ b/src/algorithm/ATOMIC-OMP.cpp
@@ -39,7 +39,7 @@ void ATOMIC::runOpenMPVariantReplicate(VariantID vid)
         #pragma omp parallel for
         for (Index_type i = ibegin; i < iend; ++i ) {
           #pragma omp atomic
-          ATOMIC_BODY(i);
+          ATOMIC_BODY(i, ATOMIC_VALUE);
         }
 
       }
@@ -52,7 +52,7 @@ void ATOMIC::runOpenMPVariantReplicate(VariantID vid)
 
       auto atomic_base_lam = [=](Index_type i) {
                                  #pragma omp atomic
-                                 ATOMIC_BODY(i);
+                                 ATOMIC_BODY(i, ATOMIC_VALUE);
                                };
 
       startTimer();
@@ -76,7 +76,7 @@ void ATOMIC::runOpenMPVariantReplicate(VariantID vid)
 
         RAJA::forall<RAJA::omp_parallel_for_exec>(
           RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-            ATOMIC_RAJA_BODY(RAJA::omp_atomic, i);
+            ATOMIC_RAJA_BODY(RAJA::omp_atomic, i, ATOMIC_VALUE);
         });
 
       }

--- a/src/algorithm/ATOMIC-OMPTarget.cpp
+++ b/src/algorithm/ATOMIC-OMPTarget.cpp
@@ -77,7 +77,7 @@ void ATOMIC::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 
   if ( vid == Base_OpenMPTarget || vid == RAJA_OpenMPTarget ) {
 
-    seq_for(atomic_replications_type{}, [&](auto replication) {
+    seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
       if (run_params.numValidAtomicReplication() == 0u ||
           run_params.validAtomicReplication(replication)) {
@@ -106,7 +106,7 @@ void ATOMIC::setOpenMPTargetTuningDefinitions(VariantID vid)
 {
   if ( vid == Base_OpenMPTarget || vid == RAJA_OpenMPTarget ) {
 
-    seq_for(atomic_replications_type{}, [&](auto replication) {
+    seq_for(gpu_atomic_replications_type{}, [&](auto replication) {
 
       if (run_params.numValidAtomicReplication() == 0u ||
           run_params.validAtomicReplication(replication)) {

--- a/src/algorithm/ATOMIC-OMPTarget.cpp
+++ b/src/algorithm/ATOMIC-OMPTarget.cpp
@@ -44,7 +44,7 @@ void ATOMIC::runOpenMPTargetReplicate(VariantID vid)
       #pragma omp teams distribute parallel for thread_limit(threads_per_team) schedule(static, 1)
       for (Index_type i = ibegin; i < iend; ++i ) {
         #pragma omp atomic
-        ATOMIC_BODY(i);
+        ATOMIC_BODY(i, ATOMIC_VALUE);
       }
 
     }
@@ -57,7 +57,7 @@ void ATOMIC::runOpenMPTargetReplicate(VariantID vid)
 
       RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
         RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          ATOMIC_RAJA_BODY(RAJA::omp_atomic, i);
+          ATOMIC_RAJA_BODY(RAJA::omp_atomic, i, ATOMIC_VALUE);
       });
 
     }

--- a/src/algorithm/ATOMIC-OMPTarget.cpp
+++ b/src/algorithm/ATOMIC-OMPTarget.cpp
@@ -1,0 +1,127 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ATOMIC.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+  //
+  // Define threads per team for target execution
+  //
+  const size_t threads_per_team = 256;
+
+template < size_t replication >
+void ATOMIC::runOpenMPTargetReplicate(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  ATOMIC_DATA_SETUP(replication);
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(atomic)
+      #pragma omp teams distribute parallel for thread_limit(threads_per_team) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        #pragma omp atomic
+        ATOMIC_BODY(i);
+      }
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+          ATOMIC_RAJA_BODY(RAJA::omp_atomic, i);
+      });
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  ATOMIC : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+
+  ATOMIC_DATA_TEARDOWN(replication);
+
+}
+
+void ATOMIC::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_OpenMPTarget || vid == RAJA_OpenMPTarget ) {
+
+    seq_for(atomic_replications_type{}, [&](auto replication) {
+
+      if (run_params.numValidAtomicReplication() == 0u ||
+          run_params.validAtomicReplication(replication)) {
+
+        if (tune_idx == t) {
+
+          runOpenMPTargetVariantReplicate<replication>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  ATOMIC : Unknown OMP Target variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void ATOMIC::setOpenMPTargetTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_OpenMPTarget || vid == RAJA_OpenMPTarget ) {
+
+    seq_for(atomic_replications_type{}, [&](auto replication) {
+
+      if (run_params.numValidAtomicReplication() == 0u ||
+          run_params.validAtomicReplication(replication)) {
+
+        addVariantTuningName(vid, "replicate_"+std::to_string(replication));
+
+      }
+
+    });
+
+  }
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/algorithm/ATOMIC-Seq.cpp
+++ b/src/algorithm/ATOMIC-Seq.cpp
@@ -1,0 +1,146 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ATOMIC.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+template < size_t replication >
+void ATOMIC::runSeqVariantReplicate(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  ATOMIC_DATA_SETUP(replication);
+
+  switch ( vid ) {
+
+    case Base_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          ATOMIC_BODY(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+#if defined(RUN_RAJA_SEQ)
+    case Lambda_Seq : {
+
+      auto atomic_base_lam = [=](Index_type i) {
+                                 ATOMIC_BODY(i);
+                               };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          atomic_base_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::forall<RAJA::seq_exec>( RAJA::RangeSegment(ibegin, iend),
+          [=](Index_type i) {
+            ATOMIC_RAJA_BODY(RAJA::seq_atomic, i);
+        });
+
+      }
+      stopTimer();
+
+      break;
+    }
+#endif
+
+    default : {
+      getCout() << "\n  ATOMIC : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+  ATOMIC_DATA_TEARDOWN(replication);
+
+}
+
+
+void ATOMIC::runSeqVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_Seq || vid == Lambda_Seq || vid == RAJA_Seq ) {
+
+    seq_for(cpu_atomic_replications_type{}, [&](auto replication) {
+
+      if (run_params.numValidAtomicReplication() == 0u ||
+          run_params.validAtomicReplication(replication)) {
+
+        if (tune_idx == t) {
+
+          runSeqVariantReplicate<replication>(vid);
+
+        }
+
+        t += 1;
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  ATOMIC : Unknown OMP Target variant id = " << vid << std::endl;
+
+  }
+
+}
+
+void ATOMIC::setSeqTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_Seq || vid == Lambda_Seq || vid == RAJA_Seq ) {
+
+    seq_for(cpu_atomic_replications_type{}, [&](auto replication) {
+
+      if (run_params.numValidAtomicReplication() == 0u ||
+          run_params.validAtomicReplication(replication)) {
+
+        addVariantTuningName(vid, "replicate_"+std::to_string(replication));
+
+      }
+
+    });
+
+  }
+
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/ATOMIC-Seq.cpp
+++ b/src/algorithm/ATOMIC-Seq.cpp
@@ -35,7 +35,7 @@ void ATOMIC::runSeqVariantReplicate(VariantID vid)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         for (Index_type i = ibegin; i < iend; ++i ) {
-          ATOMIC_BODY(i);
+          ATOMIC_BODY(i, ATOMIC_VALUE);
         }
 
       }
@@ -48,7 +48,7 @@ void ATOMIC::runSeqVariantReplicate(VariantID vid)
     case Lambda_Seq : {
 
       auto atomic_base_lam = [=](Index_type i) {
-                                 ATOMIC_BODY(i);
+                                 ATOMIC_BODY(i, ATOMIC_VALUE);
                                };
 
       startTimer();
@@ -71,7 +71,7 @@ void ATOMIC::runSeqVariantReplicate(VariantID vid)
 
         RAJA::forall<RAJA::seq_exec>( RAJA::RangeSegment(ibegin, iend),
           [=](Index_type i) {
-            ATOMIC_RAJA_BODY(RAJA::seq_atomic, i);
+            ATOMIC_RAJA_BODY(RAJA::seq_atomic, i, ATOMIC_VALUE);
         });
 
       }

--- a/src/algorithm/ATOMIC.cpp
+++ b/src/algorithm/ATOMIC.cpp
@@ -1,0 +1,79 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ATOMIC.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+
+ATOMIC::ATOMIC(const RunParams& params)
+  : KernelBase(rajaperf::Algorithm_ATOMIC, params)
+{
+  setDefaultProblemSize(1000000);
+  setDefaultReps(50);
+
+  setActualProblemSize( getTargetProblemSize() );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) +
+                  (0*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setFLOPsPerRep(getActualProblemSize());
+
+  setUsesFeature(Forall);
+  setUsesFeature(Atomic);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
+  setVariantDefined( RAJA_HIP );
+}
+
+ATOMIC::~ATOMIC()
+{
+}
+
+void ATOMIC::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  m_init = 0;
+  m_final = -static_cast<int>(vid);
+}
+
+void ATOMIC::updateChecksum(VariantID vid, size_t tune_idx)
+{
+  checksum[vid][tune_idx] += static_cast<Checksum_type>(m_final);
+}
+
+void ATOMIC::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  (void) vid;
+}
+
+} // end namespace algorithm
+} // end namespace rajaperf

--- a/src/algorithm/ATOMIC.hpp
+++ b/src/algorithm/ATOMIC.hpp
@@ -101,7 +101,7 @@ private:
   static const size_t default_cpu_atomic_replication = 64;
   using cpu_atomic_replications_type = integer::make_atomic_replication_list_type<default_cpu_atomic_replication>;
   static const size_t default_atomic_replication = 4096;
-  using atomic_replications_type = integer::make_atomic_replication_list_type<default_atomic_replication>;
+  using gpu_atomic_replications_type = integer::make_atomic_replication_list_type<default_atomic_replication>;
 
   Real_type m_init;
   Real_type m_final;

--- a/src/algorithm/ATOMIC.hpp
+++ b/src/algorithm/ATOMIC.hpp
@@ -1,0 +1,107 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// ATOMIC kernel reference implementation:
+/// Test atomic throughput with an amount of replication known at compile time.
+///
+/// for (Index_type i = 0; i < N; ++i ) {
+///   atomic[i%replication] += 1;
+/// }
+///
+
+#ifndef RAJAPerf_Algorithm_ATOMIC_HPP
+#define RAJAPerf_Algorithm_ATOMIC_HPP
+
+#define ATOMIC_DATA_SETUP(replication) \
+  Real_type init = m_init; \
+  Real_ptr atomic; \
+  allocAndInitDataConst(atomic, replication, init, vid);
+
+#define ATOMIC_DATA_TEARDOWN(replication) \
+  { \
+    auto reset_atomic = scopedMoveData(atomic, replication, vid); \
+    m_final = init; \
+    for (size_t r = 0; r < replication; ++r ) { \
+      m_final += atomic[r]; \
+    } \
+  } \
+  deallocData(atomic, vid);
+
+#define ATOMIC_BODY(i) \
+  atomic[(i)%replication] += 1.0
+
+#define ATOMIC_RAJA_BODY(policy, i) \
+  RAJA::atomicAdd<policy>(&atomic[(i)%replication], 1.0)
+
+
+#include "common/KernelBase.hpp"
+
+namespace rajaperf
+{
+class RunParams;
+
+namespace algorithm
+{
+
+class ATOMIC : public KernelBase
+{
+public:
+
+  ATOMIC(const RunParams& params);
+
+  ~ATOMIC();
+
+  void setUp(VariantID vid, size_t tune_idx);
+  void updateChecksum(VariantID vid, size_t tune_idx);
+  void tearDown(VariantID vid, size_t tune_idx);
+
+  void runSeqVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPVariant(VariantID vid, size_t tune_idx);
+  void runCudaVariant(VariantID vid, size_t tune_idx);
+  void runHipVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runKokkosVariant(VariantID vid, size_t tune_idx);
+
+  void setSeqTuningDefinitions(VariantID vid);
+  void setOpenMPTuningDefinitions(VariantID vid);
+  void setCudaTuningDefinitions(VariantID vid);
+  void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid);
+
+  template < size_t replication >
+  void runSeqVariantReplicate(VariantID vid);
+  template < size_t replication >
+  void runOpenMPVariantReplicate(VariantID vid);
+  template < size_t block_size, size_t replication >
+  void runCudaVariantReplicateGlobal(VariantID vid);
+  template < size_t block_size, size_t replication >
+  void runCudaVariantReplicateBlock(VariantID vid);
+  template < size_t block_size, size_t replication >
+  void runHipVariantReplicateGlobal(VariantID vid);
+  template < size_t block_size, size_t replication >
+  void runHipVariantReplicateBlock(VariantID vid);
+  template < size_t replication >
+  void runOpenMPTargetVariantReplicate(VariantID vid);
+
+private:
+  static const size_t default_gpu_block_size = 256;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
+  static const size_t default_cpu_atomic_replication = 64;
+  using cpu_atomic_replications_type = integer::make_atomic_replication_list_type<default_cpu_atomic_replication>;
+  static const size_t default_atomic_replication = 4096;
+  using atomic_replications_type = integer::make_atomic_replication_list_type<default_atomic_replication>;
+
+  Real_type m_init;
+  Real_type m_final;
+};
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/algorithm/ATOMIC.hpp
+++ b/src/algorithm/ATOMIC.hpp
@@ -33,11 +33,13 @@
   } \
   deallocData(atomic, vid);
 
-#define ATOMIC_BODY(i) \
-  atomic[(i)%replication] += 1.0
+#define ATOMIC_VALUE 1.0
 
-#define ATOMIC_RAJA_BODY(policy, i) \
-  RAJA::atomicAdd<policy>(&atomic[(i)%replication], 1.0)
+#define ATOMIC_BODY(i, val) \
+  atomic[(i)%replication] += (val)
+
+#define ATOMIC_RAJA_BODY(policy, i, val) \
+  RAJA::atomicAdd<policy>(&atomic[(i)%replication], (val))
 
 
 #include "common/KernelBase.hpp"
@@ -81,9 +83,13 @@ public:
   template < size_t block_size, size_t replication >
   void runCudaVariantReplicateGlobal(VariantID vid);
   template < size_t block_size, size_t replication >
-  void runCudaVariantReplicateBlock(VariantID vid);
-  template < size_t block_size, size_t replication >
   void runHipVariantReplicateGlobal(VariantID vid);
+  template < size_t block_size, size_t replication >
+  void runCudaVariantReplicateWarp(VariantID vid);
+  template < size_t block_size, size_t replication >
+  void runHipVariantReplicateWarp(VariantID vid);
+  template < size_t block_size, size_t replication >
+  void runCudaVariantReplicateBlock(VariantID vid);
   template < size_t block_size, size_t replication >
   void runHipVariantReplicateBlock(VariantID vid);
   template < size_t replication >

--- a/src/algorithm/CMakeLists.txt
+++ b/src/algorithm/CMakeLists.txt
@@ -42,5 +42,11 @@ blt_add_library(
           MEMCPY-Cuda.cpp
           MEMCPY-OMP.cpp
           MEMCPY-OMPTarget.cpp
+          ATOMIC.cpp
+          ATOMIC-Seq.cpp
+          ATOMIC-Hip.cpp
+          ATOMIC-Cuda.cpp
+          ATOMIC-OMP.cpp
+          ATOMIC-OMPTarget.cpp
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
   )

--- a/src/algorithm/MEMCPY.hpp
+++ b/src/algorithm/MEMCPY.hpp
@@ -71,7 +71,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/algorithm/MEMSET.hpp
+++ b/src/algorithm/MEMSET.hpp
@@ -71,7 +71,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_type m_val;

--- a/src/algorithm/REDUCE_SUM.hpp
+++ b/src/algorithm/REDUCE_SUM.hpp
@@ -74,7 +74,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_type m_sum_init;

--- a/src/apps/CONVECTION3DPA.hpp
+++ b/src/apps/CONVECTION3DPA.hpp
@@ -388,7 +388,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = CPA_Q1D * CPA_Q1D * CPA_Q1D;
-  using gpu_block_sizes_type = gpu_block_size::list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::list_type<default_gpu_block_size>;
 
   Real_ptr m_B;
   Real_ptr m_Bt;

--- a/src/apps/DEL_DOT_VEC_2D.hpp
+++ b/src/apps/DEL_DOT_VEC_2D.hpp
@@ -128,7 +128,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/apps/DIFFUSION3DPA.hpp
+++ b/src/apps/DIFFUSION3DPA.hpp
@@ -491,7 +491,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = DPA_Q1D * DPA_Q1D * DPA_Q1D;
-  using gpu_block_sizes_type = gpu_block_size::list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::list_type<default_gpu_block_size>;
 
   Real_ptr m_B;
   Real_ptr m_Bt;

--- a/src/apps/EDGE3D.hpp
+++ b/src/apps/EDGE3D.hpp
@@ -427,7 +427,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/apps/ENERGY.hpp
+++ b/src/apps/ENERGY.hpp
@@ -213,7 +213,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_e_new;
   Real_ptr m_e_old;

--- a/src/apps/FIR.hpp
+++ b/src/apps/FIR.hpp
@@ -88,7 +88,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_in;
   Real_ptr m_out;

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -25,8 +25,8 @@ namespace apps
 // Define thread block shape for CUDA execution
 //
 #define m_block_sz (32)
-#define g_block_sz (gpu_block_size::greater_of_squarest_factor_pair(block_size/m_block_sz))
-#define z_block_sz (gpu_block_size::lesser_of_squarest_factor_pair(block_size/m_block_sz))
+#define g_block_sz (integer::greater_of_squarest_factor_pair(block_size/m_block_sz))
+#define z_block_sz (integer::lesser_of_squarest_factor_pair(block_size/m_block_sz))
 
 #define LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA \
   m_block_sz, g_block_sz, z_block_sz

--- a/src/apps/LTIMES-Hip.cpp
+++ b/src/apps/LTIMES-Hip.cpp
@@ -25,8 +25,8 @@ namespace apps
 // Define thread block shape for Hip execution
 //
 #define m_block_sz (32)
-#define g_block_sz (gpu_block_size::greater_of_squarest_factor_pair(block_size/m_block_sz))
-#define z_block_sz (gpu_block_size::lesser_of_squarest_factor_pair(block_size/m_block_sz))
+#define g_block_sz (integer::greater_of_squarest_factor_pair(block_size/m_block_sz))
+#define z_block_sz (integer::lesser_of_squarest_factor_pair(block_size/m_block_sz))
 
 #define LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP \
   m_block_sz, g_block_sz, z_block_sz

--- a/src/apps/LTIMES.hpp
+++ b/src/apps/LTIMES.hpp
@@ -126,8 +126,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Real_ptr m_phidat;
   Real_ptr m_elldat;

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -25,8 +25,8 @@ namespace apps
 // Define thread block shape for CUDA execution
 //
 #define m_block_sz (32)
-#define g_block_sz (gpu_block_size::greater_of_squarest_factor_pair(block_size/m_block_sz))
-#define z_block_sz (gpu_block_size::lesser_of_squarest_factor_pair(block_size/m_block_sz))
+#define g_block_sz (integer::greater_of_squarest_factor_pair(block_size/m_block_sz))
+#define z_block_sz (integer::lesser_of_squarest_factor_pair(block_size/m_block_sz))
 
 #define LTIMES_NOVIEW_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA \
   m_block_sz, g_block_sz, z_block_sz

--- a/src/apps/LTIMES_NOVIEW-Hip.cpp
+++ b/src/apps/LTIMES_NOVIEW-Hip.cpp
@@ -25,8 +25,8 @@ namespace apps
 // Define thread block shape for Hip execution
 //
 #define m_block_sz (32)
-#define g_block_sz (gpu_block_size::greater_of_squarest_factor_pair(block_size/m_block_sz))
-#define z_block_sz (gpu_block_size::lesser_of_squarest_factor_pair(block_size/m_block_sz))
+#define g_block_sz (integer::greater_of_squarest_factor_pair(block_size/m_block_sz))
+#define z_block_sz (integer::lesser_of_squarest_factor_pair(block_size/m_block_sz))
 
 #define LTIMES_NOVIEW_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP \
   m_block_sz, g_block_sz, z_block_sz

--- a/src/apps/LTIMES_NOVIEW.hpp
+++ b/src/apps/LTIMES_NOVIEW.hpp
@@ -76,8 +76,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Real_ptr m_phidat;
   Real_ptr m_elldat;

--- a/src/apps/MASS3DEA.hpp
+++ b/src/apps/MASS3DEA.hpp
@@ -163,7 +163,7 @@ public:
 private:
   static const size_t default_gpu_block_size = MEA_D1D * MEA_D1D * MEA_D1D;
   using gpu_block_sizes_type =
-      gpu_block_size::list_type<default_gpu_block_size>;
+      integer::list_type<default_gpu_block_size>;
 
   Real_ptr m_B;
   Real_ptr m_Bt;

--- a/src/apps/MASS3DPA.hpp
+++ b/src/apps/MASS3DPA.hpp
@@ -373,7 +373,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = MPA_Q1D * MPA_Q1D;
-  using gpu_block_sizes_type = gpu_block_size::list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::list_type<default_gpu_block_size>;
 
   Real_ptr m_B;
   Real_ptr m_Bt;

--- a/src/apps/NODAL_ACCUMULATION_3D.hpp
+++ b/src/apps/NODAL_ACCUMULATION_3D.hpp
@@ -107,7 +107,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_vol;

--- a/src/apps/PRESSURE.hpp
+++ b/src/apps/PRESSURE.hpp
@@ -82,7 +82,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_compression;
   Real_ptr m_bvc;

--- a/src/apps/VOL3D.hpp
+++ b/src/apps/VOL3D.hpp
@@ -183,7 +183,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/apps/ZONAL_ACCUMULATION_3D.hpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D.hpp
@@ -91,7 +91,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_vol;

--- a/src/basic/ARRAY_OF_PTRS.hpp
+++ b/src/basic/ARRAY_OF_PTRS.hpp
@@ -83,7 +83,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/basic/COPY8.hpp
+++ b/src/basic/COPY8.hpp
@@ -90,7 +90,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x0;
   Real_ptr m_x1;

--- a/src/basic/DAXPY.hpp
+++ b/src/basic/DAXPY.hpp
@@ -63,7 +63,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/basic/DAXPY_ATOMIC.hpp
+++ b/src/basic/DAXPY_ATOMIC.hpp
@@ -66,7 +66,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/basic/IF_QUAD.hpp
+++ b/src/basic/IF_QUAD.hpp
@@ -80,7 +80,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_a;
   Real_ptr m_b;

--- a/src/basic/INDEXLIST.hpp
+++ b/src/basic/INDEXLIST.hpp
@@ -70,7 +70,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Int_ptr m_list;

--- a/src/basic/INDEXLIST_3LOOP.hpp
+++ b/src/basic/INDEXLIST_3LOOP.hpp
@@ -81,7 +81,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Int_ptr m_list;

--- a/src/basic/INIT3.hpp
+++ b/src/basic/INIT3.hpp
@@ -66,7 +66,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_out1;
   Real_ptr m_out2;

--- a/src/basic/INIT_VIEW1D.hpp
+++ b/src/basic/INIT_VIEW1D.hpp
@@ -77,7 +77,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_a;
   Real_type m_val;

--- a/src/basic/INIT_VIEW1D_OFFSET.hpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.hpp
@@ -76,7 +76,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_a;
   Real_type m_val;

--- a/src/basic/MAT_MAT_SHARED-Cuda.cpp
+++ b/src/basic/MAT_MAT_SHARED-Cuda.cpp
@@ -50,7 +50,7 @@ __global__ void mat_mat_shared(Index_type N, Real_ptr C, Real_ptr A,
 template < size_t block_size >
 void MAT_MAT_SHARED::runCudaVariantImpl(VariantID vid)
 {
-  constexpr Index_type tile_size = gpu_block_size::sqrt(block_size);
+  constexpr Index_type tile_size = integer::sqrt(block_size);
   static_assert(tile_size*tile_size == block_size, "Invalid block_size");
 
   const Index_type run_reps = getRunReps();

--- a/src/basic/MAT_MAT_SHARED-Hip.cpp
+++ b/src/basic/MAT_MAT_SHARED-Hip.cpp
@@ -50,7 +50,7 @@ __global__ void mat_mat_shared(Index_type N, Real_ptr C, Real_ptr A,
 template < size_t block_size >
 void MAT_MAT_SHARED::runHipVariantImpl(VariantID vid)
 {
-  constexpr Index_type tile_size = gpu_block_size::sqrt(block_size);
+  constexpr Index_type tile_size = integer::sqrt(block_size);
   static_assert(tile_size*tile_size == block_size, "Invalid block_size");
 
   const Index_type run_reps = getRunReps();

--- a/src/basic/MAT_MAT_SHARED.hpp
+++ b/src/basic/MAT_MAT_SHARED.hpp
@@ -149,7 +149,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = TL_SZ * TL_SZ;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size, gpu_block_size::ExactSqrt>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size, integer::ExactSqrt>;
 
   Real_ptr m_A;
   Real_ptr m_B;

--- a/src/basic/MULADDSUB.hpp
+++ b/src/basic/MULADDSUB.hpp
@@ -69,7 +69,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_out1;
   Real_ptr m_out2;

--- a/src/basic/NESTED_INIT.hpp
+++ b/src/basic/NESTED_INIT.hpp
@@ -69,8 +69,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Index_type m_array_length;
 

--- a/src/basic/PI_ATOMIC.hpp
+++ b/src/basic/PI_ATOMIC.hpp
@@ -72,7 +72,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_type m_dx;
   Real_type m_pi_init;

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -70,7 +70,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_type m_dx;
   Real_type m_pi;

--- a/src/basic/REDUCE3_INT.hpp
+++ b/src/basic/REDUCE3_INT.hpp
@@ -85,7 +85,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Int_ptr m_vec;
   Int_type m_vsum;

--- a/src/basic/REDUCE_STRUCT.hpp
+++ b/src/basic/REDUCE_STRUCT.hpp
@@ -122,7 +122,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
   Real_ptr m_x; Real_ptr m_y;
   Real_type	m_init_sum; 
   Real_type	m_init_min; 

--- a/src/basic/TRAP_INT.hpp
+++ b/src/basic/TRAP_INT.hpp
@@ -82,7 +82,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_type m_x0;
   Real_type m_xp;

--- a/src/comm/HALO_EXCHANGE.hpp
+++ b/src/comm/HALO_EXCHANGE.hpp
@@ -122,7 +122,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   int m_mpi_size = -1;
   int m_my_mpi_rank = -1;

--- a/src/comm/HALO_EXCHANGE_FUSED.hpp
+++ b/src/comm/HALO_EXCHANGE_FUSED.hpp
@@ -184,7 +184,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 1024;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   int m_mpi_size = -1;
   int m_my_mpi_rank = -1;

--- a/src/comm/HALO_PACKING.hpp
+++ b/src/comm/HALO_PACKING.hpp
@@ -98,7 +98,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Index_type m_num_vars;
   Index_type m_var_size;

--- a/src/comm/HALO_PACKING_FUSED.hpp
+++ b/src/comm/HALO_PACKING_FUSED.hpp
@@ -162,7 +162,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 1024;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Index_type m_num_vars;
   Index_type m_var_size;

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -168,8 +168,11 @@ Executor::Executor(int argc, char** argv)
   if (strlen(cc.adiak_cmake_hip_architectures) > 0) {
     adiak::value("cmake_hip_architectures", cc.adiak_cmake_hip_architectures);
   }
-  if (cc.adiak_gpu_targets_block_sizes.size() > 0) {
-    adiak::value("gpu_targets_block_sizes", cc.adiak_gpu_targets_block_sizes);
+  if (cc.adiak_gpu_block_sizes.size() > 0) {
+    adiak::value("gpu_block_sizes", cc.adiak_gpu_block_sizes);
+  }
+  if (cc.adiak_atomic_replications.size() > 0) {
+    adiak::value("atomic_replications", cc.adiak_atomic_replications);
   }
   if (cc.adiak_raja_hipcc_flags.size() > 0) {
     adiak::value("raja_hipcc_flags", cc.adiak_raja_hipcc_flags);

--- a/src/common/GPUUtils.hpp
+++ b/src/common/GPUUtils.hpp
@@ -19,7 +19,7 @@
 namespace rajaperf
 {
 
-namespace gpu_block_size
+namespace integer
 {
 
 namespace detail
@@ -130,7 +130,7 @@ struct ExactSqrt
 // otherwise it is a list containing just default_block_size.
 // Invalid entries are removed according to validity_checker in either case.
 template < size_t default_block_size, typename validity_checker = AllowAny >
-using make_list_type =
+using make_gpu_block_size_list_type =
       typename detail::remove_invalid<validity_checker,
         typename std::conditional< (camp::size<rajaperf::configuration::gpu_block_sizes>::value > 0),
           rajaperf::configuration::gpu_block_sizes,
@@ -138,7 +138,7 @@ using make_list_type =
         >::type
       >::type;
 
-} // closing brace for gpu_block_size namespace
+} // closing brace for integer namespace
 
 namespace gpu_algorithm {
 

--- a/src/common/GPUUtils.hpp
+++ b/src/common/GPUUtils.hpp
@@ -138,6 +138,19 @@ using make_gpu_block_size_list_type =
         >::type
       >::type;
 
+// A camp::list of camp::integral_constant<size_t, I> types.
+// If atomic_replications from the configuration is not empty it is those atomic_replications,
+// otherwise it is a list containing just default_atomic_replication.
+// Invalid entries are removed according to validity_checker in either case.
+template < size_t default_atomic_replication, typename validity_checker = AllowAny >
+using make_atomic_replication_list_type =
+      typename detail::remove_invalid<validity_checker,
+        typename std::conditional< (camp::size<rajaperf::configuration::atomic_replications>::value > 0),
+          rajaperf::configuration::atomic_replications,
+          list_type<default_atomic_replication>
+        >::type
+      >::type;
+
 } // closing brace for integer namespace
 
 namespace gpu_algorithm {

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -279,6 +279,21 @@ public:
   }
 
   template <typename T>
+  void allocAndInitDataConst(DataSpace dataSpace, T*& ptr, Size_type len, T val)
+  {
+    rajaperf::allocAndInitDataConst(dataSpace,
+        ptr, len, getDataAlignment(), val);
+  }
+
+  template <typename T>
+  rajaperf::AutoDataMover<T> scopedMoveData(DataSpace dataSpace, T*& ptr, Size_type len)
+  {
+    DataSpace hds = rajaperf::hostCopyDataSpace(dataSpace);
+    rajaperf::moveData(hds, dataSpace, ptr, len, getDataAlignment());
+    return {dataSpace, hds, ptr, len, getDataAlignment()};
+  }
+
+  template <typename T>
   void copyData(DataSpace dst_dataSpace, T* dst_ptr,
                 DataSpace src_dataSpace, const T* src_ptr,
                 Size_type len)

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -104,6 +104,7 @@
 #include "algorithm/REDUCE_SUM.hpp"
 #include "algorithm/MEMSET.hpp"
 #include "algorithm/MEMCPY.hpp"
+#include "algorithm/ATOMIC.hpp"
 
 //
 // Comm kernels...
@@ -254,6 +255,7 @@ static const std::string KernelNames [] =
   std::string("Algorithm_REDUCE_SUM"),
   std::string("Algorithm_MEMSET"),
   std::string("Algorithm_MEMCPY"),
+  std::string("Algorithm_ATOMIC"),
 
 //
 // Comm kernels...
@@ -984,6 +986,10 @@ KernelBase* getKernelObject(KernelID kid,
     }
     case Algorithm_MEMCPY: {
        kernel = new algorithm::MEMCPY(run_params);
+       break;
+    }
+    case Algorithm_ATOMIC: {
+       kernel = new algorithm::ATOMIC(run_params);
        break;
     }
 

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -164,6 +164,7 @@ enum KernelID {
   Algorithm_REDUCE_SUM,
   Algorithm_MEMSET,
   Algorithm_MEMCPY,
+  Algorithm_ATOMIC,
 
 //
 // Comm kernels...

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -40,6 +40,7 @@ RunParams::RunParams(int argc, char** argv)
    data_alignment(RAJA::DATA_ALIGN),
    gpu_stream(1),
    gpu_block_sizes(),
+   atomic_replications(),
    mpi_size(1),
    mpi_rank(0),
    mpi_3d_division({-1, -1, -1}),
@@ -122,6 +123,10 @@ void RunParams::print(std::ostream& str) const
   str << "\n gpu_block_sizes = ";
   for (size_t j = 0; j < gpu_block_sizes.size(); ++j) {
     str << "\n\t" << gpu_block_sizes[j];
+  }
+  str << "\n atomic_replications = ";
+  for (size_t j = 0; j < atomic_replications.size(); ++j) {
+    str << "\n\t" << atomic_replications[j];
   }
   str << "\n mpi_size = " << mpi_size;
   str << "\n mpi_3d_division = ";
@@ -461,6 +466,37 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
       if (!got_someting) {
         getCout() << "\nBad input:"
                   << " must give --gpu_block_size one or more values (int)"
+                  << std::endl;
+        input_state = BadInput;
+      }
+
+    } else if ( opt == std::string("--atomic_replication") ) {
+
+      bool got_someting = false;
+      bool done = false;
+      i++;
+      while ( i < argc && !done ) {
+        opt = std::string(argv[i]);
+        if ( opt.at(0) == '-' ) {
+          i--;
+          done = true;
+        } else {
+          got_someting = true;
+          int atomic_replication = ::atoi( opt.c_str() );
+          if ( atomic_replication <= 0 ) {
+            getCout() << "\nBad input:"
+                      << " must give --atomic_replication POSITIVE values (int)"
+                      << std::endl;
+            input_state = BadInput;
+          } else {
+            atomic_replications.push_back(atomic_replication);
+          }
+          ++i;
+        }
+      }
+      if (!got_someting) {
+        getCout() << "\nBad input:"
+                  << " must give --atomic_replication one or more values (int)"
                   << std::endl;
         input_state = BadInput;
       }
@@ -1076,6 +1112,14 @@ void RunParams::printHelpMessage(std::ostream& str) const
       << "\t      values give via CMake variable RAJA_PERFSUITE_GPU_BLOCKSIZES.\n";
   str << "\t\t Example...\n"
       << "\t\t --gpu_block_size 128 256 512 (runs kernels with gpu_block_size 128, 256, and 512)\n\n";
+
+  str << "\t --atomic_replication <space-separated ints> [no default]\n"
+      << "\t      (atomic replications to run for all GPU kernels)\n"
+      << "\t      GPU kernels not supporting atomic_replication option will be skipped.\n"
+      << "\t      Behavior depends on kernel implementations and \n"
+      << "\t      values give via CMake variable RAJA_PERFSUITE_ATOMIC_REPLICATIONS.\n";
+  str << "\t\t Example...\n"
+      << "\t\t --atomic_replication 128 256 512 (runs kernels with atomic_replication 128, 256, and 512)\n\n";
 
   str << "\t --mpi_3d_division <space-separated ints> [no default]\n"
       << "\t      (number of mpi ranks in each dimension in a 3d grid)\n"

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -134,6 +134,16 @@ public:
     }
     return false;
   }
+  size_t numValidAtomicReplication() const { return atomic_replications.size(); }
+  bool validAtomicReplication(size_t atomic_replication) const
+  {
+    for (size_t valid_atomic_replication : atomic_replications) {
+      if (valid_atomic_replication == atomic_replication) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   int getMPISize() const { return mpi_size; }
   int getMPIRank() const { return mpi_rank; }
@@ -233,6 +243,7 @@ private:
 
   int gpu_stream; /*!< 0 -> use stream 0; anything else -> use raja default stream */
   std::vector<size_t> gpu_block_sizes; /*!< Block sizes for gpu tunings to run (input option) */
+  std::vector<size_t> atomic_replications; /*!< Atomic replications for gpu tunings to run (input option) */
   int mpi_size;           /*!< Number of MPI ranks */
   int mpi_rank;           /*!< Rank of this MPI process */
   std::array<int, 3> mpi_3d_division; /*!< Number of MPI ranks in each dimension of a 3D grid */

--- a/src/lcals/DIFF_PREDICT.hpp
+++ b/src/lcals/DIFF_PREDICT.hpp
@@ -104,7 +104,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_px;
   Real_ptr m_cx;

--- a/src/lcals/EOS.hpp
+++ b/src/lcals/EOS.hpp
@@ -73,7 +73,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/lcals/FIRST_DIFF.hpp
+++ b/src/lcals/FIRST_DIFF.hpp
@@ -63,7 +63,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/lcals/FIRST_MIN.hpp
+++ b/src/lcals/FIRST_MIN.hpp
@@ -94,7 +94,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_type m_xmin_init;

--- a/src/lcals/FIRST_SUM.hpp
+++ b/src/lcals/FIRST_SUM.hpp
@@ -66,7 +66,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/lcals/GEN_LIN_RECUR.hpp
+++ b/src/lcals/GEN_LIN_RECUR.hpp
@@ -87,7 +87,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_b5;
   Real_ptr m_sa;

--- a/src/lcals/HYDRO_1D.hpp
+++ b/src/lcals/HYDRO_1D.hpp
@@ -68,7 +68,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/lcals/HYDRO_2D.hpp
+++ b/src/lcals/HYDRO_2D.hpp
@@ -162,8 +162,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Real_ptr m_za;
   Real_ptr m_zb;

--- a/src/lcals/INT_PREDICT.hpp
+++ b/src/lcals/INT_PREDICT.hpp
@@ -83,7 +83,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Index_type m_array_length;
   Index_type m_offset;

--- a/src/lcals/PLANCKIAN.hpp
+++ b/src/lcals/PLANCKIAN.hpp
@@ -68,7 +68,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/lcals/TRIDIAG_ELIM.hpp
+++ b/src/lcals/TRIDIAG_ELIM.hpp
@@ -68,7 +68,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_xout;
   Real_ptr m_xin;

--- a/src/polybench/POLYBENCH_2MM.hpp
+++ b/src/polybench/POLYBENCH_2MM.hpp
@@ -137,8 +137,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Index_type m_ni;
   Index_type m_nj;

--- a/src/polybench/POLYBENCH_3MM.hpp
+++ b/src/polybench/POLYBENCH_3MM.hpp
@@ -163,8 +163,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Index_type m_ni;
   Index_type m_nj;

--- a/src/polybench/POLYBENCH_ADI.hpp
+++ b/src/polybench/POLYBENCH_ADI.hpp
@@ -205,7 +205,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Index_type m_n;
   Index_type m_tsteps;

--- a/src/polybench/POLYBENCH_ATAX.hpp
+++ b/src/polybench/POLYBENCH_ATAX.hpp
@@ -125,7 +125,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Index_type m_N;
   Real_ptr m_tmp;

--- a/src/polybench/POLYBENCH_FDTD_2D.hpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.hpp
@@ -123,8 +123,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Index_type m_nx;
   Index_type m_ny;

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.hpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.hpp
@@ -86,8 +86,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Index_type m_N;
 

--- a/src/polybench/POLYBENCH_GEMM.hpp
+++ b/src/polybench/POLYBENCH_GEMM.hpp
@@ -109,8 +109,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Index_type m_ni;
   Index_type m_nj;

--- a/src/polybench/POLYBENCH_GEMVER.hpp
+++ b/src/polybench/POLYBENCH_GEMVER.hpp
@@ -162,8 +162,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Index_type m_n;
   Real_type m_alpha;

--- a/src/polybench/POLYBENCH_GESUMMV.hpp
+++ b/src/polybench/POLYBENCH_GESUMMV.hpp
@@ -108,7 +108,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Index_type m_N;
 

--- a/src/polybench/POLYBENCH_HEAT_3D.hpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.hpp
@@ -132,8 +132,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Index_type m_N;
   Index_type m_tsteps;

--- a/src/polybench/POLYBENCH_JACOBI_1D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.hpp
@@ -78,7 +78,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Index_type m_N;
   Index_type m_tsteps;

--- a/src/polybench/POLYBENCH_JACOBI_2D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.hpp
@@ -97,8 +97,8 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size,
-                                                         gpu_block_size::MultipleOf<32>>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
 
   Index_type m_N;
   Index_type m_tsteps;

--- a/src/polybench/POLYBENCH_MVT.hpp
+++ b/src/polybench/POLYBENCH_MVT.hpp
@@ -122,7 +122,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Index_type m_N;
   Real_ptr m_x1;

--- a/src/rajaperf_config.hpp.in
+++ b/src/rajaperf_config.hpp.in
@@ -53,13 +53,13 @@ inline void RAJAPERF_UNUSED_VAR(Ts&&...) { }
 
 namespace rajaperf {
 
-namespace gpu_block_size {
+namespace integer {
 
 // helper alias to convert comma separated integer literals into list
 template < size_t... Is >
 using list_type = camp::list< camp::integral_constant<size_t, Is>... >;
 
-} // closing brace for gpu_block_size namespace
+} // closing brace for integer namespace
 
 struct configuration {
 #if defined(RAJA_PERFSUITE_USE_CALIPER)
@@ -110,7 +110,7 @@ const adiak::catstring adiak_machine_build = std::string("@RAJAPERF_BUILD_HOST@"
 #endif
 
 // List of GPU block sizes
-using gpu_block_sizes = gpu_block_size::list_type<@RAJA_PERFSUITE_GPU_BLOCKSIZES@>;
+using gpu_block_sizes = integer::list_type<@RAJA_PERFSUITE_GPU_BLOCKSIZES@>;
 
 // Name of user who ran code
 std::string user_run;

--- a/src/rajaperf_config.hpp.in
+++ b/src/rajaperf_config.hpp.in
@@ -102,7 +102,8 @@ const adiak::version adiak_compiler_version = std::string("@CMAKE_CXX_COMPILER_V
 const adiak::version adiak_cuda_compiler_version = std::string("@CMAKE_CUDA_COMPILER_VERSION@");
 constexpr static const char* adiak_gpu_targets = "@GPU_TARGETS@";
 constexpr static const char* adiak_cmake_hip_architectures = "@CMAKE_HIP_ARCHIECTURES@";
-const std::vector<int> adiak_gpu_targets_block_sizes = {@RAJA_PERFSUITE_GPU_BLOCKSIZES@};
+const std::vector<int> adiak_gpu_block_sizes = {@RAJA_PERFSUITE_GPU_BLOCKSIZES@};
+const std::vector<int> adiak_atomic_replications = {@RAJA_PERFSUITE_ATOMIC_REPLICATIONS@};
 const std::vector<adiak::catstring> adiak_raja_hipcc_flags = str_to_list<adiak::catstring>(std::string("@RAJA_HIPCC_FLAGS@"));
 const adiak::catstring adiak_mpi_cxx_compiler = std::string("@MPI_CXX_COMPILER@");
 const adiak::catstring adiak_systype_build = std::string("@RAJAPERF_BUILD_SYSTYPE@");
@@ -111,6 +112,9 @@ const adiak::catstring adiak_machine_build = std::string("@RAJAPERF_BUILD_HOST@"
 
 // List of GPU block sizes
 using gpu_block_sizes = integer::list_type<@RAJA_PERFSUITE_GPU_BLOCKSIZES@>;
+
+// List of GPU atomic replications
+using atomic_replications = integer::list_type<@RAJA_PERFSUITE_ATOMIC_REPLICATIONS@>;
 
 // Name of user who ran code
 std::string user_run;

--- a/src/stream/ADD.hpp
+++ b/src/stream/ADD.hpp
@@ -63,7 +63,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_a;
   Real_ptr m_b;

--- a/src/stream/COPY.hpp
+++ b/src/stream/COPY.hpp
@@ -62,7 +62,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_a;
   Real_ptr m_c;

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -66,7 +66,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_a;
   Real_ptr m_b;

--- a/src/stream/MUL.hpp
+++ b/src/stream/MUL.hpp
@@ -63,7 +63,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_b;
   Real_ptr m_c;

--- a/src/stream/TRIAD.hpp
+++ b/src/stream/TRIAD.hpp
@@ -64,7 +64,7 @@ public:
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = gpu_block_size::make_list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_a;
   Real_ptr m_b;


### PR DESCRIPTION
# Add ATOMIC kernel

The ATOMIC kernel adds a way to look at atomic performance. It has tunings with different amounts of replication which allows atomics to be spread out over over a number of items in an array. The replications are a configure time option set by changing the cmake param RAJA_PERFSUITE_ATOMIC_REPLICATIONS to a comma separated list of integers. What is run at runtime can be set using the command line option --atomic_replication to a space separated list of integers.

Note: The large number of files changed comes from changing the name of the namespace used for handing gpu block sizes which was changed to integer so that code could be used to handle the compile time list of atomic replications.

- This PR is a feature
- It does the following (modify list as needed):
  - Adds ATOMIC kernel at the request of me
