### PR TITLE
Update Caliper Implementation

### DIFF
--- a/scripts/lc-builds/blueos_nvcc_clang-mpi_caliper.sh
+++ b/scripts/lc-builds/blueos_nvcc_clang-mpi_caliper.sh
@@ -17,7 +17,7 @@ if [[ $# -lt 5 ]]; then
   echo "   5) path to adiak cmake directory"
   echo
   echo "For example: "
-  echo "    blueos_nvcc_clang_caliper.sh 10.2.89 70 10.0.1 /usr/workspace/wsb/asde/caliper-lassen/share/cmake/caliper /usr/workspace/wsb/asde/caliper-lassen/lib/cmake/adiak"
+  echo "    blueos_nvcc_clang-mpi_caliper.sh 10.2.89 70 10.0.1 /usr/workspace/wsb/asde/caliper-lassen/share/cmake/caliper /usr/workspace/wsb/asde/caliper-lassen/lib/cmake/adiak"
   exit
 fi
 
@@ -28,7 +28,7 @@ CALI_DIR=$4
 ADIAK_DIR=$5
 shift 5
 
-BUILD_SUFFIX=lc_blueos-nvcc-${COMP_NVCC_VER}-${COMP_ARCH}-clang-${COMP_CLANG_VER}
+BUILD_SUFFIX=lc_blueos-nvcc-${COMP_NVCC_VER}-${COMP_ARCH}-clang-mpi-${COMP_CLANG_VER}-caliper
 RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/nvcc_clang_X.cmake
 
 echo
@@ -47,6 +47,7 @@ cmake \
   -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-${COMP_CLANG_VER}/bin/clang++ \
   -DBLT_CXX_STD=c++14 \
   -C ${RAJA_HOSTCONFIG} \
+  -DENABLE_MPI=ON \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \
   -DCUDA_SEPARABLE_COMPILATION=On \

--- a/scripts/lc-builds/blueos_nvcc_gcc-mpi_caliper.sh
+++ b/scripts/lc-builds/blueos_nvcc_gcc-mpi_caliper.sh
@@ -7,29 +7,29 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-if [[ $# -lt 5 ]]; then
+if [[ $# -lt 3 ]]; then
   echo
   echo "You must pass 5 arguments to the script (in this order): "
   echo "   1) compiler version number for nvcc"
   echo "   2) CUDA compute architecture (number only, not 'sm_70' for example)"
-  echo "   3) compiler version number for clang. "
+  echo "   3) compiler version number for gcc"
   echo "   4) path to caliper cmake directory"
   echo "   5) path to adiak cmake directory"
   echo
   echo "For example: "
-  echo "    blueos_nvcc_clang_caliper.sh 10.2.89 70 10.0.1 /usr/workspace/wsb/asde/caliper-lassen/share/cmake/caliper /usr/workspace/wsb/asde/caliper-lassen/lib/cmake/adiak"
+  echo "    blueos_nvcc_gcc-mpi_caliper.sh 10.2.89 70 8.3.1 /usr/workspace/wsb/asde/caliper-lassen/share/cmake/caliper /usr/workspace/wsb/asde/caliper-lassen/lib/cmake/adiak"
   exit
 fi
 
 COMP_NVCC_VER=$1
 COMP_ARCH=$2
-COMP_CLANG_VER=$3
+COMP_GCC_VER=$3
 CALI_DIR=$4
 ADIAK_DIR=$5
 shift 5
 
-BUILD_SUFFIX=lc_blueos-nvcc-${COMP_NVCC_VER}-${COMP_ARCH}-clang-${COMP_CLANG_VER}
-RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/nvcc_clang_X.cmake
+BUILD_SUFFIX=lc_blueos-nvcc-${COMP_NVCC_VER}-${COMP_ARCH}-gcc-${COMP_GCC_VER}-mpi-caliper
+RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/blueos/nvcc_gcc_X.cmake
 
 echo
 echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
@@ -44,9 +44,10 @@ module load cmake/3.20.2
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-${COMP_CLANG_VER}/bin/clang++ \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/gcc/gcc-${COMP_GCC_VER}/bin/g++ \
   -DBLT_CXX_STD=c++14 \
   -C ${RAJA_HOSTCONFIG} \
+  -DENABLE_MPI=ON \
   -DENABLE_OPENMP=On \
   -DENABLE_CUDA=On \
   -DCUDA_SEPARABLE_COMPILATION=On \

--- a/scripts/lc-builds/toss4_clang-mpi_caliper.sh
+++ b/scripts/lc-builds/toss4_clang-mpi_caliper.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJAPerf/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+if [[ $# -lt 3 ]]; then
+  echo
+  echo "You must pass 3 arguments to the script (in this order): "
+  echo "   1) compiler version number"
+  echo "   2) path to caliper cmake directory"
+  echo "   3) path to adiak cmake directory"
+  echo
+  echo "For example: "
+  echo "    toss4_clang-mpi_caliper.sh 14.0.6 /usr/workspace/wsb/asde/caliper-quartz/share/cmake/caliper /usr/workspace/wsb/asde/caliper-quartz/lib/cmake/adiak"
+  exit
+fi
+
+COMP_VER=$1
+CALI_DIR=$2
+ADIAK_DIR=$3
+shift 3
+
+BUILD_SUFFIX=lc_toss4-clang-mpi-${COMP_VER}
+RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss4/clang_X.cmake
+
+echo
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
+echo
+
+rm -rf build_${BUILD_SUFFIX} 2>/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+module load cmake/3.23.1
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/clang/clang-${COMP_VER}/bin/clang++ \
+  -DBLT_CXX_STD=c++14 \
+  -C ${RAJA_HOSTCONFIG} \
+  -DENABLE_MPI=ON \
+  -DENABLE_OPENMP=On \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  -DRAJA_PERFSUITE_USE_CALIPER=ON \
+  -Dcaliper_DIR=${CALI_DIR} \
+  -Dadiak_DIR=${ADIAK_DIR} \
+  -DCMAKE_C_FLAGS="-g -O0" \
+  -DCMAKE_CXX_FLAGS="-g -O0" \
+  "$@" \
+  ..
+
+echo
+echo "***********************************************************************"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "***********************************************************************"

--- a/scripts/lc-builds/toss4_clang_caliper.sh
+++ b/scripts/lc-builds/toss4_clang_caliper.sh
@@ -25,7 +25,7 @@ ADIAK_DIR=$3
 shift 3
 
 BUILD_SUFFIX=lc_toss4-clang-${COMP_VER}
-RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss3/clang_X.cmake
+RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss4/clang_X.cmake
 
 echo
 echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"

--- a/scripts/lc-builds/toss4_gcc-mpi_caliper.sh
+++ b/scripts/lc-builds/toss4_gcc-mpi_caliper.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJAPerf/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+if [[ $# -lt 3 ]]; then
+  echo
+  echo "You must pass 3 arguments to the script (in this order): "
+  echo "   1) compiler version number"
+  echo "   2) path to caliper cmake directory"
+  echo "   3) path to adiak cmake directory"
+  echo
+  echo "For example: "
+  echo "    toss4_gcc-mpi_caliper.sh 10.3.1 /usr/workspace/wsb/asde/caliper-quartz/share/cmake/caliper /usr/workspace/wsb/asde/caliper-quartz/lib/cmake/adiak"
+  exit
+fi
+
+COMP_VER=$1
+CALI_DIR=$2
+ADIAK_DIR=$3
+shift 3
+
+BUILD_SUFFIX=lc_toss4-gcc-mpi-${COMP_VER}
+RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/lc-builds/toss4/gcc_X.cmake
+
+echo
+echo "Creating build directory build_${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
+echo
+
+rm -rf build_${BUILD_SUFFIX} 2>/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+module load cmake/3.23.1
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER=/usr/tce/packages/gcc/gcc-${COMP_VER}/bin/gcc \
+  -DCMAKE_CXX_COMPILER=/usr/tce/packages/gcc/gcc-${COMP_VER}/bin/g++ \
+  -DBLT_CXX_STD=c++14 \
+  -C ${RAJA_HOSTCONFIG} \
+  -DENABLE_MPI=ON \
+  -DENABLE_OPENMP=On \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  -DRAJA_PERFSUITE_USE_CALIPER=ON \
+  -Dcaliper_DIR=${CALI_DIR} \
+  -Dadiak_DIR=${ADIAK_DIR} \
+  -DCMAKE_C_FLAGS="-g -O0" \
+  -DCMAKE_CXX_FLAGS="-g -O0" \
+  "$@" \
+  ..
+
+echo
+echo "***********************************************************************"
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJA Perf Suite"
+echo "***********************************************************************"

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -331,7 +331,8 @@ void Executor::setupSuite()
       KernelBase::setCaliperMgrVariantTuning(vid,
                                              tstr,
                                              run_params.getOutputDirName(),
-                                             run_params.getAddToSpotConfig());
+                                             run_params.getAddToSpotConfig(),
+                                             run_params.getAddToCaliperConfig());
 #endif
     }
 

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -124,12 +124,13 @@ Executor::Executor(int argc, char** argv)
 {
 #if defined(RAJA_PERFSUITE_USE_CALIPER)
   configuration cc;
-  adiak::init(NULL);
-  adiak::user();
-  adiak::launchdate();
-  adiak::libraries();
-  adiak::cmdline();
-  adiak::clustername();
+  #if defined(RAJA_PERFSUITE_ENABLE_MPI)
+    MPI_Comm adiak_comm = MPI_COMM_WORLD;
+    adiak::init(&adiak_comm);
+  #else
+    adiak::init(nullptr);
+  #endif
+  adiak::collect_all();
   adiak::value("perfsuite_version", cc.adiak_perfsuite_version);
   adiak::value("raja_version", cc.adiak_raja_version);
   adiak::value("cmake_build_type", cc.adiak_cmake_build_type);

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -568,7 +568,8 @@ void KernelBase::doOnceCaliMetaEnd(VariantID vid, size_t tune_idx)
 void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
                                   std::string tstr,
                                   const std::string& outdir,
-                                  const std::string& addToSpotConfig)
+                                  const std::string& addToSpotConfig,
+                                  const std::string& addToCaliConfig)
 {
   static bool ran_spot_config_check = false;
   bool config_ok = true;
@@ -631,13 +632,16 @@ void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
   }
   )json";
 
-  if(!ran_spot_config_check && (!addToSpotConfig.empty())) {
+  if(!ran_spot_config_check && ((!addToSpotConfig.empty()) || (!addToCaliConfig.empty()))) {
     cali::ConfigManager cm;
     std::string check_profile = "spot(" + addToSpotConfig + ")";
+    if (!addToCaliConfig.empty()) {
+        check_profile += "," + addToCaliConfig;
+    }
     std::string msg = cm.check(check_profile.c_str());
     if(!msg.empty()) {
       std::cerr << "Problem with Cali Config: " << check_profile << "\n";
-      std::cerr << "Check your command line argument: " << addToSpotConfig << "\n";
+      std::cerr << msg << "\n";
       config_ok = false;
       exit(-1);
     }
@@ -658,6 +662,9 @@ void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
       profile += "," + addToSpotConfig;
     }
     profile += ")";
+    if (!addToCaliConfig.empty()) {
+      profile += "," + addToCaliConfig;
+    }
     std::cout << "Profile: " << profile << std::endl;
     mgr[vid][tstr].add_option_spec(kernel_info_spec);
     mgr[vid][tstr].set_default_parameter("rajaperf_kernel_info", "true");

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -632,12 +632,22 @@ void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
   }
   )json";
 
-  if(!ran_spot_config_check && ((!addToSpotConfig.empty()) || (!addToCaliConfig.empty()))) {
+  // Skip check if both empty
+  if ((!addToSpotConfig.empty() || !addToCaliConfig.empty()) && !ran_spot_config_check) {
     cali::ConfigManager cm;
-    std::string check_profile = "spot(" + addToSpotConfig + ")";
-    if (!addToCaliConfig.empty()) {
-        check_profile += "," + addToCaliConfig;
+    std::string check_profile;
+    // If both not empty
+    if (!addToSpotConfig.empty() && !addToCaliConfig.empty()) {
+      check_profile = "spot(" + addToSpotConfig + ")," + addToCaliConfig;
     }
+    else if (!addToSpotConfig.empty()) {
+      check_profile = "spot(" + addToSpotConfig + ")";
+    }
+    // if !addToCaliConfig.empty()
+    else {
+      check_profile = addToCaliConfig;
+    }
+
     std::string msg = cm.check(check_profile.c_str());
     if(!msg.empty()) {
       std::cerr << "Problem with Cali Config: " << check_profile << "\n";

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -568,7 +568,7 @@ void KernelBase::doOnceCaliMetaEnd(VariantID vid, size_t tune_idx)
 void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
                                   std::string tstr,
                                   const std::string& outdir,
-                                  const std::string& addToConfig)
+                                  const std::string& addToSpotConfig)
 {
   static bool ran_spot_config_check = false;
   bool config_ok = true;
@@ -631,13 +631,13 @@ void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
   }
   )json";
 
-  if(!ran_spot_config_check && (!addToConfig.empty())) {
+  if(!ran_spot_config_check && (!addToSpotConfig.empty())) {
     cali::ConfigManager cm;
-    std::string check_profile = "spot()," + addToConfig;
+    std::string check_profile = "spot(" + addToSpotConfig + ")";
     std::string msg = cm.check(check_profile.c_str());
     if(!msg.empty()) {
       std::cerr << "Problem with Cali Config: " << check_profile << "\n";
-      std::cerr << "Check your command line argument: " << addToConfig << "\n";
+      std::cerr << "Check your command line argument: " << addToSpotConfig << "\n";
       config_ok = false;
       exit(-1);
     }
@@ -653,10 +653,11 @@ void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
       od = outdir + "/";
     }
     std::string vstr = getVariantName(vid);
-    std::string profile = "spot(output=" + od + vstr + "-" + tstr + ".cali)";
-    if(!addToConfig.empty()) {
-      profile += "," + addToConfig;
+    std::string profile = "spot(output=" + od + vstr + "-" + tstr + ".cali";
+    if(!addToSpotConfig.empty()) {
+      profile += "," + addToSpotConfig;
     }
+    profile += ")";
     std::cout << "Profile: " << profile << std::endl;
     mgr[vid][tstr].add_option_spec(kernel_info_spec);
     mgr[vid][tstr].set_default_parameter("rajaperf_kernel_info", "true");

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -488,7 +488,8 @@ public:
   static void setCaliperMgrVariantTuning(VariantID vid,
                                     std::string tstr,
                                     const std::string& outdir,
-                                    const std::string& addToSpotConfig);
+                                    const std::string& addToSpotConfig,
+                                    const std::string& addToCaliConfig);
 
   static void setCaliperMgrStart(VariantID vid, std::string tstr) { mgr[vid][tstr].start(); }
   static void setCaliperMgrStop(VariantID vid, std::string tstr) { mgr[vid][tstr].stop(); }

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -488,7 +488,7 @@ public:
   static void setCaliperMgrVariantTuning(VariantID vid,
                                     std::string tstr,
                                     const std::string& outdir,
-                                    const std::string& addToConfig);
+                                    const std::string& addToSpotConfig);
 
   static void setCaliperMgrStart(VariantID vid, std::string tstr) { mgr[vid][tstr].start(); }
   static void setCaliperMgrStop(VariantID vid, std::string tstr) { mgr[vid][tstr].stop(); }

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -915,6 +915,17 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
           add_to_spot_config = std::string( argv[i] );
         }
       }
+    } else if ( std::string(argv[i]) == std::string("--add-to-cali-config") ||
+               std::string(argv[i]) == std::string("-atcc") ) {
+      i++;
+      if ( i < argc ) {
+        opt = std::string(argv[i]);
+        if ( opt.at(0) == '-' ) {
+          i--;
+        } else {
+          add_to_cali_config = std::string( argv[i] );
+        }
+      }
 #endif
 
     } else {
@@ -1337,9 +1348,13 @@ void RunParams::printHelpMessage(std::ostream& str) const
 
 #if defined(RAJA_PERFSUITE_USE_CALIPER)
   str << "\t --add-to-spot-config, -atsc <string> [Default is none]\n"
-      << "\t\t appends additional parameters to the built-in Caliper spot config\n";
+      << "\t\t appends additional parameters to the built-in Caliper spot config (CALI_CONFIG=spot(...))\n";
   str << "\t\t Example to include some PAPI counters (Intel arch)\n"
       << "\t\t -atsc topdown.all\n\n";
+  str << "\t --add-to-cali-config, -atcc <string> [Default is none]\n"
+      << "\t\t include parameters in the Caliper config (same as CALI_CONFIG=...)\n";
+  str << "\t\t Example to include time spent in MPI functions\n"
+      << "\t\t -atcc mpi-report\n\n";
 #endif
 
   str << std::endl;

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -200,6 +200,7 @@ public:
 
 #if defined(RAJA_PERFSUITE_USE_CALIPER)
   const std::string& getAddToSpotConfig() const { return add_to_spot_config; }
+  const std::string& getAddToCaliperConfig() const { return add_to_cali_config; }
 #endif
 
   bool getDisableWarmup() const { return disable_warmup; }
@@ -324,6 +325,7 @@ private:
 
 #if defined(RAJA_PERFSUITE_USE_CALIPER)
   std::string add_to_spot_config;
+  std::string add_to_cali_config;
 #endif
 
   bool disable_warmup;


### PR DESCRIPTION
# Update Caliper Arguments and Adiak Metadata

Currently the `add-to-spot-config` adds to the `Caliper` config instead of the `spot` config. While useful, this is misleading. We also turn on the new Adiak `collect_all` routine which collects all [implicit Adiak routines](https://software.llnl.gov/Adiak/ApplicationAPI.html?highlight=routine#implicit-routines).

- This PR is a bugfix & feature
- It does the following (modify list as needed):
   - bugfix -> `add-to-spot-config` now works exactly as described in the help string
   - feature -> `add-to-cali-config` is a new argument that still gives the option to add to the Caliper config
   - feature -> Enable Adiak MPI routines if enabled, call `collect_all` function
   - feature -> add/update caliper build scripts in `scripts/lc-builds`
