### PR TITLE
Generalize and tune manual scan implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,8 @@ set(RAJA_PERFSUITE_GPU_BLOCKSIZES "" CACHE STRING "Comma separated list of GPU b
 
 set(RAJA_PERFSUITE_ATOMIC_REPLICATIONS "" CACHE STRING "Comma separated list of atomic replications, ex '1,256,4096'")
 
+set(RAJA_PERFSUITE_GPU_ITEMS_PER_THREAD "" CACHE STRING "Comma separated list of atomic replications, ex '1,256,4096'")
+
 set(RAJA_RANGE_ALIGN 4)
 set(RAJA_RANGE_MIN_LENGTH 32)
 set(RAJA_DATA_ALIGN 64)
@@ -93,6 +95,13 @@ if (ATOMIC_REPLICATIONS_LENGTH GREATER 0)
   message(STATUS "Using atomic replication(s): ${RAJA_PERFSUITE_ATOMIC_REPLICATIONS}")
 else()
   message(STATUS "Using default atomic replication(s)")
+endif()
+
+string(LENGTH "${RAJA_PERFSUITE_GPU_ITEMS_PER_THREAD}" GPU_ITEMS_PER_THREAD_LENGTH)
+if (GPU_ITEMS_PER_THREAD_LENGTH GREATER 0)
+  message(STATUS "Using gpu items per thread(s): ${RAJA_PERFSUITE_GPU_ITEMS_PER_THREAD}")
+else()
+  message(STATUS "Using default gpu items per thread(s)")
 endif()
 
 # exclude RAJA make targets from top-level build...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,9 @@ set(ENABLE_TBB Off CACHE BOOL "")
 
 set(RAJA_USE_CHRONO On CACHE BOOL "")
 
+set(RAJA_PERFSUITE_TUNING_CUDA_ARCH "0" CACHE STRING "CUDA arch to tune the execution for, ex '700' for sm_70")
+set(RAJA_PERFSUITE_TUNING_HIP_ARCH "0" CACHE STRING "HIP arch to tune the execution for, ex '910' for gfx90a, '942' for gfx942")
+
 set(RAJA_PERFSUITE_GPU_BLOCKSIZES "" CACHE STRING "Comma separated list of GPU block sizes, ex '256,1024'")
 
 set(RAJA_PERFSUITE_ATOMIC_REPLICATIONS "" CACHE STRING "Comma separated list of atomic replications, ex '1,256,4096'")
@@ -82,6 +85,20 @@ set(RAJA_PERFSUITE_GPU_ITEMS_PER_THREAD "" CACHE STRING "Comma separated list of
 set(RAJA_RANGE_ALIGN 4)
 set(RAJA_RANGE_MIN_LENGTH 32)
 set(RAJA_DATA_ALIGN 64)
+
+string(LENGTH "${RAJA_PERFSUITE_TUNING_CUDA_ARCH}" CUDA_ARCH_LENGTH)
+if (CUDA_ARCH_LENGTH GREATER 1)
+  message(STATUS "Using cuda tunings for arch: ${RAJA_PERFSUITE_TUNING_CUDA_ARCH}")
+else()
+  message(STATUS "Using default cuda arch tunings")
+endif()
+
+string(LENGTH "${RAJA_PERFSUITE_TUNING_HIP_ARCH}" HIP_ARCH_LENGTH)
+if (HIP_ARCH_LENGTH GREATER 1)
+  message(STATUS "Using hip tunings for arch: ${RAJA_PERFSUITE_TUNING_HIP_ARCH}")
+else()
+  message(STATUS "Using default hip arch tunings")
+endif()
 
 string(LENGTH "${RAJA_PERFSUITE_GPU_BLOCKSIZES}" BLOCKSIZES_LENGTH)
 if (BLOCKSIZES_LENGTH GREATER 0)

--- a/docs/sphinx/user_guide/build.rst
+++ b/docs/sphinx/user_guide/build.rst
@@ -229,6 +229,23 @@ replication amounts. The CMake option for this is
 will build versions of GPU kernels that use 1, 256, and 4096 atomic
 replications.
 
+Building with specific GPU items per thread tunings
+-----------------------------------------------------
+
+If desired, you can build a version of the RAJA Performance Suite code with
+multiple versions of GPU kernels that will run with different GPU items per
+thread amounts. The CMake option for this is
+``-DRAJA_PERFSUITE_GPU_ITEMS_PER_THREAD=<list,of,items,per,thread,amounts>``. For example::
+
+  $ mkdir my-gpu-build
+  $ cd my-gpu-build
+  $ cmake <cmake args> \
+    -DRAJA_PERFSUITE_GPU_ITEMS_PER_THREAD=1,2,4,8 \
+    ..
+  $ make -j
+
+will build versions of GPU kernels that use 1, 2, 4, and 8 items per thread.
+
 Building with Caliper
 ---------------------
 

--- a/src/algorithm/SCAN-Cuda.cpp
+++ b/src/algorithm/SCAN-Cuda.cpp
@@ -27,7 +27,7 @@ namespace algorithm
 
 template < size_t block_size >
 using cuda_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
-    detail::cuda::grid_scan_default_items_per_thread,
+    detail::cuda::grid_scan_default_items_per_thread<block_size, detail::cuda::default_arch>::value,
     integer::LessEqual<detail::cuda::grid_scan_max_items_per_thread<Real_type, block_size>::value>>;
 
 

--- a/src/algorithm/SCAN-Cuda.cpp
+++ b/src/algorithm/SCAN-Cuda.cpp
@@ -25,6 +25,12 @@ namespace rajaperf
 namespace algorithm
 {
 
+template < size_t block_size >
+using cuda_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
+    detail::cuda::grid_scan_default_items_per_thread,
+    integer::LessEqual<detail::cuda::grid_scan_max_items_per_thread<Real_type, block_size>::value>>;
+
+
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
 __global__ void scan(Real_ptr x,
@@ -52,7 +58,7 @@ __global__ void scan(Real_ptr x,
 
   Real_type exclusives[items_per_thread];
   Real_type inclusives[items_per_thread];
-  detail::cuda::grid_scan<block_size, items_per_thread>(
+  detail::cuda::GridScan<Real_type, block_size, items_per_thread>::grid_scan(
       block_id, vals, exclusives, inclusives, block_counts, grid_counts, block_readys);
 
   for (size_t ti = 0; ti < items_per_thread; ++ti) {
@@ -64,7 +70,7 @@ __global__ void scan(Real_ptr x,
 }
 
 
-void SCAN::runCudaVariantCub(VariantID vid)
+void SCAN::runCudaVariantLibrary(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -119,12 +125,22 @@ void SCAN::runCudaVariantCub(VariantID vid)
     // Free temporary storage
     deallocData(DataSpace::CudaDevice, temp_storage);
 
+  } else if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::exclusive_scan< RAJA::cuda_exec<0, true /*async*/> >(res, RAJA_SCAN_ARGS);
+
+    }
+    stopTimer();
+
   } else {
      getCout() << "\n  SCAN : Unknown Cuda variant id = " << vid << std::endl;
   }
 }
 
-template < size_t block_size >
+template < size_t block_size, size_t items_per_thread >
 void SCAN::runCudaVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
@@ -137,7 +153,7 @@ void SCAN::runCudaVariantImpl(VariantID vid)
 
   if ( vid == Base_CUDA ) {
 
-    const size_t grid_size = RAJA_DIVIDE_CEILING_INT((iend-ibegin), block_size*detail::cuda::grid_scan_items_per_thread);
+    const size_t grid_size = RAJA_DIVIDE_CEILING_INT((iend-ibegin), block_size*items_per_thread);
     const size_t shmem_size = 0;
 
     Real_ptr block_counts;
@@ -152,7 +168,7 @@ void SCAN::runCudaVariantImpl(VariantID vid)
 
       cudaErrchk( cudaMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size,
                                   res.get_stream()) );
-      RPlaunchCudaKernel( (scan<block_size, detail::cuda::grid_scan_items_per_thread>),
+      RPlaunchCudaKernel( (scan<block_size, items_per_thread>),
                           grid_size, block_size,
                           shmem_size, res.get_stream(),
                           x+ibegin, y+ibegin,
@@ -166,16 +182,6 @@ void SCAN::runCudaVariantImpl(VariantID vid)
     deallocData(DataSpace::CudaDevice, grid_counts);
     deallocData(DataSpace::CudaDevice, block_readys);
 
-  } else if ( vid == RAJA_CUDA ) {
-
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-      RAJA::exclusive_scan< RAJA::cuda_exec<default_gpu_block_size, true /*async*/> >(res, RAJA_SCAN_ARGS);
-
-    }
-    stopTimer();
-
   } else {
      getCout() << "\n  SCAN : Unknown Cuda variant id = " << vid << std::endl;
   }
@@ -186,27 +192,46 @@ void SCAN::runCudaVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
 
-  if ( vid == Base_CUDA ) {
-
-    if (tune_idx == t) {
-
-      runCudaVariantCub(vid);
-
-    }
-
-    t += 1;
-
-  }
 
   if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
 
     if (tune_idx == t) {
 
-      runCudaVariantImpl<default_gpu_block_size>(vid);
+      runCudaVariantLibrary(vid);
 
     }
 
     t += 1;
+
+    if ( vid == Base_CUDA ) {
+
+      seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+        if (run_params.numValidGPUBlockSize() == 0u ||
+            run_params.validGPUBlockSize(block_size)) {
+
+          seq_for(cuda_items_per_thread_type<block_size>{}, [&](auto items_per_thread) {
+
+            if (run_params.numValidItemsPerThread() == 0u ||
+                run_params.validItemsPerThread(block_size)) {
+
+              if (tune_idx == t) {
+
+                runCudaVariantImpl<decltype(block_size)::value, items_per_thread>(vid);
+
+              }
+
+              t += 1;
+
+            }
+
+          });
+
+        }
+
+      });
+
+    }
 
   } else {
 
@@ -217,15 +242,34 @@ void SCAN::runCudaVariant(VariantID vid, size_t tune_idx)
 
 void SCAN::setCudaTuningDefinitions(VariantID vid)
 {
-  if ( vid == Base_CUDA ) {
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
 
     addVariantTuningName(vid, "cub");
 
-  }
+    if ( vid == Base_CUDA ) {
 
-  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+      seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 
-    addVariantTuningName(vid, "default");
+        if (run_params.numValidGPUBlockSize() == 0u ||
+            run_params.validGPUBlockSize(block_size)) {
+
+          seq_for(cuda_items_per_thread_type<block_size>{}, [&](auto items_per_thread) {
+
+            if (run_params.numValidItemsPerThread() == 0u ||
+                run_params.validItemsPerThread(block_size)) {
+
+              addVariantTuningName(vid, "block_"+std::to_string(block_size)+
+                                        "_itemsPerThread_"+std::to_string(items_per_thread));
+
+            }
+
+          });
+
+        }
+
+      });
+
+    }
 
   }
 }

--- a/src/algorithm/SCAN-Cuda.cpp
+++ b/src/algorithm/SCAN-Cuda.cpp
@@ -16,6 +16,7 @@
 #include "cub/util_allocator.cuh"
 
 #include "common/CudaDataUtils.hpp"
+#include "common/CudaGridScan.hpp"
 
 #include <iostream>
 
@@ -24,8 +25,46 @@ namespace rajaperf
 namespace algorithm
 {
 
+template < size_t block_size, size_t items_per_thread >
+__launch_bounds__(block_size)
+__global__ void scan(Real_ptr x,
+                     Real_ptr y,
+                     Real_ptr block_counts,
+                     Real_ptr grid_counts,
+                     unsigned* block_readys,
+                     Index_type iend)
+{
+  // blocks do start running in order in cuda, so a block with a higher
+  // index can wait on a block with a lower index without deadlocking
+  // (replace with an atomicInc if this changes)
+  const int block_id = blockIdx.x;
 
-void SCAN::runCudaVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+  Real_type vals[items_per_thread];
+
+  for (size_t ti = 0; ti < items_per_thread; ++ti) {
+    Index_type i = block_id * block_size * items_per_thread + ti * block_size + threadIdx.x;
+    if (i < iend) {
+      vals[ti] = x[i];
+    } else {
+      vals[ti] = 0;
+    }
+  }
+
+  Real_type exclusives[items_per_thread];
+  Real_type inclusives[items_per_thread];
+  detail::cuda::grid_scan<block_size, items_per_thread>(
+      block_id, vals, exclusives, inclusives, block_counts, grid_counts, block_readys);
+
+  for (size_t ti = 0; ti < items_per_thread; ++ti) {
+    Index_type i = block_id * block_size * items_per_thread + ti * block_size + threadIdx.x;
+    if (i < iend) {
+      y[i] = exclusives[ti];
+    }
+  }
+}
+
+
+void SCAN::runCudaVariantCub(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -80,6 +119,53 @@ void SCAN::runCudaVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
     // Free temporary storage
     deallocData(DataSpace::CudaDevice, temp_storage);
 
+  } else {
+     getCout() << "\n  SCAN : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t block_size >
+void SCAN::runCudaVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  SCAN_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    const size_t grid_size = RAJA_DIVIDE_CEILING_INT((iend-ibegin), block_size*detail::cuda::grid_scan_items_per_thread);
+    const size_t shmem_size = 0;
+
+    Real_ptr block_counts;
+    allocData(DataSpace::CudaDevice, block_counts, grid_size);
+    Real_ptr grid_counts;
+    allocData(DataSpace::CudaDevice, grid_counts, grid_size);
+    unsigned* block_readys;
+    allocData(DataSpace::CudaDevice, block_readys, grid_size);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      cudaErrchk( cudaMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size,
+                                  res.get_stream()) );
+      RPlaunchCudaKernel( (scan<block_size, detail::cuda::grid_scan_items_per_thread>),
+                          grid_size, block_size,
+                          shmem_size, res.get_stream(),
+                          x+ibegin, y+ibegin,
+                          block_counts, grid_counts, block_readys,
+                          iend-ibegin );
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::CudaDevice, block_counts);
+    deallocData(DataSpace::CudaDevice, grid_counts);
+    deallocData(DataSpace::CudaDevice, block_readys);
+
   } else if ( vid == RAJA_CUDA ) {
 
     startTimer();
@@ -92,6 +178,55 @@ void SCAN::runCudaVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 
   } else {
      getCout() << "\n  SCAN : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+
+void SCAN::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_CUDA ) {
+
+    if (tune_idx == t) {
+
+      runCudaVariantCub(vid);
+
+    }
+
+    t += 1;
+
+  }
+
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    if (tune_idx == t) {
+
+      runCudaVariantImpl<default_gpu_block_size>(vid);
+
+    }
+
+    t += 1;
+
+  } else {
+
+    getCout() << "\n  SCAN : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+}
+
+void SCAN::setCudaTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_CUDA ) {
+
+    addVariantTuningName(vid, "cub");
+
+  }
+
+  if ( vid == Base_CUDA || vid == RAJA_CUDA ) {
+
+    addVariantTuningName(vid, "default");
+
   }
 }
 

--- a/src/algorithm/SCAN-Cuda.cpp
+++ b/src/algorithm/SCAN-Cuda.cpp
@@ -27,7 +27,7 @@ namespace algorithm
 
 template < size_t block_size >
 using cuda_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
-    detail::cuda::grid_scan_default_items_per_thread<block_size, detail::cuda::default_arch>::value,
+    detail::cuda::grid_scan_default_items_per_thread<Real_type, block_size, RAJA_PERFSUITE_TUNING_CUDA_ARCH>::value,
     integer::LessEqual<detail::cuda::grid_scan_max_items_per_thread<Real_type, block_size>::value>>;
 
 

--- a/src/algorithm/SCAN-Hip.cpp
+++ b/src/algorithm/SCAN-Hip.cpp
@@ -21,6 +21,7 @@
 #endif
 
 #include "common/HipDataUtils.hpp"
+#include "common/HipGridScan.hpp"
 
 #include <iostream>
 
@@ -29,8 +30,46 @@ namespace rajaperf
 namespace algorithm
 {
 
+template < size_t block_size, size_t items_per_thread >
+__launch_bounds__(block_size)
+__global__ void scan(Real_ptr x,
+                     Real_ptr y,
+                     Real_ptr block_counts,
+                     Real_ptr grid_counts,
+                     unsigned* block_readys,
+                     Index_type iend)
+{
+  // It looks like blocks do not start running in order in hip, so a block
+  // with a higher index can't wait on a block with a lower index without
+  // deadlocking (have to replace with an atomicInc)
+  const int block_id = blockIdx.x;
 
-void SCAN::runHipVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+  Real_type vals[items_per_thread];
+
+  for (size_t ti = 0; ti < items_per_thread; ++ti) {
+    Index_type i = block_id * block_size * items_per_thread + ti * block_size + threadIdx.x;
+    if (i < iend) {
+      vals[ti] = x[i];
+    } else {
+      vals[ti] = 0;
+    }
+  }
+
+  Real_type exclusives[items_per_thread];
+  Real_type inclusives[items_per_thread];
+  detail::hip::grid_scan<block_size, items_per_thread>(
+      block_id, vals, exclusives, inclusives, block_counts, grid_counts, block_readys);
+
+  for (size_t ti = 0; ti < items_per_thread; ++ti) {
+    Index_type i = block_id * block_size * items_per_thread + ti * block_size + threadIdx.x;
+    if (i < iend) {
+      y[i] = exclusives[ti];
+    }
+  }
+}
+
+
+void SCAN::runHipVariantRocprim(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -107,18 +146,115 @@ void SCAN::runHipVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
     // Free temporary storage
     deallocData(DataSpace::HipDevice, temp_storage);
 
+  } else {
+     getCout() << "\n  SCAN : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t block_size >
+void SCAN::runHipVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  SCAN_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    const size_t grid_size = RAJA_DIVIDE_CEILING_INT((iend-ibegin), block_size*detail::hip::grid_scan_items_per_thread);
+    const size_t shmem_size = 0;
+
+    Real_ptr block_counts;
+    allocData(DataSpace::HipDevice, block_counts, grid_size);
+    Real_ptr grid_counts;
+    allocData(DataSpace::HipDevice, grid_counts, grid_size);
+    unsigned* block_readys;
+    allocData(DataSpace::HipDevice, block_readys, grid_size);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      hipErrchk( hipMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size,
+                                res.get_stream()) );
+
+      RPlaunchHipKernel( (scan<block_size, detail::hip::grid_scan_items_per_thread>),
+                         grid_size, block_size,
+                         shmem_size, res.get_stream(),
+                         x+ibegin, y+ibegin,
+                         block_counts, grid_counts, block_readys,
+                         iend-ibegin );
+
+    }
+    stopTimer();
+
+    deallocData(DataSpace::HipDevice, block_counts);
+    deallocData(DataSpace::HipDevice, grid_counts);
+    deallocData(DataSpace::HipDevice, block_readys);
+
   } else if ( vid == RAJA_HIP ) {
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::exclusive_scan< RAJA::hip_exec<default_gpu_block_size, true /*async*/> >(res, RAJA_SCAN_ARGS);
+      RAJA::exclusive_scan< RAJA::hip_exec<block_size, true /*async*/> >(res, RAJA_SCAN_ARGS);
 
     }
     stopTimer();
 
   } else {
      getCout() << "\n  SCAN : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+
+void SCAN::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_HIP ) {
+
+    if (tune_idx == t) {
+
+      runHipVariantRocprim(vid);
+
+    }
+
+    t += 1;
+
+  }
+
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    if (tune_idx == t) {
+
+      runHipVariantImpl<default_gpu_block_size>(vid);
+
+    }
+
+    t += 1;
+
+  } else {
+
+    getCout() << "\n  SCAN : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+}
+
+void SCAN::setHipTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_HIP ) {
+
+    addVariantTuningName(vid, "rocprim");
+
+  }
+
+  if ( vid == Base_HIP || vid == RAJA_HIP ) {
+
+    addVariantTuningName(vid, "default");
+
   }
 }
 

--- a/src/algorithm/SCAN-Hip.cpp
+++ b/src/algorithm/SCAN-Hip.cpp
@@ -32,7 +32,7 @@ namespace algorithm
 
 template < size_t block_size >
 using hip_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
-    detail::hip::grid_scan_default_items_per_thread,
+    detail::hip::grid_scan_default_items_per_thread<block_size, detail::hip::default_arch>::value,
     integer::LessEqual<detail::hip::grid_scan_max_items_per_thread<Real_type, block_size>::value>>;
 
 

--- a/src/algorithm/SCAN-Hip.cpp
+++ b/src/algorithm/SCAN-Hip.cpp
@@ -32,7 +32,7 @@ namespace algorithm
 
 template < size_t block_size >
 using hip_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
-    detail::hip::grid_scan_default_items_per_thread<block_size, detail::hip::default_arch>::value,
+    detail::hip::grid_scan_default_items_per_thread<Real_type, block_size, RAJA_PERFSUITE_TUNING_HIP_ARCH>::value,
     integer::LessEqual<detail::hip::grid_scan_max_items_per_thread<Real_type, block_size>::value>>;
 
 

--- a/src/algorithm/SCAN.hpp
+++ b/src/algorithm/SCAN.hpp
@@ -64,16 +64,16 @@ public:
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void runCudaVariantCub(VariantID vid);
-  void runHipVariantRocprim(VariantID vid);
-  template < size_t block_size >
+  void runCudaVariantLibrary(VariantID vid);
+  void runHipVariantLibrary(VariantID vid);
+  template < size_t block_size, size_t items_per_thread >
   void runCudaVariantImpl(VariantID vid);
-  template < size_t block_size >
+  template < size_t block_size, size_t items_per_thread >
   void runHipVariantImpl(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = integer::list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/algorithm/SCAN.hpp
+++ b/src/algorithm/SCAN.hpp
@@ -62,8 +62,18 @@ public:
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
 
+  void setCudaTuningDefinitions(VariantID vid);
+  void setHipTuningDefinitions(VariantID vid);
+  void runCudaVariantCub(VariantID vid);
+  void runHipVariantRocprim(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantImpl(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantImpl(VariantID vid);
+
 private:
-  static const size_t default_gpu_block_size = 0;
+  static const size_t default_gpu_block_size = 256;
+  using gpu_block_sizes_type = integer::list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Real_ptr m_y;

--- a/src/basic/INDEXLIST-Cuda.cpp
+++ b/src/basic/INDEXLIST-Cuda.cpp
@@ -13,11 +13,7 @@
 #if defined(RAJA_ENABLE_CUDA)
 
 #include "common/CudaDataUtils.hpp"
-
-#include <cub/block/block_scan.cuh>
-#include <cub/block/block_exchange.cuh>
-#include <cub/warp/warp_reduce.cuh>
-#include <cub/warp/warp_scan.cuh>
+#include "common/CudaGridScan.hpp"
 
 #include <iostream>
 
@@ -25,172 +21,6 @@ namespace rajaperf
 {
 namespace basic
 {
-
-  //
-  // Define magic numbers for CUDA execution
-  //
-  const size_t warp_size = 32;
-  const size_t items_per_thread = 15;
-
-
-// perform a grid scan on val and returns the result at each thread
-// in exclusive and inclusive, note that val is used as scratch space
-template < size_t block_size, size_t items_per_thread >
-__device__ void grid_scan(const int block_id,
-                          Index_type (&val)[items_per_thread],
-                          Index_type (&exclusive)[items_per_thread],
-                          Index_type (&inclusive)[items_per_thread],
-                          Index_type* block_counts,
-                          Index_type* grid_counts,
-                          unsigned* block_readys)
-{
-  const bool first_block = (block_id == 0);
-  const bool last_block = (block_id == gridDim.x-1);
-  const bool last_thread = (threadIdx.x == block_size-1);
-  const bool last_warp = (threadIdx.x >= block_size - warp_size);
-  const int warp_index = (threadIdx.x % warp_size);
-  const unsigned warp_index_mask = (1u << warp_index);
-  const unsigned warp_index_mask_right = warp_index_mask | (warp_index_mask - 1u);
-
-  using BlockScan = cub::BlockScan<Index_type, block_size>; //, cub::BLOCK_SCAN_WARP_SCANS>;
-  using BlockExchange = cub::BlockExchange<Index_type, block_size, items_per_thread>;
-  using WarpReduce = cub::WarpReduce<Index_type, warp_size>;
-
-  union SharedStorage {
-    typename BlockScan::TempStorage block_scan_storage;
-    typename BlockExchange::TempStorage block_exchange_storage;
-    typename WarpReduce::TempStorage warp_reduce_storage;
-    volatile Index_type prev_grid_count;
-  };
-  __shared__ SharedStorage s_temp_storage;
-
-
-  BlockExchange(s_temp_storage.block_exchange_storage).StripedToBlocked(val);
-  __syncthreads();
-
-
-  BlockScan(s_temp_storage.block_scan_storage).ExclusiveSum(val, exclusive);
-  __syncthreads();
-
-  for (size_t ti = 0; ti < items_per_thread; ++ti) {
-    inclusive[ti] = exclusive[ti] + val[ti];
-  }
-
-  BlockExchange(s_temp_storage.block_exchange_storage).BlockedToStriped(exclusive);
-  __syncthreads();
-  BlockExchange(s_temp_storage.block_exchange_storage).BlockedToStriped(inclusive);
-  __syncthreads();
-  if (first_block) {
-
-    if (!last_block && last_thread) {
-      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
-      grid_counts[block_id] = inclusive[items_per_thread-1];  // write inclusive scan result for grid through block
-      __threadfence();                         // ensure block_counts, grid_counts ready (release)
-      atomicExch(&block_readys[block_id], 2u); // write block_counts, grid_counts are ready
-    }
-
-  } else {
-
-    if (!last_block && last_thread) {
-      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
-      __threadfence();                         // ensure block_counts ready (release)
-      atomicExch(&block_readys[block_id], 1u); // write block_counts is ready
-    }
-
-    // get prev_grid_count using last warp in block
-    if (last_warp) {
-
-      Index_type prev_grid_count = 0;
-
-      // accumulate previous block counts into registers of warp
-
-      int prev_block_base_id = block_id - warp_size;
-
-      unsigned prev_block_ready = 0u;
-      unsigned prev_blocks_ready_ballot = 0u;
-      unsigned prev_grids_ready_ballot = 0u;
-
-      // accumulate full warp worths of block counts
-      // stop if run out of full warps of a grid count is ready
-      while (prev_block_base_id >= 0) {
-
-        const int prev_block_id = prev_block_base_id + warp_index;
-
-        // ensure previous block_counts are ready
-        do {
-          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
-
-          prev_blocks_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready >= 1u);
-
-        } while (prev_blocks_ready_ballot != 0xffffffffu);
-
-        prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
-
-        if (prev_grids_ready_ballot != 0u) {
-          break;
-        }
-
-        __threadfence(); // ensure block_counts or grid_counts ready (acquire)
-
-        // accumulate block_counts for prev_block_id
-        prev_grid_count += block_counts[prev_block_id];
-
-        prev_block_ready = 0u;
-
-        prev_block_base_id -= warp_size;
-      }
-
-      const int prev_block_id = prev_block_base_id + warp_index;
-
-      // ensure previous block_counts are ready
-      // this checks that block counts is ready for all blocks above
-      // the highest grid count that is ready
-      while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
-
-        if (prev_block_id >= 0) {
-          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
-        }
-
-        prev_blocks_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready >= 1u);
-        prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
-      }
-      __threadfence(); // ensure block_counts or grid_counts ready (acquire)
-
-      // read one grid_count from a block with id grid_count_ready_id
-      // and read the block_counts from blocks with higher ids.
-      if (warp_index_mask > prev_grids_ready_ballot) {
-        // accumulate block_counts for prev_block_id
-        prev_grid_count += block_counts[prev_block_id];
-      } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
-        // accumulate grid_count for grid_count_ready_id
-        prev_grid_count += grid_counts[prev_block_id];
-      }
-
-
-      prev_grid_count = WarpReduce(s_temp_storage.warp_reduce_storage).Sum(prev_grid_count);
-      prev_grid_count = __shfl_sync(0xffffffffu, prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
-
-      if (last_thread) {
-
-        if (!last_block) {
-          grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
-          __threadfence();                        // ensure grid_counts ready (release)
-          atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
-        }
-
-        s_temp_storage.prev_grid_count = prev_grid_count;
-      }
-    }
-
-    __syncthreads();
-    Index_type prev_grid_count = s_temp_storage.prev_grid_count;
-
-    for (size_t ti = 0; ti < items_per_thread; ++ti) {
-      exclusive[ti] = prev_grid_count + exclusive[ti];
-      inclusive[ti] = prev_grid_count + inclusive[ti];
-    }
-  }
-}
 
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
@@ -222,7 +52,7 @@ __global__ void indexlist(Real_ptr x,
 
   Index_type exclusives[items_per_thread];
   Index_type inclusives[items_per_thread];
-  grid_scan<block_size, items_per_thread>(
+  detail::cuda::grid_scan<block_size, items_per_thread>(
       block_id, vals, exclusives, inclusives, block_counts, grid_counts, block_readys);
 
   for (size_t ti = 0; ti < items_per_thread; ++ti) {
@@ -240,6 +70,7 @@ __global__ void indexlist(Real_ptr x,
   }
 }
 
+
 template < size_t block_size >
 void INDEXLIST::runCudaVariantImpl(VariantID vid)
 {
@@ -253,7 +84,7 @@ void INDEXLIST::runCudaVariantImpl(VariantID vid)
 
   if ( vid == Base_CUDA ) {
 
-    const size_t grid_size = RAJA_DIVIDE_CEILING_INT((iend-ibegin), block_size*items_per_thread);
+    const size_t grid_size = RAJA_DIVIDE_CEILING_INT((iend-ibegin), block_size*detail::cuda::grid_scan_items_per_thread);
     const size_t shmem_size = 0;
 
     Index_type* len;
@@ -270,7 +101,7 @@ void INDEXLIST::runCudaVariantImpl(VariantID vid)
 
       cudaErrchk( cudaMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size, 
                                   res.get_stream()) );
-      RPlaunchCudaKernel( (indexlist<block_size, items_per_thread>),
+      RPlaunchCudaKernel( (indexlist<block_size, detail::cuda::grid_scan_items_per_thread>),
                           grid_size, block_size,
                           shmem_size, res.get_stream(),
                           x+ibegin, list+ibegin,

--- a/src/basic/INDEXLIST-Cuda.cpp
+++ b/src/basic/INDEXLIST-Cuda.cpp
@@ -22,6 +22,12 @@ namespace rajaperf
 namespace basic
 {
 
+template < size_t block_size >
+using cuda_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
+    detail::cuda::grid_scan_default_items_per_thread,
+    integer::LessEqual<detail::cuda::grid_scan_max_items_per_thread<Index_type, block_size>::value>>;
+
+
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
 __global__ void indexlist(Real_ptr x,
@@ -52,7 +58,7 @@ __global__ void indexlist(Real_ptr x,
 
   Index_type exclusives[items_per_thread];
   Index_type inclusives[items_per_thread];
-  detail::cuda::grid_scan<block_size, items_per_thread>(
+  detail::cuda::GridScan<Index_type, block_size, items_per_thread>::grid_scan(
       block_id, vals, exclusives, inclusives, block_counts, grid_counts, block_readys);
 
   for (size_t ti = 0; ti < items_per_thread; ++ti) {
@@ -71,7 +77,7 @@ __global__ void indexlist(Real_ptr x,
 }
 
 
-template < size_t block_size >
+template < size_t block_size, size_t items_per_thread >
 void INDEXLIST::runCudaVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
@@ -84,7 +90,7 @@ void INDEXLIST::runCudaVariantImpl(VariantID vid)
 
   if ( vid == Base_CUDA ) {
 
-    const size_t grid_size = RAJA_DIVIDE_CEILING_INT((iend-ibegin), block_size*detail::cuda::grid_scan_items_per_thread);
+    const size_t grid_size = RAJA_DIVIDE_CEILING_INT((iend-ibegin), block_size*items_per_thread);
     const size_t shmem_size = 0;
 
     Index_type* len;
@@ -101,7 +107,7 @@ void INDEXLIST::runCudaVariantImpl(VariantID vid)
 
       cudaErrchk( cudaMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size, 
                                   res.get_stream()) );
-      RPlaunchCudaKernel( (indexlist<block_size, detail::cuda::grid_scan_items_per_thread>),
+      RPlaunchCudaKernel( (indexlist<block_size, items_per_thread>),
                           grid_size, block_size,
                           shmem_size, res.get_stream(),
                           x+ibegin, list+ibegin,
@@ -124,7 +130,73 @@ void INDEXLIST::runCudaVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(INDEXLIST, Cuda)
+
+void INDEXLIST::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  if ( vid == Base_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        seq_for(cuda_items_per_thread_type<block_size>{}, [&](auto items_per_thread) {
+
+          if (run_params.numValidItemsPerThread() == 0u ||
+              run_params.validItemsPerThread(block_size)) {
+
+            if (tune_idx == t) {
+
+              runCudaVariantImpl<decltype(block_size)::value, items_per_thread>(vid);
+
+            }
+
+            t += 1;
+
+          }
+
+        });
+
+      }
+
+    });
+
+  } else {
+
+    getCout() << "\n  INDEXLIST : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+}
+
+void INDEXLIST::setCudaTuningDefinitions(VariantID vid)
+{
+  if ( vid == Base_CUDA ) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        seq_for(cuda_items_per_thread_type<block_size>{}, [&](auto items_per_thread) {
+
+          if (run_params.numValidItemsPerThread() == 0u ||
+              run_params.validItemsPerThread(block_size)) {
+
+            addVariantTuningName(vid, "block_"+std::to_string(block_size)+
+                                      "_itemsPerThread_"+std::to_string(items_per_thread));
+
+          }
+
+        });
+
+      }
+
+    });
+
+  }
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/INDEXLIST-Cuda.cpp
+++ b/src/basic/INDEXLIST-Cuda.cpp
@@ -24,7 +24,7 @@ namespace basic
 
 template < size_t block_size >
 using cuda_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
-    detail::cuda::grid_scan_default_items_per_thread<block_size, detail::cuda::default_arch>::value,
+    detail::cuda::grid_scan_default_items_per_thread<Index_type, block_size, RAJA_PERFSUITE_TUNING_CUDA_ARCH>::value,
     integer::LessEqual<detail::cuda::grid_scan_max_items_per_thread<Index_type, block_size>::value>>;
 
 

--- a/src/basic/INDEXLIST-Cuda.cpp
+++ b/src/basic/INDEXLIST-Cuda.cpp
@@ -24,7 +24,7 @@ namespace basic
 
 template < size_t block_size >
 using cuda_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
-    detail::cuda::grid_scan_default_items_per_thread,
+    detail::cuda::grid_scan_default_items_per_thread<block_size, detail::cuda::default_arch>::value,
     integer::LessEqual<detail::cuda::grid_scan_max_items_per_thread<Index_type, block_size>::value>>;
 
 

--- a/src/basic/INDEXLIST-Hip.cpp
+++ b/src/basic/INDEXLIST-Hip.cpp
@@ -24,7 +24,7 @@ namespace basic
 
 template < size_t block_size >
 using hip_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
-    detail::hip::grid_scan_default_items_per_thread<block_size, detail::hip::default_arch>::value,
+    detail::hip::grid_scan_default_items_per_thread<Index_type, block_size, RAJA_PERFSUITE_TUNING_HIP_ARCH>::value,
     integer::LessEqual<detail::hip::grid_scan_max_items_per_thread<Index_type, block_size>::value>>;
 
 

--- a/src/basic/INDEXLIST-Hip.cpp
+++ b/src/basic/INDEXLIST-Hip.cpp
@@ -13,11 +13,7 @@
 #if defined(RAJA_ENABLE_HIP)
 
 #include "common/HipDataUtils.hpp"
-
-#include <rocprim/block/block_scan.hpp>
-#include <rocprim/block/block_exchange.hpp>
-#include <rocprim/warp/warp_reduce.hpp>
-#include <rocprim/warp/warp_scan.hpp>
+#include "common/HipGridScan.hpp"
 
 #include <iostream>
 
@@ -25,172 +21,6 @@ namespace rajaperf
 {
 namespace basic
 {
-
-  //
-  // Define magic numbers for HIP execution
-  //
-  const size_t warp_size = 64;
-  const size_t items_per_thread = 8;
-
-
-// perform a grid scan on val and returns the result at each thread
-// in exclusive and inclusive, note that val is used as scratch space
-template < size_t block_size, size_t items_per_thread >
-__device__ void grid_scan(const int block_id,
-                          Index_type (&val)[items_per_thread],
-                          Index_type (&exclusive)[items_per_thread],
-                          Index_type (&inclusive)[items_per_thread],
-                          Index_type* block_counts,
-                          Index_type* grid_counts,
-                          unsigned* block_readys)
-{
-  const bool first_block = (block_id == 0);
-  const bool last_block = (block_id == static_cast<int>(gridDim.x-1));
-  const bool last_thread = (threadIdx.x == block_size-1);
-  const bool last_warp = (threadIdx.x >= block_size - warp_size);
-  const int warp_index = (threadIdx.x % warp_size);
-  const unsigned long long warp_index_mask = (1ull << warp_index);
-  const unsigned long long warp_index_mask_right = warp_index_mask | (warp_index_mask - 1ull);
-
-  using BlockScan = rocprim::block_scan<Index_type, block_size>; //, rocprim::block_scan_algorithm::reduce_then_scan>;
-  using BlockExchange = rocprim::block_exchange<Index_type, block_size, items_per_thread>;
-  using WarpReduce = rocprim::warp_reduce<Index_type, warp_size>;
-
-  union SharedStorage {
-    typename BlockScan::storage_type block_scan_storage;
-    typename BlockExchange::storage_type block_exchange_storage;
-    typename WarpReduce::storage_type warp_reduce_storage;
-    volatile Index_type prev_grid_count;
-  };
-  __shared__ SharedStorage s_temp_storage;
-
-
-  BlockExchange().striped_to_blocked(val, val, s_temp_storage.block_exchange_storage);
-  __syncthreads();
-
-
-  BlockScan().exclusive_scan(val, exclusive, Index_type{0}, s_temp_storage.block_scan_storage);
-  __syncthreads();
-
-  for (size_t ti = 0; ti < items_per_thread; ++ti) {
-    inclusive[ti] = exclusive[ti] + val[ti];
-  }
-
-  BlockExchange().blocked_to_striped(exclusive, exclusive, s_temp_storage.block_exchange_storage);
-  __syncthreads();
-  BlockExchange().blocked_to_striped(inclusive, inclusive, s_temp_storage.block_exchange_storage);
-  __syncthreads();
-  if (first_block) {
-
-    if (!last_block && last_thread) {
-      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
-      grid_counts[block_id] = inclusive[items_per_thread-1];  // write inclusive scan result for grid through block
-      __threadfence();                         // ensure block_counts, grid_counts ready (release)
-      atomicExch(&block_readys[block_id], 2u); // write block_counts, grid_counts are ready
-    }
-
-  } else {
-
-    if (!last_block && last_thread) {
-      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
-      __threadfence();                         // ensure block_counts ready (release)
-      atomicExch(&block_readys[block_id], 1u); // write block_counts is ready
-    }
-
-    // get prev_grid_count using last warp in block
-    if (last_warp) {
-
-      Index_type prev_grid_count = 0;
-
-      // accumulate previous block counts into registers of warp
-
-      int prev_block_base_id = block_id - warp_size;
-
-      unsigned prev_block_ready = 0u;
-      unsigned long long prev_blocks_ready_ballot = 0ull;
-      unsigned long long prev_grids_ready_ballot = 0ull;
-
-      // accumulate full warp worths of block counts
-      // stop if run out of full warps of a grid count is ready
-      while (prev_block_base_id >= 0) {
-
-        const int prev_block_id = prev_block_base_id + warp_index;
-
-        // ensure previous block_counts are ready
-        do {
-          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
-
-          prev_blocks_ready_ballot = __ballot(prev_block_ready >= 1u);
-
-        } while (prev_blocks_ready_ballot != 0xffffffffffffffffull);
-
-        prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
-
-        if (prev_grids_ready_ballot != 0ull) {
-          break;
-        }
-
-        __threadfence(); // ensure block_counts or grid_counts ready (acquire)
-
-        // accumulate block_counts for prev_block_id
-        prev_grid_count += block_counts[prev_block_id];
-
-        prev_block_ready = 0u;
-
-        prev_block_base_id -= warp_size;
-      }
-
-      const int prev_block_id = prev_block_base_id + warp_index;
-
-      // ensure previous block_counts are ready
-      // this checks that block counts is ready for all blocks above
-      // the highest grid count that is ready
-      while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
-
-        if (prev_block_id >= 0) {
-          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
-        }
-
-        prev_blocks_ready_ballot = __ballot(prev_block_ready >= 1u);
-        prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
-      }
-      __threadfence(); // ensure block_counts or grid_counts ready (acquire)
-
-      // read one grid_count from a block with id grid_count_ready_id
-      // and read the block_counts from blocks with higher ids.
-      if (warp_index_mask > prev_grids_ready_ballot) {
-        // accumulate block_counts for prev_block_id
-        prev_grid_count += block_counts[prev_block_id];
-      } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
-        // accumulate grid_count for grid_count_ready_id
-        prev_grid_count += grid_counts[prev_block_id];
-      }
-
-
-      WarpReduce().reduce(prev_grid_count, prev_grid_count, s_temp_storage.warp_reduce_storage);
-      prev_grid_count = __shfl(prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
-
-      if (last_thread) {
-
-        if (!last_block) {
-          grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
-          __threadfence();                        // ensure grid_counts ready (release)
-          atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
-        }
-
-        s_temp_storage.prev_grid_count = prev_grid_count;
-      }
-    }
-
-    __syncthreads();
-    Index_type prev_grid_count = s_temp_storage.prev_grid_count;
-
-    for (size_t ti = 0; ti < items_per_thread; ++ti) {
-      exclusive[ti] = prev_grid_count + exclusive[ti];
-      inclusive[ti] = prev_grid_count + inclusive[ti];
-    }
-  }
-}
 
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
@@ -222,7 +52,7 @@ __global__ void indexlist(Real_ptr x,
 
   Index_type exclusives[items_per_thread];
   Index_type inclusives[items_per_thread];
-  grid_scan<block_size, items_per_thread>(
+  detail::hip::grid_scan<block_size, items_per_thread>(
       block_id, vals, exclusives, inclusives, block_counts, grid_counts, block_readys);
 
   for (size_t ti = 0; ti < items_per_thread; ++ti) {
@@ -253,7 +83,7 @@ void INDEXLIST::runHipVariantImpl(VariantID vid)
 
   if ( vid == Base_HIP ) {
 
-    const size_t grid_size = RAJA_DIVIDE_CEILING_INT((iend-ibegin), block_size*items_per_thread);
+    const size_t grid_size = RAJA_DIVIDE_CEILING_INT((iend-ibegin), block_size*detail::hip::grid_scan_items_per_thread);
     const size_t shmem_size = 0;
 
     Index_type* len;
@@ -271,7 +101,7 @@ void INDEXLIST::runHipVariantImpl(VariantID vid)
       hipErrchk( hipMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size,
                                 res.get_stream()) );
 
-      RPlaunchHipKernel( (indexlist<block_size, items_per_thread>),
+      RPlaunchHipKernel( (indexlist<block_size, detail::hip::grid_scan_items_per_thread>),
                          grid_size, block_size,
                          shmem_size, res.get_stream(),
                          x+ibegin, list+ibegin,

--- a/src/basic/INDEXLIST-Hip.cpp
+++ b/src/basic/INDEXLIST-Hip.cpp
@@ -24,7 +24,7 @@ namespace basic
 
 template < size_t block_size >
 using hip_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
-    detail::hip::grid_scan_default_items_per_thread,
+    detail::hip::grid_scan_default_items_per_thread<block_size, detail::hip::default_arch>::value,
     integer::LessEqual<detail::hip::grid_scan_max_items_per_thread<Index_type, block_size>::value>>;
 
 

--- a/src/basic/INDEXLIST.hpp
+++ b/src/basic/INDEXLIST.hpp
@@ -63,14 +63,14 @@ public:
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  template < size_t block_size >
+  template < size_t block_size, size_t items_per_thread >
   void runCudaVariantImpl(VariantID vid);
-  template < size_t block_size >
+  template < size_t block_size, size_t items_per_thread >
   void runHipVariantImpl(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;
-  using gpu_block_sizes_type = integer::list_type<default_gpu_block_size>;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
 
   Real_ptr m_x;
   Int_ptr m_list;

--- a/src/common/CudaGridScan.hpp
+++ b/src/common/CudaGridScan.hpp
@@ -24,28 +24,19 @@ namespace cuda
 // Define magic numbers for CUDA execution
 //
 const size_t warp_size = 32;
-const size_t grid_scan_items_per_thread = 15;
+const size_t max_static_shmem = 49154;
+
+// grid scan tunings are in (block_size, items_per_thread)
+// these tunings maximize throughput while minimizing items_per_thread
+// sm_70: (64, 13), (128, 9), (256, 6), (512, 5), (1024, 5)
+const size_t grid_scan_default_items_per_thread = 7;
 
 
 // perform a grid scan on val and returns the result at each thread
 // in exclusive and inclusive, note that val is used as scratch space
-template < size_t block_size, size_t items_per_thread, typename DataType >
-__device__ void grid_scan(const int block_id,
-                          DataType (&val)[items_per_thread],
-                          DataType (&exclusive)[items_per_thread],
-                          DataType (&inclusive)[items_per_thread],
-                          DataType* block_counts,
-                          DataType* grid_counts,
-                          unsigned* block_readys)
+template < typename DataType, size_t block_size, size_t items_per_thread >
+struct GridScan
 {
-  const bool first_block = (block_id == 0);
-  const bool last_block = (block_id == gridDim.x-1);
-  const bool last_thread = (threadIdx.x == block_size-1);
-  const bool last_warp = (threadIdx.x >= block_size - warp_size);
-  const int warp_index = (threadIdx.x % warp_size);
-  const unsigned warp_index_mask = (1u << warp_index);
-  const unsigned warp_index_mask_right = warp_index_mask | (warp_index_mask - 1u);
-
   using BlockScan = cub::BlockScan<DataType, block_size>; //, cub::BLOCK_SCAN_WARP_SCANS>;
   using BlockExchange = cub::BlockExchange<DataType, block_size, items_per_thread>;
   using WarpReduce = cub::WarpReduce<DataType, warp_size>;
@@ -56,135 +47,177 @@ __device__ void grid_scan(const int block_id,
     typename WarpReduce::TempStorage warp_reduce_storage;
     volatile DataType prev_grid_count;
   };
-  __shared__ SharedStorage s_temp_storage;
+
+  static constexpr size_t shmem_size = sizeof(SharedStorage);
+
+  __device__
+  static void grid_scan(const int block_id,
+                        DataType (&val)[items_per_thread],
+                        DataType (&exclusive)[items_per_thread],
+                        DataType (&inclusive)[items_per_thread],
+                        DataType* block_counts,
+                        DataType* grid_counts,
+                        unsigned* block_readys)
+  {
+    const bool first_block = (block_id == 0);
+    const bool last_block = (block_id == gridDim.x-1);
+    const bool last_thread = (threadIdx.x == block_size-1);
+    const bool last_warp = (threadIdx.x >= block_size - warp_size);
+    const int warp_index = (threadIdx.x % warp_size);
+    const unsigned warp_index_mask = (1u << warp_index);
+    const unsigned warp_index_mask_right = warp_index_mask | (warp_index_mask - 1u);
+
+    __shared__ SharedStorage s_temp_storage;
 
 
-  BlockExchange(s_temp_storage.block_exchange_storage).StripedToBlocked(val);
-  __syncthreads();
+    BlockExchange(s_temp_storage.block_exchange_storage).StripedToBlocked(val);
+    __syncthreads();
 
 
-  BlockScan(s_temp_storage.block_scan_storage).ExclusiveSum(val, exclusive);
-  __syncthreads();
+    BlockScan(s_temp_storage.block_scan_storage).ExclusiveSum(val, exclusive);
+    __syncthreads();
 
-  for (size_t ti = 0; ti < items_per_thread; ++ti) {
-    inclusive[ti] = exclusive[ti] + val[ti];
-  }
-
-  BlockExchange(s_temp_storage.block_exchange_storage).BlockedToStriped(exclusive);
-  __syncthreads();
-  BlockExchange(s_temp_storage.block_exchange_storage).BlockedToStriped(inclusive);
-  __syncthreads();
-  if (first_block) {
-
-    if (!last_block && last_thread) {
-      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
-      grid_counts[block_id] = inclusive[items_per_thread-1];  // write inclusive scan result for grid through block
-      __threadfence();                         // ensure block_counts, grid_counts ready (release)
-      atomicExch(&block_readys[block_id], 2u); // write block_counts, grid_counts are ready
+    for (size_t ti = 0; ti < items_per_thread; ++ti) {
+      inclusive[ti] = exclusive[ti] + val[ti];
     }
 
-  } else {
+    BlockExchange(s_temp_storage.block_exchange_storage).BlockedToStriped(exclusive);
+    __syncthreads();
+    BlockExchange(s_temp_storage.block_exchange_storage).BlockedToStriped(inclusive);
+    __syncthreads();
+    if (first_block) {
 
-    if (!last_block && last_thread) {
-      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
-      __threadfence();                         // ensure block_counts ready (release)
-      atomicExch(&block_readys[block_id], 1u); // write block_counts is ready
-    }
+      if (!last_block && last_thread) {
+        block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
+        grid_counts[block_id] = inclusive[items_per_thread-1];  // write inclusive scan result for grid through block
+        __threadfence();                         // ensure block_counts, grid_counts ready (release)
+        atomicExch(&block_readys[block_id], 2u); // write block_counts, grid_counts are ready
+      }
 
-    // get prev_grid_count using last warp in block
-    if (last_warp) {
+    } else {
 
-      DataType prev_grid_count = 0;
+      if (!last_block && last_thread) {
+        block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
+        __threadfence();                         // ensure block_counts ready (release)
+        atomicExch(&block_readys[block_id], 1u); // write block_counts is ready
+      }
 
-      // accumulate previous block counts into registers of warp
+      // get prev_grid_count using last warp in block
+      if (last_warp) {
 
-      int prev_block_base_id = block_id - warp_size;
+        DataType prev_grid_count = 0;
 
-      unsigned prev_block_ready = 0u;
-      unsigned prev_blocks_ready_ballot = 0u;
-      unsigned prev_grids_ready_ballot = 0u;
+        // accumulate previous block counts into registers of warp
 
-      // accumulate full warp worths of block counts
-      // stop if run out of full warps of a grid count is ready
-      while (prev_block_base_id >= 0) {
+        int prev_block_base_id = block_id - warp_size;
+
+        unsigned prev_block_ready = 0u;
+        unsigned prev_blocks_ready_ballot = 0u;
+        unsigned prev_grids_ready_ballot = 0u;
+
+        // accumulate full warp worths of block counts
+        // stop if run out of full warps of a grid count is ready
+        while (prev_block_base_id >= 0) {
+
+          const int prev_block_id = prev_block_base_id + warp_index;
+
+          // ensure previous block_counts are ready
+          do {
+            prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+
+            prev_blocks_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready >= 1u);
+
+          } while (prev_blocks_ready_ballot != 0xffffffffu);
+
+          prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
+
+          if (prev_grids_ready_ballot != 0u) {
+            break;
+          }
+
+          __threadfence(); // ensure block_counts or grid_counts ready (acquire)
+
+          // accumulate block_counts for prev_block_id
+          prev_grid_count += block_counts[prev_block_id];
+
+          prev_block_ready = 0u;
+
+          prev_block_base_id -= warp_size;
+        }
 
         const int prev_block_id = prev_block_base_id + warp_index;
 
         // ensure previous block_counts are ready
-        do {
-          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+        // this checks that block counts is ready for all blocks above
+        // the highest grid count that is ready
+        while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
+
+          if (prev_block_id >= 0) {
+            prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+          }
 
           prev_blocks_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready >= 1u);
-
-        } while (prev_blocks_ready_ballot != 0xffffffffu);
-
-        prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
-
-        if (prev_grids_ready_ballot != 0u) {
-          break;
+          prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
         }
-
         __threadfence(); // ensure block_counts or grid_counts ready (acquire)
 
-        // accumulate block_counts for prev_block_id
-        prev_grid_count += block_counts[prev_block_id];
-
-        prev_block_ready = 0u;
-
-        prev_block_base_id -= warp_size;
-      }
-
-      const int prev_block_id = prev_block_base_id + warp_index;
-
-      // ensure previous block_counts are ready
-      // this checks that block counts is ready for all blocks above
-      // the highest grid count that is ready
-      while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
-
-        if (prev_block_id >= 0) {
-          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+        // read one grid_count from a block with id grid_count_ready_id
+        // and read the block_counts from blocks with higher ids.
+        if (warp_index_mask > prev_grids_ready_ballot) {
+          // accumulate block_counts for prev_block_id
+          prev_grid_count += block_counts[prev_block_id];
+        } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
+          // accumulate grid_count for grid_count_ready_id
+          prev_grid_count += grid_counts[prev_block_id];
         }
 
-        prev_blocks_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready >= 1u);
-        prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
-      }
-      __threadfence(); // ensure block_counts or grid_counts ready (acquire)
 
-      // read one grid_count from a block with id grid_count_ready_id
-      // and read the block_counts from blocks with higher ids.
-      if (warp_index_mask > prev_grids_ready_ballot) {
-        // accumulate block_counts for prev_block_id
-        prev_grid_count += block_counts[prev_block_id];
-      } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
-        // accumulate grid_count for grid_count_ready_id
-        prev_grid_count += grid_counts[prev_block_id];
-      }
+        prev_grid_count = WarpReduce(s_temp_storage.warp_reduce_storage).Sum(prev_grid_count);
+        prev_grid_count = __shfl_sync(0xffffffffu, prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
 
+        if (last_thread) {
 
-      prev_grid_count = WarpReduce(s_temp_storage.warp_reduce_storage).Sum(prev_grid_count);
-      prev_grid_count = __shfl_sync(0xffffffffu, prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
+          if (!last_block) {
+            grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
+            __threadfence();                        // ensure grid_counts ready (release)
+            atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
+          }
 
-      if (last_thread) {
-
-        if (!last_block) {
-          grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
-          __threadfence();                        // ensure grid_counts ready (release)
-          atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
+          s_temp_storage.prev_grid_count = prev_grid_count;
         }
-
-        s_temp_storage.prev_grid_count = prev_grid_count;
       }
-    }
 
-    __syncthreads();
-    DataType prev_grid_count = s_temp_storage.prev_grid_count;
+      __syncthreads();
+      DataType prev_grid_count = s_temp_storage.prev_grid_count;
 
-    for (size_t ti = 0; ti < items_per_thread; ++ti) {
-      exclusive[ti] = prev_grid_count + exclusive[ti];
-      inclusive[ti] = prev_grid_count + inclusive[ti];
+      for (size_t ti = 0; ti < items_per_thread; ++ti) {
+        exclusive[ti] = prev_grid_count + exclusive[ti];
+        inclusive[ti] = prev_grid_count + inclusive[ti];
+      }
     }
   }
+
+};
+
+
+namespace detail
+{
+
+template < typename T, size_t block_size, size_t max_items_per_thread >
+struct grid_scan_max_items_per_thread
+  : std::conditional_t< (GridScan<T, block_size, max_items_per_thread>::shmem_size <= max_static_shmem),
+        grid_scan_max_items_per_thread<T, block_size, max_items_per_thread+1>,
+        std::integral_constant<size_t, max_items_per_thread-1> >
+{
+};
+
 }
+
+template < typename T, size_t block_size >
+struct grid_scan_max_items_per_thread
+  : detail::grid_scan_max_items_per_thread<T, block_size, 1>
+{
+};
 
 } // end namespace cuda
 } // end namespace detail

--- a/src/common/CudaGridScan.hpp
+++ b/src/common/CudaGridScan.hpp
@@ -26,10 +26,26 @@ namespace cuda
 const size_t warp_size = 32;
 const size_t max_static_shmem = 49154;
 
-// grid scan tunings are in (block_size, items_per_thread)
-// these tunings maximize throughput while minimizing items_per_thread
-// sm_70: (64, 13), (128, 9), (256, 6), (512, 5), (1024, 5)
-const size_t grid_scan_default_items_per_thread = 7;
+const size_t default_arch = 700;
+
+// grid scan tunings that maximize throughput while minimizing items_per_thread
+template < size_t block_size, size_t cuda_arch >
+struct grid_scan_default_items_per_thread
+{
+  static constexpr size_t value = 1;
+};
+
+// tuning for sm_70
+template < size_t block_size >
+struct grid_scan_default_items_per_thread<block_size, 700>
+{
+  static constexpr size_t value =
+      (block_size <= 64) ? 13 :
+      (block_size <= 128) ? 9 :
+      (block_size <= 256) ? 6 :
+      (block_size <= 512) ? 5 :
+      (block_size <= 1024) ? 5 : 1;
+};
 
 
 // perform a grid scan on val and returns the result at each thread

--- a/src/common/CudaGridScan.hpp
+++ b/src/common/CudaGridScan.hpp
@@ -1,0 +1,193 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include <cub/block/block_scan.cuh>
+#include <cub/block/block_exchange.cuh>
+#include <cub/warp/warp_reduce.cuh>
+#include <cub/warp/warp_scan.cuh>
+
+namespace rajaperf
+{
+namespace detail
+{
+namespace cuda
+{
+
+//
+// Define magic numbers for CUDA execution
+//
+const size_t warp_size = 32;
+const size_t grid_scan_items_per_thread = 15;
+
+
+// perform a grid scan on val and returns the result at each thread
+// in exclusive and inclusive, note that val is used as scratch space
+template < size_t block_size, size_t items_per_thread, typename DataType >
+__device__ void grid_scan(const int block_id,
+                          DataType (&val)[items_per_thread],
+                          DataType (&exclusive)[items_per_thread],
+                          DataType (&inclusive)[items_per_thread],
+                          DataType* block_counts,
+                          DataType* grid_counts,
+                          unsigned* block_readys)
+{
+  const bool first_block = (block_id == 0);
+  const bool last_block = (block_id == gridDim.x-1);
+  const bool last_thread = (threadIdx.x == block_size-1);
+  const bool last_warp = (threadIdx.x >= block_size - warp_size);
+  const int warp_index = (threadIdx.x % warp_size);
+  const unsigned warp_index_mask = (1u << warp_index);
+  const unsigned warp_index_mask_right = warp_index_mask | (warp_index_mask - 1u);
+
+  using BlockScan = cub::BlockScan<DataType, block_size>; //, cub::BLOCK_SCAN_WARP_SCANS>;
+  using BlockExchange = cub::BlockExchange<DataType, block_size, items_per_thread>;
+  using WarpReduce = cub::WarpReduce<DataType, warp_size>;
+
+  union SharedStorage {
+    typename BlockScan::TempStorage block_scan_storage;
+    typename BlockExchange::TempStorage block_exchange_storage;
+    typename WarpReduce::TempStorage warp_reduce_storage;
+    volatile DataType prev_grid_count;
+  };
+  __shared__ SharedStorage s_temp_storage;
+
+
+  BlockExchange(s_temp_storage.block_exchange_storage).StripedToBlocked(val);
+  __syncthreads();
+
+
+  BlockScan(s_temp_storage.block_scan_storage).ExclusiveSum(val, exclusive);
+  __syncthreads();
+
+  for (size_t ti = 0; ti < items_per_thread; ++ti) {
+    inclusive[ti] = exclusive[ti] + val[ti];
+  }
+
+  BlockExchange(s_temp_storage.block_exchange_storage).BlockedToStriped(exclusive);
+  __syncthreads();
+  BlockExchange(s_temp_storage.block_exchange_storage).BlockedToStriped(inclusive);
+  __syncthreads();
+  if (first_block) {
+
+    if (!last_block && last_thread) {
+      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
+      grid_counts[block_id] = inclusive[items_per_thread-1];  // write inclusive scan result for grid through block
+      __threadfence();                         // ensure block_counts, grid_counts ready (release)
+      atomicExch(&block_readys[block_id], 2u); // write block_counts, grid_counts are ready
+    }
+
+  } else {
+
+    if (!last_block && last_thread) {
+      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
+      __threadfence();                         // ensure block_counts ready (release)
+      atomicExch(&block_readys[block_id], 1u); // write block_counts is ready
+    }
+
+    // get prev_grid_count using last warp in block
+    if (last_warp) {
+
+      DataType prev_grid_count = 0;
+
+      // accumulate previous block counts into registers of warp
+
+      int prev_block_base_id = block_id - warp_size;
+
+      unsigned prev_block_ready = 0u;
+      unsigned prev_blocks_ready_ballot = 0u;
+      unsigned prev_grids_ready_ballot = 0u;
+
+      // accumulate full warp worths of block counts
+      // stop if run out of full warps of a grid count is ready
+      while (prev_block_base_id >= 0) {
+
+        const int prev_block_id = prev_block_base_id + warp_index;
+
+        // ensure previous block_counts are ready
+        do {
+          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+
+          prev_blocks_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready >= 1u);
+
+        } while (prev_blocks_ready_ballot != 0xffffffffu);
+
+        prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
+
+        if (prev_grids_ready_ballot != 0u) {
+          break;
+        }
+
+        __threadfence(); // ensure block_counts or grid_counts ready (acquire)
+
+        // accumulate block_counts for prev_block_id
+        prev_grid_count += block_counts[prev_block_id];
+
+        prev_block_ready = 0u;
+
+        prev_block_base_id -= warp_size;
+      }
+
+      const int prev_block_id = prev_block_base_id + warp_index;
+
+      // ensure previous block_counts are ready
+      // this checks that block counts is ready for all blocks above
+      // the highest grid count that is ready
+      while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
+
+        if (prev_block_id >= 0) {
+          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+        }
+
+        prev_blocks_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready >= 1u);
+        prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
+      }
+      __threadfence(); // ensure block_counts or grid_counts ready (acquire)
+
+      // read one grid_count from a block with id grid_count_ready_id
+      // and read the block_counts from blocks with higher ids.
+      if (warp_index_mask > prev_grids_ready_ballot) {
+        // accumulate block_counts for prev_block_id
+        prev_grid_count += block_counts[prev_block_id];
+      } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
+        // accumulate grid_count for grid_count_ready_id
+        prev_grid_count += grid_counts[prev_block_id];
+      }
+
+
+      prev_grid_count = WarpReduce(s_temp_storage.warp_reduce_storage).Sum(prev_grid_count);
+      prev_grid_count = __shfl_sync(0xffffffffu, prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
+
+      if (last_thread) {
+
+        if (!last_block) {
+          grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
+          __threadfence();                        // ensure grid_counts ready (release)
+          atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
+        }
+
+        s_temp_storage.prev_grid_count = prev_grid_count;
+      }
+    }
+
+    __syncthreads();
+    DataType prev_grid_count = s_temp_storage.prev_grid_count;
+
+    for (size_t ti = 0; ti < items_per_thread; ++ti) {
+      exclusive[ti] = prev_grid_count + exclusive[ti];
+      inclusive[ti] = prev_grid_count + inclusive[ti];
+    }
+  }
+}
+
+} // end namespace cuda
+} // end namespace detail
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -174,6 +174,9 @@ Executor::Executor(int argc, char** argv)
   if (cc.adiak_atomic_replications.size() > 0) {
     adiak::value("atomic_replications", cc.adiak_atomic_replications);
   }
+  if (cc.adiak_gpu_items_per_thread.size() > 0) {
+    adiak::value("gpu_items_per_thread", cc.adiak_gpu_items_per_thread);
+  }
   if (cc.adiak_raja_hipcc_flags.size() > 0) {
     adiak::value("raja_hipcc_flags", cc.adiak_raja_hipcc_flags);
   }

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -168,6 +168,12 @@ Executor::Executor(int argc, char** argv)
   if (strlen(cc.adiak_cmake_hip_architectures) > 0) {
     adiak::value("cmake_hip_architectures", cc.adiak_cmake_hip_architectures);
   }
+  if (strlen(cc.adiak_tuning_cuda_arch) > 0) {
+    adiak::value("tuning_cuda_arch", cc.adiak_tuning_cuda_arch);
+  }
+  if (strlen(cc.adiak_tuning_hip_arch) > 0) {
+    adiak::value("tuning_hip_arch", cc.adiak_tuning_hip_arch);
+  }
   if (cc.adiak_gpu_block_sizes.size() > 0) {
     adiak::value("gpu_block_sizes", cc.adiak_gpu_block_sizes);
   }

--- a/src/common/GPUUtils.hpp
+++ b/src/common/GPUUtils.hpp
@@ -125,6 +125,12 @@ struct ExactSqrt
   static constexpr bool valid(size_t i) { return sqrt(i)*sqrt(i) == i; }
 };
 
+template < size_t N >
+struct LessEqual
+{
+  static constexpr bool valid(size_t i) { return i <= N; }
+};
+
 // A camp::list of camp::integral_constant<size_t, I> types.
 // If gpu_block_sizes from the configuration is not empty it is those gpu_block_sizes,
 // otherwise it is a list containing just default_block_size.
@@ -148,6 +154,19 @@ using make_atomic_replication_list_type =
         typename std::conditional< (camp::size<rajaperf::configuration::atomic_replications>::value > 0),
           rajaperf::configuration::atomic_replications,
           list_type<default_atomic_replication>
+        >::type
+      >::type;
+
+// A camp::list of camp::integral_constant<size_t, I> types.
+// If gpu_items_per_thread from the configuration is not empty it is those gpu_items_per_thread,
+// otherwise it is a list containing just default_gpu_items_per_thread.
+// Invalid entries are removed according to validity_checker in either case.
+template < size_t default_gpu_items_per_thread, typename validity_checker = AllowAny >
+using make_gpu_items_per_thread_list_type =
+      typename detail::remove_invalid<validity_checker,
+        typename std::conditional< (camp::size<rajaperf::configuration::gpu_items_per_thread>::value > 0),
+          rajaperf::configuration::gpu_items_per_thread,
+          list_type<default_gpu_items_per_thread>
         >::type
       >::type;
 

--- a/src/common/HipGridScan.hpp
+++ b/src/common/HipGridScan.hpp
@@ -28,11 +28,38 @@ namespace hip
 const size_t warp_size = 64;
 const size_t max_static_shmem = 65536;
 
-// grid scan tunings are in (block_size, items_per_thread)
-// these tunings maximize throughput while minimizing items_per_thread
-// gfx90a: (64, 6), (128, 4), (256, 4), (512, 4), (1024, 2)
-// gfx942: (64, 22), (128, 22), (256, 19), (512, 13), (1024, 7)
-const size_t grid_scan_default_items_per_thread = 4;
+const size_t default_arch = 910;
+
+// grid scan tunings that maximize throughput while minimizing items_per_thread
+template < size_t block_size, size_t hip_arch >
+struct grid_scan_default_items_per_thread
+{
+  static constexpr size_t value = 1;
+};
+
+// tuning for gfx90a
+template < size_t block_size >
+struct grid_scan_default_items_per_thread<block_size, 910>
+{
+  static constexpr size_t value =
+      (block_size <= 64) ? 6 :
+      (block_size <= 128) ? 4 :
+      (block_size <= 256) ? 4 :
+      (block_size <= 512) ? 4 :
+      (block_size <= 1024) ? 2 : 1;
+};
+
+// tuning for gfx942
+template < size_t block_size >
+struct grid_scan_default_items_per_thread<block_size, 942>
+{
+  static constexpr size_t value =
+      (block_size <= 64) ? 22 :
+      (block_size <= 128) ? 22 :
+      (block_size <= 256) ? 19 :
+      (block_size <= 512) ? 13 :
+      (block_size <= 1024) ? 7 : 1;
+};
 
 
 // perform a grid scan on val and returns the result at each thread

--- a/src/common/HipGridScan.hpp
+++ b/src/common/HipGridScan.hpp
@@ -31,6 +31,7 @@ const size_t max_static_shmem = 65536;
 // grid scan tunings are in (block_size, items_per_thread)
 // these tunings maximize throughput while minimizing items_per_thread
 // gfx90a: (64, 6), (128, 4), (256, 4), (512, 4), (1024, 2)
+// gfx942: (64, 22), (128, 22), (256, 19), (512, 13), (1024, 7)
 const size_t grid_scan_default_items_per_thread = 4;
 
 

--- a/src/common/HipGridScan.hpp
+++ b/src/common/HipGridScan.hpp
@@ -1,0 +1,195 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-22, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#if defined(RAJA_ENABLE_HIP)
+
+#include <rocprim/block/block_scan.hpp>
+#include <rocprim/block/block_exchange.hpp>
+#include <rocprim/warp/warp_reduce.hpp>
+#include <rocprim/warp/warp_scan.hpp>
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace detail
+{
+namespace hip
+{
+
+//
+// Define magic numbers for HIP execution
+//
+const size_t warp_size = 64;
+const size_t grid_scan_items_per_thread = 8;
+
+
+// perform a grid scan on val and returns the result at each thread
+// in exclusive and inclusive, note that val is used as scratch space
+template < size_t block_size, size_t items_per_thread, typename DataType >
+__device__ void grid_scan(const int block_id,
+                          DataType (&val)[items_per_thread],
+                          DataType (&exclusive)[items_per_thread],
+                          DataType (&inclusive)[items_per_thread],
+                          DataType* block_counts,
+                          DataType* grid_counts,
+                          unsigned* block_readys)
+{
+  const bool first_block = (block_id == 0);
+  const bool last_block = (block_id == static_cast<int>(gridDim.x-1));
+  const bool last_thread = (threadIdx.x == block_size-1);
+  const bool last_warp = (threadIdx.x >= block_size - warp_size);
+  const int warp_index = (threadIdx.x % warp_size);
+  const unsigned long long warp_index_mask = (1ull << warp_index);
+  const unsigned long long warp_index_mask_right = warp_index_mask | (warp_index_mask - 1ull);
+
+  using BlockScan = rocprim::block_scan<DataType, block_size>; //, rocprim::block_scan_algorithm::reduce_then_scan>;
+  using BlockExchange = rocprim::block_exchange<DataType, block_size, items_per_thread>;
+  using WarpReduce = rocprim::warp_reduce<DataType, warp_size>;
+
+  union SharedStorage {
+    typename BlockScan::storage_type block_scan_storage;
+    typename BlockExchange::storage_type block_exchange_storage;
+    typename WarpReduce::storage_type warp_reduce_storage;
+    volatile DataType prev_grid_count;
+  };
+  __shared__ SharedStorage s_temp_storage;
+
+
+  BlockExchange().striped_to_blocked(val, val, s_temp_storage.block_exchange_storage);
+  __syncthreads();
+
+
+  BlockScan().exclusive_scan(val, exclusive, DataType{0}, s_temp_storage.block_scan_storage);
+  __syncthreads();
+
+  for (size_t ti = 0; ti < items_per_thread; ++ti) {
+    inclusive[ti] = exclusive[ti] + val[ti];
+  }
+
+  BlockExchange().blocked_to_striped(exclusive, exclusive, s_temp_storage.block_exchange_storage);
+  __syncthreads();
+  BlockExchange().blocked_to_striped(inclusive, inclusive, s_temp_storage.block_exchange_storage);
+  __syncthreads();
+  if (first_block) {
+
+    if (!last_block && last_thread) {
+      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
+      grid_counts[block_id] = inclusive[items_per_thread-1];  // write inclusive scan result for grid through block
+      __threadfence();                         // ensure block_counts, grid_counts ready (release)
+      atomicExch(&block_readys[block_id], 2u); // write block_counts, grid_counts are ready
+    }
+
+  } else {
+
+    if (!last_block && last_thread) {
+      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
+      __threadfence();                         // ensure block_counts ready (release)
+      atomicExch(&block_readys[block_id], 1u); // write block_counts is ready
+    }
+
+    // get prev_grid_count using last warp in block
+    if (last_warp) {
+
+      DataType prev_grid_count = 0;
+
+      // accumulate previous block counts into registers of warp
+
+      int prev_block_base_id = block_id - warp_size;
+
+      unsigned prev_block_ready = 0u;
+      unsigned long long prev_blocks_ready_ballot = 0ull;
+      unsigned long long prev_grids_ready_ballot = 0ull;
+
+      // accumulate full warp worths of block counts
+      // stop if run out of full warps of a grid count is ready
+      while (prev_block_base_id >= 0) {
+
+        const int prev_block_id = prev_block_base_id + warp_index;
+
+        // ensure previous block_counts are ready
+        do {
+          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+
+          prev_blocks_ready_ballot = __ballot(prev_block_ready >= 1u);
+
+        } while (prev_blocks_ready_ballot != 0xffffffffffffffffull);
+
+        prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
+
+        if (prev_grids_ready_ballot != 0ull) {
+          break;
+        }
+
+        __threadfence(); // ensure block_counts or grid_counts ready (acquire)
+
+        // accumulate block_counts for prev_block_id
+        prev_grid_count += block_counts[prev_block_id];
+
+        prev_block_ready = 0u;
+
+        prev_block_base_id -= warp_size;
+      }
+
+      const int prev_block_id = prev_block_base_id + warp_index;
+
+      // ensure previous block_counts are ready
+      // this checks that block counts is ready for all blocks above
+      // the highest grid count that is ready
+      while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
+
+        if (prev_block_id >= 0) {
+          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+        }
+
+        prev_blocks_ready_ballot = __ballot(prev_block_ready >= 1u);
+        prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
+      }
+      __threadfence(); // ensure block_counts or grid_counts ready (acquire)
+
+      // read one grid_count from a block with id grid_count_ready_id
+      // and read the block_counts from blocks with higher ids.
+      if (warp_index_mask > prev_grids_ready_ballot) {
+        // accumulate block_counts for prev_block_id
+        prev_grid_count += block_counts[prev_block_id];
+      } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
+        // accumulate grid_count for grid_count_ready_id
+        prev_grid_count += grid_counts[prev_block_id];
+      }
+
+
+      WarpReduce().reduce(prev_grid_count, prev_grid_count, s_temp_storage.warp_reduce_storage);
+      prev_grid_count = __shfl(prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
+
+      if (last_thread) {
+
+        if (!last_block) {
+          grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
+          __threadfence();                        // ensure grid_counts ready (release)
+          atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
+        }
+
+        s_temp_storage.prev_grid_count = prev_grid_count;
+      }
+    }
+
+    __syncthreads();
+    DataType prev_grid_count = s_temp_storage.prev_grid_count;
+
+    for (size_t ti = 0; ti < items_per_thread; ++ti) {
+      exclusive[ti] = prev_grid_count + exclusive[ti];
+      inclusive[ti] = prev_grid_count + inclusive[ti];
+    }
+  }
+}
+
+} // end namespace hip
+} // end namespace detail
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_HIP

--- a/src/common/HipGridScan.hpp
+++ b/src/common/HipGridScan.hpp
@@ -26,28 +26,19 @@ namespace hip
 // Define magic numbers for HIP execution
 //
 const size_t warp_size = 64;
-const size_t grid_scan_items_per_thread = 8;
+const size_t max_static_shmem = 65536;
+
+// grid scan tunings are in (block_size, items_per_thread)
+// these tunings maximize throughput while minimizing items_per_thread
+// gfx90a: (64, 6), (128, 4), (256, 4), (512, 4), (1024, 2)
+const size_t grid_scan_default_items_per_thread = 4;
 
 
 // perform a grid scan on val and returns the result at each thread
 // in exclusive and inclusive, note that val is used as scratch space
-template < size_t block_size, size_t items_per_thread, typename DataType >
-__device__ void grid_scan(const int block_id,
-                          DataType (&val)[items_per_thread],
-                          DataType (&exclusive)[items_per_thread],
-                          DataType (&inclusive)[items_per_thread],
-                          DataType* block_counts,
-                          DataType* grid_counts,
-                          unsigned* block_readys)
+template < typename DataType, size_t block_size, size_t items_per_thread >
+struct GridScan
 {
-  const bool first_block = (block_id == 0);
-  const bool last_block = (block_id == static_cast<int>(gridDim.x-1));
-  const bool last_thread = (threadIdx.x == block_size-1);
-  const bool last_warp = (threadIdx.x >= block_size - warp_size);
-  const int warp_index = (threadIdx.x % warp_size);
-  const unsigned long long warp_index_mask = (1ull << warp_index);
-  const unsigned long long warp_index_mask_right = warp_index_mask | (warp_index_mask - 1ull);
-
   using BlockScan = rocprim::block_scan<DataType, block_size>; //, rocprim::block_scan_algorithm::reduce_then_scan>;
   using BlockExchange = rocprim::block_exchange<DataType, block_size, items_per_thread>;
   using WarpReduce = rocprim::warp_reduce<DataType, warp_size>;
@@ -58,135 +49,177 @@ __device__ void grid_scan(const int block_id,
     typename WarpReduce::storage_type warp_reduce_storage;
     volatile DataType prev_grid_count;
   };
-  __shared__ SharedStorage s_temp_storage;
+
+  static constexpr size_t shmem_size = sizeof(SharedStorage);
+
+  __device__
+  static void grid_scan(const int block_id,
+                        DataType (&val)[items_per_thread],
+                        DataType (&exclusive)[items_per_thread],
+                        DataType (&inclusive)[items_per_thread],
+                        DataType* block_counts,
+                        DataType* grid_counts,
+                        unsigned* block_readys)
+  {
+    const bool first_block = (block_id == 0);
+    const bool last_block = (block_id == static_cast<int>(gridDim.x-1));
+    const bool last_thread = (threadIdx.x == block_size-1);
+    const bool last_warp = (threadIdx.x >= block_size - warp_size);
+    const int warp_index = (threadIdx.x % warp_size);
+    const unsigned long long warp_index_mask = (1ull << warp_index);
+    const unsigned long long warp_index_mask_right = warp_index_mask | (warp_index_mask - 1ull);
+
+    __shared__ SharedStorage s_temp_storage;
 
 
-  BlockExchange().striped_to_blocked(val, val, s_temp_storage.block_exchange_storage);
-  __syncthreads();
+    BlockExchange().striped_to_blocked(val, val, s_temp_storage.block_exchange_storage);
+    __syncthreads();
 
 
-  BlockScan().exclusive_scan(val, exclusive, DataType{0}, s_temp_storage.block_scan_storage);
-  __syncthreads();
+    BlockScan().exclusive_scan(val, exclusive, DataType{0}, s_temp_storage.block_scan_storage);
+    __syncthreads();
 
-  for (size_t ti = 0; ti < items_per_thread; ++ti) {
-    inclusive[ti] = exclusive[ti] + val[ti];
-  }
-
-  BlockExchange().blocked_to_striped(exclusive, exclusive, s_temp_storage.block_exchange_storage);
-  __syncthreads();
-  BlockExchange().blocked_to_striped(inclusive, inclusive, s_temp_storage.block_exchange_storage);
-  __syncthreads();
-  if (first_block) {
-
-    if (!last_block && last_thread) {
-      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
-      grid_counts[block_id] = inclusive[items_per_thread-1];  // write inclusive scan result for grid through block
-      __threadfence();                         // ensure block_counts, grid_counts ready (release)
-      atomicExch(&block_readys[block_id], 2u); // write block_counts, grid_counts are ready
+    for (size_t ti = 0; ti < items_per_thread; ++ti) {
+      inclusive[ti] = exclusive[ti] + val[ti];
     }
 
-  } else {
+    BlockExchange().blocked_to_striped(exclusive, exclusive, s_temp_storage.block_exchange_storage);
+    __syncthreads();
+    BlockExchange().blocked_to_striped(inclusive, inclusive, s_temp_storage.block_exchange_storage);
+    __syncthreads();
+    if (first_block) {
 
-    if (!last_block && last_thread) {
-      block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
-      __threadfence();                         // ensure block_counts ready (release)
-      atomicExch(&block_readys[block_id], 1u); // write block_counts is ready
-    }
+      if (!last_block && last_thread) {
+        block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
+        grid_counts[block_id] = inclusive[items_per_thread-1];  // write inclusive scan result for grid through block
+        __threadfence();                         // ensure block_counts, grid_counts ready (release)
+        atomicExch(&block_readys[block_id], 2u); // write block_counts, grid_counts are ready
+      }
 
-    // get prev_grid_count using last warp in block
-    if (last_warp) {
+    } else {
 
-      DataType prev_grid_count = 0;
+      if (!last_block && last_thread) {
+        block_counts[block_id] = inclusive[items_per_thread-1]; // write inclusive scan result for block
+        __threadfence();                         // ensure block_counts ready (release)
+        atomicExch(&block_readys[block_id], 1u); // write block_counts is ready
+      }
 
-      // accumulate previous block counts into registers of warp
+      // get prev_grid_count using last warp in block
+      if (last_warp) {
 
-      int prev_block_base_id = block_id - warp_size;
+        DataType prev_grid_count = 0;
 
-      unsigned prev_block_ready = 0u;
-      unsigned long long prev_blocks_ready_ballot = 0ull;
-      unsigned long long prev_grids_ready_ballot = 0ull;
+        // accumulate previous block counts into registers of warp
 
-      // accumulate full warp worths of block counts
-      // stop if run out of full warps of a grid count is ready
-      while (prev_block_base_id >= 0) {
+        int prev_block_base_id = block_id - warp_size;
+
+        unsigned prev_block_ready = 0u;
+        unsigned long long prev_blocks_ready_ballot = 0ull;
+        unsigned long long prev_grids_ready_ballot = 0ull;
+
+        // accumulate full warp worths of block counts
+        // stop if run out of full warps of a grid count is ready
+        while (prev_block_base_id >= 0) {
+
+          const int prev_block_id = prev_block_base_id + warp_index;
+
+          // ensure previous block_counts are ready
+          do {
+            prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+
+            prev_blocks_ready_ballot = __ballot(prev_block_ready >= 1u);
+
+          } while (prev_blocks_ready_ballot != 0xffffffffffffffffull);
+
+          prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
+
+          if (prev_grids_ready_ballot != 0ull) {
+            break;
+          }
+
+          __threadfence(); // ensure block_counts or grid_counts ready (acquire)
+
+          // accumulate block_counts for prev_block_id
+          prev_grid_count += block_counts[prev_block_id];
+
+          prev_block_ready = 0u;
+
+          prev_block_base_id -= warp_size;
+        }
 
         const int prev_block_id = prev_block_base_id + warp_index;
 
         // ensure previous block_counts are ready
-        do {
-          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+        // this checks that block counts is ready for all blocks above
+        // the highest grid count that is ready
+        while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
+
+          if (prev_block_id >= 0) {
+            prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+          }
 
           prev_blocks_ready_ballot = __ballot(prev_block_ready >= 1u);
-
-        } while (prev_blocks_ready_ballot != 0xffffffffffffffffull);
-
-        prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
-
-        if (prev_grids_ready_ballot != 0ull) {
-          break;
+          prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
         }
-
         __threadfence(); // ensure block_counts or grid_counts ready (acquire)
 
-        // accumulate block_counts for prev_block_id
-        prev_grid_count += block_counts[prev_block_id];
-
-        prev_block_ready = 0u;
-
-        prev_block_base_id -= warp_size;
-      }
-
-      const int prev_block_id = prev_block_base_id + warp_index;
-
-      // ensure previous block_counts are ready
-      // this checks that block counts is ready for all blocks above
-      // the highest grid count that is ready
-      while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
-
-        if (prev_block_id >= 0) {
-          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+        // read one grid_count from a block with id grid_count_ready_id
+        // and read the block_counts from blocks with higher ids.
+        if (warp_index_mask > prev_grids_ready_ballot) {
+          // accumulate block_counts for prev_block_id
+          prev_grid_count += block_counts[prev_block_id];
+        } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
+          // accumulate grid_count for grid_count_ready_id
+          prev_grid_count += grid_counts[prev_block_id];
         }
 
-        prev_blocks_ready_ballot = __ballot(prev_block_ready >= 1u);
-        prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
-      }
-      __threadfence(); // ensure block_counts or grid_counts ready (acquire)
 
-      // read one grid_count from a block with id grid_count_ready_id
-      // and read the block_counts from blocks with higher ids.
-      if (warp_index_mask > prev_grids_ready_ballot) {
-        // accumulate block_counts for prev_block_id
-        prev_grid_count += block_counts[prev_block_id];
-      } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
-        // accumulate grid_count for grid_count_ready_id
-        prev_grid_count += grid_counts[prev_block_id];
-      }
+        WarpReduce().reduce(prev_grid_count, prev_grid_count, s_temp_storage.warp_reduce_storage);
+        prev_grid_count = __shfl(prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
 
+        if (last_thread) {
 
-      WarpReduce().reduce(prev_grid_count, prev_grid_count, s_temp_storage.warp_reduce_storage);
-      prev_grid_count = __shfl(prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
+          if (!last_block) {
+            grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
+            __threadfence();                        // ensure grid_counts ready (release)
+            atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
+          }
 
-      if (last_thread) {
-
-        if (!last_block) {
-          grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
-          __threadfence();                        // ensure grid_counts ready (release)
-          atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
+          s_temp_storage.prev_grid_count = prev_grid_count;
         }
-
-        s_temp_storage.prev_grid_count = prev_grid_count;
       }
-    }
 
-    __syncthreads();
-    DataType prev_grid_count = s_temp_storage.prev_grid_count;
+      __syncthreads();
+      DataType prev_grid_count = s_temp_storage.prev_grid_count;
 
-    for (size_t ti = 0; ti < items_per_thread; ++ti) {
-      exclusive[ti] = prev_grid_count + exclusive[ti];
-      inclusive[ti] = prev_grid_count + inclusive[ti];
+      for (size_t ti = 0; ti < items_per_thread; ++ti) {
+        exclusive[ti] = prev_grid_count + exclusive[ti];
+        inclusive[ti] = prev_grid_count + inclusive[ti];
+      }
     }
   }
+
+};
+
+
+namespace detail
+{
+
+template < typename T, size_t block_size, size_t max_items_per_thread >
+struct grid_scan_max_items_per_thread
+  : std::conditional_t< (GridScan<T, block_size, max_items_per_thread>::shmem_size <= max_static_shmem),
+        grid_scan_max_items_per_thread<T, block_size, max_items_per_thread+1>,
+        std::integral_constant<size_t, max_items_per_thread-1> >
+{
+};
+
 }
+
+template < typename T, size_t block_size >
+struct grid_scan_max_items_per_thread
+  : detail::grid_scan_max_items_per_thread<T, block_size, 1>
+{
+};
 
 } // end namespace hip
 } // end namespace detail

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -41,6 +41,7 @@ RunParams::RunParams(int argc, char** argv)
    gpu_stream(1),
    gpu_block_sizes(),
    atomic_replications(),
+   items_per_threads(),
    mpi_size(1),
    mpi_rank(0),
    mpi_3d_division({-1, -1, -1}),
@@ -127,6 +128,10 @@ void RunParams::print(std::ostream& str) const
   str << "\n atomic_replications = ";
   for (size_t j = 0; j < atomic_replications.size(); ++j) {
     str << "\n\t" << atomic_replications[j];
+  }
+  str << "\n items_per_threads = ";
+  for (size_t j = 0; j < items_per_threads.size(); ++j) {
+    str << "\n\t" << items_per_threads[j];
   }
   str << "\n mpi_size = " << mpi_size;
   str << "\n mpi_3d_division = ";
@@ -497,6 +502,37 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
       if (!got_someting) {
         getCout() << "\nBad input:"
                   << " must give --atomic_replication one or more values (int)"
+                  << std::endl;
+        input_state = BadInput;
+      }
+
+    } else if ( opt == std::string("--items_per_thread") ) {
+
+      bool got_someting = false;
+      bool done = false;
+      i++;
+      while ( i < argc && !done ) {
+        opt = std::string(argv[i]);
+        if ( opt.at(0) == '-' ) {
+          i--;
+          done = true;
+        } else {
+          got_someting = true;
+          int items_per_thread = ::atoi( opt.c_str() );
+          if ( items_per_thread <= 0 ) {
+            getCout() << "\nBad input:"
+                      << " must give --items_per_thread POSITIVE values (int)"
+                      << std::endl;
+            input_state = BadInput;
+          } else {
+            items_per_threads.push_back(items_per_thread);
+          }
+          ++i;
+        }
+      }
+      if (!got_someting) {
+        getCout() << "\nBad input:"
+                  << " must give --items_per_thread one or more values (int)"
                   << std::endl;
         input_state = BadInput;
       }
@@ -1120,6 +1156,14 @@ void RunParams::printHelpMessage(std::ostream& str) const
       << "\t      values give via CMake variable RAJA_PERFSUITE_ATOMIC_REPLICATIONS.\n";
   str << "\t\t Example...\n"
       << "\t\t --atomic_replication 128 256 512 (runs kernels with atomic_replication 128, 256, and 512)\n\n";
+
+  str << "\t --items_per_thread <space-separated ints> [no default]\n"
+      << "\t      (items per thread to run for all GPU kernels)\n"
+      << "\t      GPU kernels not supporting items_per_thread option will be skipped.\n"
+      << "\t      Behavior depends on kernel implementations and \n"
+      << "\t      values give via CMake variable RAJA_PERFSUITE_GPU_ITEMS_PER_THREAD.\n";
+  str << "\t\t Example...\n"
+      << "\t\t --items_per_thread 128 256 512 (runs kernels with items_per_thread 128, 256, and 512)\n\n";
 
   str << "\t --mpi_3d_division <space-separated ints> [no default]\n"
       << "\t      (number of mpi ranks in each dimension in a 3d grid)\n"

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -144,6 +144,16 @@ public:
     }
     return false;
   }
+  size_t numValidItemsPerThread() const { return items_per_threads.size(); }
+  bool validItemsPerThread(size_t items_per_thread) const
+  {
+    for (size_t valid_items_per_thread : items_per_threads) {
+      if (valid_items_per_thread == items_per_thread) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   int getMPISize() const { return mpi_size; }
   int getMPIRank() const { return mpi_rank; }
@@ -244,6 +254,7 @@ private:
   int gpu_stream; /*!< 0 -> use stream 0; anything else -> use raja default stream */
   std::vector<size_t> gpu_block_sizes; /*!< Block sizes for gpu tunings to run (input option) */
   std::vector<size_t> atomic_replications; /*!< Atomic replications for gpu tunings to run (input option) */
+  std::vector<size_t> items_per_threads; /*!< Items per thread for gpu tunings to run (input option) */
   int mpi_size;           /*!< Number of MPI ranks */
   int mpi_rank;           /*!< Rank of this MPI process */
   std::array<int, 3> mpi_3d_division; /*!< Number of MPI ranks in each dimension of a 3D grid */

--- a/src/rajaperf_config.hpp.in
+++ b/src/rajaperf_config.hpp.in
@@ -30,7 +30,12 @@
 #cmakedefine RAJA_PERFSUITE_ENABLE_MPI
 #cmakedefine RAJA_PERFSUITE_ENABLE_OPENMP5_SCAN
 
+#if defined(RAJA_ENABLE_CUDA)
+#define RAJA_PERFSUITE_TUNING_CUDA_ARCH @RAJA_PERFSUITE_TUNING_CUDA_ARCH@
+#endif
+
 #if defined(RAJA_ENABLE_HIP)
+#define RAJA_PERFSUITE_TUNING_HIP_ARCH @RAJA_PERFSUITE_TUNING_HIP_ARCH@
 #include <hip/hip_version.h>
 #if (HIP_VERSION_MAJOR > 5) || \
     (HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR >= 2)
@@ -102,6 +107,8 @@ const adiak::version adiak_compiler_version = std::string("@CMAKE_CXX_COMPILER_V
 const adiak::version adiak_cuda_compiler_version = std::string("@CMAKE_CUDA_COMPILER_VERSION@");
 constexpr static const char* adiak_gpu_targets = "@GPU_TARGETS@";
 constexpr static const char* adiak_cmake_hip_architectures = "@CMAKE_HIP_ARCHIECTURES@";
+constexpr static const char* adiak_tuning_cuda_arch = "@RAJA_PERFSUITE_TUNING_CUDA_ARCH@";
+constexpr static const char* adiak_tuning_hip_arch = "@RAJA_PERFSUITE_TUNING_HIP_ARCH@";
 const std::vector<int> adiak_gpu_block_sizes = {@RAJA_PERFSUITE_GPU_BLOCKSIZES@};
 const std::vector<int> adiak_atomic_replications = {@RAJA_PERFSUITE_ATOMIC_REPLICATIONS@};
 const std::vector<int> adiak_gpu_items_per_thread = {@RAJA_PERFSUITE_GPU_ITEMS_PER_THREAD@};

--- a/src/rajaperf_config.hpp.in
+++ b/src/rajaperf_config.hpp.in
@@ -104,6 +104,7 @@ constexpr static const char* adiak_gpu_targets = "@GPU_TARGETS@";
 constexpr static const char* adiak_cmake_hip_architectures = "@CMAKE_HIP_ARCHIECTURES@";
 const std::vector<int> adiak_gpu_block_sizes = {@RAJA_PERFSUITE_GPU_BLOCKSIZES@};
 const std::vector<int> adiak_atomic_replications = {@RAJA_PERFSUITE_ATOMIC_REPLICATIONS@};
+const std::vector<int> adiak_gpu_items_per_thread = {@RAJA_PERFSUITE_GPU_ITEMS_PER_THREAD@};
 const std::vector<adiak::catstring> adiak_raja_hipcc_flags = str_to_list<adiak::catstring>(std::string("@RAJA_HIPCC_FLAGS@"));
 const adiak::catstring adiak_mpi_cxx_compiler = std::string("@MPI_CXX_COMPILER@");
 const adiak::catstring adiak_systype_build = std::string("@RAJAPERF_BUILD_SYSTYPE@");
@@ -115,6 +116,9 @@ using gpu_block_sizes = integer::list_type<@RAJA_PERFSUITE_GPU_BLOCKSIZES@>;
 
 // List of GPU atomic replications
 using atomic_replications = integer::list_type<@RAJA_PERFSUITE_ATOMIC_REPLICATIONS@>;
+
+// List of GPU items per thread
+using gpu_items_per_thread = integer::list_type<@RAJA_PERFSUITE_GPU_ITEMS_PER_THREAD@>;
 
 // Name of user who ran code
 std::string user_run;


### PR DESCRIPTION
# Generalize and tune manual scan implementation

The manual cuda and hip grid scan implementation from INDEXLIST have been moved to common headers. The SCAN kernel has been updated to use the manual grid scan implementation. The manual scan implementation has tunings with different numbers of items per thread which trades work per thread with amount of parallelism. By reducing parallelism fewer blocks are run which means less information has to be passed between blocks. The manual grid scan has been tuned for items per thread for a few architectures.
The items per thread is a configure time option set by changing the cmake param RAJA_PERFSUITE_GPU_ITEMS_PER_THREAD to a comma separated list of integers. What is run at runtime can be set using the command line option --items_per_thread to a space separated list of integers. The manual grid scan will filter out integers that lead to tunings that would not be able to compile.
The cuda and hip architecture that we are tuning for can be set by changing the cmake params RAJA_PERFSUITE_TUNING_CUDA_ARCH and RAJA_PERFSUITE_TUNING_HIP_ARCH. For example if tuning for Nvidia V100 (sm_70) set RAJA_PERFSUITE_TUNING_CUDA_ARCH to 700, if tuning for AMD MI250X (gfx90a) set RAJA_PERFSUITE_TUNING_HIP_ARCH to 910.
The plan is to move the tuning architecture settings into RAJA in the future so RAJA can have default tuning parameters that are appropriate for a given architecture.

- This PR is a feature
- It does the following (modify list as needed):
  - Adds more manual scan tunings and tuning options at the request of me
