### PR TITLE
Simplify ADomain Coding

### DIFF
--- a/src/apps/AppsData.cpp
+++ b/src/apps/AppsData.cpp
@@ -104,20 +104,13 @@ void setMeshPositions_2d(Real_ptr x, Real_type dx,
   Index_type npnl = domain.NPNL;
   Index_type npnr = domain.NPNR;
 
-  Real_ptr x1, x2, x3, x4;
-  Real_ptr y1, y2, y3, y4;
-  NDSET2D(domain.jp, x, x1,x2,x3,x4) ;
-  NDSET2D(domain.jp, y, y1,y2,y3,y4) ;
+  for (Index_type j = jmin - npnl; j < jmax+1 + npnr; j++) {
+     for (Index_type i = imin - npnl; i < imax+1 + npnr; i++) {
+        Index_type in = i + j*jp ;
 
-  for (Index_type j = jmin - npnl; j < jmax + npnr; j++) {
-     for (Index_type i = imin - npnl; i < imax + npnr; i++) {
-        Index_type iz = i + j*jp ;
+        x[in] = i*dx;
 
-        x3[iz] = x4[iz] = i*dx;
-        x1[iz] = x2[iz] = (i+1)*dx;
-
-        y1[iz] = y4[iz] = j*dy;
-        y2[iz] = y3[iz] = (j+1)*dy;
+        y[in] = j*dy;
 
      }
   }
@@ -150,26 +143,16 @@ void setMeshPositions_3d(Real_ptr x, Real_type dx,
   Index_type npnl = domain.NPNL;
   Index_type npnr = domain.NPNR;
 
-  Real_ptr x0, x1, x2, x3, x4, x5, x6, x7;
-  Real_ptr y0, y1, y2, y3, y4, y5, y6, y7;
-  Real_ptr z0, z1, z2, z3, z4, z5, z6, z7;
-  NDPTRSET(domain.jp, domain.kp, x,x0,x1,x2,x3,x4,x5,x6,x7) ;
-  NDPTRSET(domain.jp, domain.kp, y,y0,y1,y2,y3,y4,y5,y6,y7) ;
-  NDPTRSET(domain.jp, domain.kp, z,z0,z1,z2,z3,z4,z5,z6,z7) ;
+  for (Index_type k = kmin - npnl; k < kmax+1 + npnr; k++) {
+     for (Index_type j = jmin - npnl; j < jmax+1 + npnr; j++) {
+        for (Index_type i = imin - npnl; i < imax+1 + npnr; i++) {
+           Index_type in = i + j*jp + k*kp ;
 
-  for (Index_type k = kmin - npnl; k < kmax + npnr; k++) {
-     for (Index_type j = jmin - npnl; j < jmax + npnr; j++) {
-        for (Index_type i = imin - npnl; i < imax + npnr; i++) {
-           Index_type iz = i + j*jp + k*kp ;
+           x[in] = i*dx;
 
-           x0[iz] = x2[iz] = x4[iz] = x6[iz] = i*dx;
-           x1[iz] = x3[iz] = x5[iz] = x7[iz] = (i+1)*dx;
+           y[in] = j*dy;
 
-           y0[iz] = y1[iz] = y4[iz] = y5[iz] = j*dy;
-           y2[iz] = y3[iz] = y6[iz] = y7[iz] = (j+1)*dy;
-
-           z0[iz] = z1[iz] = z2[iz] = z3[iz] = k*dz;
-           z4[iz] = z5[iz] = z6[iz] = z7[iz] = (k+1)*dz;
+           z[in] = k*dz;
 
         }
      }

--- a/src/apps/AppsData.cpp
+++ b/src/apps/AppsData.cpp
@@ -38,10 +38,10 @@ void setRealZones_2d(Index_type* real_zones,
 
   for (Index_type j = jmin; j < jmax; j++) {
      for (Index_type i = imin; i < imax; i++) {
-        Index_type ip = i + j*jp ;
+        Index_type iz = i + j*jp ;
 
-        Index_type id = (i-imin) + (j-jmin)*j_stride ;
-        real_zones[id] = ip;
+        Index_type il = (i-imin) + (j-jmin)*j_stride ;
+        real_zones[il] = iz;
      }
   }
 }
@@ -73,10 +73,10 @@ void setRealZones_3d(Index_type* real_zones,
   for (Index_type k = kmin; k < kmax; k++) {
      for (Index_type j = jmin; j < jmax; j++) {
         for (Index_type i = imin; i < imax; i++) {
-           Index_type ip = i + j*jp + k*kp ;
+           Index_type iz = i + j*jp + k*kp ;
 
-           Index_type id = (i-imin) + (j-jmin)*j_stride + (k-kmin)*k_stride ;
-           real_zones[id] = ip;
+           Index_type il = (i-imin) + (j-jmin)*j_stride + (k-kmin)*k_stride ;
+           real_zones[il] = iz;
         }
      }
   }

--- a/src/apps/AppsData.cpp
+++ b/src/apps/AppsData.cpp
@@ -16,6 +16,40 @@ namespace rajaperf
 namespace apps
 {
 
+
+std::ostream& operator<<(std::ostream& stream, const ADomain& domain)
+{
+   return stream
+
+     << "ADomain"
+
+     << " ndims " << domain.ndims
+     << " NPNL " << domain.NPNL
+     << " NPNR " << domain.NPNR
+
+     << " imin " << domain.imin
+     << " jmin " << domain.jmin
+     << " kmin " << domain.kmin
+     << " imax " << domain.imax
+     << " jmax " << domain.jmax
+     << " kmax " << domain.kmax
+
+     << " jp " << domain.jp
+     << " kp " << domain.kp
+     << " nnalls " << domain.nnalls
+
+     << " fpn " << domain.fpn
+     << " lpn " << domain.lpn
+     << " frn " << domain.frn
+     << " lrn " << domain.lrn
+
+     << " fpz " << domain.fpz
+     << " lpz " << domain.lpz
+
+     << " n_real_zones " << domain.n_real_zones
+     << " n_real_nodes " << domain.n_real_nodes ;
+}
+
 //
 // Set zone indices for 2d mesh.
 //

--- a/src/apps/AppsData.hpp
+++ b/src/apps/AppsData.hpp
@@ -9,6 +9,8 @@
 #ifndef RAJAPerf_AppsData_HPP
 #define RAJAPerf_AppsData_HPP
 
+#include <ostream>
+
 #include "common/RPTypes.hpp"
 
 namespace rajaperf
@@ -130,6 +132,8 @@ public:
    Index_type  n_real_zones;
    Index_type  n_real_nodes;
 };
+
+std::ostream& operator<<(std::ostream& stream, const ADomain& domain);
 
 //
 // Routines for initializing real zone indices for 2d/3d domains.

--- a/src/apps/AppsData.hpp
+++ b/src/apps/AppsData.hpp
@@ -47,40 +47,57 @@ public:
 
    ADomain() = delete;
 
-   ADomain( Index_type rzmax, Index_type ndims ) 
+   ADomain( Index_type real_nodes_per_dim, Index_type ndims )
       : ndims(ndims), NPNL(2), NPNR(1)
    {
-      imin = NPNL;
-      jmin = NPNL;
-      imax = rzmax + NPNR;
-      jmax = rzmax + NPNR;
-      jp = imax - imin + 1 + NPNL + NPNR;
-      n_real_zones = (imax - imin);
-      n_real_nodes = (imax+1 - imin);
+      int NPZL = NPNL - 1;
+      int NPZR = NPNR+1 - 1;
 
-      if ( ndims == 2 ) {
+      if ( ndims >= 1 ) {
+         imin = NPNL;
+         imax = NPNL + real_nodes_per_dim-1;
+         nnalls = (imax+1 - imin + NPNL + NPNR);
+         n_real_zones = (imax - imin);
+         n_real_nodes = (imax+1 - imin);
+      } else {
+         imin = 0;
+         imax = 0;
+         nnalls = 0;
+      }
+
+      if ( ndims >= 2 ) {
+         jmin = NPNL;
+         jmax = NPNL + real_nodes_per_dim-1;
+         jp = nnalls;
+         nnalls *= (jmax+1 - jmin + NPNL + NPNR);
+         n_real_zones *= (jmax - jmin);
+         n_real_nodes *= (jmax+1 - jmin);
+      } else {
+         jmin = 0;
+         jmax = 0;
+         jp = 0;
+      }
+
+      if ( ndims >= 3 ) {
+         kmin = NPNL;
+         kmax = NPNL + rzmax-1;
+         kp = nnalls;
+         nnalls *= (kmax+1 - kmin + NPNL + NPNR);
+         n_real_zones *= (kmax - kmin);
+         n_real_nodes *= (kmax+1 - kmin);
+      } else {
          kmin = 0;
          kmax = 0;
          kp = 0;
-         nnalls = jp * (jmax - jmin + 1 + NPNL + NPNR) ;
-         n_real_zones *= (jmax - jmin);
-         n_real_nodes *= (jmax+1 - jmin);
-      } else if ( ndims == 3 ) {
-         kmin = NPNL;
-         kmax = rzmax + NPNR;
-         kp = jp * (jmax - jmin + 1 + NPNL + NPNR);
-         nnalls = kp * (kmax - kmin + 1 + NPNL + NPNR) ;
-         n_real_zones *= (jmax - jmin) * (kmax - kmin);
-         n_real_nodes *= (jmax+1 - jmin) * (kmax+1 - kmin);
       }
 
-      fpn = 0;
-      lpn = nnalls - 1;
-      frn = fpn + NPNL * (kp + jp) + NPNL;
-      lrn = lpn - NPNR * (kp + jp) - NPNR;
+      frn = kmin*kp + jmin*jp + imin;
+      lrn = kmax*kp + jmax*jp + imax;
+      fpn = (kmin - NPNL)*kp + (jmin - NPNL)*jp + (imin - NPNL);
+      lpn = (kmax + NPNR)*kp + (jmax + NPNR)*jp + (imax + NPNR);
 
-      fpz = frn - jp - kp - 1;
-      lpz = lrn;
+      fpz = (kmin - NPZL)*kp + (jmin - NPZL)*jp + (imin - NPZL);
+      lpz = (kmax-1 + NPZR)*kp + (jmax-1 + NPZR)*jp + (imax-1 + NPZR);
    }
 
    ~ADomain()

--- a/src/apps/AppsData.hpp
+++ b/src/apps/AppsData.hpp
@@ -80,7 +80,7 @@ public:
 
       if ( ndims >= 3 ) {
          kmin = NPNL;
-         kmax = NPNL + rzmax-1;
+         kmax = NPNL + real_nodes_per_dim-1;
          kp = nnalls;
          nnalls *= (kmax+1 - kmin + NPNL + NPNR);
          n_real_zones *= (kmax - kmin);


### PR DESCRIPTION
# Simplify ADomain Coding

Simplify ADomain coding so its easier to understand how the mesh is specified.

- This PR is a refactoring
- It does the following (modify list as needed):
  - Modifies/refactors ADomain to make it easier to understand
