### PR TITLE
Rework SYCL queue usage

### DIFF
--- a/scripts/lc-builds/corona_sycl.sh
+++ b/scripts/lc-builds/corona_sycl.sh
@@ -13,7 +13,7 @@ if [[ $# -lt 1 ]]; then
   echo "   1) SYCL compiler installation path"
   echo
   echo "For example: "
-  echo "    corona_sycl.sh /usr/workspace/raja-dev/clang_sycl_a0117ab8692a_hip_gcc10.2.1_rocm5.6.0"
+  echo "    corona_sycl.sh /usr/workspace/raja-dev/clang_sycl_2f03ef85fee5_hip_gcc10.3.1_rocm5.7.1"
   exit
 fi
 

--- a/src/apps/DEL_DOT_VEC_2D-Sycl.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-Sycl.cpp
@@ -31,6 +31,7 @@ void DEL_DOT_VEC_2D::runSyclVariantImpl(VariantID vid)
   const Index_type iend = m_domain->n_real_zones;
 
   auto res{getSyclResource()};
+  auto qu = res.get_queue();
 
   DEL_DOT_VEC_2D_DATA_SETUP;
 
@@ -55,7 +56,6 @@ void DEL_DOT_VEC_2D::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -72,7 +72,6 @@ void DEL_DOT_VEC_2D::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/apps/ENERGY-Sycl.cpp
+++ b/src/apps/ENERGY-Sycl.cpp
@@ -28,12 +28,13 @@ void ENERGY::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   ENERGY_DATA_SETUP;
 
   using sycl::sqrt;
   using sycl::fabs;
-
-  auto res{getSyclResource()};
 
   if ( vid == Base_SYCL ) {
 
@@ -101,8 +102,7 @@ void ENERGY::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h)
-      {
+      qu->submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (grid_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -114,7 +114,6 @@ void ENERGY::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -159,7 +158,6 @@ void ENERGY::runSyclVariantImpl(VariantID vid)
       }); // end sequential region (for single-source code)
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/apps/FIR-Sycl.cpp
+++ b/src/apps/FIR-Sycl.cpp
@@ -44,9 +44,10 @@ void FIR::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize() - m_coefflen;
 
-  FIR_DATA_SETUP;
-
   auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
+  FIR_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
 
@@ -71,7 +72,6 @@ void FIR::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
     FIR_DATA_TEARDOWN_SYCL;
@@ -91,7 +91,6 @@ void FIR::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
     FIR_DATA_TEARDOWN_SYCL;

--- a/src/apps/LTIMES-Sycl.cpp
+++ b/src/apps/LTIMES-Sycl.cpp
@@ -33,6 +33,9 @@ void LTIMES::runSyclVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   LTIMES_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -62,7 +65,6 @@ void LTIMES::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -96,7 +98,6 @@ void LTIMES::runSyclVariantImpl(VariantID vid)
         });
 
       }
-      qu->wait();
       stopTimer();
 
   } else {

--- a/src/apps/LTIMES_NOVIEW-Sycl.cpp
+++ b/src/apps/LTIMES_NOVIEW-Sycl.cpp
@@ -33,6 +33,9 @@ void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   LTIMES_NOVIEW_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -62,7 +65,6 @@ void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -94,7 +96,6 @@ void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/apps/PRESSURE-Sycl.cpp
+++ b/src/apps/PRESSURE-Sycl.cpp
@@ -28,11 +28,12 @@ void PRESSURE::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   PRESSURE_DATA_SETUP;
 
   using sycl::fabs;
-
-  auto res{getSyclResource()};
 
   if ( vid == Base_SYCL ) {
 
@@ -66,7 +67,6 @@ void PRESSURE::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -91,7 +91,6 @@ void PRESSURE::runSyclVariantImpl(VariantID vid)
       }); // end sequential region (for single-source code)
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/apps/VOL3D-Sycl.cpp
+++ b/src/apps/VOL3D-Sycl.cpp
@@ -30,7 +30,8 @@ void VOL3D::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = m_domain->fpz;
   const Index_type iend = m_domain->lpz+1;
 
-  auto res{getSyclResource()}; 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
 
   VOL3D_DATA_SETUP;
 
@@ -54,7 +55,6 @@ void VOL3D::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
  
   } else if ( vid == RAJA_SYCL ) {
@@ -68,7 +68,6 @@ void VOL3D::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/basic/DAXPY-Sycl.cpp
+++ b/src/basic/DAXPY-Sycl.cpp
@@ -29,6 +29,7 @@ void DAXPY::runSyclVariantImpl(VariantID vid)
   const Index_type iend = getActualProblemSize();
 
   auto res{getSyclResource()};
+  auto qu = res.get_queue();
 
   DAXPY_DATA_SETUP;
 
@@ -51,7 +52,6 @@ void DAXPY::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -65,7 +65,6 @@ void DAXPY::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/basic/IF_QUAD-Sycl.cpp
+++ b/src/basic/IF_QUAD-Sycl.cpp
@@ -28,6 +28,9 @@ void IF_QUAD::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   IF_QUAD_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -49,7 +52,6 @@ void IF_QUAD::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait(); // Wait for computation to finish before stopping timer
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -63,7 +65,6 @@ void IF_QUAD::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/basic/IF_QUAD-Sycl.cpp
+++ b/src/basic/IF_QUAD-Sycl.cpp
@@ -14,7 +14,6 @@
 
 #include <iostream>
 
-#include <sycl.hpp>
 #include "common/SyclDataUtils.hpp"
 
 namespace rajaperf

--- a/src/basic/INIT3-Sycl.cpp
+++ b/src/basic/INIT3-Sycl.cpp
@@ -28,6 +28,9 @@ void INIT3::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   INIT3_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -50,7 +53,6 @@ void INIT3::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -64,7 +66,6 @@ void INIT3::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/basic/INIT_VIEW1D-Sycl.cpp
+++ b/src/basic/INIT_VIEW1D-Sycl.cpp
@@ -28,6 +28,9 @@ void INIT_VIEW1D::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   INIT_VIEW1D_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -38,7 +41,6 @@ void INIT_VIEW1D::runSyclVariantImpl(VariantID vid)
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
       qu->submit([&] (sycl::handler& h) {
-
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                                         [=] (sycl::nd_item<1> item ) {
 
@@ -46,10 +48,10 @@ void INIT_VIEW1D::runSyclVariantImpl(VariantID vid)
           if (i < iend) {
             INIT_VIEW1D_BODY
           }
+
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -65,7 +67,6 @@ void INIT_VIEW1D::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/basic/INIT_VIEW1D-Sycl.cpp
+++ b/src/basic/INIT_VIEW1D-Sycl.cpp
@@ -14,7 +14,6 @@
 
 #include <iostream>
 
-#include <CL/sycl.hpp>
 #include "common/SyclDataUtils.hpp"
 
 namespace rajaperf

--- a/src/basic/INIT_VIEW1D_OFFSET-Sycl.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Sycl.cpp
@@ -28,6 +28,9 @@ void INIT_VIEW1D_OFFSET::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 1;
   const Index_type iend = getActualProblemSize()+1;
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   INIT_VIEW1D_OFFSET_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -50,7 +53,6 @@ void INIT_VIEW1D_OFFSET::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
   
   } else if ( vid == RAJA_SYCL ) {
@@ -64,7 +66,6 @@ void INIT_VIEW1D_OFFSET::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/basic/MULADDSUB-Sycl.cpp
+++ b/src/basic/MULADDSUB-Sycl.cpp
@@ -28,6 +28,9 @@ void MULADDSUB::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   MULADDSUB_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -50,7 +53,6 @@ void MULADDSUB::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -64,7 +66,6 @@ void MULADDSUB::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/basic/NESTED_INIT-Sycl.cpp
+++ b/src/basic/NESTED_INIT-Sycl.cpp
@@ -33,6 +33,9 @@ void NESTED_INIT::runSyclVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   NESTED_INIT_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -56,11 +59,11 @@ void NESTED_INIT::runSyclVariantImpl(VariantID vid)
           if (i < ni && j < nj && k < nk) {
             NESTED_INIT_BODY;
           }
+
         });
       });
 
     }
-    qu->wait();
     stopTimer();
   
   } else if ( vid == RAJA_SYCL ) {
@@ -89,7 +92,6 @@ void NESTED_INIT::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/basic/REDUCE3_INT-Sycl.cpp
+++ b/src/basic/REDUCE3_INT-Sycl.cpp
@@ -41,6 +41,9 @@ void REDUCE3_INT::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   REDUCE3_INT_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -93,7 +96,6 @@ void REDUCE3_INT::runSyclVariantImpl(VariantID vid)
       m_vmax = RAJA_MAX(m_vmax, lmax);
 
     } // for (RepIndex_type irep = ...
-    qu->wait();
     stopTimer();
   
     REDUCE3_INT_DATA_TEARDOWN_SYCL;
@@ -117,7 +119,6 @@ void REDUCE3_INT::runSyclVariantImpl(VariantID vid)
       m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/basic/TRAP_INT-Sycl.cpp
+++ b/src/basic/TRAP_INT-Sycl.cpp
@@ -31,6 +31,9 @@ void TRAP_INT::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   TRAP_INT_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -67,7 +70,6 @@ void TRAP_INT::runSyclVariantImpl(VariantID vid)
       m_sumx += lsumx * h;
 
     }
-    qu->wait();
     stopTimer();
   
     deallocSyclDeviceData(sumx, qu);
@@ -87,7 +89,6 @@ void TRAP_INT::runSyclVariantImpl(VariantID vid)
       m_sumx += static_cast<Real_type>(sumx.get()) * h;
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/common/DataUtils.cpp
+++ b/src/common/DataUtils.cpp
@@ -350,7 +350,7 @@ void copyData(DataSpace dst_dataSpace, void* dst_ptr,
   else if (isSyclDataSpace(dst_dataSpace) ||
            isSyclDataSpace(src_dataSpace)) {
     auto qu = camp::resources::Sycl::get_default().get_queue();
-    detail::copySyclData(dst_ptr, src_ptr, nbytes,qu);
+    detail::copySyclData(dst_ptr, src_ptr, nbytes, qu);
   }
 #endif
 
@@ -441,17 +441,17 @@ void deallocData(DataSpace dataSpace, void* ptr)
     case DataSpace::SyclPinned:
     {
       auto qu = camp::resources::Sycl::get_default().get_queue();
-      detail::deallocSyclPinnedData(ptr,qu);
+      detail::deallocSyclPinnedData(ptr, qu);
     } break;
     case DataSpace::SyclManaged:
     {
       auto qu = camp::resources::Sycl::get_default().get_queue();
-      detail::deallocSyclManagedData(ptr,qu);
+      detail::deallocSyclManagedData(ptr, qu);
     } break;
     case DataSpace::SyclDevice:
     {
       auto qu = camp::resources::Sycl::get_default().get_queue();
-      detail::deallocSyclDeviceData(ptr,qu);
+      detail::deallocSyclDeviceData(ptr, qu);
     } break;
 #endif
 

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -247,10 +247,6 @@ void Executor::setupSuite()
 
   getCout() << "\nSetting up suite based on input..." << endl;
 
-#if defined(RAJA_ENABLE_SYCL)
-  KernelBase::qu = camp::resources::Sycl().get_queue();
-#endif
-
   using Svector = vector<string>;
 
   //

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -280,7 +280,7 @@ public:
 #if defined(RAJA_ENABLE_SYCL)
     if ( running_variant == Base_SYCL ||
          running_variant == RAJA_SYCL ) {
-      getSyclResource().wait();
+      getSyclResource().get_queue()->wait();
     }
 #endif
 
@@ -465,19 +465,18 @@ public:
   virtual void runOpenMPTargetVariant(VariantID vid, size_t tune_idx) = 0;
 #endif
 
-#if defined(RUN_KOKKOS)
-  virtual void runKokkosVariant(VariantID vid, size_t tune_idx)
-  {
-     getCout() << "\n KernelBase: Unimplemented Kokkos variant id = " << vid << std::endl;
-  }
-#endif
 #if defined(RAJA_ENABLE_SYCL)
   virtual void runSyclVariant(VariantID vid, size_t tune_idx)
   {
      getCout() << "\n KernelBase: Unimplemented Sycl variant id = " << vid << std::endl;
   }
-  static sycl::queue* qu;
-  static camp::resources::Resource sycl_res;
+#endif
+
+#if defined(RUN_KOKKOS)
+  virtual void runKokkosVariant(VariantID vid, size_t tune_idx)
+  {
+     getCout() << "\n KernelBase: Unimplemented Kokkos variant id = " << vid << std::endl;
+  }
 #endif
 
 

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -27,9 +27,9 @@
 #endif
 #if defined(RAJA_ENABLE_SYCL)
 #include <sycl.hpp>
-#include "camp/resource.hpp"
 #endif
 
+#include "camp/resource.hpp"
 
 #include <string>
 #include <vector>

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -633,17 +633,24 @@ bool isDataSpaceAvailable(DataSpace dataSpace)
   bool ret_val = false;
 
   switch (dataSpace) {
-    case DataSpace::Host:
-      ret_val = true; break;
+
+    case DataSpace::Host: {
+      ret_val = true;
+      break;
+    }
 
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
-    case DataSpace::Omp:
-      ret_val = true; break;
+    case DataSpace::Omp: {
+      ret_val = true;
+      break;
+    }
 #endif
 
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
-    case DataSpace::OmpTarget:
-      ret_val = true; break;
+    case DataSpace::OmpTarget: {
+      ret_val = true;
+      break;
+    }
 #endif
 
 #if defined(RAJA_ENABLE_CUDA)
@@ -653,8 +660,10 @@ bool isDataSpaceAvailable(DataSpace dataSpace)
     case DataSpace::CudaManagedDevicePreferred:
     case DataSpace::CudaManagedHostPreferredDeviceAccessed:
     case DataSpace::CudaManagedDevicePreferredHostAccessed:
-    case DataSpace::CudaDevice:
-      ret_val = true; break;
+    case DataSpace::CudaDevice: {
+      ret_val = true;
+      break;
+    }
 #endif
 
 #if defined(RAJA_ENABLE_HIP)
@@ -671,20 +680,27 @@ bool isDataSpaceAvailable(DataSpace dataSpace)
     case DataSpace::HipManagedAdviseCoarse:
 #endif
     case DataSpace::HipDevice:
-    case DataSpace::HipDeviceFine:
-      ret_val = true; break;
+    case DataSpace::HipDeviceFine: {
+      ret_val = true;
+      break;
+    } 
 #endif
 
 #if defined(RAJA_ENABLE_SYCL)
     case DataSpace::SyclPinned:
     case DataSpace::SyclManaged:
-    case DataSpace::SyclDevice:
-      ret_val = true; break;
+    case DataSpace::SyclDevice: {
+      ret_val = true;
+      break;
+    }
 #endif
 
-    default:
-      ret_val = false; break;
-  }
+    default: {
+      ret_val = false;
+      break;
+    }
+
+  } // close switch (dataSpace)
 
   return ret_val;
 }
@@ -701,10 +717,16 @@ bool isPseudoDataSpace(DataSpace dataSpace)
   bool ret_val = false;
 
   switch (dataSpace) {
-    case DataSpace::Copy:
-      ret_val = true; break;
-    default:
-      ret_val = false; break;
+
+    case DataSpace::Copy: {
+      ret_val = true;
+      break;
+    }
+    default: {
+      ret_val = false;
+      break;
+    }
+
   }
 
   return ret_val;

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -1078,9 +1078,6 @@ KernelBase* getKernelObject(KernelID kid,
   return kernel;
 }
 
-#if defined(RAJA_ENABLE_SYCL)
-sycl::queue* KernelBase::qu;
-#endif
 
 // subclass of streambuf that ignores overflow
 // never printing anything to the underlying stream

--- a/src/lcals/DIFF_PREDICT-Sycl.cpp
+++ b/src/lcals/DIFF_PREDICT-Sycl.cpp
@@ -28,7 +28,8 @@ void DIFF_PREDICT::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
-  auto res{getSyclResource()}; 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
 
   DIFF_PREDICT_DATA_SETUP;
 
@@ -52,7 +53,6 @@ void DIFF_PREDICT::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -66,7 +66,6 @@ void DIFF_PREDICT::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/lcals/EOS-Sycl.cpp
+++ b/src/lcals/EOS-Sycl.cpp
@@ -28,6 +28,9 @@ void EOS::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   EOS_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -49,7 +52,6 @@ void EOS::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait(); // Wait for computation to finish before stopping timer
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -63,7 +65,6 @@ void EOS::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/lcals/FIRST_DIFF-Sycl.cpp
+++ b/src/lcals/FIRST_DIFF-Sycl.cpp
@@ -27,6 +27,9 @@ void FIRST_DIFF::runSyclVariantImpl(VariantID vid)
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
+  
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
 
   FIRST_DIFF_DATA_SETUP;
 
@@ -36,6 +39,7 @@ void FIRST_DIFF::runSyclVariantImpl(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
+
       qu->submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
@@ -48,7 +52,6 @@ void FIRST_DIFF::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -62,7 +65,6 @@ void FIRST_DIFF::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/lcals/GEN_LIN_RECUR-Sycl.cpp
+++ b/src/lcals/GEN_LIN_RECUR-Sycl.cpp
@@ -26,6 +26,9 @@ void GEN_LIN_RECUR::runSyclVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   GEN_LIN_RECUR_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -61,7 +64,6 @@ void GEN_LIN_RECUR::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -80,7 +82,6 @@ void GEN_LIN_RECUR::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/lcals/HYDRO_1D-Sycl.cpp
+++ b/src/lcals/HYDRO_1D-Sycl.cpp
@@ -28,6 +28,9 @@ void HYDRO_1D::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   HYDRO_1D_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -49,7 +52,6 @@ void HYDRO_1D::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -63,7 +65,6 @@ void HYDRO_1D::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else { 

--- a/src/lcals/HYDRO_2D-Sycl.cpp
+++ b/src/lcals/HYDRO_2D-Sycl.cpp
@@ -36,6 +36,9 @@ void HYDRO_2D::runSyclVariantImpl(VariantID vid) {
   const Index_type jbeg = 1;
   const Index_type jend = m_jn - 1;
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   HYDRO_2D_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -46,6 +49,7 @@ void HYDRO_2D::runSyclVariantImpl(VariantID vid) {
  
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
       qu->submit([&] (sycl::handler& h) { 
 
         h.parallel_for(sycl::nd_range<2>( global_dim, wkgroup_dim),
@@ -90,7 +94,6 @@ void HYDRO_2D::runSyclVariantImpl(VariantID vid) {
       });
 
     }
-    qu->wait(); // Wait for computation to finish before stopping timer
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -133,7 +136,6 @@ void HYDRO_2D::runSyclVariantImpl(VariantID vid) {
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else { 

--- a/src/lcals/INT_PREDICT-Sycl.cpp
+++ b/src/lcals/INT_PREDICT-Sycl.cpp
@@ -28,6 +28,9 @@ void INT_PREDICT::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   INT_PREDICT_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -37,8 +40,7 @@ void INT_PREDICT::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h)
-      {
+      qu->submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -50,7 +52,6 @@ void INT_PREDICT::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -64,7 +65,6 @@ void INT_PREDICT::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/lcals/PLANCKIAN-Sycl.cpp
+++ b/src/lcals/PLANCKIAN-Sycl.cpp
@@ -29,6 +29,9 @@ void PLANCKIAN::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue(); 
+
   PLANCKIAN_DATA_SETUP;
 
   using sycl::exp;
@@ -52,7 +55,6 @@ void PLANCKIAN::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -66,7 +68,6 @@ void PLANCKIAN::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/lcals/PLANCKIAN-Sycl.cpp
+++ b/src/lcals/PLANCKIAN-Sycl.cpp
@@ -15,7 +15,6 @@
 #include <iostream>
 #include <cmath>
 
-#include <sycl.hpp>
 #include "common/SyclDataUtils.hpp"
 
 namespace rajaperf 

--- a/src/lcals/TRIDIAG_ELIM-Sycl.cpp
+++ b/src/lcals/TRIDIAG_ELIM-Sycl.cpp
@@ -28,6 +28,9 @@ void TRIDIAG_ELIM::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 1;
   const Index_type iend = m_N;
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   TRIDIAG_ELIM_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -49,7 +52,6 @@ void TRIDIAG_ELIM::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -63,7 +65,6 @@ void TRIDIAG_ELIM::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/polybench/POLYBENCH_2MM-Sycl.cpp
+++ b/src/polybench/POLYBENCH_2MM-Sycl.cpp
@@ -15,7 +15,6 @@
 #include <iostream>
 #include <cmath>
 
-#include <sycl.hpp>
 #include "common/SyclDataUtils.hpp"
 
 namespace rajaperf 

--- a/src/polybench/POLYBENCH_2MM-Sycl.cpp
+++ b/src/polybench/POLYBENCH_2MM-Sycl.cpp
@@ -50,6 +50,9 @@ void POLYBENCH_2MM::runSyclVariant(VariantID vid)
 {
   const unsigned long run_reps = getRunReps();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   POLYBENCH_2MM_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -62,12 +65,11 @@ void POLYBENCH_2MM::runSyclVariant(VariantID vid)
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-        qu->submit([&] (sycl::handler& h)
-        {
 
+        qu->submit([&] (sycl::handler& h) {
           h.parallel_for<class polybench2MM_1>(sycl::nd_range<2> 
-                                                 {sycl::range<2> {ni_grid_size, nj_grid_size},
-                                                  sycl::range<2> {block_size, block_size}},
+                                               {sycl::range<2> {ni_grid_size, nj_grid_size},
+                                                sycl::range<2> {block_size, block_size}},
                                                [=] (sycl::nd_item<2> item) {
 
            Index_type i = item.get_global_id(0); 
@@ -80,12 +82,11 @@ void POLYBENCH_2MM::runSyclVariant(VariantID vid)
               }
               POLYBENCH_2MM_BODY3;
             }
+
           });
         });
 
-        qu->submit([&] (sycl::handler& h)
-        {
-
+        qu->submit([&] (sycl::handler& h) {
           h.parallel_for<class polybench2MM_2>(sycl::nd_range<2>
                                                  {sycl::range<2> {ni_grid_size, nl_grid_size},
                                                   sycl::range<2> {block_size, block_size}},
@@ -104,8 +105,8 @@ void POLYBENCH_2MM::runSyclVariant(VariantID vid)
           });
         });
       }
-      qu->wait(); // Wait for computation to finish before stopping timer
       stopTimer();
+
     }
 
     POLYBENCH_2MM_TEARDOWN_SYCL;

--- a/src/stream/ADD-Sycl.cpp
+++ b/src/stream/ADD-Sycl.cpp
@@ -29,6 +29,7 @@ void ADD::runSyclVariantImpl(VariantID vid)
   const Index_type iend = getActualProblemSize();
 
   auto res{getSyclResource()};
+  auto qu = res.get_queue();
 
   ADD_DATA_SETUP;
 
@@ -51,7 +52,6 @@ void ADD::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -65,7 +65,6 @@ void ADD::runSyclVariantImpl(VariantID vid)
       });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/stream/COPY-Sycl.cpp
+++ b/src/stream/COPY-Sycl.cpp
@@ -28,6 +28,9 @@ void COPY::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   COPY_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -49,7 +52,6 @@ void COPY::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -63,7 +65,6 @@ void COPY::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/stream/DOT-Sycl.cpp
+++ b/src/stream/DOT-Sycl.cpp
@@ -29,6 +29,9 @@ void DOT::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   DOT_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -65,7 +68,6 @@ void DOT::runSyclVariantImpl(VariantID vid)
       m_dot += ldot;       
 
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {

--- a/src/stream/MUL-Sycl.cpp
+++ b/src/stream/MUL-Sycl.cpp
@@ -28,6 +28,9 @@ void MUL::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   MUL_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -48,7 +51,6 @@ void MUL::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -62,7 +64,6 @@ void MUL::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/stream/TRIAD-Sycl.cpp
+++ b/src/stream/TRIAD-Sycl.cpp
@@ -28,6 +28,9 @@ void TRIAD::runSyclVariantImpl(VariantID vid)
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
 
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
   TRIAD_DATA_SETUP;
 
   if ( vid == Base_SYCL ) {
@@ -36,6 +39,7 @@ void TRIAD::runSyclVariantImpl(VariantID vid)
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
       qu->submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
@@ -48,7 +52,6 @@ void TRIAD::runSyclVariantImpl(VariantID vid)
         });
       });
     }
-    qu->wait();
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
@@ -62,7 +65,6 @@ void TRIAD::runSyclVariantImpl(VariantID vid)
        });
 
     }
-    qu->wait();
     stopTimer();
 
   } else {

--- a/src/stream/TRIAD-Sycl.cpp
+++ b/src/stream/TRIAD-Sycl.cpp
@@ -14,7 +14,6 @@
 
 #include <iostream>
 
-#include <sycl.hpp>
 #include "common/SyclDataUtils.hpp"
 
 namespace rajaperf 


### PR DESCRIPTION
# Summary 

- This PR reworks usage of SYCL resource and queue in the code.
- It eliminates static variables, calls to queue "wait" method before stopping timers, and makes SYCL kernel variants look more like CUDA and HIP variants.

- This PR also updates RAJA and BLT to match RAJA develop to quiet compiler warnings.

Resolves https://github.com/LLNL/RAJAPerf/issues/434