### PR TITLE
SYCL variants for a couple more Basic kernels

### DIFF
--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -26,7 +26,7 @@ variables:
 
 # Poodle
 # Arguments for top level allocation
-  POODLE_SHARED_ALLOC: "--exclusive --time=20 --nodes=1"
+  POODLE_SHARED_ALLOC: "--exclusive --time=40 --nodes=1"
 # Arguments for job level allocation
   POODLE_JOB_ALLOC: "--nodes=1"
 # Project specific variants for poodle

--- a/src/basic/ARRAY_OF_PTRS-Sycl.cpp
+++ b/src/basic/ARRAY_OF_PTRS-Sycl.cpp
@@ -36,8 +36,6 @@ void ARRAY_OF_PTRS::runSyclVariantImpl(VariantID vid)
 
   if ( vid == Base_SYCL ) {
 
-    ARRAY_OF_PTRS_Array x_array = x;
-
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
@@ -49,7 +47,7 @@ void ARRAY_OF_PTRS::runSyclVariantImpl(VariantID vid)
 
           Index_type i = item.get_global_id(0);
           if (i < iend) {
-            ARRAY_OF_PTRS_BODY(x_array.array);
+            ARRAY_OF_PTRS_BODY(x);
           }
 
         });

--- a/src/basic/ARRAY_OF_PTRS-Sycl.cpp
+++ b/src/basic/ARRAY_OF_PTRS-Sycl.cpp
@@ -1,0 +1,84 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "ARRAY_OF_PTRS.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_SYCL)
+
+#include "common/SyclDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+
+template < size_t work_group_size >
+void ARRAY_OF_PTRS::runSyclVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
+  ARRAY_OF_PTRS_DATA_SETUP;
+
+  if ( vid == Base_SYCL ) {
+
+    ARRAY_OF_PTRS_Array x_array = x;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
+
+      qu->submit([&] (sycl::handler& h) {
+        h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
+                       [=] (sycl::nd_item<1> item ) {
+
+          Index_type i = item.get_global_id(0);
+          if (i < iend) {
+            ARRAY_OF_PTRS_BODY(x_array.array);
+          }
+
+        });
+      });
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_SYCL ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::sycl_exec<work_group_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] (Index_type i) {
+        ARRAY_OF_PTRS_BODY(x);
+      });
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  ARRAY_OF_PTRS : Unknown Sycl variant id = " << vid << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(ARRAY_OF_PTRS, Sycl)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_SYCL

--- a/src/basic/ARRAY_OF_PTRS.cpp
+++ b/src/basic/ARRAY_OF_PTRS.cpp
@@ -54,6 +54,9 @@ ARRAY_OF_PTRS::ARRAY_OF_PTRS(const RunParams& params)
   setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
 
+  setVariantDefined( Base_SYCL );
+  setVariantDefined( RAJA_SYCL );
+
   setVariantDefined( Kokkos_Lambda );
 }
 

--- a/src/basic/ARRAY_OF_PTRS.hpp
+++ b/src/basic/ARRAY_OF_PTRS.hpp
@@ -72,16 +72,20 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runSyclVariant(VariantID vid, size_t tune_idx);
 
   void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size >
   void runCudaVariantImpl(VariantID vid);
   template < size_t block_size >
   void runHipVariantImpl(VariantID vid);
+  template < size_t work_group_size >
+  void runSyclVariantImpl(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -14,6 +14,7 @@ blt_add_library(
           ARRAY_OF_PTRS-Cuda.cpp
           ARRAY_OF_PTRS-OMP.cpp
           ARRAY_OF_PTRS-OMPTarget.cpp
+          ARRAY_OF_PTRS-Sycl.cpp
           COPY8.cpp
           COPY8-Seq.cpp
           COPY8-Hip.cpp

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -21,6 +21,7 @@ blt_add_library(
           COPY8-Cuda.cpp
           COPY8-OMP.cpp
           COPY8-OMPTarget.cpp
+          COPY8-Sycl.cpp
           DAXPY.cpp
           DAXPY-Seq.cpp
           DAXPY-Hip.cpp

--- a/src/basic/COPY8-Sycl.cpp
+++ b/src/basic/COPY8-Sycl.cpp
@@ -1,0 +1,82 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "COPY8.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_SYCL)
+
+#include "common/SyclDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+
+template < size_t work_group_size >
+void COPY8::runSyclVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
+  COPY8_DATA_SETUP;
+
+  if ( vid == Base_SYCL ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
+
+      qu->submit([&] (sycl::handler& h) {
+        h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
+                       [=] (sycl::nd_item<1> item ) {
+
+          Index_type i = item.get_global_id(0);
+          if (i < iend) {
+            COPY8_BODY;
+          }
+
+        });
+      });
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_SYCL ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::sycl_exec<work_group_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] (Index_type i) {
+        COPY8_BODY;
+      });
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  COPY8 : Unknown Sycl variant id = " << vid << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(COPY8, Sycl)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_SYCL

--- a/src/basic/COPY8.cpp
+++ b/src/basic/COPY8.cpp
@@ -51,6 +51,9 @@ COPY8::COPY8(const RunParams& params)
   setVariantDefined( Base_HIP );
   setVariantDefined( Lambda_HIP );
   setVariantDefined( RAJA_HIP );
+
+  setVariantDefined( Base_SYCL );
+  setVariantDefined( RAJA_SYCL );
 }
 
 COPY8::~COPY8()

--- a/src/basic/COPY8.hpp
+++ b/src/basic/COPY8.hpp
@@ -79,16 +79,20 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runSyclVariant(VariantID vid, size_t tune_idx);
 
   void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size >
   void runCudaVariantImpl(VariantID vid);
   template < size_t block_size >
   void runHipVariantImpl(VariantID vid);
+  template < size_t work_group_size >
+  void runSyclVariantImpl(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;


### PR DESCRIPTION
# Summary

- This PR adds SYCL variants for Basic kernels: ARRAY_OF_PTRS and COPY8.

This PR resolves https://github.com/LLNL/RAJAPerf/issues/431
