### PR TITLE
Add new reduction interface versions of kernels

### DIFF
--- a/src/algorithm/ATOMIC-OMPTarget.cpp
+++ b/src/algorithm/ATOMIC-OMPTarget.cpp
@@ -27,7 +27,7 @@ namespace algorithm
   const size_t threads_per_team = 256;
 
 template < size_t replication >
-void ATOMIC::runOpenMPTargetReplicate(VariantID vid)
+void ATOMIC::runOpenMPTargetVariantReplicate(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;

--- a/src/algorithm/CMakeLists.txt
+++ b/src/algorithm/CMakeLists.txt
@@ -30,6 +30,7 @@ blt_add_library(
           REDUCE_SUM-Cuda.cpp
           REDUCE_SUM-OMP.cpp
           REDUCE_SUM-OMPTarget.cpp
+          REDUCE_SUM-Sycl.cpp
           MEMSET.cpp
           MEMSET-Seq.cpp
           MEMSET-Hip.cpp

--- a/src/algorithm/REDUCE_SUM-Cuda.cpp
+++ b/src/algorithm/REDUCE_SUM-Cuda.cpp
@@ -218,6 +218,49 @@ void REDUCE_SUM::runCudaVariantRAJA(VariantID vid)
 
 }
 
+template < size_t block_size, typename MappingHelper >
+void REDUCE_SUM::runCudaVariantRAJANewReduce(VariantID vid)
+{
+  using exec_policy = std::conditional_t<MappingHelper::direct,
+      RAJA::cuda_exec<block_size, true /*async*/>,
+      RAJA::cuda_exec_occ_calc<block_size, true /*async*/>>;
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  REDUCE_SUM_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type tsum = m_sum_init;
+
+      RAJA::forall<exec_policy>( res,
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tsum),
+        [=] __device__ (Index_type i, Real_type& sum) {
+          REDUCE_SUM_BODY;
+        }
+      );
+
+      m_sum = static_cast<Real_type>(tsum);
+
+    }
+    stopTimer();
+
+  } else {
+
+    getCout() << "\n  REDUCE_SUM : Unknown Cuda variant id = " << vid << std::endl;
+
+  }
+
+}
+
 void REDUCE_SUM::runCudaVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
@@ -272,6 +315,16 @@ void REDUCE_SUM::runCudaVariant(VariantID vid, size_t tune_idx)
 
             });
 
+            if (tune_idx == t) {
+
+              setBlockSize(block_size);
+              runCudaVariantRAJANewReduce<decltype(block_size){},
+                                          decltype(mapping_helper)>(vid);
+
+            }
+
+            t += 1;
+
           }
 
         });
@@ -312,6 +365,7 @@ void REDUCE_SUM::setCudaTuningDefinitions(VariantID vid)
             addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
                                       decltype(mapping_helper)::get_name()+"_"+
                                       std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning 
 
           } else if ( vid == RAJA_CUDA ) {
 
@@ -322,6 +376,13 @@ void REDUCE_SUM::setCudaTuningDefinitions(VariantID vid)
                                         std::to_string(block_size));
 
             });
+
+            auto algorithm_helper = gpu_algorithm::block_device_helper{};
+
+            addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      "new_"+std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
           }
 

--- a/src/algorithm/REDUCE_SUM-Hip.cpp
+++ b/src/algorithm/REDUCE_SUM-Hip.cpp
@@ -245,6 +245,49 @@ void REDUCE_SUM::runHipVariantRAJA(VariantID vid)
 
 }
 
+template < size_t block_size, typename MappingHelper >
+void REDUCE_SUM::runHipVariantRAJANewReduce(VariantID vid)
+{
+  using exec_policy = std::conditional_t<MappingHelper::direct,
+      RAJA::hip_exec<block_size, true /*async*/>,
+      RAJA::hip_exec_occ_calc<block_size, true /*async*/>>;
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  REDUCE_SUM_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type tsum = m_sum_init;
+
+      RAJA::forall<exec_policy>( res,
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tsum),
+        [=] __device__ (Index_type i, Real_type& sum) {
+          REDUCE_SUM_BODY;
+        }
+      );
+
+      m_sum = static_cast<Real_type>(tsum);
+
+    }
+    stopTimer();
+
+  } else {
+
+    getCout() << "\n  REDUCE_SUM : Unknown Hip variant id = " << vid << std::endl;
+
+  }
+
+}
+
 void REDUCE_SUM::runHipVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
@@ -298,6 +341,16 @@ void REDUCE_SUM::runHipVariant(VariantID vid, size_t tune_idx)
               t += 1;
 
             });
+
+            if (tune_idx == t) {
+
+              setBlockSize(block_size);
+              runHipVariantRAJANewReduce<decltype(block_size){},
+                                         decltype(mapping_helper)>(vid);
+
+            }
+
+            t += 1;
 
           }
 
@@ -353,6 +406,13 @@ void REDUCE_SUM::setHipTuningDefinitions(VariantID vid)
                                         std::to_string(block_size));
 
             });
+
+            auto algorithm_helper = gpu_algorithm::block_device_helper{};
+
+            addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      "new_"+std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
           }
 

--- a/src/algorithm/REDUCE_SUM-OMP.cpp
+++ b/src/algorithm/REDUCE_SUM-OMP.cpp
@@ -94,9 +94,7 @@ void REDUCE_SUM::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -116,6 +114,8 @@ void REDUCE_SUM::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  REDUCE_SUM : Unknown OpenMP tuning index = " << tune_idx << std::endl;
       }
 
 

--- a/src/algorithm/REDUCE_SUM-OMP.cpp
+++ b/src/algorithm/REDUCE_SUM-OMP.cpp
@@ -18,7 +18,7 @@ namespace algorithm
 {
 
 
-void REDUCE_SUM::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void REDUCE_SUM::runOpenMPVariant(VariantID vid, size_t tune_idx)
 {
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
 
@@ -76,21 +76,48 @@ void REDUCE_SUM::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
 
     case RAJA_OpenMP : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
 
-        RAJA::ReduceSum<RAJA::omp_reduce, Real_type> sum(m_sum_init);
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::omp_parallel_for_exec>(
-          RAJA::RangeSegment(ibegin, iend),
-          [=](Index_type i) {
-            REDUCE_SUM_BODY;
-        });
+          RAJA::ReduceSum<RAJA::omp_reduce, Real_type> sum(m_sum_init);
 
-        m_sum = sum.get();
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend),
+            [=](Index_type i) {
+              REDUCE_SUM_BODY;
+          });
+
+          m_sum = sum.get();
+
+        }
+        stopTimer();
 
       }
-      stopTimer();
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type tsum = m_sum_init;
+
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tsum),
+            [=] (Index_type i, Real_type& sum) {
+              REDUCE_SUM_BODY;
+            }
+          );
+
+          m_sum = static_cast<Real_type>(tsum);
+
+        }
+        stopTimer();
+
+      }
+
 
       break;
     }
@@ -103,7 +130,16 @@ void REDUCE_SUM::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
 
 #else
   RAJA_UNUSED_VAR(vid);
+  RAJA_UNUSED_VAR(tune_idx);
 #endif
+}
+
+void REDUCE_SUM::setOpenMPTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMP) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace algorithm

--- a/src/algorithm/REDUCE_SUM-OMPTarget.cpp
+++ b/src/algorithm/REDUCE_SUM-OMPTarget.cpp
@@ -27,7 +27,7 @@ namespace algorithm
   const size_t threads_per_team = 256;
 
 
-void REDUCE_SUM::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void REDUCE_SUM::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -56,26 +56,60 @@ void REDUCE_SUM::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_AR
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+    if (tune_idx == 0) {
 
-      RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> sum(m_sum_init);
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-        RAJA::RangeSegment(ibegin, iend),
-        [=](Index_type i) {
-          REDUCE_SUM_BODY;
-      });
+        RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> sum(m_sum_init);
 
-      m_sum = sum.get();
+        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+          RAJA::RangeSegment(ibegin, iend),
+          [=](Index_type i) {
+            REDUCE_SUM_BODY;
+        });
 
-    }
-    stopTimer();
+        m_sum = sum.get();
+
+      }
+      stopTimer();
+
+     }
+
+     if (tune_idx == 1) {
+
+       startTimer();
+       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+         Real_type tsum = m_sum_init;
+
+         RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+           RAJA::RangeSegment(ibegin, iend),
+           RAJA::expt::Reduce<RAJA::operators::plus>(&tsum),
+           [=] (Index_type i, Real_type& sum) {
+             REDUCE_SUM_BODY;
+           }
+         );
+
+         m_sum = static_cast<Real_type>(tsum);
+
+       }
+       stopTimer();
+
+     }
 
   } else {
     getCout() << "\n  REDUCE_SUM : Unknown OMP Target variant id = " << vid << std::endl;
   }
 
+}
+
+void REDUCE_SUM::setOpenMPTargetTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMPTarget) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace algorithm

--- a/src/algorithm/REDUCE_SUM-OMPTarget.cpp
+++ b/src/algorithm/REDUCE_SUM-OMPTarget.cpp
@@ -74,29 +74,29 @@ void REDUCE_SUM::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
       }
       stopTimer();
 
-     } else if (tune_idx == 1) {
+    } else if (tune_idx == 1) {
 
-       startTimer();
-       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-         Real_type tsum = m_sum_init;
+        Real_type tsum = m_sum_init;
 
-         RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-           RAJA::RangeSegment(ibegin, iend),
-           RAJA::expt::Reduce<RAJA::operators::plus>(&tsum),
-           [=] (Index_type i, Real_type& sum) {
-             REDUCE_SUM_BODY;
-           }
-         );
+        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+          RAJA::RangeSegment(ibegin, iend),
+          RAJA::expt::Reduce<RAJA::operators::plus>(&tsum),
+          [=] (Index_type i, Real_type& sum) {
+            REDUCE_SUM_BODY;
+          }
+        );
 
-         m_sum = static_cast<Real_type>(tsum);
+        m_sum = static_cast<Real_type>(tsum);
 
-       }
-       stopTimer();
+      }
+      stopTimer();
 
-     } else {
-       getCout() << "\n  REDUCE_SUM : Unknown OpenMP Target tuning index = " << tune_idx << std::endl;
-     }
+    } else {
+      getCout() << "\n  REDUCE_SUM : Unknown OMP Target tuning index = " << tune_idx << std::endl;
+    }
 
   } else {
     getCout() << "\n  REDUCE_SUM : Unknown OMP Target variant id = " << vid << std::endl;

--- a/src/algorithm/REDUCE_SUM-OMPTarget.cpp
+++ b/src/algorithm/REDUCE_SUM-OMPTarget.cpp
@@ -74,9 +74,7 @@ void REDUCE_SUM::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
       }
       stopTimer();
 
-     }
-
-     if (tune_idx == 1) {
+     } else if (tune_idx == 1) {
 
        startTimer();
        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -96,6 +94,8 @@ void REDUCE_SUM::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
        }
        stopTimer();
 
+     } else {
+       getCout() << "\n  REDUCE_SUM : Unknown OpenMP Target tuning index = " << tune_idx << std::endl;
      }
 
   } else {

--- a/src/algorithm/REDUCE_SUM-Seq.cpp
+++ b/src/algorithm/REDUCE_SUM-Seq.cpp
@@ -93,9 +93,7 @@ void REDUCE_SUM::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -114,10 +112,12 @@ void REDUCE_SUM::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  REDUCE_SUM : Unknown Seq tuning index = " << tune_idx << std::endl; 
       }
 
       break;
-    }
+   }
 #endif
 
     default : {

--- a/src/algorithm/REDUCE_SUM-Seq.cpp
+++ b/src/algorithm/REDUCE_SUM-Seq.cpp
@@ -18,8 +18,11 @@ namespace algorithm
 {
 
 
-void REDUCE_SUM::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void REDUCE_SUM::runSeqVariant(VariantID vid, size_t tune_idx)
 {
+#if !defined(RUN_RAJA_SEQ)
+  RAJA_UNUSED_VAR(tune_idx);
+#endif
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
@@ -73,20 +76,45 @@ void REDUCE_SUM::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_id
 
     case RAJA_Seq : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
 
-        RAJA::ReduceSum<RAJA::seq_reduce, Real_type> sum(m_sum_init);
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::seq_exec>( RAJA::RangeSegment(ibegin, iend),
-          [=](Index_type i) {
-            REDUCE_SUM_BODY;
-        });
+          RAJA::ReduceSum<RAJA::seq_reduce, Real_type> sum(m_sum_init);
 
-        m_sum = sum.get();
+          RAJA::forall<RAJA::seq_exec>( RAJA::RangeSegment(ibegin, iend),
+            [=](Index_type i) {
+              REDUCE_SUM_BODY;
+          });
+
+          m_sum = sum.get();
+
+        }
+        stopTimer();
 
       }
-      stopTimer();
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type tsum = m_sum_init;
+
+          RAJA::forall<RAJA::seq_exec>( RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tsum),
+            [=] (Index_type i, Real_type& sum) {
+              REDUCE_SUM_BODY;
+            }
+          );
+
+          m_sum = static_cast<Real_type>(tsum);
+
+        }
+        stopTimer();
+
+      }
 
       break;
     }
@@ -98,6 +126,14 @@ void REDUCE_SUM::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_id
 
   }
 
+}
+
+void REDUCE_SUM::setSeqTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_Seq) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace algorithm

--- a/src/algorithm/REDUCE_SUM-Sycl.cpp
+++ b/src/algorithm/REDUCE_SUM-Sycl.cpp
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#include "DOT.hpp"
+#include "REDUCE_SUM.hpp"
 
 #include "RAJA/RAJA.hpp"
 

--- a/src/algorithm/REDUCE_SUM-Sycl.cpp
+++ b/src/algorithm/REDUCE_SUM-Sycl.cpp
@@ -1,0 +1,103 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-24, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DOT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_SYCL)
+
+#include "common/SyclDataUtils.hpp"
+
+#include <iostream>
+
+
+namespace rajaperf
+{
+namespace algorithm
+{
+
+template <size_t work_group_size >
+void REDUCE_SUM::runSyclVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
+  REDUCE_SUM_DATA_SETUP;
+
+  if ( vid == Base_SYCL ) {
+
+    Real_ptr sum;
+    allocAndInitSyclDeviceData(sum, &m_sum_init, 1, qu);
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
+
+      initSyclDeviceData(sum, &m_sum_init, 1, qu); 
+
+      qu->submit([&] (sycl::handler& h) {
+
+        auto sumReduction = sycl::reduction(sum, sycl::plus<Real_type>());
+
+        h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
+                       sumReduction,
+                       [=] (sycl::nd_item<1> item, auto& sum) {
+
+          Index_type i = item.get_global_id(0);
+          if (i < iend) {
+            REDUCE_SUM_BODY;
+          }
+
+        });
+      });
+
+      Real_type lsum;
+      Real_ptr plsum = &lsum;
+      getSyclDeviceData(plsum, sum, 1, qu);
+      m_sum = lsum;
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_SYCL ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       Real_type tsum = m_sum_init;
+       RAJA::forall< RAJA::sycl_exec<work_group_size, true /*async*/> >( 
+         res,
+         RAJA::RangeSegment(ibegin, iend), 
+         RAJA::expt::Reduce<RAJA::operators::plus>(&tsum),
+         [=]  (Index_type i, Real_type& sum) {
+           REDUCE_SUM_BODY;
+         }
+       );
+
+       m_sum = static_cast<Real_type>(tsum);
+
+    }
+    stopTimer();
+
+  } else {
+     std::cout << "\n  REDUCE_SUM : Unknown Sycl variant id = " << vid << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(REDUCE_SUM, Sycl)
+
+} // end namespace algorithm
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_SYCL

--- a/src/algorithm/REDUCE_SUM.cpp
+++ b/src/algorithm/REDUCE_SUM.cpp
@@ -51,6 +51,9 @@ REDUCE_SUM::REDUCE_SUM(const RunParams& params)
 
   setVariantDefined( Base_HIP );
   setVariantDefined( RAJA_HIP );
+
+  setVariantDefined( Base_SYCL );
+  setVariantDefined( RAJA_SYCL );
 }
 
 REDUCE_SUM::~REDUCE_SUM()

--- a/src/algorithm/REDUCE_SUM.hpp
+++ b/src/algorithm/REDUCE_SUM.hpp
@@ -59,18 +59,27 @@ public:
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
 
+  void setSeqTuningDefinitions(VariantID vid);
+  void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid); 
+
   void runCudaVariantCub(VariantID vid);
-  void runHipVariantRocprim(VariantID vid);
   template < size_t block_size, typename MappingHelper >
   void runCudaVariantBase(VariantID vid);
+  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  void runCudaVariantRAJA(VariantID vid);
+  template < size_t block_size, typename MappingHelper >
+  void runCudaVariantRAJANewReduce(VariantID vid);
+
+  void runHipVariantRocprim(VariantID vid);
   template < size_t block_size, typename MappingHelper >
   void runHipVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
-  void runCudaVariantRAJA(VariantID vid);
-  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
+  template < size_t block_size, typename MappingHelper >
+  void runHipVariantRAJANewReduce(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/algorithm/REDUCE_SUM.hpp
+++ b/src/algorithm/REDUCE_SUM.hpp
@@ -58,12 +58,14 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runSyclVariant(VariantID vid, size_t tune_idx);
 
   void setSeqTuningDefinitions(VariantID vid);
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void setOpenMPTargetTuningDefinitions(VariantID vid); 
+  void setOpenMPTargetTuningDefinitions(VariantID vid);
+  void setSyclTuningDefinitions(VariantID vid);
 
   void runCudaVariantCub(VariantID vid);
   template < size_t block_size, typename MappingHelper >
@@ -80,6 +82,9 @@ public:
   void runHipVariantRAJA(VariantID vid);
   template < size_t block_size, typename MappingHelper >
   void runHipVariantRAJANewReduce(VariantID vid);
+
+  template < size_t work_group_size >
+  void runSyclVariantImpl(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/apps/EDGE3D-OMPTarget.cpp
+++ b/src/apps/EDGE3D-OMPTarget.cpp
@@ -37,11 +37,6 @@ void EDGE3D::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
 
   EDGE3D_DATA_SETUP;
 
-  auto edge3d_lam =
-    [=](Index_type i) {
-      EDGE3D_BODY;
-    };
-
   if ( vid == Base_OpenMPTarget ) {
 
     startTimer();

--- a/src/apps/MATVEC_3D_STENCIL-OMPTarget.cpp
+++ b/src/apps/MATVEC_3D_STENCIL-OMPTarget.cpp
@@ -42,8 +42,14 @@ void MATVEC_3D_STENCIL::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UN
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      #pragma omp target is_device_ptr(x0,x1,x2,x3,x4,x5,x6,x7, \
-                                       vol, real_zones) device( did )
+      #pragma omp target is_device_ptr(b, \
+                                       dbl, dbc, dbr, dcl, dcc, dcr, dfl, dfc, dfr, \
+                                       xdbl, xdbc, xdbr, xdcl, xdcc, xdcr, xdfl, xdfc, xdfr, \
+                                       cbl, cbc, cbr, ccl, ccc, ccr, cfl, cfc, cfr, \
+                                       xcbl, xcbc, xcbr, xccl, xccc, xccr, xcfl, xcfc, xcfr, \
+                                       ubl, ubc, ubr, ucl, ucc, ucr, ufl, ufc, ufr, \
+                                       xubl, xubc, xubr, xucl, xucc, xucr, xufl, xufc, xufr, \
+                                       real_zones) device( did )
       #pragma omp teams distribute parallel for thread_limit(threads_per_team) schedule(static, 1)
       for (Index_type ii = ibegin ; ii < iend ; ++ii ) {
         MATVEC_3D_STENCIL_BODY_INDEX;

--- a/src/basic/ARRAY_OF_PTRS-Seq.cpp
+++ b/src/basic/ARRAY_OF_PTRS-Seq.cpp
@@ -26,9 +26,11 @@ void ARRAY_OF_PTRS::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
 
   ARRAY_OF_PTRS_DATA_SETUP;
 
+#if defined(RUN_RAJA_SEQ)
   auto array_of_ptrs_lam = [=](Index_type i) {
                      ARRAY_OF_PTRS_BODY(x);
                    };
+#endif
 
   switch ( vid ) {
 

--- a/src/basic/PI_REDUCE-Cuda.cpp
+++ b/src/basic/PI_REDUCE-Cuda.cpp
@@ -144,7 +144,7 @@ void PI_REDUCE::runCudaVariantRAJA(VariantID vid)
 }
 
 
-template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+template < size_t block_size, typename MappingHelper >
 void PI_REDUCE::runCudaVariantRAJANewReduce(VariantID vid)
 {
   using exec_policy = std::conditional_t<MappingHelper::direct,
@@ -228,12 +228,9 @@ void PI_REDUCE::runCudaVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
   
-              auto algorithm_helper = gpu_algorithm::block_device_helper{};
               setBlockSize(block_size);
               runCudaVariantRAJANewReduce<decltype(block_size){},
-                                          decltype(algorithm_helper),
                                           decltype(mapping_helper)>(vid);
-              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
   
             }
   

--- a/src/basic/PI_REDUCE-Cuda.cpp
+++ b/src/basic/PI_REDUCE-Cuda.cpp
@@ -145,7 +145,7 @@ void PI_REDUCE::runCudaVariantRAJA(VariantID vid)
 
 
 template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
-void PI_REDUCE::runCudaVariantNewRAJA(VariantID vid)
+void PI_REDUCE::runCudaVariantRAJANewReduce(VariantID vid)
 {
   using exec_policy = std::conditional_t<MappingHelper::direct,
       RAJA::cuda_exec<block_size, true /*async*/>,
@@ -231,9 +231,9 @@ void PI_REDUCE::runCudaVariant(VariantID vid, size_t tune_idx)
   
               auto algorithm_helper = gpu_algorithm::block_device_helper{};
               setBlockSize(block_size);
-              runCudaVariantNewRAJA<decltype(block_size){},
-                                    decltype(algorithm_helper),
-                                    decltype(mapping_helper)>(vid);
+              runCudaVariantRAJANewReduce<decltype(block_size){},
+                                          decltype(algorithm_helper),
+                                          decltype(mapping_helper)>(vid);
   
             }
   

--- a/src/basic/PI_REDUCE-Cuda.cpp
+++ b/src/basic/PI_REDUCE-Cuda.cpp
@@ -234,6 +234,7 @@ void PI_REDUCE::runCudaVariant(VariantID vid, size_t tune_idx)
               runCudaVariantRAJANewReduce<decltype(block_size){},
                                           decltype(algorithm_helper),
                                           decltype(mapping_helper)>(vid);
+              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
   
             }
   
@@ -273,6 +274,7 @@ void PI_REDUCE::setCudaTuningDefinitions(VariantID vid)
             addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
                                       decltype(mapping_helper)::get_name()+"_"+
                                       std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
           } else if ( vid == RAJA_CUDA ) {
 
@@ -288,6 +290,7 @@ void PI_REDUCE::setCudaTuningDefinitions(VariantID vid)
               
             addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
                                       "new_"+std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
           }
 

--- a/src/basic/PI_REDUCE-Cuda.cpp
+++ b/src/basic/PI_REDUCE-Cuda.cpp
@@ -166,8 +166,7 @@ void PI_REDUCE::runCudaVariantRAJANewReduce(VariantID vid)
 
       Real_type tpi = m_pi_init;
 
-      RAJA::forall< exec_policy >(
-        res,
+      RAJA::forall< exec_policy >( res,
         RAJA::RangeSegment(ibegin, iend),
         RAJA::expt::Reduce<RAJA::operators::plus>(&tpi),
         [=] __device__ (Index_type i, Real_type& pi) {

--- a/src/basic/PI_REDUCE-Cuda.cpp
+++ b/src/basic/PI_REDUCE-Cuda.cpp
@@ -166,7 +166,7 @@ void PI_REDUCE::runCudaVariantRAJANewReduce(VariantID vid)
 
       Real_type tpi = m_pi_init;
 
-      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >(
+      RAJA::forall< exec_policy >(
         res,
         RAJA::RangeSegment(ibegin, iend),
         RAJA::expt::Reduce<RAJA::operators::plus>(&tpi),
@@ -289,6 +289,7 @@ void PI_REDUCE::setCudaTuningDefinitions(VariantID vid)
             auto algorithm_helper = gpu_algorithm::block_device_helper{};
               
             addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
                                       "new_"+std::to_string(block_size));
             RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 

--- a/src/basic/PI_REDUCE-Hip.cpp
+++ b/src/basic/PI_REDUCE-Hip.cpp
@@ -143,6 +143,47 @@ void PI_REDUCE::runHipVariantRAJA(VariantID vid)
   }
 }
 
+template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+void PI_REDUCE::runHipVariantRAJANewReduce(VariantID vid)
+{
+  using exec_policy = std::conditional_t<MappingHelper::direct,
+      RAJA::hip_exec<block_size, true /*async*/>,
+      RAJA::hip_exec_occ_calc<block_size, true /*async*/>>;
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  PI_REDUCE_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type tpi = m_pi_init;
+
+      RAJA::forall< exec_policy >(
+        res,
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tpi),
+        [=] __device__ (Index_type i, Real_type& pi) {
+          PI_REDUCE_BODY;
+        }
+      );
+
+      m_pi = static_cast<Real_type>(tpi) * 4.0;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  PI_REDUCE : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
 void PI_REDUCE::runHipVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
@@ -184,6 +225,19 @@ void PI_REDUCE::runHipVariant(VariantID vid, size_t tune_idx)
               t += 1;
 
             });
+
+            if (tune_idx == t) {
+
+              auto algorithm_helper = gpu_algorithm::block_device_helper{};
+              setBlockSize(block_size);
+              runHipVariantRAJANewReduce<decltype(block_size){},
+                                         decltype(algorithm_helper),
+                                         decltype(mapping_helper)>(vid);
+              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
+
+            }
+
+            t += 1;
 
           }
 
@@ -229,6 +283,13 @@ void PI_REDUCE::setHipTuningDefinitions(VariantID vid)
                                         std::to_string(block_size));
 
             });
+
+            auto algorithm_helper = gpu_algorithm::block_device_helper{};
+
+            addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      "new_"+std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning 
 
           }
 

--- a/src/basic/PI_REDUCE-Hip.cpp
+++ b/src/basic/PI_REDUCE-Hip.cpp
@@ -143,7 +143,7 @@ void PI_REDUCE::runHipVariantRAJA(VariantID vid)
   }
 }
 
-template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+template < size_t block_size, typename MappingHelper >
 void PI_REDUCE::runHipVariantRAJANewReduce(VariantID vid)
 {
   using exec_policy = std::conditional_t<MappingHelper::direct,
@@ -228,12 +228,9 @@ void PI_REDUCE::runHipVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              auto algorithm_helper = gpu_algorithm::block_device_helper{};
               setBlockSize(block_size);
               runHipVariantRAJANewReduce<decltype(block_size){},
-                                         decltype(algorithm_helper),
                                          decltype(mapping_helper)>(vid);
-              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
             }
 

--- a/src/basic/PI_REDUCE-OMP.cpp
+++ b/src/basic/PI_REDUCE-OMP.cpp
@@ -18,7 +18,7 @@ namespace basic
 {
 
 
-void PI_REDUCE::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void PI_REDUCE::runOpenMPVariant(VariantID vid, size_t tune_idx)
 {
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
 
@@ -77,21 +77,47 @@ void PI_REDUCE::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
 
     case RAJA_OpenMP : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
 
-        RAJA::ReduceSum<RAJA::omp_reduce, Real_type> pi(m_pi_init);
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::omp_parallel_for_exec>(
-          RAJA::RangeSegment(ibegin, iend),
-          [=](Index_type i) {
-            PI_REDUCE_BODY;
-        });
+          RAJA::ReduceSum<RAJA::omp_reduce, Real_type> pi(m_pi_init);
 
-        m_pi = 4.0 * pi.get();
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend),
+            [=](Index_type i) {
+              PI_REDUCE_BODY;
+          });
+
+          m_pi = 4.0 * pi.get();
+
+        }
+        stopTimer();
 
       }
-      stopTimer();
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type tpi = m_pi_init;
+
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tpi),
+            [=] (Index_type i, Real_type& pi) {
+              PI_REDUCE_BODY;
+            }
+          );
+
+          m_pi = static_cast<Real_type>(tpi) * 4.0;
+
+        }
+        stopTimer();
+
+      }
 
       break;
     }
@@ -105,6 +131,16 @@ void PI_REDUCE::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
 #else
   RAJA_UNUSED_VAR(vid);
 #endif
+}
+
+void PI_REDUCE::setOpenMPTuningDefinitions(VariantID vid)
+{
+  if (vid == Base_OpenMP || vid == Lambda_OpenMP) {
+    addVariantTuningName(vid, "default");
+  } else if (vid == RAJA_OpenMP) {
+    addVariantTuningName(vid, "default");
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace basic

--- a/src/basic/PI_REDUCE-OMP.cpp
+++ b/src/basic/PI_REDUCE-OMP.cpp
@@ -95,9 +95,7 @@ void PI_REDUCE::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -117,6 +115,8 @@ void PI_REDUCE::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  PI_REDUCE : Unknown OpenMP tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/basic/PI_REDUCE-OMP.cpp
+++ b/src/basic/PI_REDUCE-OMP.cpp
@@ -135,10 +135,8 @@ void PI_REDUCE::runOpenMPVariant(VariantID vid, size_t tune_idx)
 
 void PI_REDUCE::setOpenMPTuningDefinitions(VariantID vid)
 {
-  if (vid == Base_OpenMP || vid == Lambda_OpenMP) {
-    addVariantTuningName(vid, "default");
-  } else if (vid == RAJA_OpenMP) {
-    addVariantTuningName(vid, "default");
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMP) {
     addVariantTuningName(vid, "new");
   }
 }

--- a/src/basic/PI_REDUCE-OMP.cpp
+++ b/src/basic/PI_REDUCE-OMP.cpp
@@ -130,6 +130,7 @@ void PI_REDUCE::runOpenMPVariant(VariantID vid, size_t tune_idx)
 
 #else
   RAJA_UNUSED_VAR(vid);
+  RAJA_UNUSED_VAR(tune_idx);
 #endif
 }
 

--- a/src/basic/PI_REDUCE-OMPTarget.cpp
+++ b/src/basic/PI_REDUCE-OMPTarget.cpp
@@ -74,9 +74,7 @@ void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
       }
       stopTimer();
 
-    }
-
-    if (tune_idx == 1) {
+    } else if (tune_idx == 1) {
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -96,6 +94,8 @@ void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
       }
       stopTimer();
 
+    } else {
+       getCout() << "\n  PI_REDUCE : Unknown OMP Target tuning index = " << tune_idx << std::endl;
     }
 
   } else {

--- a/src/basic/PI_REDUCE-OMPTarget.cpp
+++ b/src/basic/PI_REDUCE-OMPTarget.cpp
@@ -74,28 +74,29 @@ void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
       }
       stopTimer();
 
-      }
+    }
 
-      if (tune_idx == 1) {
+    if (tune_idx == 1) {
 
-        startTimer();
-        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-          Real_type tpi = m_pi_init;
-          RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-            RAJA::RangeSegment(ibegin, iend),
-            RAJA::expt::Reduce<RAJA::operators::plus>(&tpi),
-            [=] (Index_type i, Real_type& pi) {
-              PI_REDUCE_BODY;
-            }
-          );
+        Real_type tpi = m_pi_init;
 
-          m_pi = static_cast<Real_type>(tpi) * 4.0;
+        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+          RAJA::RangeSegment(ibegin, iend),
+          RAJA::expt::Reduce<RAJA::operators::plus>(&tpi),
+          [=] (Index_type i, Real_type& pi) {
+            PI_REDUCE_BODY;
+          }
+        );
 
-        }
-        stopTimer();
+        m_pi = static_cast<Real_type>(tpi) * 4.0;
 
       }
+      stopTimer();
+
+    }
 
   } else {
     getCout() << "\n  PI_REDUCE : Unknown OMP Target variant id = " << vid << std::endl;

--- a/src/basic/PI_REDUCE-OMPTarget.cpp
+++ b/src/basic/PI_REDUCE-OMPTarget.cpp
@@ -27,7 +27,7 @@ namespace basic
   const size_t threads_per_team = 256;
 
 
-void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -56,26 +56,61 @@ void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+    if (tune_idx == 0) {
 
-      RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> pi(m_pi_init);
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-        RAJA::RangeSegment(ibegin, iend),
-        [=](Index_type i) {
-          PI_REDUCE_BODY;
-      });
+        RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> pi(m_pi_init);
 
-      m_pi = 4.0 * pi.get();
+        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+          RAJA::RangeSegment(ibegin, iend),
+          [=](Index_type i) {
+            PI_REDUCE_BODY;
+        });
 
-    }
-    stopTimer();
+        m_pi = 4.0 * pi.get();
+
+      }
+      stopTimer();
+
+      }
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type tpi = m_pi_init;
+#if 0 
+          RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tpi),
+            [=] (Index_type i, Real_type& pi) {
+              PI_REDUCE_BODY;
+            }
+          );
+#endif
+
+          m_pi = static_cast<Real_type>(tpi) * 4.0;
+
+        }
+        stopTimer();
+
+      }
 
   } else {
     getCout() << "\n  PI_REDUCE : Unknown OMP Target variant id = " << vid << std::endl;
   }
 
+}
+
+void PI_REDUCE::setOpenMPTargetTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMP) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace basic

--- a/src/basic/PI_REDUCE-OMPTarget.cpp
+++ b/src/basic/PI_REDUCE-OMPTarget.cpp
@@ -82,7 +82,6 @@ void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
           Real_type tpi = m_pi_init;
-#if 0 
           RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
             RAJA::RangeSegment(ibegin, iend),
             RAJA::expt::Reduce<RAJA::operators::plus>(&tpi),
@@ -90,7 +89,6 @@ void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
               PI_REDUCE_BODY;
             }
           );
-#endif
 
           m_pi = static_cast<Real_type>(tpi) * 4.0;
 
@@ -108,7 +106,7 @@ void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 void PI_REDUCE::setOpenMPTargetTuningDefinitions(VariantID vid)
 {
   addVariantTuningName(vid, "default");
-  if (vid == RAJA_OpenMP) {
+  if (vid == RAJA_OpenMPTarget) {
     addVariantTuningName(vid, "new");
   }
 }

--- a/src/basic/PI_REDUCE-Seq.cpp
+++ b/src/basic/PI_REDUCE-Seq.cpp
@@ -20,6 +20,9 @@ namespace basic
 
 void PI_REDUCE::runSeqVariant(VariantID vid, size_t tune_idx)
 {
+#if !defined(RUN_RAJA_SEQ)
+  RAJA_UNUSED_VAR(tune_idx);
+#endif
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();

--- a/src/basic/PI_REDUCE-Seq.cpp
+++ b/src/basic/PI_REDUCE-Seq.cpp
@@ -128,10 +128,8 @@ void PI_REDUCE::runSeqVariant(VariantID vid, size_t tune_idx)
 
 void PI_REDUCE::setSeqTuningDefinitions(VariantID vid)
 {
-  if (vid == Base_Seq || vid == Lambda_Seq) {
-    addVariantTuningName(vid, "default");
-  } else if (vid == RAJA_Seq) {
-    addVariantTuningName(vid, "default");
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_Seq) {
     addVariantTuningName(vid, "new");
   }
 }

--- a/src/basic/PI_REDUCE-Seq.cpp
+++ b/src/basic/PI_REDUCE-Seq.cpp
@@ -18,7 +18,7 @@ namespace basic
 {
 
 
-void PI_REDUCE::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void PI_REDUCE::runSeqVariant(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -74,20 +74,45 @@ void PI_REDUCE::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
 
     case RAJA_Seq : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
 
-        RAJA::ReduceSum<RAJA::seq_reduce, Real_type> pi(m_pi_init);
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::seq_exec>( RAJA::RangeSegment(ibegin, iend),
-          [=](Index_type i) {
-            PI_REDUCE_BODY;
-        });
+          RAJA::ReduceSum<RAJA::seq_reduce, Real_type> pi(m_pi_init);
+  
+          RAJA::forall<RAJA::seq_exec>( RAJA::RangeSegment(ibegin, iend),
+            [=](Index_type i) {
+              PI_REDUCE_BODY;
+          });
 
-        m_pi = 4.0 * pi.get();
+          m_pi = 4.0 * pi.get();
+
+        }
+        stopTimer();
 
       }
-      stopTimer();
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type tpi = m_pi_init;
+ 
+          RAJA::forall<RAJA::seq_exec>( RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tpi),
+            [=] __device__ (Index_type i, Real_type& pi) {
+              PI_REDUCE_BODY;
+            }
+          );
+
+          m_pi = static_cast<Real_type>(tpi) * 4.0;
+
+        }
+        stopTimer();       
+  
+      }
 
       break;
     }
@@ -99,6 +124,14 @@ void PI_REDUCE::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
 
   }
 
+}
+
+void PI_REDUCE::setSeqTuningDefinitions(VariantID vid)
+{
+  if (vid == RAJA_Seq) {
+    addVariantTuningName(vid, "default");
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace basic

--- a/src/basic/PI_REDUCE-Seq.cpp
+++ b/src/basic/PI_REDUCE-Seq.cpp
@@ -94,9 +94,7 @@ void PI_REDUCE::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -115,6 +113,8 @@ void PI_REDUCE::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();       
   
+      } else {
+        getCout() << "\n  PI_REDUCE : Unknown Seq tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/basic/PI_REDUCE-Seq.cpp
+++ b/src/basic/PI_REDUCE-Seq.cpp
@@ -102,7 +102,7 @@ void PI_REDUCE::runSeqVariant(VariantID vid, size_t tune_idx)
  
           RAJA::forall<RAJA::seq_exec>( RAJA::RangeSegment(ibegin, iend),
             RAJA::expt::Reduce<RAJA::operators::plus>(&tpi),
-            [=] __device__ (Index_type i, Real_type& pi) {
+            [=] (Index_type i, Real_type& pi) {
               PI_REDUCE_BODY;
             }
           );

--- a/src/basic/PI_REDUCE-Seq.cpp
+++ b/src/basic/PI_REDUCE-Seq.cpp
@@ -128,7 +128,9 @@ void PI_REDUCE::runSeqVariant(VariantID vid, size_t tune_idx)
 
 void PI_REDUCE::setSeqTuningDefinitions(VariantID vid)
 {
-  if (vid == RAJA_Seq) {
+  if (vid == Base_Seq || vid == Lambda_Seq) {
+    addVariantTuningName(vid, "default");
+  } else if (vid == RAJA_Seq) {
     addVariantTuningName(vid, "default");
     addVariantTuningName(vid, "new");
   }

--- a/src/basic/PI_REDUCE.cpp
+++ b/src/basic/PI_REDUCE.cpp
@@ -48,7 +48,6 @@ PI_REDUCE::PI_REDUCE(const RunParams& params)
 
   setVariantDefined( Base_CUDA );
   setVariantDefined( RAJA_CUDA );
-  setVariantDefined( RAJA_CUDA_NewReduce );
 
   setVariantDefined( Base_HIP );
   setVariantDefined( RAJA_HIP );

--- a/src/basic/PI_REDUCE.cpp
+++ b/src/basic/PI_REDUCE.cpp
@@ -48,6 +48,7 @@ PI_REDUCE::PI_REDUCE(const RunParams& params)
 
   setVariantDefined( Base_CUDA );
   setVariantDefined( RAJA_CUDA );
+  setVariantDefined( RAJA_CUDA_NewReduce );
 
   setVariantDefined( Base_HIP );
   setVariantDefined( RAJA_HIP );

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -59,22 +59,24 @@ public:
   void runSyclVariant(VariantID vid, size_t tune_idx);
 
   void setSeqTuningDefinitions(VariantID vid);
+  void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runCudaVariantBase(VariantID vid);
-  template < size_t block_size, typename MappingHelper >
-  void runHipVariantBase(VariantID vid);
-
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJANewReduce(VariantID vid);
 
+  template < size_t block_size, typename MappingHelper >
+  void runHipVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
+  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  void runHipVariantRAJANewReduce(VariantID vid);
 
   template < size_t work_group_size >
   void runSyclVariantImpl(VariantID vid);

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -70,6 +70,9 @@ public:
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  void runCudaVariantRAJANewReduce(VariantID vid);
+
+  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
 
   template < size_t work_group_size >

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -58,6 +58,7 @@ public:
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
   void runSyclVariant(VariantID vid, size_t tune_idx);
 
+  void setSeqTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -62,6 +62,7 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -69,14 +69,14 @@ public:
   void runCudaVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
-  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  template < size_t block_size, typename MappingHelper >
   void runCudaVariantRAJANewReduce(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runHipVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
-  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  template < size_t block_size, typename MappingHelper >
   void runHipVariantRAJANewReduce(VariantID vid);
 
   template < size_t work_group_size >

--- a/src/basic/REDUCE3_INT-Cuda.cpp
+++ b/src/basic/REDUCE3_INT-Cuda.cpp
@@ -165,7 +165,7 @@ void REDUCE3_INT::runCudaVariantRAJA(VariantID vid)
   }
 }
 
-template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+template < size_t block_size, typename MappingHelper >
 void REDUCE3_INT::runCudaVariantRAJANewReduce(VariantID vid)
 {
   using exec_policy = std::conditional_t<MappingHelper::direct,
@@ -256,12 +256,9 @@ void REDUCE3_INT::runCudaVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              auto algorithm_helper = gpu_algorithm::block_device_helper{};
               setBlockSize(block_size);
               runCudaVariantRAJANewReduce<decltype(block_size){},
-                                          decltype(algorithm_helper),
                                           decltype(mapping_helper)>(vid);
-              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
             }
 

--- a/src/basic/REDUCE3_INT-Hip.cpp
+++ b/src/basic/REDUCE3_INT-Hip.cpp
@@ -165,6 +165,53 @@ void REDUCE3_INT::runHipVariantRAJA(VariantID vid)
   }
 }
 
+template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+void REDUCE3_INT::runHipVariantRAJANewReduce(VariantID vid)
+{
+  using exec_policy = std::conditional_t<MappingHelper::direct,
+      RAJA::hip_exec<block_size, true /*async*/>,
+      RAJA::hip_exec_occ_calc<block_size, true /*async*/>>;
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  REDUCE3_INT_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Int_type tvsum = m_vsum_init;
+      Int_type tvmin = m_vmin_init;
+      Int_type tvmax = m_vmax_init;
+
+      RAJA::forall<exec_policy>( res,
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tvsum),
+        RAJA::expt::Reduce<RAJA::operators::minimum>(&tvmin),
+        RAJA::expt::Reduce<RAJA::operators::maximum>(&tvmax),
+        [=] __device__ (Index_type i,
+                        Int_type& vsum, Int_type& vmin, Int_type& vmax) {
+          REDUCE3_INT_BODY;
+        }
+      );
+
+      m_vsum += static_cast<Int_type>(tvsum);
+      m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(tvmin));
+      m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(tvmax));
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  REDUCE3_INT : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
 void REDUCE3_INT::runHipVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
@@ -206,6 +253,18 @@ void REDUCE3_INT::runHipVariant(VariantID vid, size_t tune_idx)
               t += 1;
 
             });
+
+            if (tune_idx == t) {
+
+              auto algorithm_helper = gpu_algorithm::block_device_helper{};
+              setBlockSize(block_size);
+              runHipVariantRAJANewReduce<decltype(block_size){},
+                                         decltype(algorithm_helper),
+                                         decltype(mapping_helper)>(vid);
+
+            }
+
+            t += 1;
 
           }
 
@@ -252,6 +311,12 @@ void REDUCE3_INT::setHipTuningDefinitions(VariantID vid)
 
             });
 
+            auto algorithm_helper = gpu_algorithm::block_device_helper{};
+
+            addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      "new_"+std::to_string(block_size));
+
           }
 
         });
@@ -261,7 +326,6 @@ void REDUCE3_INT::setHipTuningDefinitions(VariantID vid)
     });
 
   }
-
 }
 
 } // end namespace basic

--- a/src/basic/REDUCE3_INT-Hip.cpp
+++ b/src/basic/REDUCE3_INT-Hip.cpp
@@ -165,7 +165,7 @@ void REDUCE3_INT::runHipVariantRAJA(VariantID vid)
   }
 }
 
-template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+template < size_t block_size, typename MappingHelper >
 void REDUCE3_INT::runHipVariantRAJANewReduce(VariantID vid)
 {
   using exec_policy = std::conditional_t<MappingHelper::direct,
@@ -256,10 +256,8 @@ void REDUCE3_INT::runHipVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              auto algorithm_helper = gpu_algorithm::block_device_helper{};
               setBlockSize(block_size);
               runHipVariantRAJANewReduce<decltype(block_size){},
-                                         decltype(algorithm_helper),
                                          decltype(mapping_helper)>(vid);
 
             }

--- a/src/basic/REDUCE3_INT-OMP.cpp
+++ b/src/basic/REDUCE3_INT-OMP.cpp
@@ -136,8 +136,7 @@ void REDUCE3_INT::runOpenMPVariant(VariantID vid, size_t tune_idx)
           m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(tvmax));
 
         }
-      }
-      stopTimer();
+        stopTimer();
 
       } else {
         getCout() << "\n  REDUCE3_INT : Unknown OpenMP tuning index = " << tune_idx << std::endl;

--- a/src/basic/REDUCE3_INT-OMP.cpp
+++ b/src/basic/REDUCE3_INT-OMP.cpp
@@ -152,6 +152,7 @@ void REDUCE3_INT::runOpenMPVariant(VariantID vid, size_t tune_idx)
 
 #else
   RAJA_UNUSED_VAR(vid);
+  RAJA_UNUSED_VAR(tune_idx);
 #endif
 }
 

--- a/src/basic/REDUCE3_INT-OMP.cpp
+++ b/src/basic/REDUCE3_INT-OMP.cpp
@@ -112,9 +112,7 @@ void REDUCE3_INT::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      } 
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -140,6 +138,10 @@ void REDUCE3_INT::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
       }
       stopTimer();
+
+      } else {
+        getCout() << "\n  REDUCE3_INT : Unknown OpenMP tuning index = " << tune_idx << std::endl;
+      }
 
       break;
     }

--- a/src/basic/REDUCE3_INT-OMP.cpp
+++ b/src/basic/REDUCE3_INT-OMP.cpp
@@ -19,7 +19,7 @@ namespace basic
 {
 
 
-void REDUCE3_INT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void REDUCE3_INT::runOpenMPVariant(VariantID vid, size_t tune_idx)
 {
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
 
@@ -91,22 +91,53 @@ void REDUCE3_INT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tun
 
     case RAJA_OpenMP : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
 
-        RAJA::ReduceSum<RAJA::omp_reduce, Int_type> vsum(m_vsum_init);
-        RAJA::ReduceMin<RAJA::omp_reduce, Int_type> vmin(m_vmin_init);
-        RAJA::ReduceMax<RAJA::omp_reduce, Int_type> vmax(m_vmax_init);
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::omp_parallel_for_exec>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          REDUCE3_INT_BODY_RAJA;
-        });
+          RAJA::ReduceSum<RAJA::omp_reduce, Int_type> vsum(m_vsum_init);
+          RAJA::ReduceMin<RAJA::omp_reduce, Int_type> vmin(m_vmin_init);
+          RAJA::ReduceMax<RAJA::omp_reduce, Int_type> vmax(m_vmax_init);
+  
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+            REDUCE3_INT_BODY_RAJA;
+          });
 
-        m_vsum += static_cast<Int_type>(vsum.get());
-        m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
-        m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
+          m_vsum += static_cast<Int_type>(vsum.get());
+          m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
+          m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
 
+        }
+        stopTimer();
+
+      } 
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Int_type tvsum = m_vsum_init;
+          Int_type tvmin = m_vmin_init;
+          Int_type tvmax = m_vmax_init;
+
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tvsum),
+            RAJA::expt::Reduce<RAJA::operators::minimum>(&tvmin),
+            RAJA::expt::Reduce<RAJA::operators::maximum>(&tvmax),
+            [=](Index_type i, Int_type& vsum, Int_type& vmin, Int_type& vmax) {
+              REDUCE3_INT_BODY;
+            }
+          );
+
+          m_vsum += static_cast<Int_type>(tvsum);
+          m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(tvmin));
+          m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(tvmax));
+
+        }
       }
       stopTimer();
 
@@ -122,6 +153,14 @@ void REDUCE3_INT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tun
 #else
   RAJA_UNUSED_VAR(vid);
 #endif
+}
+
+void REDUCE3_INT::setOpenMPTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMP) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace basic

--- a/src/basic/REDUCE3_INT-OMPTarget.cpp
+++ b/src/basic/REDUCE3_INT-OMPTarget.cpp
@@ -27,7 +27,7 @@ namespace basic
   const size_t threads_per_team = 256;
 
 
-void REDUCE3_INT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void REDUCE3_INT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -62,28 +62,71 @@ void REDUCE3_INT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_A
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+    if (tune_idx == 0) {
 
-      RAJA::ReduceSum<RAJA::omp_target_reduce, Int_type> vsum(m_vsum_init);
-      RAJA::ReduceMin<RAJA::omp_target_reduce, Int_type> vmin(m_vmin_init);
-      RAJA::ReduceMax<RAJA::omp_target_reduce, Int_type> vmax(m_vmax_init);
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-        RAJA::RangeSegment(ibegin, iend),
-        [=](Index_type i) {
-        REDUCE3_INT_BODY_RAJA;
-      });
+        Int_type tvsum = m_vsum_init;
+        Int_type tvmin = m_vmin_init;
+        Int_type tvmax = m_vmax_init;
 
-      m_vsum += static_cast<Real_type>(vsum.get());
-      m_vmin = RAJA_MIN(m_vmin, static_cast<Real_type>(vmin.get()));
-      m_vmax = RAJA_MAX(m_vmax, static_cast<Real_type>(vmax.get()));
+        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+          RAJA::RangeSegment(ibegin, iend),
+          RAJA::expt::Reduce<RAJA::operators::plus>(&tvsum),
+          RAJA::expt::Reduce<RAJA::operators::minimum>(&tvmin),
+          RAJA::expt::Reduce<RAJA::operators::maximum>(&tvmax),
+          [=](Index_type i, Int_type& vsum, Int_type& vmin, Int_type& vmax) {
+            REDUCE3_INT_BODY;
+          }
+        );
+
+        m_vsum += static_cast<Real_type>(tvsum);
+        m_vmin = RAJA_MIN(m_vmin, static_cast<Real_type>(tvmin));
+        m_vmax = RAJA_MAX(m_vmax, static_cast<Real_type>(tvmax));
+
+      }
+      stopTimer();
 
     }
-    stopTimer();
+
+    if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Int_type tvsum = m_vsum_init;
+          Int_type tvmin = m_vmin_init;
+          Int_type tvmax = m_vmax_init;
+
+          RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tvsum),
+            RAJA::expt::Reduce<RAJA::operators::minimum>(&tvmin),
+            RAJA::expt::Reduce<RAJA::operators::maximum>(&tvmax),
+            [=](Index_type i, Int_type& vsum, Int_type& vmin, Int_type& vmax) {
+              REDUCE3_INT_BODY;
+            }
+          );
+
+          m_vsum += static_cast<Int_type>(tvsum);
+          m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(tvmin));
+          m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(tvmax));
+
+        }
+      }
+      stopTimer();
 
   } else {
      getCout() << "\n  REDUCE3_INT : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+void REDUCE3_INT::setOpenMPTargetTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMPTarget) {
+    addVariantTuningName(vid, "new");
   }
 }
 

--- a/src/basic/REDUCE3_INT-Seq.cpp
+++ b/src/basic/REDUCE3_INT-Seq.cpp
@@ -108,9 +108,7 @@ void REDUCE3_INT::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      } 
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -136,6 +134,8 @@ void REDUCE3_INT::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  REDUCE3_INT : Unknown Seq tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/basic/REDUCE3_INT-Seq.cpp
+++ b/src/basic/REDUCE3_INT-Seq.cpp
@@ -19,8 +19,11 @@ namespace basic
 {
 
 
-void REDUCE3_INT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void REDUCE3_INT::runSeqVariant(VariantID vid, size_t tune_idx)
 {
+#if !defined(RUN_RAJA_SEQ)
+  RAJA_UNUSED_VAR(tune_idx);
+#endif
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
@@ -84,24 +87,56 @@ void REDUCE3_INT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_i
 
     case RAJA_Seq : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
 
-        RAJA::ReduceSum<RAJA::seq_reduce, Int_type> vsum(m_vsum_init);
-        RAJA::ReduceMin<RAJA::seq_reduce, Int_type> vmin(m_vmin_init);
-        RAJA::ReduceMax<RAJA::seq_reduce, Int_type> vmax(m_vmax_init);
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::seq_exec>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          REDUCE3_INT_BODY_RAJA;
-        });
+          RAJA::ReduceSum<RAJA::seq_reduce, Int_type> vsum(m_vsum_init);
+          RAJA::ReduceMin<RAJA::seq_reduce, Int_type> vmin(m_vmin_init);
+          RAJA::ReduceMax<RAJA::seq_reduce, Int_type> vmax(m_vmax_init);
+  
+          RAJA::forall<RAJA::seq_exec>(
+            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+            REDUCE3_INT_BODY_RAJA;
+          });
+  
+          m_vsum += static_cast<Int_type>(vsum.get());
+          m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
+          m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
+  
+        }
+        stopTimer();
 
-        m_vsum += static_cast<Int_type>(vsum.get());
-        m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
-        m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
+      } 
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Int_type tvsum = m_vsum_init; 
+          Int_type tvmin = m_vmin_init; 
+          Int_type tvmax = m_vmax_init; 
+
+          RAJA::forall<RAJA::seq_exec>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tvsum),
+            RAJA::expt::Reduce<RAJA::operators::minimum>(&tvmin),
+            RAJA::expt::Reduce<RAJA::operators::maximum>(&tvmax),
+            [=](Index_type i, Int_type& vsum, Int_type& vmin, Int_type& vmax) {
+              REDUCE3_INT_BODY;
+            }
+          );
+
+          m_vsum += static_cast<Int_type>(tvsum);
+          m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(tvmin));
+          m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(tvmax));
+
+        }
+        stopTimer();
 
       }
-      stopTimer();
 
       break;
     }
@@ -113,6 +148,14 @@ void REDUCE3_INT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_i
 
   }
 
+}
+
+void REDUCE3_INT::setSeqTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_Seq) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace basic

--- a/src/basic/REDUCE3_INT.hpp
+++ b/src/basic/REDUCE3_INT.hpp
@@ -85,14 +85,14 @@ public:
   void runCudaVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
-  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  template < size_t block_size, typename MappingHelper >
   void runCudaVariantRAJANewReduce(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runHipVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
-  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  template < size_t block_size, typename MappingHelper >
   void runHipVariantRAJANewReduce(VariantID vid);
 
   template < size_t work_group_size > 

--- a/src/basic/REDUCE3_INT.hpp
+++ b/src/basic/REDUCE3_INT.hpp
@@ -74,19 +74,26 @@ public:
 
   void runKokkosVariant(VariantID vid, size_t tune_idx);
 
+  void setSeqTuningDefinitions(VariantID vid);
+  void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid); 
   void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runCudaVariantBase(VariantID vid);
-  template < size_t block_size, typename MappingHelper >
-  void runHipVariantBase(VariantID vid);
-
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  void runCudaVariantRAJANewReduce(VariantID vid);
+
+  template < size_t block_size, typename MappingHelper >
+  void runHipVariantBase(VariantID vid);
+  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
+  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  void runHipVariantRAJANewReduce(VariantID vid);
 
   template < size_t work_group_size > 
   void runSyclVariantImpl(VariantID vid);

--- a/src/basic/REDUCE_STRUCT-Cuda.cpp
+++ b/src/basic/REDUCE_STRUCT-Cuda.cpp
@@ -207,6 +207,65 @@ void REDUCE_STRUCT::runCudaVariantRAJA(VariantID vid)
 
 }
 
+template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+void REDUCE_STRUCT::runCudaVariantRAJANewReduce(VariantID vid)
+{
+  using exec_policy = std::conditional_t<MappingHelper::direct,
+      RAJA::cuda_exec<block_size, true /*async*/>,
+      RAJA::cuda_exec_occ_calc<block_size, true /*async*/>>;
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  REDUCE_STRUCT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type txsum = m_init_sum;
+      Real_type tysum = m_init_sum;
+      Real_type txmin = m_init_min;
+      Real_type tymin = m_init_min;
+      Real_type txmax = m_init_max;
+      Real_type tymax = m_init_max;
+
+      RAJA::forall<exec_policy>(
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&txsum),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tysum),
+        RAJA::expt::Reduce<RAJA::operators::minimum>(&txmin),
+        RAJA::expt::Reduce<RAJA::operators::minimum>(&tymin),
+        RAJA::expt::Reduce<RAJA::operators::maximum>(&txmax),
+        RAJA::expt::Reduce<RAJA::operators::maximum>(&tymax),
+        [=] __device__ (Index_type i, Real_type& xsum, Real_type& ysum,
+                                      Real_type& xmin, Real_type& ymin,
+                                      Real_type& xmax, Real_type& ymax) {
+          REDUCE_STRUCT_BODY;
+        }
+      );
+
+      points.SetCenter(static_cast<Real_type>(txsum)/(points.N),
+                       static_cast<Real_type>(tysum)/(points.N));
+      points.SetXMin(static_cast<Real_type>(txmin));
+      points.SetXMax(static_cast<Real_type>(txmax));
+      points.SetYMin(static_cast<Real_type>(tymin));
+      points.SetYMax(static_cast<Real_type>(tymax));
+      m_points = points;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  REDUCE_STRUCT : Unknown CUDA variant id = " << vid << std::endl;
+  }
+
+}
+
 void REDUCE_STRUCT::runCudaVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
@@ -249,6 +308,19 @@ void REDUCE_STRUCT::runCudaVariant(VariantID vid, size_t tune_idx)
 
             });
 
+            if (tune_idx == t) {
+
+              auto algorithm_helper = gpu_algorithm::block_device_helper{};
+              setBlockSize(block_size);
+              runCudaVariantRAJANewReduce<decltype(block_size){},
+                                          decltype(algorithm_helper),
+                                          decltype(mapping_helper)>(vid);
+              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
+
+            }
+
+            t += 1;
+
           }
 
         });
@@ -283,6 +355,7 @@ void REDUCE_STRUCT::setCudaTuningDefinitions(VariantID vid)
             addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
                                       decltype(mapping_helper)::get_name()+"_"+
                                       std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
           } else if ( vid == RAJA_CUDA ) {
 
@@ -293,6 +366,13 @@ void REDUCE_STRUCT::setCudaTuningDefinitions(VariantID vid)
                                         std::to_string(block_size));
 
             });
+
+            auto algorithm_helper = gpu_algorithm::block_device_helper{};
+
+            addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      "new_"+std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
           }
 

--- a/src/basic/REDUCE_STRUCT-Cuda.cpp
+++ b/src/basic/REDUCE_STRUCT-Cuda.cpp
@@ -207,7 +207,7 @@ void REDUCE_STRUCT::runCudaVariantRAJA(VariantID vid)
 
 }
 
-template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+template < size_t block_size, typename MappingHelper >
 void REDUCE_STRUCT::runCudaVariantRAJANewReduce(VariantID vid)
 {
   using exec_policy = std::conditional_t<MappingHelper::direct,
@@ -310,12 +310,9 @@ void REDUCE_STRUCT::runCudaVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              auto algorithm_helper = gpu_algorithm::block_device_helper{};
               setBlockSize(block_size);
               runCudaVariantRAJANewReduce<decltype(block_size){},
-                                          decltype(algorithm_helper),
                                           decltype(mapping_helper)>(vid);
-              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
             }
 

--- a/src/basic/REDUCE_STRUCT-Hip.cpp
+++ b/src/basic/REDUCE_STRUCT-Hip.cpp
@@ -141,7 +141,7 @@ void REDUCE_STRUCT::runHipVariantBase(VariantID vid)
       points.SetXMax(rmem[2]);
       points.SetYMin(rmem[4]);
       points.SetYMax(rmem[5]);
-      m_points=points;
+      m_points = points;
 
     }
     stopTimer();
@@ -196,13 +196,72 @@ void REDUCE_STRUCT::runHipVariantRAJA(VariantID vid)
       points.SetXMax((xmax.get()));
       points.SetYMin((ymin.get()));
       points.SetYMax((ymax.get()));
-      m_points=points;
+      m_points = points;
 
     }
     stopTimer();
 
   } else {
      getCout() << "\n  REDUCE_STRUCT : Unknown Hip variant id = " << vid << std::endl;
+  }
+
+}
+
+template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+void REDUCE_STRUCT::runHipVariantRAJANewReduce(VariantID vid)
+{
+  using exec_policy = std::conditional_t<MappingHelper::direct,
+      RAJA::hip_exec<block_size, true /*async*/>,
+      RAJA::hip_exec_occ_calc<block_size, true /*async*/>>;
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  REDUCE_STRUCT_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type txsum = m_init_sum;
+      Real_type tysum = m_init_sum;
+      Real_type txmin = m_init_min;
+      Real_type tymin = m_init_min;
+      Real_type txmax = m_init_max;
+      Real_type tymax = m_init_max;
+
+      RAJA::forall<exec_policy>( res,
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&txsum),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tysum),
+        RAJA::expt::Reduce<RAJA::operators::minimum>(&txmin),
+        RAJA::expt::Reduce<RAJA::operators::minimum>(&tymin),
+        RAJA::expt::Reduce<RAJA::operators::maximum>(&txmax),
+        RAJA::expt::Reduce<RAJA::operators::maximum>(&tymax),
+        [=] __device__ (Index_type i, Real_type& xsum, Real_type& ysum,
+                                      Real_type& xmin, Real_type& ymin,
+                                      Real_type& xmax, Real_type& ymax) {
+          REDUCE_STRUCT_BODY;
+        }
+      );
+
+      points.SetCenter(static_cast<Real_type>(txsum)/(points.N),
+                       static_cast<Real_type>(tysum)/(points.N));
+      points.SetXMin(static_cast<Real_type>(txmin));
+      points.SetXMax(static_cast<Real_type>(txmax));
+      points.SetYMin(static_cast<Real_type>(tymin));
+      points.SetYMax(static_cast<Real_type>(tymax));
+      m_points = points;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  REDUCE_STRUCT : Unknown HIP variant id = " << vid << std::endl;
   }
 
 }
@@ -249,6 +308,18 @@ void REDUCE_STRUCT::runHipVariant(VariantID vid, size_t tune_idx)
 
             });
 
+            if (tune_idx == t) {
+
+              auto algorithm_helper = gpu_algorithm::block_device_helper{};
+              setBlockSize(block_size);
+              runHipVariantRAJANewReduce<decltype(block_size){},
+                                         decltype(algorithm_helper),
+                                         decltype(mapping_helper)>(vid);
+
+            }
+
+            t += 1;
+
           }
 
         });
@@ -293,6 +364,12 @@ void REDUCE_STRUCT::setHipTuningDefinitions(VariantID vid)
                                         std::to_string(block_size));
 
             });
+
+            auto algorithm_helper = gpu_algorithm::block_device_helper{};
+
+            addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      "new_"+std::to_string(block_size));
 
           }
 

--- a/src/basic/REDUCE_STRUCT-Hip.cpp
+++ b/src/basic/REDUCE_STRUCT-Hip.cpp
@@ -207,7 +207,7 @@ void REDUCE_STRUCT::runHipVariantRAJA(VariantID vid)
 
 }
 
-template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+template < size_t block_size, typename MappingHelper >
 void REDUCE_STRUCT::runHipVariantRAJANewReduce(VariantID vid)
 {
   using exec_policy = std::conditional_t<MappingHelper::direct,
@@ -310,10 +310,8 @@ void REDUCE_STRUCT::runHipVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              auto algorithm_helper = gpu_algorithm::block_device_helper{};
               setBlockSize(block_size);
               runHipVariantRAJANewReduce<decltype(block_size){},
-                                         decltype(algorithm_helper),
                                          decltype(mapping_helper)>(vid);
 
             }

--- a/src/basic/REDUCE_STRUCT-OMP.cpp
+++ b/src/basic/REDUCE_STRUCT-OMP.cpp
@@ -19,7 +19,7 @@ namespace basic
 {
 
 
-void REDUCE_STRUCT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void REDUCE_STRUCT::runOpenMPVariant(VariantID vid, size_t tune_idx)
 {
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
 
@@ -55,7 +55,7 @@ void REDUCE_STRUCT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
         points.SetXMax(xmax);
         points.SetYMin(ymin); 
         points.SetYMax(ymax);
-        m_points=points;
+        m_points = points;
 
       }
       stopTimer();
@@ -100,7 +100,7 @@ void REDUCE_STRUCT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
         points.SetXMax(xmax);
         points.SetYMin(ymin);
         points.SetYMax(ymax);
-        m_points=points;
+        m_points = points;
 
       } 
       stopTimer();
@@ -110,31 +110,75 @@ void REDUCE_STRUCT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
 
     case RAJA_OpenMP : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
  
-        RAJA::ReduceSum<RAJA::omp_reduce, Real_type> xsum(m_init_sum);
-        RAJA::ReduceSum<RAJA::omp_reduce, Real_type> ysum(m_init_sum);
-        RAJA::ReduceMin<RAJA::omp_reduce, Real_type> xmin(m_init_min); 
-        RAJA::ReduceMin<RAJA::omp_reduce, Real_type> ymin(m_init_min);
-        RAJA::ReduceMax<RAJA::omp_reduce, Real_type> xmax(m_init_max); 
-        RAJA::ReduceMax<RAJA::omp_reduce, Real_type> ymax(m_init_max);
+          RAJA::ReduceSum<RAJA::omp_reduce, Real_type> xsum(m_init_sum);
+          RAJA::ReduceSum<RAJA::omp_reduce, Real_type> ysum(m_init_sum);
+          RAJA::ReduceMin<RAJA::omp_reduce, Real_type> xmin(m_init_min); 
+          RAJA::ReduceMin<RAJA::omp_reduce, Real_type> ymin(m_init_min);
+          RAJA::ReduceMax<RAJA::omp_reduce, Real_type> xmax(m_init_max); 
+          RAJA::ReduceMax<RAJA::omp_reduce, Real_type> ymax(m_init_max);
 
-        RAJA::forall<RAJA::omp_parallel_for_exec>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          REDUCE_STRUCT_BODY_RAJA;
-        });
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+              REDUCE_STRUCT_BODY_RAJA;
+          });
+  
+          points.SetCenter((xsum.get()/(points.N)),
+                           (ysum.get()/(points.N)));
+          points.SetXMin((xmin.get())); 
+          points.SetXMax((xmax.get()));
+          points.SetYMin((ymin.get())); 
+          points.SetYMax((ymax.get()));
+          m_points = points;
 
-        points.SetCenter((xsum.get()/(points.N)),
-                         (ysum.get()/(points.N)));
-        points.SetXMin((xmin.get())); 
-        points.SetXMax((xmax.get()));
-        points.SetYMin((ymin.get())); 
-        points.SetYMax((ymax.get()));
-        m_points=points;
+        }
+        stopTimer();
 
       }
-      stopTimer();
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type txsum = m_init_sum;
+          Real_type tysum = m_init_sum;
+          Real_type txmin = m_init_min;
+          Real_type tymin = m_init_min;
+          Real_type txmax = m_init_max;
+          Real_type tymax = m_init_max;
+
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&txsum),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tysum),
+            RAJA::expt::Reduce<RAJA::operators::minimum>(&txmin),
+            RAJA::expt::Reduce<RAJA::operators::minimum>(&tymin),
+            RAJA::expt::Reduce<RAJA::operators::maximum>(&txmax),
+            RAJA::expt::Reduce<RAJA::operators::maximum>(&tymax),
+            [=](Index_type i, Real_type& xsum, Real_type& ysum,
+                              Real_type& xmin, Real_type& ymin,
+                              Real_type& xmax, Real_type& ymax) {
+              REDUCE_STRUCT_BODY;
+            }
+          );
+
+          points.SetCenter(static_cast<Real_type>(txsum)/(points.N),
+                           static_cast<Real_type>(tysum)/(points.N));
+          points.SetXMin(static_cast<Real_type>(txmin));
+          points.SetXMax(static_cast<Real_type>(txmax));
+          points.SetYMin(static_cast<Real_type>(tymin));
+          points.SetYMax(static_cast<Real_type>(tymax));
+          m_points = points;
+
+        }
+        stopTimer();
+
+      }
 
       break;
     }
@@ -148,6 +192,14 @@ void REDUCE_STRUCT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
 #else 
   RAJA_UNUSED_VAR(vid);
 #endif
+}
+
+void REDUCE_STRUCT::setOpenMPTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMP) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace basic

--- a/src/basic/REDUCE_STRUCT-OMP.cpp
+++ b/src/basic/REDUCE_STRUCT-OMP.cpp
@@ -191,6 +191,7 @@ void REDUCE_STRUCT::runOpenMPVariant(VariantID vid, size_t tune_idx)
 
 #else 
   RAJA_UNUSED_VAR(vid);
+  RAJA_UNUSED_VAR(tune_idx);
 #endif
 }
 

--- a/src/basic/REDUCE_STRUCT-OMP.cpp
+++ b/src/basic/REDUCE_STRUCT-OMP.cpp
@@ -138,9 +138,7 @@ void REDUCE_STRUCT::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -178,6 +176,8 @@ void REDUCE_STRUCT::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  REDUCE_STRUCT : Unknown OpenMP tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/basic/REDUCE_STRUCT-OMPTarget.cpp
+++ b/src/basic/REDUCE_STRUCT-OMPTarget.cpp
@@ -27,8 +27,7 @@ namespace basic
   const size_t threads_per_team = 256;
 
 
-void REDUCE_STRUCT::runOpenMPTargetVariant(VariantID vid, 
-                                           size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void REDUCE_STRUCT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -36,78 +35,140 @@ void REDUCE_STRUCT::runOpenMPTargetVariant(VariantID vid,
 
   REDUCE_STRUCT_DATA_SETUP;
 
-  if ( vid == Base_OpenMPTarget ) {
+  switch ( vid ) {
 
-    Real_ptr xa = points.x;
-    Real_ptr ya = points.y;
+    case Base_OpenMPTarget : {
 
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      Real_ptr xa = points.x;
+      Real_ptr ya = points.y;
 
-      Real_type xsum = m_init_sum; Real_type ysum = m_init_sum;
-      Real_type xmin = m_init_min; Real_type ymin = m_init_min;
-      Real_type xmax = m_init_max; Real_type ymax = m_init_max;
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      #pragma omp target is_device_ptr(xa, ya) device( did ) map(tofrom:xsum, xmin, xmax, ysum, ymin, ymax)
-      #pragma omp teams distribute parallel for thread_limit(threads_per_team) schedule(static,1) \
+        Real_type xsum = m_init_sum; Real_type ysum = m_init_sum;
+        Real_type xmin = m_init_min; Real_type ymin = m_init_min;
+        Real_type xmax = m_init_max; Real_type ymax = m_init_max;
+
+        #pragma omp target is_device_ptr(xa, ya) device( did ) \
+                           map(tofrom:xsum, xmin, xmax, ysum, ymin, ymax)
+        #pragma omp teams distribute parallel for \
+                          thread_limit(threads_per_team) schedule(static,1) \
                                reduction(+:xsum) \
                                reduction(min:xmin) \
                                reduction(max:xmax), \
                                reduction(+:ysum), \
                                reduction(min:ymin), \
                                reduction(max:ymax)
-      for (Index_type i = ibegin; i < iend; ++i ) {
-        xsum += xa[i] ;
-        xmin = RAJA_MIN(xmin, xa[i]) ;
-        xmax = RAJA_MAX(xmax, xa[i]) ;
-        ysum += ya[i] ;
-        ymin = RAJA_MIN(ymin, ya[i]) ;
-        ymax = RAJA_MAX(ymax, ya[i]) ;
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          xsum += xa[i] ;
+          xmin = RAJA_MIN(xmin, xa[i]) ;
+          xmax = RAJA_MAX(xmax, xa[i]) ;
+          ysum += ya[i] ;
+          ymin = RAJA_MIN(ymin, ya[i]) ;
+          ymax = RAJA_MAX(ymax, ya[i]) ;
+        }
+
+        points.SetCenter(xsum/points.N, ysum/points.N);
+        points.SetXMin(xmin);
+        points.SetXMax(xmax);
+        points.SetYMin(ymin); 
+        points.SetYMax(ymax);
+        m_points = points;
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_OpenMPTarget : {
+
+      if (tune_idx == 0) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> xsum(m_init_sum);
+          RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> ysum(m_init_sum);
+          RAJA::ReduceMin<RAJA::omp_target_reduce, Real_type> xmin(m_init_min);
+          RAJA::ReduceMin<RAJA::omp_target_reduce, Real_type> ymin(m_init_min);
+          RAJA::ReduceMax<RAJA::omp_target_reduce, Real_type> xmax(m_init_max);
+          RAJA::ReduceMax<RAJA::omp_target_reduce, Real_type> ymax(m_init_max);
+
+          RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+            RAJA::RangeSegment(ibegin, iend),
+            [=](Index_type i) {
+              REDUCE_STRUCT_BODY_RAJA;
+          });
+
+          points.SetCenter(xsum.get()/(points.N),
+                           ysum.get()/(points.N));
+          points.SetXMin(xmin.get());
+          points.SetXMax(xmax.get());
+          points.SetYMin(ymin.get());
+          points.SetYMax(ymax.get());
+          m_points = points;
+
+        }
+        stopTimer();
+
       }
 
-      points.SetCenter(xsum/points.N, ysum/points.N);
-      points.SetXMin(xmin);
-      points.SetXMax(xmax);
-      points.SetYMin(ymin); 
-      points.SetYMax(ymax);
-      m_points=points;
+      if (tune_idx == 1) {
 
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type txsum = m_init_sum;
+          Real_type tysum = m_init_sum;
+          Real_type txmin = m_init_min;
+          Real_type tymin = m_init_min;
+          Real_type txmax = m_init_max;
+          Real_type tymax = m_init_max;
+
+          RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&txsum),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tysum),
+            RAJA::expt::Reduce<RAJA::operators::minimum>(&txmin),
+            RAJA::expt::Reduce<RAJA::operators::minimum>(&tymin),
+            RAJA::expt::Reduce<RAJA::operators::maximum>(&txmax),
+            RAJA::expt::Reduce<RAJA::operators::maximum>(&tymax),
+            [=](Index_type i, Real_type& xsum, Real_type& ysum,
+                              Real_type& xmin, Real_type& ymin,
+                              Real_type& xmax, Real_type& ymax) {
+              REDUCE_STRUCT_BODY;
+            }
+          );
+
+          points.SetCenter(static_cast<Real_type>(txsum)/(points.N),
+                           static_cast<Real_type>(tysum)/(points.N));
+          points.SetXMin(static_cast<Real_type>(txmin));
+          points.SetXMax(static_cast<Real_type>(txmax));
+          points.SetYMin(static_cast<Real_type>(tymin));
+          points.SetYMax(static_cast<Real_type>(tymax));
+          m_points = points;
+
+        }
+        stopTimer();
+
+      }
+
+      break;
     }
-    stopTimer();
 
-  } else if ( vid == RAJA_OpenMPTarget ) {
-
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-      RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> xsum(m_init_sum);
-      RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> ysum(m_init_sum);
-      RAJA::ReduceMin<RAJA::omp_target_reduce, Real_type> xmin(m_init_min);
-      RAJA::ReduceMin<RAJA::omp_target_reduce, Real_type> ymin(m_init_min);
-      RAJA::ReduceMax<RAJA::omp_target_reduce, Real_type> xmax(m_init_max);
-      RAJA::ReduceMax<RAJA::omp_target_reduce, Real_type> ymax(m_init_max);
-
-      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-        RAJA::RangeSegment(ibegin, iend),
-        [=](Index_type i) {
-        REDUCE_STRUCT_BODY_RAJA;
-      });
-
-      points.SetCenter(xsum.get()/(points.N),
-                       ysum.get()/(points.N));
-      points.SetXMin(xmin.get());
-      points.SetXMax(xmax.get());
-      points.SetYMin(ymin.get());
-      points.SetYMax(ymax.get());
-      m_points=points;
-
-    }
-    stopTimer();
-
-  } else {
+    default:
      getCout() << "\n  REDUCE_STRUCT : Unknown OMP Target variant id = " << vid << std::endl;
   }
 
+}
+
+void REDUCE_STRUCT::setOpenMPTargetTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMPTarget) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace basic

--- a/src/basic/REDUCE_STRUCT-OMPTarget.cpp
+++ b/src/basic/REDUCE_STRUCT-OMPTarget.cpp
@@ -112,9 +112,7 @@ void REDUCE_STRUCT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -152,6 +150,8 @@ void REDUCE_STRUCT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  REDUCE_STRUCT : Unknown OMP Target tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/basic/REDUCE_STRUCT-Seq.cpp
+++ b/src/basic/REDUCE_STRUCT-Seq.cpp
@@ -19,8 +19,11 @@ namespace basic
 {
 
 
-void REDUCE_STRUCT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void REDUCE_STRUCT::runSeqVariant(VariantID vid, size_t tune_idx)
 {
+#if !defined(RUN_RAJA_SEQ)
+  RAJA_UNUSED_VAR(tune_idx);
+#endif
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();
@@ -47,7 +50,7 @@ void REDUCE_STRUCT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
         points.SetXMax(xmax);
         points.SetYMin(ymin);
         points.SetYMax(ymax);
-        m_points=points;
+        m_points = points;
 
       }
       stopTimer();
@@ -87,7 +90,7 @@ void REDUCE_STRUCT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
         points.SetXMax(xmax);
         points.SetYMin(ymin); 
         points.SetYMax(ymax);
-        m_points=points;
+        m_points = points;
 
       }
       stopTimer();
@@ -97,31 +100,75 @@ void REDUCE_STRUCT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
 
     case RAJA_Seq : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
 
-        RAJA::ReduceSum<RAJA::seq_reduce, Real_type> xsum(m_init_sum);
-        RAJA::ReduceSum<RAJA::seq_reduce, Real_type> ysum(m_init_sum);
-        RAJA::ReduceMin<RAJA::seq_reduce, Real_type> xmin(m_init_min);
-        RAJA::ReduceMin<RAJA::seq_reduce, Real_type> ymin(m_init_min);
-        RAJA::ReduceMax<RAJA::seq_reduce, Real_type> xmax(m_init_max);
-        RAJA::ReduceMax<RAJA::seq_reduce, Real_type> ymax(m_init_max);
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+  
+          RAJA::ReduceSum<RAJA::seq_reduce, Real_type> xsum(m_init_sum);
+          RAJA::ReduceSum<RAJA::seq_reduce, Real_type> ysum(m_init_sum);
+          RAJA::ReduceMin<RAJA::seq_reduce, Real_type> xmin(m_init_min);
+          RAJA::ReduceMin<RAJA::seq_reduce, Real_type> ymin(m_init_min);
+          RAJA::ReduceMax<RAJA::seq_reduce, Real_type> xmax(m_init_max);
+          RAJA::ReduceMax<RAJA::seq_reduce, Real_type> ymax(m_init_max);
+  
+          RAJA::forall<RAJA::seq_exec>(
+            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+            REDUCE_STRUCT_BODY_RAJA;
+          });
+  
+          points.SetCenter(xsum.get()/(points.N),
+                           ysum.get()/(points.N));
+          points.SetXMin(xmin.get());
+          points.SetXMax(xmax.get());
+          points.SetYMin(ymin.get());
+          points.SetYMax(ymax.get());
+          m_points = points;
 
-        RAJA::forall<RAJA::seq_exec>(
-        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-        REDUCE_STRUCT_BODY_RAJA;
-        });
-
-      	points.SetCenter(xsum.get()/(points.N),
-                         ysum.get()/(points.N));
-        points.SetXMin(xmin.get());
-        points.SetXMax(xmax.get());
-        points.SetYMin(ymin.get());
-        points.SetYMax(ymax.get());
-        m_points=points;
+        }
+        stopTimer();
 
       }
-      stopTimer();
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type txsum = m_init_sum; 
+          Real_type tysum = m_init_sum; 
+          Real_type txmin = m_init_min; 
+          Real_type tymin = m_init_min; 
+          Real_type txmax = m_init_max; 
+          Real_type tymax = m_init_max; 
+ 
+          RAJA::forall<RAJA::seq_exec>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&txsum),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tysum),
+            RAJA::expt::Reduce<RAJA::operators::minimum>(&txmin),
+            RAJA::expt::Reduce<RAJA::operators::minimum>(&tymin),
+            RAJA::expt::Reduce<RAJA::operators::maximum>(&txmax), 
+            RAJA::expt::Reduce<RAJA::operators::maximum>(&tymax), 
+            [=](Index_type i, Real_type& xsum, Real_type& ysum,
+                              Real_type& xmin, Real_type& ymin,
+                              Real_type& xmax, Real_type& ymax) {
+              REDUCE_STRUCT_BODY;
+            }
+          );
+ 
+          points.SetCenter(static_cast<Real_type>(txsum)/(points.N),
+                           static_cast<Real_type>(tysum)/(points.N));
+          points.SetXMin(static_cast<Real_type>(txmin));
+          points.SetXMax(static_cast<Real_type>(txmax));
+          points.SetYMin(static_cast<Real_type>(tymin));
+          points.SetYMax(static_cast<Real_type>(tymax));
+          m_points = points;
+
+        }
+        stopTimer();
+
+      }
 
       break;
     }
@@ -132,7 +179,14 @@ void REDUCE_STRUCT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
     }
 
   }
+}
 
+void REDUCE_STRUCT::setSeqTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_Seq) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace basic

--- a/src/basic/REDUCE_STRUCT-Seq.cpp
+++ b/src/basic/REDUCE_STRUCT-Seq.cpp
@@ -128,9 +128,7 @@ void REDUCE_STRUCT::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -168,6 +166,8 @@ void REDUCE_STRUCT::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  REDUCE_STRUCT : Unknown Seq tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/basic/REDUCE_STRUCT.hpp
+++ b/src/basic/REDUCE_STRUCT.hpp
@@ -87,18 +87,25 @@ public:
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
 
+  void setSeqTuningDefinitions(VariantID vid);
+  void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runCudaVariantBase(VariantID vid);
-  template < size_t block_size, typename MappingHelper >
-  void runHipVariantBase(VariantID vid);
-
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  void runCudaVariantRAJANewReduce(VariantID vid);
+
+  template < size_t block_size, typename MappingHelper >
+  void runHipVariantBase(VariantID vid);
+  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
+  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  void runHipVariantRAJANewReduce(VariantID vid);
 
   struct PointsType {
     Index_type N;

--- a/src/basic/REDUCE_STRUCT.hpp
+++ b/src/basic/REDUCE_STRUCT.hpp
@@ -97,14 +97,14 @@ public:
   void runCudaVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
-  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  template < size_t block_size, typename MappingHelper >
   void runCudaVariantRAJANewReduce(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runHipVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
-  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  template < size_t block_size, typename MappingHelper >
   void runHipVariantRAJANewReduce(VariantID vid);
 
   struct PointsType {

--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -173,8 +173,7 @@ void TRAP_INT::runCudaVariantRAJANewReduce(VariantID vid)
 
       Real_type tsumx = m_sumx_init;
 
-      RAJA::forall<exec_policy>(
-        res,
+      RAJA::forall<exec_policy>( res,
         RAJA::RangeSegment(ibegin, iend),
         RAJA::expt::Reduce<RAJA::operators::plus>(&tsumx),
         [=] __device__ (Index_type i, Real_type& sumx) {

--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -151,6 +151,47 @@ void TRAP_INT::runCudaVariantRAJA(VariantID vid)
   }
 }
 
+template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+void TRAP_INT::runCudaVariantRAJANewReduce(VariantID vid)
+{
+  using exec_policy = std::conditional_t<MappingHelper::direct,
+      RAJA::cuda_exec<block_size, true /*async*/>,
+      RAJA::cuda_exec_occ_calc<block_size, true /*async*/>>;
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  TRAP_INT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type tsumx = m_sumx_init;
+
+      RAJA::forall<exec_policy>(
+        res,
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tsumx),
+        [=] __device__ (Index_type i, Real_type& sumx) {
+          TRAP_INT_BODY;
+        }
+      );
+
+      m_sumx += static_cast<Real_type>(tsumx) * h;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  TRAP_INT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
 void TRAP_INT::runCudaVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
@@ -193,6 +234,19 @@ void TRAP_INT::runCudaVariant(VariantID vid, size_t tune_idx)
 
             });
 
+            if (tune_idx == t) {
+
+              auto algorithm_helper = gpu_algorithm::block_device_helper{};
+              setBlockSize(block_size);
+              runCudaVariantRAJANewReduce<decltype(block_size){},
+                                          decltype(algorithm_helper),
+                                          decltype(mapping_helper)>(vid);
+              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
+
+            }
+
+            t += 1;
+
           }
 
         });
@@ -227,6 +281,7 @@ void TRAP_INT::setCudaTuningDefinitions(VariantID vid)
             addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
                                       decltype(mapping_helper)::get_name()+"_"+
                                       std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
           } else if ( vid == RAJA_CUDA ) {
 
@@ -237,6 +292,13 @@ void TRAP_INT::setCudaTuningDefinitions(VariantID vid)
                                         std::to_string(block_size));
 
             });
+
+            auto algorithm_helper = gpu_algorithm::block_device_helper{};
+
+            addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      "new_"+std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
           }
 

--- a/src/basic/TRAP_INT-Cuda.cpp
+++ b/src/basic/TRAP_INT-Cuda.cpp
@@ -151,7 +151,7 @@ void TRAP_INT::runCudaVariantRAJA(VariantID vid)
   }
 }
 
-template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+template < size_t block_size, typename MappingHelper >
 void TRAP_INT::runCudaVariantRAJANewReduce(VariantID vid)
 {
   using exec_policy = std::conditional_t<MappingHelper::direct,
@@ -235,12 +235,9 @@ void TRAP_INT::runCudaVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              auto algorithm_helper = gpu_algorithm::block_device_helper{};
               setBlockSize(block_size);
               runCudaVariantRAJANewReduce<decltype(block_size){},
-                                          decltype(algorithm_helper),
                                           decltype(mapping_helper)>(vid);
-              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
             }
 

--- a/src/basic/TRAP_INT-Hip.cpp
+++ b/src/basic/TRAP_INT-Hip.cpp
@@ -151,6 +151,47 @@ void TRAP_INT::runHipVariantRAJA(VariantID vid)
   }
 }
 
+template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+void TRAP_INT::runHipVariantRAJANewReduce(VariantID vid)
+{
+  using exec_policy = std::conditional_t<MappingHelper::direct,
+      RAJA::hip_exec<block_size, true /*async*/>,
+      RAJA::hip_exec_occ_calc<block_size, true /*async*/>>;
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  TRAP_INT_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      Real_type tsumx = m_sumx_init;
+
+      RAJA::forall<exec_policy>(
+        res,
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tsumx),
+        [=] __device__ (Index_type i, Real_type& sumx) {
+          TRAP_INT_BODY;
+        }
+      );
+
+      m_sumx += static_cast<Real_type>(tsumx) * h;
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  TRAP_INT : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
 void TRAP_INT::runHipVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
@@ -192,6 +233,19 @@ void TRAP_INT::runHipVariant(VariantID vid, size_t tune_idx)
               t += 1;
 
             });
+
+            if (tune_idx == t) {
+
+              auto algorithm_helper = gpu_algorithm::block_device_helper{};
+              setBlockSize(block_size);
+              runHipVariantRAJANewReduce<decltype(block_size){},
+                                          decltype(algorithm_helper),
+                                          decltype(mapping_helper)>(vid);
+              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
+
+            }
+
+            t += 1;
 
           }
 
@@ -237,6 +291,12 @@ void TRAP_INT::setHipTuningDefinitions(VariantID vid)
                                         std::to_string(block_size));
 
             });
+
+            auto algorithm_helper = gpu_algorithm::block_device_helper{};
+
+            addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      "new_"+std::to_string(block_size));
 
           }
 

--- a/src/basic/TRAP_INT-Hip.cpp
+++ b/src/basic/TRAP_INT-Hip.cpp
@@ -151,7 +151,7 @@ void TRAP_INT::runHipVariantRAJA(VariantID vid)
   }
 }
 
-template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+template < size_t block_size, typename MappingHelper >
 void TRAP_INT::runHipVariantRAJANewReduce(VariantID vid)
 {
   using exec_policy = std::conditional_t<MappingHelper::direct,
@@ -236,12 +236,9 @@ void TRAP_INT::runHipVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              auto algorithm_helper = gpu_algorithm::block_device_helper{};
               setBlockSize(block_size);
               runHipVariantRAJANewReduce<decltype(block_size){},
-                                          decltype(algorithm_helper),
                                           decltype(mapping_helper)>(vid);
-              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
             }
 

--- a/src/basic/TRAP_INT-OMP.cpp
+++ b/src/basic/TRAP_INT-OMP.cpp
@@ -20,7 +20,7 @@ namespace basic
 {
 
 
-void TRAP_INT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void TRAP_INT::runOpenMPVariant(VariantID vid, size_t tune_idx)
 {
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
 
@@ -79,20 +79,46 @@ void TRAP_INT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_i
 
     case RAJA_OpenMP : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
 
-        RAJA::ReduceSum<RAJA::omp_reduce, Real_type> sumx(m_sumx_init);
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::omp_parallel_for_exec>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          TRAP_INT_BODY;
-        });
+          RAJA::ReduceSum<RAJA::omp_reduce, Real_type> sumx(m_sumx_init);
 
-        m_sumx += static_cast<Real_type>(sumx.get()) * h;
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+            TRAP_INT_BODY;
+          });
+
+          m_sumx += static_cast<Real_type>(sumx.get()) * h;
+
+        }
+        stopTimer();
+  
+      }
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type tsumx = m_sumx_init;
+
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tsumx),
+            [=] (Index_type i, Real_type& sumx) {
+              TRAP_INT_BODY;
+            }
+          );
+
+          m_sumx += static_cast<Real_type>(tsumx) * h;
+
+        }
+        stopTimer();
 
       }
-      stopTimer();
 
       break;
     }
@@ -106,6 +132,14 @@ void TRAP_INT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_i
 #else
   RAJA_UNUSED_VAR(vid);
 #endif
+}
+
+void TRAP_INT::setOpenMPTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMP) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace basic

--- a/src/basic/TRAP_INT-OMP.cpp
+++ b/src/basic/TRAP_INT-OMP.cpp
@@ -131,6 +131,7 @@ void TRAP_INT::runOpenMPVariant(VariantID vid, size_t tune_idx)
 
 #else
   RAJA_UNUSED_VAR(vid);
+  RAJA_UNUSED_VAR(tune_idx);
 #endif
 }
 

--- a/src/basic/TRAP_INT-OMP.cpp
+++ b/src/basic/TRAP_INT-OMP.cpp
@@ -96,9 +96,7 @@ void TRAP_INT::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
   
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -118,6 +116,8 @@ void TRAP_INT::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  TRAP_INT : Unknown OpenMP tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/basic/TRAP_INT-OMPTarget.cpp
+++ b/src/basic/TRAP_INT-OMPTarget.cpp
@@ -29,7 +29,7 @@ namespace basic
   const size_t threads_per_team = 256;
 
 
-void TRAP_INT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void TRAP_INT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -46,7 +46,8 @@ void TRAP_INT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(
 
       Real_type sumx = m_sumx_init;
 
-      #pragma omp target teams distribute parallel for map(tofrom: sumx) reduction(+:sumx) \
+      #pragma omp target teams distribute parallel for \
+                         map(tofrom: sumx) reduction(+:sumx) \
                          thread_limit(threads_per_team) schedule(static, 1)
 
       for (Index_type i = ibegin; i < iend; ++i ) {
@@ -62,23 +63,57 @@ void TRAP_INT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+    if (tune_idx == 0) {
 
-      RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> sumx(m_sumx_init);
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-        TRAP_INT_BODY;
-      });
+        RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> sumx(m_sumx_init);
 
-      m_sumx += static_cast<Real_type>(sumx.get()) * h;
+        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+          TRAP_INT_BODY;
+        });
+
+        m_sumx += static_cast<Real_type>(sumx.get()) * h;
+
+      }
+      stopTimer();
 
     }
-    stopTimer();
+
+    if (tune_idx == 1) {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        Real_type tsumx = m_sumx_init;
+
+        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+          RAJA::RangeSegment(ibegin, iend),
+          RAJA::expt::Reduce<RAJA::operators::plus>(&tsumx),
+          [=] (Index_type i, Real_type& sumx) {
+            TRAP_INT_BODY;
+          }
+        );
+
+        m_sumx += static_cast<Real_type>(tsumx) * h;
+
+      }
+      stopTimer();
+
+    }
 
   } else {
      getCout() << "\n  TRAP_INT : Unknown OMP Targetvariant id = " << vid << std::endl;
+  }
+}
+
+void TRAP_INT::setOpenMPTargetTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMPTarget) {
+    addVariantTuningName(vid, "new");
   }
 }
 

--- a/src/basic/TRAP_INT-OMPTarget.cpp
+++ b/src/basic/TRAP_INT-OMPTarget.cpp
@@ -80,9 +80,7 @@ void TRAP_INT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
       }
       stopTimer();
 
-    }
-
-    if (tune_idx == 1) {
+    } else if (tune_idx == 1) {
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -102,10 +100,12 @@ void TRAP_INT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
       }
       stopTimer();
 
+    } else {
+      getCout() << "\n  TRAP_INT : Unknown OMP Target tuning index = " << tune_idx << std::endl;
     }
 
   } else {
-     getCout() << "\n  TRAP_INT : Unknown OMP Targetvariant id = " << vid << std::endl;
+     getCout() << "\n  TRAP_INT : Unknown OMP Target variant id = " << vid << std::endl;
   }
 }
 

--- a/src/basic/TRAP_INT-Seq.cpp
+++ b/src/basic/TRAP_INT-Seq.cpp
@@ -20,7 +20,7 @@ namespace basic
 {
 
 
-void TRAP_INT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void TRAP_INT::runSeqVariant(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -76,20 +76,46 @@ void TRAP_INT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx)
 
     case RAJA_Seq : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
 
-        RAJA::ReduceSum<RAJA::seq_reduce, Real_type> sumx(m_sumx_init);
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::seq_exec>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          TRAP_INT_BODY;
-        });
+          RAJA::ReduceSum<RAJA::seq_reduce, Real_type> sumx(m_sumx_init);
 
-        m_sumx += static_cast<Real_type>(sumx.get()) * h;
+          RAJA::forall<RAJA::seq_exec>(
+            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+            TRAP_INT_BODY;
+          });
+
+          m_sumx += static_cast<Real_type>(sumx.get()) * h;
+
+        }
+        stopTimer();
 
       }
-      stopTimer();
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type tsumx = m_sumx_init;
+
+          RAJA::forall<RAJA::seq_exec>( 
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tsumx),
+            [=] (Index_type i, Real_type& sumx) {
+              TRAP_INT_BODY;
+            }
+          );
+
+          m_sumx += static_cast<Real_type>(tsumx) * h;
+
+        }
+        stopTimer();
+
+      }
 
       break;
     }
@@ -101,6 +127,14 @@ void TRAP_INT::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx)
 
   }
 
+}
+
+void TRAP_INT::setSeqTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_Seq) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace basic

--- a/src/basic/TRAP_INT-Seq.cpp
+++ b/src/basic/TRAP_INT-Seq.cpp
@@ -22,6 +22,9 @@ namespace basic
 
 void TRAP_INT::runSeqVariant(VariantID vid, size_t tune_idx)
 {
+#if !defined(RUN_RAJA_SEQ)
+  RAJA_UNUSED_VAR(tune_idx);
+#endif
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
   const Index_type iend = getActualProblemSize();

--- a/src/basic/TRAP_INT-Seq.cpp
+++ b/src/basic/TRAP_INT-Seq.cpp
@@ -96,9 +96,7 @@ void TRAP_INT::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -118,6 +116,8 @@ void TRAP_INT::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  TRAP_INT : Unknown Seq tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/basic/TRAP_INT.hpp
+++ b/src/basic/TRAP_INT.hpp
@@ -82,14 +82,14 @@ public:
   void runCudaVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
-  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  template < size_t block_size, typename MappingHelper >
   void runCudaVariantRAJANewReduce(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runHipVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
-  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  template < size_t block_size, typename MappingHelper >
   void runHipVariantRAJANewReduce(VariantID vid);
 
   template < size_t work_group_size >

--- a/src/basic/TRAP_INT.hpp
+++ b/src/basic/TRAP_INT.hpp
@@ -71,19 +71,26 @@ public:
 
   void runKokkosVariant(VariantID vid, size_t tune_idx);
 
+  void setSeqTuningDefinitions(VariantID vid);
+  void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runCudaVariantBase(VariantID vid);
-  template < size_t block_size, typename MappingHelper >
-  void runHipVariantBase(VariantID vid);
-
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  void runCudaVariantRAJANewReduce(VariantID vid);
+
+  template < size_t block_size, typename MappingHelper >
+  void runHipVariantBase(VariantID vid);
+  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
+  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  void runHipVariantRAJANewReduce(VariantID vid);
 
   template < size_t work_group_size >
   void runSyclVariantImpl(VariantID vid);

--- a/src/comm/HALO_PACKING_FUSED-Seq.cpp
+++ b/src/comm/HALO_PACKING_FUSED-Seq.cpp
@@ -189,14 +189,14 @@ void HALO_PACKING_FUSED::runSeqVariantDirect(VariantID vid)
 template < typename dispatch_helper >
 void HALO_PACKING_FUSED::runSeqVariantWorkGroup(VariantID vid)
 {
-  const Index_type run_reps = getRunReps();
-
-  HALO_PACKING_FUSED_DATA_SETUP;
-
   switch ( vid ) {
 
-#if defined(RUN_RAJA_SEQ)
     case RAJA_Seq : {
+
+#if defined(RUN_RAJA_SEQ)
+      const Index_type run_reps = getRunReps();
+
+      HALO_PACKING_FUSED_DATA_SETUP;
 
       using AllocatorHolder = RAJAPoolAllocatorHolder<
         RAJA::basic_mempool::MemPool<RAJA::basic_mempool::generic_allocator>>;
@@ -281,10 +281,10 @@ void HALO_PACKING_FUSED::runSeqVariantWorkGroup(VariantID vid)
 
       }
       stopTimer();
+#endif // RUN_RAJA_SEQ
 
       break;
     }
-#endif // RUN_RAJA_SEQ
 
     default : {
       getCout() << "\n HALO_PACKING_FUSED : Unknown variant id = " << vid << std::endl;

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -160,6 +160,7 @@ void KernelBase::setVariantDefined(VariantID vid)
     case Base_CUDA :
     case Lambda_CUDA :
     case RAJA_CUDA :
+    case RAJA_CUDA_NewReduce :
     {
 #if defined(RAJA_ENABLE_CUDA)
       setCudaTuningDefinitions(vid);
@@ -239,6 +240,7 @@ DataSpace KernelBase::getDataSpace(VariantID vid) const
     case Base_CUDA :
     case Lambda_CUDA :
     case RAJA_CUDA :
+    case RAJA_CUDA_NewReduce :
       return run_params.getCudaDataSpace();
 
     case Base_HIP :
@@ -279,6 +281,7 @@ DataSpace KernelBase::getMPIDataSpace(VariantID vid) const
     case Base_CUDA :
     case Lambda_CUDA :
     case RAJA_CUDA :
+    case RAJA_CUDA_NewReduce :
       return run_params.getCudaMPIDataSpace();
 
     case Base_HIP :
@@ -319,6 +322,7 @@ DataSpace KernelBase::getReductionDataSpace(VariantID vid) const
     case Base_CUDA :
     case Lambda_CUDA :
     case RAJA_CUDA :
+    case RAJA_CUDA_NewReduce :
       return run_params.getCudaReductionDataSpace();
 
     case Base_HIP :
@@ -421,6 +425,7 @@ void KernelBase::runKernel(VariantID vid, size_t tune_idx)
     case Base_CUDA :
     case Lambda_CUDA :
     case RAJA_CUDA :
+    case RAJA_CUDA_NewReduce :
     {
 #if defined(RAJA_ENABLE_CUDA)
       runCudaVariant(vid, tune_idx);

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -160,7 +160,6 @@ void KernelBase::setVariantDefined(VariantID vid)
     case Base_CUDA :
     case Lambda_CUDA :
     case RAJA_CUDA :
-    case RAJA_CUDA_NewReduce :
     {
 #if defined(RAJA_ENABLE_CUDA)
       setCudaTuningDefinitions(vid);
@@ -240,7 +239,6 @@ DataSpace KernelBase::getDataSpace(VariantID vid) const
     case Base_CUDA :
     case Lambda_CUDA :
     case RAJA_CUDA :
-    case RAJA_CUDA_NewReduce :
       return run_params.getCudaDataSpace();
 
     case Base_HIP :
@@ -281,7 +279,6 @@ DataSpace KernelBase::getMPIDataSpace(VariantID vid) const
     case Base_CUDA :
     case Lambda_CUDA :
     case RAJA_CUDA :
-    case RAJA_CUDA_NewReduce :
       return run_params.getCudaMPIDataSpace();
 
     case Base_HIP :
@@ -322,7 +319,6 @@ DataSpace KernelBase::getReductionDataSpace(VariantID vid) const
     case Base_CUDA :
     case Lambda_CUDA :
     case RAJA_CUDA :
-    case RAJA_CUDA_NewReduce :
       return run_params.getCudaReductionDataSpace();
 
     case Base_HIP :
@@ -425,7 +421,6 @@ void KernelBase::runKernel(VariantID vid, size_t tune_idx)
     case Base_CUDA :
     case Lambda_CUDA :
     case RAJA_CUDA :
-    case RAJA_CUDA_NewReduce :
     {
 #if defined(RAJA_ENABLE_CUDA)
       runCudaVariant(vid, tune_idx);

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -266,8 +266,7 @@ public:
 #if defined(RAJA_ENABLE_CUDA)
     if ( running_variant == Base_CUDA ||
          running_variant == Lambda_CUDA ||
-         running_variant == RAJA_CUDA ||
-         running_variant == RAJA_CUDA_NewReduce ) {
+         running_variant == RAJA_CUDA ) {
       cudaErrchk( cudaDeviceSynchronize() );
     }
 #endif

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -266,7 +266,8 @@ public:
 #if defined(RAJA_ENABLE_CUDA)
     if ( running_variant == Base_CUDA ||
          running_variant == Lambda_CUDA ||
-         running_variant == RAJA_CUDA ) {
+         running_variant == RAJA_CUDA ||
+         running_variant == RAJA_CUDA_NewReduce ) {
       cudaErrchk( cudaDeviceSynchronize() );
     }
 #endif

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -304,6 +304,7 @@ static const std::string VariantNames [] =
   std::string("Base_CUDA"),
   std::string("Lambda_CUDA"),
   std::string("RAJA_CUDA"),
+  std::string("RAJA_CUDA_NewReduce"),
 
   std::string("Base_HIP"),
   std::string("Lambda_HIP"),
@@ -501,7 +502,8 @@ bool isVariantAvailable(VariantID vid)
 #if defined(RAJA_ENABLE_CUDA)
   if ( vid == Base_CUDA ||
        vid == Lambda_CUDA ||
-       vid == RAJA_CUDA ) {
+       vid == RAJA_CUDA ||
+       vid == RAJA_CUDA_NewReduce ) {
     ret_val = true;
   }
 #endif
@@ -569,7 +571,8 @@ bool isVariantGPU(VariantID vid)
 #if defined(RAJA_ENABLE_CUDA)
   if ( vid == Base_CUDA ||
        vid == Lambda_CUDA ||
-       vid == RAJA_CUDA ) {
+       vid == RAJA_CUDA ||
+       vid == RAJA_CUDA_NewReduce ) {
     ret_val = true;
   }
 #endif

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -304,7 +304,6 @@ static const std::string VariantNames [] =
   std::string("Base_CUDA"),
   std::string("Lambda_CUDA"),
   std::string("RAJA_CUDA"),
-  std::string("RAJA_CUDA_NewReduce"),
 
   std::string("Base_HIP"),
   std::string("Lambda_HIP"),
@@ -502,8 +501,7 @@ bool isVariantAvailable(VariantID vid)
 #if defined(RAJA_ENABLE_CUDA)
   if ( vid == Base_CUDA ||
        vid == Lambda_CUDA ||
-       vid == RAJA_CUDA ||
-       vid == RAJA_CUDA_NewReduce ) {
+       vid == RAJA_CUDA ) {
     ret_val = true;
   }
 #endif
@@ -571,8 +569,7 @@ bool isVariantGPU(VariantID vid)
 #if defined(RAJA_ENABLE_CUDA)
   if ( vid == Base_CUDA ||
        vid == Lambda_CUDA ||
-       vid == RAJA_CUDA ||
-       vid == RAJA_CUDA_NewReduce ) {
+       vid == RAJA_CUDA ) {
     ret_val = true;
   }
 #endif

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -211,6 +211,7 @@ enum VariantID {
   Base_CUDA,
   Lambda_CUDA,
   RAJA_CUDA,
+  RAJA_CUDA_NewReduce,
 
   Base_HIP,
   Lambda_HIP,

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -211,7 +211,6 @@ enum VariantID {
   Base_CUDA,
   Lambda_CUDA,
   RAJA_CUDA,
-  RAJA_CUDA_NewReduce,
 
   Base_HIP,
   Lambda_HIP,

--- a/src/lcals/FIRST_MIN-Hip.cpp
+++ b/src/lcals/FIRST_MIN-Hip.cpp
@@ -151,6 +151,48 @@ void FIRST_MIN::runHipVariantRAJA(VariantID vid)
   }
 }
 
+template < size_t block_size, typename MappingHelper >
+void FIRST_MIN::runHipVariantRAJANewReduce(VariantID vid)
+{
+  using exec_policy = std::conditional_t<MappingHelper::direct,
+      RAJA::hip_exec<block_size, true /*async*/>,
+      RAJA::hip_exec_occ_calc<block_size, true /*async*/>>;
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  FIRST_MIN_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    using VL_TYPE = RAJA::expt::ValLoc<Real_type>;
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       VL_TYPE tloc(m_xmin_init, m_initloc);
+
+       RAJA::forall<exec_policy>( res,
+         RAJA::RangeSegment(ibegin, iend),
+         RAJA::expt::Reduce<RAJA::operators::minimum>(&tloc),
+         [=] __device__ (Index_type i, VL_TYPE& loc) {
+           loc.min(x[i], i);
+         }
+       );
+
+       m_minloc = static_cast<Index_type>(tloc.getLoc());
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  FIRST_MIN : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
 void FIRST_MIN::runHipVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
@@ -183,6 +225,16 @@ void FIRST_MIN::runHipVariant(VariantID vid, size_t tune_idx)
               setBlockSize(block_size);
               runHipVariantRAJA<decltype(block_size){},
                                 decltype(mapping_helper)>(vid);
+
+            }
+
+            t += 1;
+
+            if (tune_idx == t) {
+
+              setBlockSize(block_size);
+              runHipVariantRAJANewReduce<decltype(block_size){},
+                                         decltype(mapping_helper)>(vid);
 
             }
 
@@ -230,6 +282,10 @@ void FIRST_MIN::setHipTuningDefinitions(VariantID vid)
             addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
                                       decltype(mapping_helper)::get_name()+"_"+
                                       std::to_string(block_size));
+
+            addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      "new_"+std::to_string(block_size)); 
 
           }
 

--- a/src/lcals/FIRST_MIN-OMP.cpp
+++ b/src/lcals/FIRST_MIN-OMP.cpp
@@ -105,9 +105,7 @@ void FIRST_MIN::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         using VL_TYPE = RAJA::expt::ValLoc<Real_type>;
 
@@ -129,6 +127,8 @@ void FIRST_MIN::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  FIRST_MIN : Unknown OpenMP tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/lcals/FIRST_MIN-OMP.cpp
+++ b/src/lcals/FIRST_MIN-OMP.cpp
@@ -18,7 +18,7 @@ namespace lcals
 {
 
 
-void FIRST_MIN::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void FIRST_MIN::runOpenMPVariant(VariantID vid, size_t tune_idx)
 {
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
 
@@ -87,21 +87,49 @@ void FIRST_MIN::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
 
     case RAJA_OpenMP : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
 
-        RAJA::ReduceMinLoc<RAJA::omp_reduce, Real_type, Index_type> loc(
-                                                        m_xmin_init, m_initloc);
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+  
+          RAJA::ReduceMinLoc<RAJA::omp_reduce, Real_type, Index_type> loc(
+                                                          m_xmin_init, m_initloc);
 
-        RAJA::forall<RAJA::omp_parallel_for_exec>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          FIRST_MIN_BODY_RAJA;
-        });
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+            FIRST_MIN_BODY_RAJA;
+          });
 
-        m_minloc = loc.getLoc();
+          m_minloc = loc.getLoc();
+
+        }
+        stopTimer();
 
       }
-      stopTimer();
+
+      if (tune_idx == 1) {
+
+        using VL_TYPE = RAJA::expt::ValLoc<Real_type>;
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          VL_TYPE tloc(m_xmin_init, m_initloc);
+
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::minimum>(&tloc),
+            [=](Index_type i, VL_TYPE& loc) {
+              loc.min(x[i], i);
+            }
+          );
+
+          m_minloc = static_cast<Index_type>(tloc.getLoc());
+
+        }
+        stopTimer();
+
+      }
 
       break;
     }
@@ -114,7 +142,16 @@ void FIRST_MIN::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
 
 #else
   RAJA_UNUSED_VAR(vid);
+  RAJA_UNUSED_VAR(tune_idx);
 #endif
+}
+
+void FIRST_MIN::setOpenMPTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMP) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace lcals

--- a/src/lcals/FIRST_MIN-OMPTarget.cpp
+++ b/src/lcals/FIRST_MIN-OMPTarget.cpp
@@ -78,9 +78,7 @@ void FIRST_MIN::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
       }
       stopTimer();
 
-    }
-
-    if (tune_idx == 1) {
+    } else if (tune_idx == 1) {
 
       using VL_TYPE = RAJA::expt::ValLoc<Real_type>;
 
@@ -102,6 +100,8 @@ void FIRST_MIN::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
       }
       stopTimer();
 
+    } else {
+      getCout() << "\n  FIRST_MIN : Unknown OMP Target tuning index = " << tune_idx << std::endl;
     }
 
   } else {

--- a/src/lcals/FIRST_MIN-OMPTarget.cpp
+++ b/src/lcals/FIRST_MIN-OMPTarget.cpp
@@ -27,7 +27,7 @@ namespace lcals
   const size_t threads_per_team = 256;
 
 
-void FIRST_MIN::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void FIRST_MIN::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -60,26 +60,62 @@ void FIRST_MIN::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+    if (tune_idx == 0) {
 
-      RAJA::ReduceMinLoc<RAJA::omp_target_reduce, Real_type, Index_type> loc(
-                                                  m_xmin_init, m_initloc);
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-        FIRST_MIN_BODY_RAJA;
-      });
+        RAJA::ReduceMinLoc<RAJA::omp_target_reduce, Real_type, Index_type> loc(
+                                                    m_xmin_init, m_initloc);
 
-      m_minloc = loc.getLoc();
+        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+          FIRST_MIN_BODY_RAJA;
+        });
+
+        m_minloc = loc.getLoc();
+
+      }
+      stopTimer();
 
     }
-    stopTimer();
+
+    if (tune_idx == 1) {
+
+      using VL_TYPE = RAJA::expt::ValLoc<Real_type>;
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        VL_TYPE tloc(m_xmin_init, m_initloc);
+
+        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+          RAJA::RangeSegment(ibegin, iend),
+          RAJA::expt::Reduce<RAJA::operators::minimum>(&tloc),
+          [=](Index_type i, VL_TYPE& loc) {
+            loc.min(x[i], i);
+          }
+        );
+
+        m_minloc = static_cast<Index_type>(tloc.getLoc());
+
+      }
+      stopTimer();
+
+    }
 
   } else {
      getCout() << "\n  FIRST_MIN : Unknown OMP Target variant id = " << vid << std::endl;
   }
 
+}
+
+void FIRST_MIN::setOpenMPTargetTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMPTarget) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace lcals

--- a/src/lcals/FIRST_MIN-Seq.cpp
+++ b/src/lcals/FIRST_MIN-Seq.cpp
@@ -97,9 +97,7 @@ void FIRST_MIN::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      } 
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         using VL_TYPE = RAJA::expt::ValLoc<Real_type>;
 
@@ -121,6 +119,8 @@ void FIRST_MIN::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  FIRST_MIN : Unknown Seq tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/lcals/FIRST_MIN.hpp
+++ b/src/lcals/FIRST_MIN.hpp
@@ -83,19 +83,26 @@ public:
 
   void runKokkosVariant(VariantID vid, size_t tune_idx);
 
+  void setSeqTuningDefinitions(VariantID vid);
+  void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid); 
 
   template < size_t block_size, typename MappingHelper >
   void runCudaVariantBase(VariantID vid);
   template < size_t block_size, typename MappingHelper >
-  void runHipVariantBase(VariantID vid);
-
-  template < size_t block_size, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
   template < size_t block_size, typename MappingHelper >
+  void runCudaVariantRAJANewReduce(VariantID vid);
+
+  template < size_t block_size, typename MappingHelper >
+  void runHipVariantBase(VariantID vid);
+  template < size_t block_size, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
+  template < size_t block_size, typename MappingHelper >
+  void runHipVariantRAJANewReduce(VariantID vid);
 
   template < size_t work_group_size >
   void runSyclVariantImpl(VariantID vid);

--- a/src/polybench/POLYBENCH_JACOBI_1D-Seq.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-Seq.cpp
@@ -25,12 +25,14 @@ void POLYBENCH_JACOBI_1D::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_AR
 
   POLYBENCH_JACOBI_1D_DATA_SETUP;
 
+#if defined(RUN_RAJA_SEQ)
   auto poly_jacobi1d_lam1 = [=] (Index_type i) {
                               POLYBENCH_JACOBI_1D_BODY1;
                             };
   auto poly_jacobi1d_lam2 = [=] (Index_type i) {
                               POLYBENCH_JACOBI_1D_BODY2;
                             };
+#endif
 
   switch ( vid ) {
 

--- a/src/stream/DOT-Cuda.cpp
+++ b/src/stream/DOT-Cuda.cpp
@@ -140,6 +140,46 @@ void DOT::runCudaVariantRAJA(VariantID vid)
   }
 }
 
+template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+void DOT::runCudaVariantRAJANewReduce(VariantID vid)
+{
+  using exec_policy = std::conditional_t<MappingHelper::direct,
+      RAJA::cuda_exec<block_size, true /*async*/>,
+      RAJA::cuda_exec_occ_calc<block_size, true /*async*/>>;
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  DOT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+       Real_type tdot = m_dot_init;
+
+       RAJA::forall<exec_policy>( res,
+         RAJA::RangeSegment(ibegin, iend),
+         RAJA::expt::Reduce<RAJA::operators::plus>(&tdot),
+         [=] __device__ (Index_type i, Real_type& dot) {
+           DOT_BODY;
+         }
+       );
+
+       m_dot += static_cast<Real_type>(tdot);
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  DOT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
 void DOT::runCudaVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
@@ -182,6 +222,19 @@ void DOT::runCudaVariant(VariantID vid, size_t tune_idx)
 
             });
 
+            if (tune_idx == t) {
+
+              auto algorithm_helper = gpu_algorithm::block_device_helper{};
+              setBlockSize(block_size);
+              runCudaVariantRAJANewReduce<decltype(block_size){},
+                                          decltype(algorithm_helper),
+                                          decltype(mapping_helper)>(vid);
+              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
+
+            }
+
+            t += 1;
+
           }
 
         });
@@ -216,6 +269,7 @@ void DOT::setCudaTuningDefinitions(VariantID vid)
             addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
                                       decltype(mapping_helper)::get_name()+"_"+
                                       std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
           } else if ( vid == RAJA_CUDA ) {
 
@@ -226,6 +280,13 @@ void DOT::setCudaTuningDefinitions(VariantID vid)
                                         std::to_string(block_size));
 
             });
+
+            auto algorithm_helper = gpu_algorithm::block_device_helper{};
+
+            addVariantTuningName(vid, decltype(algorithm_helper)::get_name()+"_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      "new_"+std::to_string(block_size));
+            RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
           }
 

--- a/src/stream/DOT-Cuda.cpp
+++ b/src/stream/DOT-Cuda.cpp
@@ -140,7 +140,7 @@ void DOT::runCudaVariantRAJA(VariantID vid)
   }
 }
 
-template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+template < size_t block_size, typename MappingHelper >
 void DOT::runCudaVariantRAJANewReduce(VariantID vid)
 {
   using exec_policy = std::conditional_t<MappingHelper::direct,
@@ -224,12 +224,9 @@ void DOT::runCudaVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              auto algorithm_helper = gpu_algorithm::block_device_helper{};
               setBlockSize(block_size);
               runCudaVariantRAJANewReduce<decltype(block_size){},
-                                          decltype(algorithm_helper),
                                           decltype(mapping_helper)>(vid);
-              RAJA_UNUSED_VAR(algorithm_helper); // to quiet compiler warning
 
             }
 

--- a/src/stream/DOT-Hip.cpp
+++ b/src/stream/DOT-Hip.cpp
@@ -140,7 +140,7 @@ void DOT::runHipVariantRAJA(VariantID vid)
   }
 }
 
-template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+template < size_t block_size, typename MappingHelper >
 void DOT::runHipVariantRAJANewReduce(VariantID vid)
 {
   using exec_policy = std::conditional_t<MappingHelper::direct,
@@ -224,10 +224,8 @@ void DOT::runHipVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              auto algorithm_helper = gpu_algorithm::block_device_helper{};
               setBlockSize(block_size);
               runHipVariantRAJANewReduce<decltype(block_size){},
-                                         decltype(algorithm_helper),
                                          decltype(mapping_helper)>(vid);
 
             }

--- a/src/stream/DOT-OMP.cpp
+++ b/src/stream/DOT-OMP.cpp
@@ -64,8 +64,6 @@ void DOT::runOpenMPVariant(VariantID vid, size_t tune_idx)
         #pragma omp parallel for reduction(+:dot)
         for (Index_type i = ibegin; i < iend; ++i ) {
           dot += dot_base_lam(i);
-        }
-
         m_dot += dot;
 
       }
@@ -93,9 +91,7 @@ void DOT::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -115,6 +111,8 @@ void DOT::runOpenMPVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  DOT : Unknown OpenMP tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/stream/DOT-OMP.cpp
+++ b/src/stream/DOT-OMP.cpp
@@ -18,7 +18,7 @@ namespace stream
 {
 
 
-void DOT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void DOT::runOpenMPVariant(VariantID vid, size_t tune_idx)
 {
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
 
@@ -76,20 +76,46 @@ void DOT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 
     case RAJA_OpenMP : {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      if (tune_idx == 0) {
 
-        RAJA::ReduceSum<RAJA::omp_reduce, Real_type> dot(m_dot_init);
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::forall<RAJA::omp_parallel_for_exec>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          DOT_BODY;
-        });
+          RAJA::ReduceSum<RAJA::omp_reduce, Real_type> dot(m_dot_init);
 
-        m_dot += dot;
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+            DOT_BODY;
+          });
+
+          m_dot += dot;
+
+        }
+        stopTimer();
 
       }
-      stopTimer();
+
+      if (tune_idx == 1) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type tdot = m_dot_init;
+
+          RAJA::forall<RAJA::omp_parallel_for_exec>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tdot),
+            [=] (Index_type i, Real_type& dot) {
+              DOT_BODY;
+            }
+          );
+
+          m_dot += static_cast<Real_type>(tdot);
+
+        }
+        stopTimer();
+
+      }
 
       break;
     }
@@ -102,7 +128,16 @@ void DOT::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 
 #else
   RAJA_UNUSED_VAR(vid);
+  RAJA_UNUSED_VAR(tune_idx);
 #endif
+}
+
+void DOT::setOpenMPTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMP) {
+    addVariantTuningName(vid, "new");
+  }
 }
 
 } // end namespace stream

--- a/src/stream/DOT-OMP.cpp
+++ b/src/stream/DOT-OMP.cpp
@@ -64,6 +64,8 @@ void DOT::runOpenMPVariant(VariantID vid, size_t tune_idx)
         #pragma omp parallel for reduction(+:dot)
         for (Index_type i = ibegin; i < iend; ++i ) {
           dot += dot_base_lam(i);
+        }
+
         m_dot += dot;
 
       }

--- a/src/stream/DOT-OMPTarget.cpp
+++ b/src/stream/DOT-OMPTarget.cpp
@@ -77,9 +77,7 @@ void DOT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -99,6 +97,8 @@ void DOT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  DOT : Unknown OMP Target tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/stream/DOT-OMPTarget.cpp
+++ b/src/stream/DOT-OMPTarget.cpp
@@ -26,7 +26,7 @@ namespace stream
   //
   const size_t threads_per_team = 256;
 
-void DOT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void DOT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -34,44 +34,89 @@ void DOT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
 
   DOT_DATA_SETUP;
 
-  if ( vid == Base_OpenMPTarget ) {
+  switch ( vid ) {
 
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+    case Base_OpenMPTarget : {
 
-      Real_type dot = m_dot_init;
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      #pragma omp target is_device_ptr(a, b) device( did ) map(tofrom:dot)
-      #pragma omp teams distribute parallel for reduction(+:dot) \
-              thread_limit(threads_per_team) schedule(static, 1)
-      for (Index_type i = ibegin; i < iend; ++i ) {
-        DOT_BODY;
+        Real_type dot = m_dot_init;
+
+        #pragma omp target is_device_ptr(a, b) device( did ) map(tofrom:dot)
+        #pragma omp teams distribute parallel for reduction(+:dot) \
+                thread_limit(threads_per_team) schedule(static, 1)
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          DOT_BODY;
+        }
+
+        m_dot += dot;
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_OpenMPTarget : {
+
+      if (tune_idx == 0) {
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> dot(m_dot_init);
+
+          RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+            DOT_BODY;
+          });
+
+          m_dot += static_cast<Real_type>(dot.get());
+
+        }
+        stopTimer();
+
       }
 
-      m_dot += dot;
+      if (tune_idx == 1) {
 
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          Real_type tdot = m_dot_init;
+
+          RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+            RAJA::RangeSegment(ibegin, iend),
+            RAJA::expt::Reduce<RAJA::operators::plus>(&tdot),
+            [=] (Index_type i, Real_type& dot) {
+              DOT_BODY;
+            }
+          );
+
+          m_dot += static_cast<Real_type>(tdot);
+
+        }
+        stopTimer();
+
+      }
+
+      break;
     }
-    stopTimer();
 
-  } else if ( vid == RAJA_OpenMPTarget ) {
-
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-      RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> dot(m_dot_init);
-
-      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-        DOT_BODY;
-      });
-
-      m_dot += static_cast<Real_type>(dot.get());
-
+    default : {
+      getCout() << "\n  DOT : Unknown OMP Target variant id = " << vid << std::endl;
     }
-    stopTimer();
 
-  } else {
-     getCout() << "\n  DOT : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+
+}
+
+void DOT::setOpenMPTargetTuningDefinitions(VariantID vid)
+{
+  addVariantTuningName(vid, "default");
+  if (vid == RAJA_OpenMPTarget) {
+    addVariantTuningName(vid, "new");
   }
 }
 

--- a/src/stream/DOT-Seq.cpp
+++ b/src/stream/DOT-Seq.cpp
@@ -93,9 +93,7 @@ void DOT::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
-      }
-
-      if (tune_idx == 1) {
+      } else if (tune_idx == 1) {
 
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -114,6 +112,8 @@ void DOT::runSeqVariant(VariantID vid, size_t tune_idx)
         }
         stopTimer();
 
+      } else {
+        getCout() << "\n  DOT : Unknown Seq tuning index = " << tune_idx << std::endl;
       }
 
       break;

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -66,14 +66,14 @@ public:
   void runCudaVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
-  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  template < size_t block_size, typename MappingHelper >
   void runCudaVariantRAJANewReduce(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runHipVariantBase(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
-  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  template < size_t block_size, typename MappingHelper >
   void runHipVariantRAJANewReduce(VariantID vid);
 
   template < size_t work_group_size >

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -55,19 +55,26 @@ public:
 
   void runKokkosVariant(VariantID vid, size_t tune_idx);
 
+  void setSeqTuningDefinitions(VariantID vid);
+  void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runCudaVariantBase(VariantID vid);
-  template < size_t block_size, typename MappingHelper >
-  void runHipVariantBase(VariantID vid);
-
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runCudaVariantRAJA(VariantID vid);
   template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  void runCudaVariantRAJANewReduce(VariantID vid);
+
+  template < size_t block_size, typename MappingHelper >
+  void runHipVariantBase(VariantID vid);
+  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
   void runHipVariantRAJA(VariantID vid);
+  template < size_t block_size, typename AlgorithmHelper, typename MappingHelper >
+  void runHipVariantRAJANewReduce(VariantID vid);
 
   template < size_t work_group_size >
   void runSyclVariantImpl(VariantID vid);


### PR DESCRIPTION
# Summary

- This PR is am enhancement that adds reduction "tunings" for kernels with reductions. One for the RAJA default reduction interface and one for the new interface. This allows us to easily compare performance of the two RAJA reduction interfaces.
- Implementations of all kernels with reductions using the new interface have been added.
- SYCL variant of REDUCE_SUM kernel also added.
- Lastly it fixes a few compilation issues discovered when manually testing all back-ends (e.g., openmp target)

Resolves: https://github.com/LLNL/RAJAPerf/issues/339