### PR TITLE
SYCL reduction kernels

### DIFF
--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -108,6 +108,7 @@ blt_add_library(
           PI_REDUCE-Cuda.cpp
           PI_REDUCE-OMP.cpp
           PI_REDUCE-OMPTarget.cpp
+          PI_REDUCE-Sycl.cpp
           REDUCE3_INT.cpp
           REDUCE3_INT-Seq.cpp
           REDUCE3_INT-Hip.cpp

--- a/src/basic/PI_REDUCE-Sycl.cpp
+++ b/src/basic/PI_REDUCE-Sycl.cpp
@@ -1,0 +1,109 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "PI_REDUCE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_SYCL)
+
+#include "common/SyclDataUtils.hpp"
+
+#include <iostream>
+#include <utility>
+#include <type_traits>
+#include <limits>
+
+
+namespace rajaperf
+{
+namespace basic
+{
+
+
+template < size_t work_group_size >
+void PI_REDUCE::runSyclVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
+  PI_REDUCE_DATA_SETUP;
+
+  if ( vid == Base_SYCL ) {
+
+    Real_ptr pi;
+    allocAndInitSyclDeviceData(pi, &m_pi_init, 1, qu);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
+
+      initSyclDeviceData(pi, &m_pi_init, 1, qu);
+
+      qu->submit([&] (sycl::handler& hdl) {
+
+        auto sum_reduction = sycl::reduction(pi, sycl::plus<>());
+
+        hdl.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
+                         sum_reduction,
+                         [=] (sycl::nd_item<1> item, auto& pi) {
+
+          Index_type i = item.get_global_id(0);
+          if (i < iend) {
+            PI_REDUCE_BODY;
+          }
+
+        });
+      });
+
+      Real_type lpi;
+      Real_ptr plpi = &lpi;
+      getSyclDeviceData(plpi, pi, 1, qu);
+      m_pi = 4.0 * lpi;
+
+    }
+    stopTimer();
+
+    deallocSyclDeviceData(pi, qu);
+
+  } else if ( vid == RAJA_SYCL ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type tpi = m_pi_init;
+
+      RAJA::forall< RAJA::sycl_exec<work_group_size, false /*async*/> >(
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tpi),
+        [=] (Index_type i, Real_type& pi) {
+          PI_REDUCE_BODY;
+        }
+      );
+
+      m_pi = static_cast<Real_type>(tpi) * 4.0;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  PI_REDUCE : Unknown Sycl variant id = " << vid << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(PI_REDUCE, Sycl)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_SYCL

--- a/src/basic/PI_REDUCE.cpp
+++ b/src/basic/PI_REDUCE.cpp
@@ -51,6 +51,9 @@ PI_REDUCE::PI_REDUCE(const RunParams& params)
 
   setVariantDefined( Base_HIP );
   setVariantDefined( RAJA_HIP );
+
+  setVariantDefined( Base_SYCL );
+  setVariantDefined( RAJA_SYCL );
 }
 
 PI_REDUCE::~PI_REDUCE()

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -56,9 +56,11 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runSyclVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runCudaVariantBase(VariantID vid);
@@ -69,6 +71,9 @@ public:
   void runCudaVariantRAJA(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
+
+  template < size_t work_group_size >
+  void runSyclVariantImpl(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/basic/REDUCE3_INT-Sycl.cpp
+++ b/src/basic/REDUCE3_INT-Sycl.cpp
@@ -21,18 +21,6 @@ namespace rajaperf
 namespace basic
 {
 
-#define REDUCE3_INT_DATA_SETUP_SYCL \
-  Int_ptr hsum; \
-  allocAndInitSyclDeviceData(hsum, &m_vsum_init, 1, qu); \
-  Int_ptr hmin; \
-  allocAndInitSyclDeviceData(hmin, &m_vmin_init, 1, qu); \
-  Int_ptr hmax; \
-  allocAndInitSyclDeviceData(hmax, &m_vmax_init, 1, qu);
-
-#define REDUCE3_INT_DATA_TEARDOWN_SYCL \
-  deallocSyclDeviceData(hsum, qu); \
-  deallocSyclDeviceData(hmin, qu); \
-  deallocSyclDeviceData(hmax, qu);
 
 template <size_t work_group_size >
 void REDUCE3_INT::runSyclVariantImpl(VariantID vid)
@@ -48,7 +36,12 @@ void REDUCE3_INT::runSyclVariantImpl(VariantID vid)
 
   if ( vid == Base_SYCL ) {
 
-    REDUCE3_INT_DATA_SETUP_SYCL;
+    Int_ptr hsum;
+    allocAndInitSyclDeviceData(hsum, &m_vsum_init, 1, qu);
+    Int_ptr hmin;
+    allocAndInitSyclDeviceData(hmin, &m_vmin_init, 1, qu);
+    Int_ptr hmax;
+    allocAndInitSyclDeviceData(hmax, &m_vmax_init, 1, qu);
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -98,25 +91,32 @@ void REDUCE3_INT::runSyclVariantImpl(VariantID vid)
     } // for (RepIndex_type irep = ...
     stopTimer();
   
-    REDUCE3_INT_DATA_TEARDOWN_SYCL;
+    deallocSyclDeviceData(hsum, qu);
+    deallocSyclDeviceData(hmin, qu);
+    deallocSyclDeviceData(hmax, qu);
 
   } else if ( vid == RAJA_SYCL ) {
 
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::ReduceSum<RAJA::sycl_reduce, Int_type> vsum(m_vsum_init);
-      RAJA::ReduceMin<RAJA::sycl_reduce, Int_type> vmin(m_vmin_init);
-      RAJA::ReduceMax<RAJA::sycl_reduce, Int_type> vmax(m_vmax_init);
+      Int_type tvsum = m_vsum_init;
+      Int_type tvmin = m_vmin_init;
+      Int_type tvmax = m_vmax_init;
 
       RAJA::forall< RAJA::sycl_exec<work_group_size, false /*async*/> >(
-        RAJA::RangeSegment(ibegin, iend), [=] (Index_type i) {
-        REDUCE3_INT_BODY_RAJA;
-      });
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tvsum),
+        RAJA::expt::Reduce<RAJA::operators::minimum>(&tvmin),
+        RAJA::expt::Reduce<RAJA::operators::maximum>(&tvmax),
+        [=] (Index_type i, Int_type& vsum, Int_type& vmin, Int_type& vmax) {
+          REDUCE3_INT_BODY;
+        }
+      );
 
-      m_vsum += static_cast<Int_type>(vsum.get());
-      m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
-      m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
+      m_vsum += static_cast<Int_type>(tvsum);
+      m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(tvmin));
+      m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(tvmax));
 
     }
     stopTimer();

--- a/src/lcals/CMakeLists.txt
+++ b/src/lcals/CMakeLists.txt
@@ -35,6 +35,7 @@ blt_add_library(
           FIRST_MIN-Cuda.cpp
           FIRST_MIN-OMP.cpp
           FIRST_MIN-OMPTarget.cpp
+          FIRST_MIN-Sycl.cpp
           FIRST_SUM.cpp
           FIRST_SUM-Seq.cpp
           FIRST_SUM-Hip.cpp

--- a/src/lcals/FIRST_MIN-Sycl.cpp
+++ b/src/lcals/FIRST_MIN-Sycl.cpp
@@ -1,0 +1,100 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "FIRST_MIN.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_SYCL)
+
+#include "common/SyclDataUtils.hpp"
+
+#include <iostream>
+
+
+namespace rajaperf
+{
+namespace lcals
+{
+
+template <size_t work_group_size >
+void FIRST_MIN::runSyclVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
+  FIRST_MIN_DATA_SETUP;
+
+  if ( vid == Base_SYCL ) {
+
+#if 0 // RDH
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
+
+      define and init reduction...
+
+      qu->submit([&] (sycl::handler& h) {
+
+        h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
+                       pass reduction...,
+                       [=] (sycl::nd_item<1> item, auto& dot) {
+
+          Index_type i = item.get_global_id(0);
+          if (i < iend) {
+            // body
+          }
+
+        });
+      });
+
+      m_minloc = get loc value... 
+
+    }
+    stopTimer();
+#endif
+
+  } else if ( vid == RAJA_SYCL ) {
+
+    using VL_TYPE = RAJA::expt::ValLoc<Real_type>;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       VL_TYPE tloc(m_xmin_init, m_initloc);
+
+       RAJA::forall< RAJA::sycl_exec<work_group_size, true /*async*/> >(
+         res,
+         RAJA::RangeSegment(ibegin, iend), 
+         RAJA::expt::Reduce<RAJA::operators::minimum>(&tloc),
+         [=]  (Index_type i, VL_TYPE& loc) {
+           loc.min(x[i], i);
+         }
+       );
+
+       m_minloc = static_cast<Index_type>(tloc.getLoc());
+
+    }
+    stopTimer();
+
+  } else {
+     std::cout << "\n  FIRST_MIN : Unknown Sycl variant id = " << vid << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(FIRST_MIN, Sycl)
+
+} // end namespace lcals
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_SYCL

--- a/src/lcals/FIRST_MIN.cpp
+++ b/src/lcals/FIRST_MIN.cpp
@@ -58,6 +58,9 @@ FIRST_MIN::FIRST_MIN(const RunParams& params)
   setVariantDefined( Base_HIP );
   setVariantDefined( RAJA_HIP );
 
+  setVariantDefined( Base_SYCL );
+  setVariantDefined( RAJA_SYCL );
+
   setVariantDefined( Kokkos_Lambda );
 }
 

--- a/src/lcals/FIRST_MIN.hpp
+++ b/src/lcals/FIRST_MIN.hpp
@@ -79,11 +79,13 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runSyclVariant(VariantID vid, size_t tune_idx);
 
   void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setSyclTuningDefinitions(VariantID vid); 
 
   template < size_t block_size, typename MappingHelper >
   void runCudaVariantBase(VariantID vid);
@@ -94,6 +96,9 @@ public:
   void runCudaVariantRAJA(VariantID vid);
   template < size_t block_size, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
+
+  template < size_t work_group_size >
+  void runSyclVariantImpl(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;


### PR DESCRIPTION
# Summary (Write a short headline summary of PR)

- This PR converts RAJA_SYCL variants of basic reduction kernels to new RAJA reduction interface
- It also fills in missing basic reduction kernels for SYCL.

There are a few other more complex reduction kernels. These will be addressed in future PRs.

Resolves https://github.com/LLNL/RAJAPerf/issues/444