### PR TITLE
Centralize function used in TRAP_INT kernel to avoid redundancy

### DIFF
--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -12,6 +12,8 @@
 
 #if defined(RAJA_ENABLE_CUDA)
 
+#include "TRAP_INT-func.hpp"
+
 #include "common/CudaDataUtils.hpp"
 
 #include <iostream>
@@ -24,21 +26,6 @@ namespace rajaperf
 {
 namespace basic
 {
-
-//
-// Function used in TRAP_INT loop.
-//
-RAJA_INLINE
-RAJA_DEVICE
-Real_type trap_int_func(Real_type x,
-                        Real_type y,
-                        Real_type xp,
-                        Real_type yp)
-{
-   Real_type denom = (x - xp)*(x - xp) + (y - yp)*(y - yp);
-   denom = 1.0/sqrt(denom);
-   return denom;
-}
 
 
 template < size_t block_size >

--- a/src/basic/TRAP_INT-Hip.cpp
+++ b/src/basic/TRAP_INT-Hip.cpp
@@ -12,6 +12,8 @@
 
 #if defined(RAJA_ENABLE_HIP)
 
+#include "TRAP_INT-func.hpp"
+
 #include "common/HipDataUtils.hpp"
 
 #include <iostream>
@@ -24,21 +26,6 @@ namespace rajaperf
 {
 namespace basic
 {
-
-//
-// Function used in TRAP_INT loop.
-//
-RAJA_INLINE
-RAJA_DEVICE
-Real_type trap_int_func(Real_type x,
-                        Real_type y,
-                        Real_type xp,
-                        Real_type yp)
-{
-   Real_type denom = (x - xp)*(x - xp) + (y - yp)*(y - yp);
-   denom = 1.0/sqrt(denom);
-   return denom;
-}
 
 
 template < size_t block_size >

--- a/src/basic/TRAP_INT-OMP.cpp
+++ b/src/basic/TRAP_INT-OMP.cpp
@@ -10,26 +10,14 @@
 
 #include "RAJA/RAJA.hpp"
 
+#include "TRAP_INT-func.hpp"
+
 #include <iostream>
 
 namespace rajaperf
 {
 namespace basic
 {
-
-//
-// Function used in TRAP_INT loop.
-//
-RAJA_INLINE
-Real_type trap_int_func(Real_type x,
-                        Real_type y,
-                        Real_type xp,
-                        Real_type yp)
-{
-   Real_type denom = (x - xp)*(x - xp) + (y - yp)*(y - yp);
-   denom = 1.0/sqrt(denom);
-   return denom;
-}
 
 
 void TRAP_INT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/src/basic/TRAP_INT-OMPTarget.cpp
+++ b/src/basic/TRAP_INT-OMPTarget.cpp
@@ -12,6 +12,8 @@
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
 
+#include "TRAP_INT-func.hpp"
+
 #include "common/OpenMPTargetDataUtils.hpp"
 
 #include <iostream>
@@ -20,20 +22,6 @@ namespace rajaperf
 {
 namespace basic
 {
-
-//
-// Function used in TRAP_INT loop.
-//
-RAJA_INLINE
-Real_type trap_int_func(Real_type x,
-                        Real_type y,
-                        Real_type xp,
-                        Real_type yp)
-{
-   Real_type denom = (x - xp)*(x - xp) + (y - yp)*(y - yp);
-   denom = 1.0/sqrt(denom);
-   return denom;
-}
 
   //
   // Define threads per team for target execution

--- a/src/basic/TRAP_INT-Seq.cpp
+++ b/src/basic/TRAP_INT-Seq.cpp
@@ -10,26 +10,14 @@
 
 #include "RAJA/RAJA.hpp"
 
+#include "TRAP_INT-func.hpp"
+
 #include <iostream>
 
 namespace rajaperf
 {
 namespace basic
 {
-
-//
-// Function used in TRAP_INT loop.
-//
-RAJA_INLINE
-Real_type trap_int_func(Real_type x,
-                        Real_type y,
-                        Real_type xp,
-                        Real_type yp)
-{
-   Real_type denom = (x - xp)*(x - xp) + (y - yp)*(y - yp);
-   denom = 1.0/sqrt(denom);
-   return denom;
-}
 
 
 void TRAP_INT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/src/basic/TRAP_INT-Sycl.cpp
+++ b/src/basic/TRAP_INT-Sycl.cpp
@@ -12,6 +12,8 @@
 
 #if defined(RAJA_ENABLE_SYCL)
 
+#include "TRAP_INT-func.hpp"
+
 #include "common/SyclDataUtils.hpp"
 
 #include <iostream>
@@ -21,20 +23,6 @@ namespace rajaperf
 namespace basic
 {
 
-//
-// Function used in TRAP_INT loop.
-//
-RAJA_INLINE
-RAJA_DEVICE
-Real_type trap_int_func(Real_type x,
-                        Real_type y,
-                        Real_type xp,
-                        Real_type yp)
-{
-   Real_type denom = (x - xp)*(x - xp) + (y - yp)*(y - yp);
-   denom = 1.0/sqrt(denom);
-   return denom;
-}
 
 template <size_t work_group_size >
 void TRAP_INT::runSyclVariantImpl(VariantID vid)

--- a/src/basic/TRAP_INT-func.hpp
+++ b/src/basic/TRAP_INT-func.hpp
@@ -1,0 +1,35 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#ifndef RAJAPerf_Basic_TRAP_INT_FUNC_HPP
+#define RAJAPerf_Basic_TRAP_INT_FUNC_HPP
+
+namespace rajaperf
+{
+namespace basic
+{
+
+//
+// Function used in TRAP_INT loop in each variant.
+//
+RAJA_INLINE
+RAJA_HOST_DEVICE
+Real_type trap_int_func(Real_type x,
+                        Real_type y,
+                        Real_type xp,
+                        Real_type yp)
+{
+   Real_type denom = (x - xp)*(x - xp) + (y - yp)*(y - yp);
+   denom = 1.0/sqrt(denom);
+   return denom;
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // closing endif for header file include guard


### PR DESCRIPTION
This PR is a minor refactoring that eliminates redundant implementations of the function used in  the TRAP_INT kernel

It resolves https://github.com/LLNL/RAJAPerf/issues/435
