### PR TITLE
Split byte counters into reads and writes

### DIFF
--- a/src/algorithm/ATOMIC.cpp
+++ b/src/algorithm/ATOMIC.cpp
@@ -28,8 +28,9 @@ ATOMIC::ATOMIC(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) +
-                  (0*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
   setFLOPsPerRep(getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/algorithm/MEMCPY.cpp
+++ b/src/algorithm/MEMCPY.cpp
@@ -28,7 +28,9 @@ MEMCPY::MEMCPY(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Forall);

--- a/src/algorithm/MEMSET.cpp
+++ b/src/algorithm/MEMSET.cpp
@@ -28,7 +28,7 @@ MEMSET::MEMSET(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) );
+  setBytesReadPerRep( 0 );
   setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);

--- a/src/algorithm/MEMSET.cpp
+++ b/src/algorithm/MEMSET.cpp
@@ -28,8 +28,9 @@ MEMSET::MEMSET(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (0*sizeof(Real_type) + 1*sizeof(Real_type)) +
-                  (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Forall);

--- a/src/algorithm/REDUCE_SUM.cpp
+++ b/src/algorithm/REDUCE_SUM.cpp
@@ -28,8 +28,9 @@ REDUCE_SUM::REDUCE_SUM(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) * (1+getActualProblemSize()) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/algorithm/SCAN.cpp
+++ b/src/algorithm/SCAN.cpp
@@ -28,7 +28,9 @@ SCAN::SCAN(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * getActualProblemSize());
 
   checksum_scale_factor = 1e-2 *

--- a/src/algorithm/SCAN.hpp
+++ b/src/algorithm/SCAN.hpp
@@ -10,9 +10,10 @@
 /// SCAN kernel reference implementation:
 ///
 /// // exclusive scan
-/// y[ibegin] = 0;
-/// for (Index_type i = ibegin+1; i < iend; ++i) {
-///   y[i] = y[i-1] + x[i-1];
+/// Real_type scan_var = 0;
+/// for (Index_type i = ibegin; i < iend; ++i) {
+///   y[i] = scan_var;
+///   scan_var += x[i];
 /// }
 ///
 

--- a/src/algorithm/SORT.cpp
+++ b/src/algorithm/SORT.cpp
@@ -28,7 +28,9 @@ SORT::SORT(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() ); // touched data size, not actual number of stores and loads
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // not useful in this case due to O(n*log(n)) algorithm
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // not useful in this case due to O(n*log(n)) algorithm
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Sort);

--- a/src/algorithm/SORTPAIRS.cpp
+++ b/src/algorithm/SORTPAIRS.cpp
@@ -28,7 +28,9 @@ SORTPAIRS::SORTPAIRS(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (2*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() ); // touched data size, not actual number of stores and loads
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // not useful in this case due to O(n*log(n)) algorithm
+  setBytesWrittenPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // not useful in this case due to O(n*log(n)) algorithm
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Sort);

--- a/src/apps/CONVECTION3DPA.cpp
+++ b/src/apps/CONVECTION3DPA.cpp
@@ -28,7 +28,7 @@ CONVECTION3DPA::CONVECTION3DPA(const RunParams& params)
   setDefaultProblemSize(m_NE_default*CPA_Q1D*CPA_Q1D*CPA_Q1D);
   setDefaultReps(50);
 
-  m_NE = std::max(getTargetProblemSize()/(CPA_Q1D*CPA_Q1D*CPA_Q1D), Index_type(1));
+  m_NE = std::max((getTargetProblemSize() + (CPA_Q1D*CPA_Q1D*CPA_Q1D)/2) / (CPA_Q1D*CPA_Q1D*CPA_Q1D), Index_type(1));
 
   setActualProblemSize( m_NE*CPA_Q1D*CPA_Q1D*CPA_Q1D );
 

--- a/src/apps/CONVECTION3DPA.cpp
+++ b/src/apps/CONVECTION3DPA.cpp
@@ -35,10 +35,11 @@ CONVECTION3DPA::CONVECTION3DPA(const RunParams& params)
   setItsPerRep(getActualProblemSize());
   setKernelsPerRep(1);
 
-  setBytesPerRep( 3*CPA_Q1D*CPA_D1D*sizeof(Real_type)  +
-                  CPA_VDIM*CPA_Q1D*CPA_Q1D*CPA_Q1D*m_NE*sizeof(Real_type) +
-                  CPA_D1D*CPA_D1D*CPA_D1D*m_NE*sizeof(Real_type) +
-                  CPA_D1D*CPA_D1D*CPA_D1D*m_NE*sizeof(Real_type) );
+  setBytesReadPerRep( 3*sizeof(Real_type) * CPA_Q1D*CPA_D1D + // b, bt, g
+                      2*sizeof(Real_type) * CPA_D1D*CPA_D1D*CPA_D1D*m_NE + // x, y
+               CPA_VDIM*sizeof(Real_type) * CPA_Q1D*CPA_Q1D*CPA_Q1D*m_NE ); // d
+  setBytesWrittenPerRep( 1*sizeof(Real_type) + CPA_D1D*CPA_D1D*CPA_D1D*m_NE ); // y
+  setBytesAtomicModifyWrittenPerRep( 0 );
 
   setFLOPsPerRep(m_NE * (
                          4 * CPA_D1D * CPA_Q1D * CPA_D1D * CPA_D1D + //2

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -37,9 +37,10 @@ DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (0*sizeof(Index_type) + 1*sizeof(Index_type)) * getItsPerRep() +
-                  (1*sizeof(Real_type)  + 0*sizeof(Real_type) ) * getItsPerRep() +
-                  (0*sizeof(Real_type)  + 4*sizeof(Real_type) ) * m_domain->n_real_nodes ) ; // touched data size, not actual number of stores and loads
+  setBytesReadPerRep( 1*sizeof(Index_type) * getItsPerRep() +
+                      4*sizeof(Real_type) * m_domain->n_real_nodes ); // 4 variables with 2d nodal stencil pattern: 4 touches per iterate
+  setBytesWrittenPerRep( 1*sizeof(Index_type) * getItsPerRep() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(54 * m_domain->n_real_zones);
 
   setUsesFeature(Forall);

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -28,7 +28,7 @@ DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
   setDefaultProblemSize(1000*1000);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::sqrt(getTargetProblemSize())+1;
+  Index_type rzmax = std::sqrt(getTargetProblemSize()) + 1 + std::sqrt(2)-1;
   m_domain = new ADomain(rzmax, /* ndims = */ 2);
 
   m_array_length = m_domain->nnalls;

--- a/src/apps/DIFFUSION3DPA.cpp
+++ b/src/apps/DIFFUSION3DPA.cpp
@@ -28,7 +28,7 @@ DIFFUSION3DPA::DIFFUSION3DPA(const RunParams& params)
   setDefaultProblemSize(m_NE_default*DPA_Q1D*DPA_Q1D*DPA_Q1D);
   setDefaultReps(50);
 
-  m_NE = std::max(getTargetProblemSize()/(DPA_Q1D*DPA_Q1D*DPA_Q1D), Index_type(1));
+  m_NE = std::max((getTargetProblemSize() + (DPA_Q1D*DPA_Q1D*DPA_Q1D)/2) / (DPA_Q1D*DPA_Q1D*DPA_Q1D), Index_type(1));
 
   setActualProblemSize( m_NE*DPA_Q1D*DPA_Q1D*DPA_Q1D );
 

--- a/src/apps/DIFFUSION3DPA.cpp
+++ b/src/apps/DIFFUSION3DPA.cpp
@@ -35,10 +35,11 @@ DIFFUSION3DPA::DIFFUSION3DPA(const RunParams& params)
   setItsPerRep(getActualProblemSize());
   setKernelsPerRep(1);
 
-  setBytesPerRep( 2*DPA_Q1D*DPA_D1D*sizeof(Real_type)  +
-                  DPA_Q1D*DPA_Q1D*DPA_Q1D*SYM*m_NE*sizeof(Real_type) +
-                  DPA_D1D*DPA_D1D*DPA_D1D*m_NE*sizeof(Real_type) +
-                  DPA_D1D*DPA_D1D*DPA_D1D*m_NE*sizeof(Real_type) );
+  setBytesReadPerRep( 2*sizeof(Real_type) * DPA_Q1D*DPA_D1D + // b, g
+                      2*sizeof(Real_type) * DPA_D1D*DPA_D1D*DPA_D1D*m_NE + // x, y
+                    SYM*sizeof(Real_type) * DPA_Q1D*DPA_Q1D*DPA_Q1D*m_NE ); // d
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * DPA_D1D*DPA_D1D*DPA_D1D*m_NE ); // y
+  setBytesAtomicModifyWrittenPerRep( 0 );
 
   setFLOPsPerRep(m_NE * (DPA_Q1D * DPA_D1D +
                          5 * DPA_D1D * DPA_D1D * DPA_Q1D * DPA_D1D +

--- a/src/apps/EDGE3D.cpp
+++ b/src/apps/EDGE3D.cpp
@@ -33,7 +33,7 @@ EDGE3D::EDGE3D(const RunParams& params)
   m_array_length = m_domain->nnalls;
   size_t number_of_elements = m_domain->lpz+1 - m_domain->fpz;
 
-  setActualProblemSize( number_of_elements );
+  setActualProblemSize( m_domain->n_real_zones );
 
   setItsPerRep( number_of_elements );
   setKernelsPerRep(1);

--- a/src/apps/EDGE3D.cpp
+++ b/src/apps/EDGE3D.cpp
@@ -27,7 +27,7 @@ EDGE3D::EDGE3D(const RunParams& params)
 {
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(10);
-  Index_type rzmax = std::cbrt(getTargetProblemSize())+1;
+  Index_type rzmax = std::cbrt(getTargetProblemSize()) + 1 + std::cbrt(3)-1;
   m_domain = new ADomain(rzmax, /* ndims = */ 3);
 
   m_array_length = m_domain->nnalls;

--- a/src/apps/EDGE3D.cpp
+++ b/src/apps/EDGE3D.cpp
@@ -40,10 +40,9 @@ EDGE3D::EDGE3D(const RunParams& params)
 
   // touched data size, not actual number of stores and loads
   // see VOL3D.cpp
-  size_t reads_per_node = 3*sizeof(Real_type);
-  size_t writes_per_zone = 1*sizeof(Real_type);
-  setBytesPerRep( writes_per_zone * getItsPerRep() +
-                  reads_per_node * (getItsPerRep() + 1+m_domain->jp+m_domain->kp) );
+  setBytesReadPerRep( 3*sizeof(Real_type) * (getItsPerRep() + 1+m_domain->jp+m_domain->kp) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
 
   constexpr size_t flops_k_loop = 15
                                   + 6*flops_Jxx()

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -29,13 +29,22 @@ ENERGY::ENERGY(const RunParams& params)
   setItsPerRep( 6 * getActualProblemSize() );
   setKernelsPerRep(6);
   // some branches are never taken due to the nature of the initialization of delvc
-  // the additional reads and writes that would be done if those branches were taken are noted in the comments
-  setBytesPerRep( (1*sizeof(Real_type) + 5*sizeof(Real_type)) * getActualProblemSize() +
-                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() + /* 1 + 8 */
-                  (1*sizeof(Real_type) + 6*sizeof(Real_type)) * getActualProblemSize() +
-                  (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() +
-                  (1*sizeof(Real_type) + 7*sizeof(Real_type)) * getActualProblemSize() + /* 1 + 12 */
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() ); /* 1 + 8 */
+  // the additional reads that would be done if those branches were taken are noted in the comments
+  setBytesReadPerRep((5*sizeof(Real_type) +
+                      1*sizeof(Real_type) + // 8
+                      6*sizeof(Real_type) +
+                      2*sizeof(Real_type) +
+                      7*sizeof(Real_type) + // 12
+                      1*sizeof(Real_type)   // 8
+                      ) * getActualProblemSize() );
+  setBytesWrittenPerRep((1*sizeof(Real_type) +
+                         1*sizeof(Real_type) +
+                         1*sizeof(Real_type) +
+                         1*sizeof(Real_type) +
+                         1*sizeof(Real_type) +
+                         0*sizeof(Real_type)
+                         ) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep((6  +
                   11 + // 1 sqrt
                   8  +

--- a/src/apps/FIR-Cuda.cpp
+++ b/src/apps/FIR-Cuda.cpp
@@ -83,7 +83,7 @@ void FIR::runCudaVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getActualProblemSize() - m_coefflen;
+  const Index_type iend = getActualProblemSize();
 
   auto res{getCudaResource()};
 

--- a/src/apps/FIR-Hip.cpp
+++ b/src/apps/FIR-Hip.cpp
@@ -81,7 +81,7 @@ void FIR::runHipVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getActualProblemSize() - m_coefflen;
+  const Index_type iend = getActualProblemSize();
 
   auto res{getHipResource()};
 

--- a/src/apps/FIR-OMP.cpp
+++ b/src/apps/FIR-OMP.cpp
@@ -25,7 +25,7 @@ void FIR::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getActualProblemSize() - m_coefflen;
+  const Index_type iend = getActualProblemSize();
 
   FIR_COEFF;
 

--- a/src/apps/FIR-OMPTarget.cpp
+++ b/src/apps/FIR-OMPTarget.cpp
@@ -43,7 +43,7 @@ void FIR::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getActualProblemSize() - m_coefflen;
+  const Index_type iend = getActualProblemSize();
 
   FIR_DATA_SETUP;
 

--- a/src/apps/FIR-Seq.cpp
+++ b/src/apps/FIR-Seq.cpp
@@ -23,7 +23,7 @@ void FIR::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getActualProblemSize() - m_coefflen;
+  const Index_type iend = getActualProblemSize();
 
   FIR_COEFF;
 

--- a/src/apps/FIR-Sycl.cpp
+++ b/src/apps/FIR-Sycl.cpp
@@ -42,7 +42,7 @@ void FIR::runSyclVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
-  const Index_type iend = getActualProblemSize() - m_coefflen;
+  const Index_type iend = getActualProblemSize();
 
   auto res{getSyclResource()};
   auto qu = res.get_queue();

--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -28,11 +28,13 @@ FIR::FIR(const RunParams& params)
 
   setActualProblemSize( getTargetProblemSize() );
 
-  setItsPerRep( getActualProblemSize() - m_coefflen );
+  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getItsPerRep() +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() );
-  setFLOPsPerRep((2 * m_coefflen) * (getActualProblemSize() - m_coefflen));
+  setBytesReadPerRep( m_coefflen*sizeof(Real_type) +
+                      1*sizeof(Real_type) * (getActualProblemSize() + m_coefflen-1) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep((2 * m_coefflen) * getActualProblemSize());
 
   checksum_scale_factor = 0.0001 *
               ( static_cast<Checksum_type>(getDefaultProblemSize()) /
@@ -67,7 +69,7 @@ FIR::~FIR()
 
 void FIR::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  allocAndInitData(m_in, getActualProblemSize(), vid);
+  allocAndInitData(m_in, getActualProblemSize() + m_coefflen-1, vid);
   allocAndInitDataConst(m_out, getActualProblemSize(), 0.0, vid);
 }
 

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -47,9 +47,11 @@ LTIMES::LTIMES(const RunParams& params)
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   // using total data size instead of writes and reads
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * m_philen +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_elllen +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_psilen );
+  setBytesReadPerRep( 1*sizeof(Real_type) * m_philen +
+                      1*sizeof(Real_type) * m_elllen +
+                      1*sizeof(Real_type) * m_psilen );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * m_philen );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * m_num_z * m_num_g * m_num_m * m_num_d);
 
   checksum_scale_factor = 0.001 *

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -31,9 +31,7 @@ LTIMES::LTIMES(const RunParams& params)
   setDefaultProblemSize(m_num_d_default * m_num_g_default * m_num_z_default);
   setDefaultReps(50);
 
-  m_num_z = std::max( getTargetProblemSize() /
-                      (m_num_d_default * m_num_g_default),
-                      Index_type(1) );
+  m_num_z = std::max((getTargetProblemSize() + (m_num_d_default * m_num_g_default)/2) / (m_num_d_default * m_num_g_default), Index_type(1));
   m_num_g = m_num_g_default;
   m_num_m = m_num_m_default;
   m_num_d = m_num_d_default;

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -31,9 +31,7 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   setDefaultProblemSize(m_num_d_default * m_num_g_default * m_num_z_default);
   setDefaultReps(50);
 
-  m_num_z = std::max( getTargetProblemSize() /
-                      (m_num_d_default * m_num_g_default),
-                      Index_type(1) );
+  m_num_z = std::max((getTargetProblemSize() + (m_num_d_default * m_num_g_default)/2) / (m_num_d_default * m_num_g_default), Index_type(1));
   m_num_g = m_num_g_default;
   m_num_m = m_num_m_default;
   m_num_d = m_num_d_default;

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -47,9 +47,11 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   // using total data size instead of writes and reads
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * m_philen +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_elllen +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_psilen );
+  setBytesReadPerRep( 1*sizeof(Real_type) * m_philen +
+                      1*sizeof(Real_type) * m_elllen +
+                      1*sizeof(Real_type) * m_psilen );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * m_philen );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * m_num_z * m_num_g * m_num_m * m_num_d);
 
   checksum_scale_factor = 0.001 *

--- a/src/apps/MASS3DEA.cpp
+++ b/src/apps/MASS3DEA.cpp
@@ -37,9 +37,10 @@ MASS3DEA::MASS3DEA(const RunParams& params)
   setItsPerRep(getActualProblemSize());
   setKernelsPerRep(1);
 
-  setBytesPerRep( MEA_Q1D*MEA_D1D*sizeof(Real_type)  + // B
-                  MEA_Q1D*MEA_Q1D*MEA_Q1D*m_NE*sizeof(Real_type) + // D
-                  ea_mat_entries*m_NE*sizeof(Real_type) ); // M_e
+  setBytesReadPerRep( 1*sizeof(Real_type) * MEA_Q1D*MEA_D1D + // B
+                      1*sizeof(Real_type) * MEA_Q1D*MEA_Q1D*MEA_Q1D*m_NE ); // D
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * ea_mat_entries*m_NE ); // M_e
+  setBytesAtomicModifyWrittenPerRep( 0 );
 
   setFLOPsPerRep(m_NE * 7 * ea_mat_entries);
 

--- a/src/apps/MASS3DEA.cpp
+++ b/src/apps/MASS3DEA.cpp
@@ -30,7 +30,7 @@ MASS3DEA::MASS3DEA(const RunParams& params)
 
   const int ea_mat_entries = MEA_D1D*MEA_D1D*MEA_D1D*MEA_D1D*MEA_D1D*MEA_D1D;
 
-  m_NE = std::max(getTargetProblemSize()/(ea_mat_entries), Index_type(1));
+  m_NE = std::max((getTargetProblemSize() + (ea_mat_entries)/2) / (ea_mat_entries), Index_type(1));
 
   setActualProblemSize( m_NE*ea_mat_entries);
 

--- a/src/apps/MASS3DPA.cpp
+++ b/src/apps/MASS3DPA.cpp
@@ -35,11 +35,11 @@ MASS3DPA::MASS3DPA(const RunParams& params)
   setItsPerRep(getActualProblemSize());
   setKernelsPerRep(1);
 
-  setBytesPerRep( MPA_Q1D*MPA_D1D*sizeof(Real_type)  +
-                  MPA_Q1D*MPA_D1D*sizeof(Real_type)  +
-                  MPA_Q1D*MPA_Q1D*MPA_Q1D*m_NE*sizeof(Real_type) +
-                  MPA_D1D*MPA_D1D*MPA_D1D*m_NE*sizeof(Real_type) +
-                  MPA_D1D*MPA_D1D*MPA_D1D*m_NE*sizeof(Real_type) );
+  setBytesReadPerRep( 2*sizeof(Real_type) * MPA_Q1D*MPA_D1D + // B, Bt
+                      2*sizeof(Real_type) * MPA_D1D*MPA_D1D*MPA_D1D*m_NE + // X, Y
+                      1*sizeof(Real_type) * MPA_Q1D*MPA_Q1D*MPA_Q1D*m_NE ); // D
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * MPA_D1D*MPA_D1D*MPA_D1D*m_NE ); // Y
+  setBytesAtomicModifyWrittenPerRep( 0 );
 
   setFLOPsPerRep(m_NE * (2 * MPA_D1D * MPA_D1D * MPA_D1D * MPA_Q1D +
                          2 * MPA_D1D * MPA_D1D * MPA_Q1D * MPA_Q1D +

--- a/src/apps/MASS3DPA.cpp
+++ b/src/apps/MASS3DPA.cpp
@@ -28,7 +28,7 @@ MASS3DPA::MASS3DPA(const RunParams& params)
   setDefaultProblemSize(m_NE_default*MPA_Q1D*MPA_Q1D*MPA_Q1D);
   setDefaultReps(50);
 
-  m_NE = std::max(getTargetProblemSize()/(MPA_Q1D*MPA_Q1D*MPA_Q1D), Index_type(1));
+  m_NE = std::max((getTargetProblemSize() + (MPA_Q1D*MPA_Q1D*MPA_Q1D)/2) / (MPA_Q1D*MPA_Q1D*MPA_Q1D), Index_type(1));
 
   setActualProblemSize( m_NE*MPA_Q1D*MPA_Q1D*MPA_Q1D );
 

--- a/src/apps/MATVEC_3D_STENCIL.cpp
+++ b/src/apps/MATVEC_3D_STENCIL.cpp
@@ -69,10 +69,11 @@ MATVEC_3D_STENCIL::MATVEC_3D_STENCIL(const RunParams& params)
                             get_size_matrix(1, 1, 1) +
                             get_size_matrix(0, 1, 1) +
                             get_size_matrix(1, 1, 1) ;
-  setBytesPerRep( getItsPerRep()*sizeof(Index_type) +
-                  b_accessed*sizeof(Real_type) +
-                  x_accessed*sizeof(Real_type) +
-                  m_accessed*sizeof(Real_type) );
+  setBytesReadPerRep( 1*sizeof(Index_type) * getItsPerRep() +
+                      1*sizeof(Real_type) * x_accessed +
+                      1*sizeof(Real_type) * m_accessed );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * b_accessed );
+  setBytesAtomicModifyWrittenPerRep( 0 );
 
   const size_t multiplies = 27;
   const size_t adds = 26;

--- a/src/apps/MATVEC_3D_STENCIL.cpp
+++ b/src/apps/MATVEC_3D_STENCIL.cpp
@@ -28,7 +28,7 @@ MATVEC_3D_STENCIL::MATVEC_3D_STENCIL(const RunParams& params)
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::cbrt(getTargetProblemSize())+1;
+  Index_type rzmax = std::cbrt(getTargetProblemSize()) + 1 + std::cbrt(3)-1;
   m_domain = new ADomain(rzmax, /* ndims = */ 3);
 
   m_zonal_array_length = m_domain->lpz+1;

--- a/src/apps/NODAL_ACCUMULATION_3D.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D.cpp
@@ -39,9 +39,11 @@ NODAL_ACCUMULATION_3D::NODAL_ACCUMULATION_3D(const RunParams& params)
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   // touched data size, not actual number of stores and loads
-  setBytesPerRep( (0*sizeof(Index_type) + 1*sizeof(Index_type)) * getItsPerRep() +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() +
-                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * m_domain->n_real_nodes);
+  setBytesReadPerRep( 1*sizeof(Index_type) * getItsPerRep() +
+                      1*sizeof(Real_type) * getItsPerRep() +
+                      1*sizeof(Real_type) * m_domain->n_real_nodes);
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * m_domain->n_real_nodes );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(9 * getItsPerRep());
 
   checksum_scale_factor = 0.001 *

--- a/src/apps/NODAL_ACCUMULATION_3D.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D.cpp
@@ -28,7 +28,7 @@ NODAL_ACCUMULATION_3D::NODAL_ACCUMULATION_3D(const RunParams& params)
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::cbrt(getTargetProblemSize())+1;
+  Index_type rzmax = std::cbrt(getTargetProblemSize()) + 1 + std::cbrt(3)-1;
   m_domain = new ADomain(rzmax, /* ndims = */ 3);
 
   m_nodal_array_length = m_domain->nnalls;

--- a/src/apps/PRESSURE.cpp
+++ b/src/apps/PRESSURE.cpp
@@ -28,8 +28,11 @@ PRESSURE::PRESSURE(const RunParams& params)
 
   setItsPerRep( 2 * getActualProblemSize() );
   setKernelsPerRep(2);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() +
-                  (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() +
+                      3*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() +
+                         1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep((2 +
                   1
                   ) * getActualProblemSize());

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -33,7 +33,7 @@ VOL3D::VOL3D(const RunParams& params)
 
   m_array_length = m_domain->nnalls;
 
-  setActualProblemSize( m_domain->lpz+1 - m_domain->fpz );
+  setActualProblemSize( m_domain->n_real_zones );
 
   setItsPerRep( m_domain->lpz+1 - m_domain->fpz );
   setKernelsPerRep(1);

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -38,8 +38,9 @@ VOL3D::VOL3D(const RunParams& params)
   setItsPerRep( m_domain->lpz+1 - m_domain->fpz );
   setKernelsPerRep(1);
   // touched data size, not actual number of stores and loads
-  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getItsPerRep() +
-                  (0*sizeof(Real_type) + 3*sizeof(Real_type)) * (getItsPerRep() + 1+m_domain->jp+m_domain->kp) );
+  setBytesReadPerRep( 3*sizeof(Real_type) * (getItsPerRep() + 1+m_domain->jp+m_domain->kp) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(72 * (m_domain->lpz+1 - m_domain->fpz));
 
   checksum_scale_factor = 0.001 *

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -28,7 +28,7 @@ VOL3D::VOL3D(const RunParams& params)
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::cbrt(getTargetProblemSize())+1;
+  Index_type rzmax = std::cbrt(getTargetProblemSize()) + 1 + std::cbrt(3)-1;
   m_domain = new ADomain(rzmax, /* ndims = */ 3);
 
   m_array_length = m_domain->nnalls;

--- a/src/apps/ZONAL_ACCUMULATION_3D.cpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D.cpp
@@ -39,9 +39,10 @@ ZONAL_ACCUMULATION_3D::ZONAL_ACCUMULATION_3D(const RunParams& params)
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   // touched data size, not actual number of stores and loads
-  setBytesPerRep( (0*sizeof(Index_type) + 1*sizeof(Index_type)) * getItsPerRep() +
-                  (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getItsPerRep() +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_domain->n_real_nodes);
+  setBytesReadPerRep( 1*sizeof(Index_type) * getItsPerRep() +
+                      1*sizeof(Real_type) * (getItsPerRep() + 1+m_domain->jp+m_domain->kp) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(8 * getItsPerRep());
 
   checksum_scale_factor = 0.001 *

--- a/src/apps/ZONAL_ACCUMULATION_3D.cpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D.cpp
@@ -28,7 +28,7 @@ ZONAL_ACCUMULATION_3D::ZONAL_ACCUMULATION_3D(const RunParams& params)
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::cbrt(getTargetProblemSize())+1;
+  Index_type rzmax = std::cbrt(getTargetProblemSize()) + 1 + std::cbrt(3)-1;
   m_domain = new ADomain(rzmax, /* ndims = */ 3);
 
   m_nodal_array_length = m_domain->nnalls;

--- a/src/apps/ZONAL_ACCUMULATION_3D.cpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D.cpp
@@ -40,7 +40,7 @@ ZONAL_ACCUMULATION_3D::ZONAL_ACCUMULATION_3D(const RunParams& params)
   setKernelsPerRep(1);
   // touched data size, not actual number of stores and loads
   setBytesReadPerRep( 1*sizeof(Index_type) * getItsPerRep() +
-                      1*sizeof(Real_type) * (getItsPerRep() + 1+m_domain->jp+m_domain->kp) );
+                      1*sizeof(Real_type) * m_domain->n_real_nodes );
   setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(8 * getItsPerRep());

--- a/src/basic/ARRAY_OF_PTRS.cpp
+++ b/src/basic/ARRAY_OF_PTRS.cpp
@@ -30,7 +30,9 @@ ARRAY_OF_PTRS::ARRAY_OF_PTRS(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + m_array_size*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( m_array_size*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(m_array_size * getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/basic/COPY8.cpp
+++ b/src/basic/COPY8.cpp
@@ -28,7 +28,9 @@ COPY8::COPY8(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (8*sizeof(Real_type) + 8*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 8*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 8*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Forall);

--- a/src/basic/DAXPY.cpp
+++ b/src/basic/DAXPY.cpp
@@ -28,7 +28,9 @@ DAXPY::DAXPY(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/basic/DAXPY_ATOMIC.cpp
+++ b/src/basic/DAXPY_ATOMIC.cpp
@@ -28,7 +28,9 @@ DAXPY_ATOMIC::DAXPY_ATOMIC(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
   setFLOPsPerRep(2 * getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -28,7 +28,9 @@ IF_QUAD::IF_QUAD(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (2*sizeof(Real_type) + 3*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 3*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 2*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(11 * getActualProblemSize()); // 1 sqrt
 
   checksum_scale_factor = 0.0001 *

--- a/src/basic/INDEXLIST.cpp
+++ b/src/basic/INDEXLIST.cpp
@@ -28,9 +28,11 @@ INDEXLIST::INDEXLIST(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Index_type) + 1*sizeof(Index_type)) +
-                  (1*sizeof(Int_type) + 0*sizeof(Int_type)) * getActualProblemSize() / 2 + // about 50% output
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Index_type) +
+                      1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Index_type) +
+                         1*sizeof(Int_type) * getActualProblemSize() / 2 ); // about 50% output
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Forall);

--- a/src/basic/INDEXLIST_3LOOP.cpp
+++ b/src/basic/INDEXLIST_3LOOP.cpp
@@ -28,14 +28,19 @@ INDEXLIST_3LOOP::INDEXLIST_3LOOP(const RunParams& params)
 
   setItsPerRep( 3 * getActualProblemSize() + 1 );
   setKernelsPerRep(3);
-  setBytesPerRep( (1*sizeof(Int_type) + 0*sizeof(Int_type)) * getActualProblemSize() +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getActualProblemSize() +
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() +
 
-                  (1*sizeof(Index_type) + 1*sizeof(Index_type)) +
-                  (1*sizeof(Int_type) + 1*sizeof(Int_type)) * (getActualProblemSize()+1) +
+                      1*sizeof(Index_type) +
+                      1*sizeof(Index_type) * (getActualProblemSize()+1) +
 
-                  (0*sizeof(Int_type) + 1*sizeof(Int_type)) * (getActualProblemSize()+1) +
-                  (1*sizeof(Int_type) + 0*sizeof(Int_type)) * getActualProblemSize() / 2 ); // about 50% output
+                      1*sizeof(Index_type) * (getActualProblemSize()+1) );
+  setBytesWrittenPerRep( 1*sizeof(Index_type) * getActualProblemSize() +
+
+                         1*sizeof(Index_type) +
+                         1*sizeof(Index_type) * (getActualProblemSize()+1) +
+
+                         1*sizeof(Int_type) * (getActualProblemSize()+1) / 2 ); // about 50% output
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Forall);

--- a/src/basic/INIT3.cpp
+++ b/src/basic/INIT3.cpp
@@ -28,7 +28,9 @@ INIT3::INIT3(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (3*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 3*sizeof(Real_type) * getActualProblemSize()  );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -28,7 +28,9 @@ INIT_VIEW1D::INIT_VIEW1D(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize()  );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -28,7 +28,7 @@ INIT_VIEW1D::INIT_VIEW1D(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) );
+  setBytesReadPerRep( 0 );
   setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize()  );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * getActualProblemSize());

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -28,7 +28,7 @@ INIT_VIEW1D_OFFSET::INIT_VIEW1D_OFFSET(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) );
+  setBytesReadPerRep( 0 );
   setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize()  );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * getActualProblemSize());

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -28,7 +28,9 @@ INIT_VIEW1D_OFFSET::INIT_VIEW1D_OFFSET(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize()  );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/basic/MAT_MAT_SHARED.cpp
+++ b/src/basic/MAT_MAT_SHARED.cpp
@@ -31,8 +31,9 @@ MAT_MAT_SHARED::MAT_MAT_SHARED(const RunParams &params)
   setItsPerRep(getActualProblemSize());
   setKernelsPerRep(1);
 
-  setBytesPerRep( m_N*m_N*sizeof(Real_type) +
-                  m_N*m_N*sizeof(Real_type) );
+  setBytesReadPerRep( 2*sizeof(Real_type) * m_N*m_N );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * m_N*m_N  );
+  setBytesAtomicModifyWrittenPerRep( 0 );
 
   const Index_type no_tiles = (TL_SZ + m_N - 1) / TL_SZ;
   const Index_type no_blocks = RAJA_DIVIDE_CEILING_INT(m_N, TL_SZ);

--- a/src/basic/MAT_MAT_SHARED.cpp
+++ b/src/basic/MAT_MAT_SHARED.cpp
@@ -24,7 +24,7 @@ MAT_MAT_SHARED::MAT_MAT_SHARED(const RunParams &params)
   setDefaultProblemSize(m_N_default*m_N_default);
   setDefaultReps(5);
 
-  m_N = std::max(Index_type(std::sqrt(getTargetProblemSize())), Index_type(1));
+  m_N = std::sqrt(getTargetProblemSize()) + std::sqrt(2)-1;
 
   setActualProblemSize(m_N * m_N);
 

--- a/src/basic/MULADDSUB.cpp
+++ b/src/basic/MULADDSUB.cpp
@@ -28,7 +28,9 @@ MULADDSUB::MULADDSUB(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (3*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 3*sizeof(Real_type) * getActualProblemSize()  );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(3 * getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -39,7 +39,9 @@ NESTED_INIT::NESTED_INIT(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize()  );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(3 * getActualProblemSize());
 
   setUsesFeature(Kernel);

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -29,7 +29,7 @@ NESTED_INIT::NESTED_INIT(const RunParams& params)
   setDefaultProblemSize(m_n_init * m_n_init * m_n_init);
   setDefaultReps(1000);
 
-  auto n_final = std::cbrt( getTargetProblemSize() );
+  auto n_final = std::cbrt( getTargetProblemSize() ) + std::cbrt(3)-1;
   m_ni = n_final;
   m_nj = n_final;
   m_nk = n_final;

--- a/src/basic/PI_ATOMIC.cpp
+++ b/src/basic/PI_ATOMIC.cpp
@@ -28,8 +28,9 @@ PI_ATOMIC::PI_ATOMIC(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) +
-                  (0*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 0  );
+  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Real_type) );
   setFLOPsPerRep(6 * getActualProblemSize() + 1);
 
   setUsesFeature(Forall);

--- a/src/basic/PI_REDUCE.cpp
+++ b/src/basic/PI_REDUCE.cpp
@@ -28,8 +28,9 @@ PI_REDUCE::PI_REDUCE(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) +
-                  (0*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(6 * getActualProblemSize() + 1);
 
   setUsesFeature(Forall);

--- a/src/basic/REDUCE3_INT.cpp
+++ b/src/basic/REDUCE3_INT.cpp
@@ -33,8 +33,10 @@ REDUCE3_INT::REDUCE3_INT(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (3*sizeof(Int_type) + 3*sizeof(Int_type)) +
-                  (0*sizeof(Int_type) + 1*sizeof(Int_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 3*sizeof(Int_type) +
+                      1*sizeof(Int_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 3*sizeof(Int_type) );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * getActualProblemSize() + 1);
 
   setUsesFeature(Forall);

--- a/src/basic/REDUCE_STRUCT.cpp
+++ b/src/basic/REDUCE_STRUCT.cpp
@@ -33,7 +33,10 @@ REDUCE_STRUCT::REDUCE_STRUCT(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( 6*sizeof(Real_type) + 2*sizeof(Real_type)*getActualProblemSize());
+  setBytesReadPerRep( 6*sizeof(Real_type) +
+                      2*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 6*sizeof(Real_type) );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * getActualProblemSize() + 2);
     
 

--- a/src/basic/TRAP_INT.cpp
+++ b/src/basic/TRAP_INT.cpp
@@ -28,8 +28,9 @@ TRAP_INT::TRAP_INT(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) +
-                  (0*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(10 * getActualProblemSize()); // 1 sqrt
 
   setUsesFeature(Forall);

--- a/src/comm/HALO_EXCHANGE.cpp
+++ b/src/comm/HALO_EXCHANGE.cpp
@@ -31,12 +31,19 @@ HALO_EXCHANGE::HALO_EXCHANGE(const RunParams& params)
 
   setItsPerRep( m_num_vars * (m_var_size - getActualProblemSize()) );
   setKernelsPerRep( 2 * s_num_neighbors * m_num_vars );
-  setBytesPerRep( (0*sizeof(Int_type)  + 1*sizeof(Int_type) ) * getItsPerRep() +  // pack
-                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() +  // pack
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() +  // send
-                  (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getItsPerRep() +  // recv
-                  (0*sizeof(Int_type)  + 1*sizeof(Int_type) ) * getItsPerRep() +  // unpack
-                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() ); // unpack
+  setBytesReadPerRep( 1*sizeof(Int_type) * getItsPerRep() +   // pack
+                      1*sizeof(Real_type) * getItsPerRep() +  // pack
+
+                      1*sizeof(Real_type) * getItsPerRep() +  // send
+
+                      1*sizeof(Int_type) * getItsPerRep() +   // unpack
+                      1*sizeof(Real_type) * getItsPerRep() ); // unpack
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() +  // pack
+
+                         1*sizeof(Real_type) * getItsPerRep() +  // recv
+
+                         1*sizeof(Real_type) * getItsPerRep() ); // unpack
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Forall);

--- a/src/comm/HALO_EXCHANGE_FUSED.cpp
+++ b/src/comm/HALO_EXCHANGE_FUSED.cpp
@@ -31,12 +31,19 @@ HALO_EXCHANGE_FUSED::HALO_EXCHANGE_FUSED(const RunParams& params)
 
   setItsPerRep( m_num_vars * (m_var_size - getActualProblemSize()) );
   setKernelsPerRep( 2 );
-  setBytesPerRep( (0*sizeof(Int_type)  + 1*sizeof(Int_type) ) * getItsPerRep() +  // pack
-                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() +  // pack
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() +  // send
-                  (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getItsPerRep() +  // recv
-                  (0*sizeof(Int_type)  + 1*sizeof(Int_type) ) * getItsPerRep() +  // unpack
-                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() ); // unpack
+  setBytesReadPerRep( 1*sizeof(Int_type) * getItsPerRep() +   // pack
+                      1*sizeof(Real_type) * getItsPerRep() +  // pack
+
+                      1*sizeof(Real_type) * getItsPerRep() +  // send
+
+                      1*sizeof(Int_type) * getItsPerRep() +   // unpack
+                      1*sizeof(Real_type) * getItsPerRep() ); // unpack
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() +  // pack
+
+                         1*sizeof(Real_type) * getItsPerRep() +  // recv
+
+                         1*sizeof(Real_type) * getItsPerRep() ); // unpack
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Workgroup);

--- a/src/comm/HALO_PACKING.cpp
+++ b/src/comm/HALO_PACKING.cpp
@@ -25,10 +25,15 @@ HALO_PACKING::HALO_PACKING(const RunParams& params)
 
   setItsPerRep( m_num_vars * (m_var_size - getActualProblemSize()) );
   setKernelsPerRep( 2 * s_num_neighbors * m_num_vars );
-  setBytesPerRep( (0*sizeof(Int_type)  + 1*sizeof(Int_type) ) * getItsPerRep() +  // pack
-                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() +  // pack
-                  (0*sizeof(Int_type)  + 1*sizeof(Int_type) ) * getItsPerRep() +  // unpack
-                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() ); // unpack
+  setBytesReadPerRep( 1*sizeof(Int_type) * getItsPerRep() +   // pack
+                      1*sizeof(Real_type) * getItsPerRep() +  // pack
+
+                      1*sizeof(Int_type) * getItsPerRep() +   // unpack
+                      1*sizeof(Real_type) * getItsPerRep() ); // unpack
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() +  // pack
+
+                         1*sizeof(Real_type) * getItsPerRep() ); // unpack
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Forall);

--- a/src/comm/HALO_PACKING_FUSED.cpp
+++ b/src/comm/HALO_PACKING_FUSED.cpp
@@ -25,10 +25,15 @@ HALO_PACKING_FUSED::HALO_PACKING_FUSED(const RunParams& params)
 
   setItsPerRep( m_num_vars * (m_var_size - getActualProblemSize()) );
   setKernelsPerRep( 2 );
-  setBytesPerRep( (0*sizeof(Int_type)  + 1*sizeof(Int_type) ) * getItsPerRep() +  // pack
-                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() +  // pack
-                  (0*sizeof(Int_type)  + 1*sizeof(Int_type) ) * getItsPerRep() +  // unpack
-                  (1*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() ); // unpack
+  setBytesReadPerRep( 1*sizeof(Int_type) * getItsPerRep() +   // pack
+                      1*sizeof(Real_type) * getItsPerRep() +  // pack
+
+                      1*sizeof(Int_type) * getItsPerRep() +   // unpack
+                      1*sizeof(Real_type) * getItsPerRep() ); // unpack
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() +  // pack
+
+                         1*sizeof(Real_type) * getItsPerRep() ); // unpack
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Workgroup);

--- a/src/comm/HALO_SENDRECV.cpp
+++ b/src/comm/HALO_SENDRECV.cpp
@@ -31,8 +31,9 @@ HALO_SENDRECV::HALO_SENDRECV(const RunParams& params)
 
   setItsPerRep( m_num_vars * (m_var_size - getActualProblemSize()) );
   setKernelsPerRep( 0 );
-  setBytesPerRep( (0*sizeof(Real_type) + 1*sizeof(Real_type)) * getItsPerRep() +  // send
-                  (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getItsPerRep() ); // recv
+  setBytesReadPerRep( 1*sizeof(Real_type) * getItsPerRep() ); // send
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() ); // recv
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Forall);

--- a/src/comm/HALO_base.cpp
+++ b/src/comm/HALO_base.cpp
@@ -30,7 +30,7 @@ HALO_base::HALO_base(KernelID kid, const RunParams& params)
                          s_grid_dims_default[1] *
                          s_grid_dims_default[2] );
 
-  double cbrt_run_size = std::cbrt(getTargetProblemSize());
+  double cbrt_run_size = std::cbrt(getTargetProblemSize()) + std::cbrt(3)-1;
 
   m_grid_dims[0] = cbrt_run_size;
   m_grid_dims[1] = cbrt_run_size;

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -522,15 +522,21 @@ void Executor::writeKernelInfoSummary(ostream& str, bool to_file) const
   Index_type itsrep_width = 0;
   Index_type bytesrep_width = 0;
   Index_type flopsrep_width = 0;
+  Index_type bytesReadrep_width = 0;
+  Index_type bytesWrittenrep_width = 0;
+  Index_type bytesAtomicModifyWrittenrep_width = 0;
   Index_type dash_width = 0;
 
   for (size_t ik = 0; ik < kernels.size(); ++ik) {
     kercol_width = max(kercol_width, kernels[ik]->getName().size());
     psize_width = max(psize_width, kernels[ik]->getActualProblemSize());
     reps_width = max(reps_width, kernels[ik]->getRunReps());
-    itsrep_width = max(reps_width, kernels[ik]->getItsPerRep());
+    itsrep_width = max(itsrep_width, kernels[ik]->getItsPerRep());
     bytesrep_width = max(bytesrep_width, kernels[ik]->getBytesPerRep());
-    flopsrep_width = max(bytesrep_width, kernels[ik]->getFLOPsPerRep());
+    flopsrep_width = max(flopsrep_width, kernels[ik]->getFLOPsPerRep());
+    bytesReadrep_width = max(bytesReadrep_width, kernels[ik]->getBytesReadPerRep());
+    bytesWrittenrep_width = max(bytesWrittenrep_width, kernels[ik]->getBytesWrittenPerRep());
+    bytesAtomicModifyWrittenrep_width = max(bytesAtomicModifyWrittenrep_width, kernels[ik]->getBytesAtomicModifyWrittenPerRep());
   }
 
   const string sepchr(" , ");
@@ -574,6 +580,24 @@ void Executor::writeKernelInfoSummary(ostream& str, bool to_file) const
                          static_cast<Index_type>(frsize) ) + 3;
   dash_width += flopsrep_width + static_cast<Index_type>(sepchr.size());
 
+  double brrsize = log10( static_cast<double>(bytesReadrep_width) );
+  string bytesReadrep_head("BytesRead/rep");
+  bytesReadrep_width = max( static_cast<Index_type>(bytesReadrep_head.size()),
+                        static_cast<Index_type>(brrsize) ) + 3;
+  dash_width += bytesReadrep_width + static_cast<Index_type>(sepchr.size());
+
+  double bwrsize = log10( static_cast<double>(bytesWrittenrep_width) );
+  string bytesWrittenrep_head("BytesWritten/rep");
+  bytesWrittenrep_width = max( static_cast<Index_type>(bytesWrittenrep_head.size()),
+                        static_cast<Index_type>(bwrsize) ) + 3;
+  dash_width += bytesWrittenrep_width + static_cast<Index_type>(sepchr.size());
+
+  double bamrrsize = log10( static_cast<double>(bytesAtomicModifyWrittenrep_width) );
+  string bytesAtomicModifyWrittenrep_head("BytesAtomicModifyWritten/rep");
+  bytesAtomicModifyWrittenrep_width = max( static_cast<Index_type>(bytesAtomicModifyWrittenrep_head.size()),
+                        static_cast<Index_type>(bamrrsize) ) + 3;
+  dash_width += bytesAtomicModifyWrittenrep_width + static_cast<Index_type>(sepchr.size());
+
   str <<left<< setw(kercol_width) << kern_head
       << sepchr <<right<< setw(psize_width) << psize_head
       << sepchr <<right<< setw(reps_width) << rsize_head
@@ -581,6 +605,9 @@ void Executor::writeKernelInfoSummary(ostream& str, bool to_file) const
       << sepchr <<right<< setw(kernsrep_width) << kernsrep_head
       << sepchr <<right<< setw(bytesrep_width) << bytesrep_head
       << sepchr <<right<< setw(flopsrep_width) << flopsrep_head
+      << sepchr <<right<< setw(bytesReadrep_width) << bytesReadrep_head
+      << sepchr <<right<< setw(bytesWrittenrep_width) << bytesWrittenrep_head
+      << sepchr <<right<< setw(bytesAtomicModifyWrittenrep_width) << bytesAtomicModifyWrittenrep_head
       << endl;
 
   if ( !to_file ) {
@@ -599,6 +626,9 @@ void Executor::writeKernelInfoSummary(ostream& str, bool to_file) const
         << sepchr <<right<< setw(kernsrep_width) << kern->getKernelsPerRep()
         << sepchr <<right<< setw(bytesrep_width) << kern->getBytesPerRep()
         << sepchr <<right<< setw(flopsrep_width) << kern->getFLOPsPerRep()
+        << sepchr <<right<< setw(bytesReadrep_width) << kern->getBytesReadPerRep()
+        << sepchr <<right<< setw(bytesWrittenrep_width) << kern->getBytesWrittenPerRep()
+        << sepchr <<right<< setw(bytesAtomicModifyWrittenrep_width) << kern->getBytesAtomicModifyWrittenPerRep()
         << endl;
   }
 

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -75,7 +75,7 @@ KernelBase::KernelBase(KernelID kid, const RunParams& params)
                                               CALI_ATTR_ASVALUE |
                                               CALI_ATTR_AGGREGATABLE |
                                               CALI_ATTR_SKIP_EVENTS);
-  Bytes_Rep_Written_attr = cali_create_attribute("BytesWritten/Rep", CALI_TYPE_DOUBLE,
+  Bytes_Written_Rep_attr = cali_create_attribute("BytesWritten/Rep", CALI_TYPE_DOUBLE,
                                                  CALI_ATTR_ASVALUE |
                                                  CALI_ATTR_AGGREGATABLE |
                                                  CALI_ATTR_SKIP_EVENTS);
@@ -564,9 +564,9 @@ void KernelBase::doOnceCaliMetaBegin(VariantID vid, size_t tune_idx)
     cali_set_double(Iters_Rep_attr,(double)getItsPerRep());
     cali_set_double(Kernels_Rep_attr,(double)getKernelsPerRep());
     cali_set_double(Bytes_Rep_attr,(double)getBytesPerRep());
-    cali_set_double(BytesRead_Rep_attr,(double)getBytesReadPerRep());
-    cali_set_double(BytesWritten_Rep_attr,(double)getBytesWrittenPerRep());
-    cali_set_double(BytesAtomicModifyWritten_Rep_attr,(double)getBytesAtomicModifyWrittenPerRep());
+    cali_set_double(Bytes_Read_Rep_attr,(double)getBytesReadPerRep());
+    cali_set_double(Bytes_Written_Rep_attr,(double)getBytesWrittenPerRep());
+    cali_set_double(Bytes_AtomicModifyWritten_Rep_attr,(double)getBytesAtomicModifyWrittenPerRep());
     cali_set_double(Flops_Rep_attr,(double)getFLOPsPerRep());
     cali_set_double(BlockSize_attr, getBlockSize());
     for (unsigned i = 0; i < FeatureID::NumFeatures; ++i) {

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -38,7 +38,9 @@ KernelBase::KernelBase(KernelID kid, const RunParams& params)
 
   its_per_rep = -1;
   kernels_per_rep = -1;
-  bytes_per_rep = -1;
+  bytes_read_per_rep = -1;
+  bytes_written_per_rep = -1;
+  bytes_atomic_modify_written_per_rep = -1;
   FLOPs_per_rep = -1;
 
   running_variant = NumVariants;
@@ -69,6 +71,18 @@ KernelBase::KernelBase(KernelID kid, const RunParams& params)
                                          CALI_ATTR_ASVALUE |
                                          CALI_ATTR_AGGREGATABLE |
                                          CALI_ATTR_SKIP_EVENTS);
+  Bytes_Read_Rep_attr = cali_create_attribute("BytesRead/Rep", CALI_TYPE_DOUBLE,
+                                              CALI_ATTR_ASVALUE |
+                                              CALI_ATTR_AGGREGATABLE |
+                                              CALI_ATTR_SKIP_EVENTS);
+  Bytes_Rep_Written_attr = cali_create_attribute("BytesWritten/Rep", CALI_TYPE_DOUBLE,
+                                                 CALI_ATTR_ASVALUE |
+                                                 CALI_ATTR_AGGREGATABLE |
+                                                 CALI_ATTR_SKIP_EVENTS);
+  Bytes_AtomicModifyWritten_Rep_attr = cali_create_attribute("BytesAtomicModifyWritten/Rep", CALI_TYPE_DOUBLE,
+                                                             CALI_ATTR_ASVALUE |
+                                                             CALI_ATTR_AGGREGATABLE |
+                                                             CALI_ATTR_SKIP_EVENTS);
   Flops_Rep_attr = cali_create_attribute("Flops/Rep", CALI_TYPE_DOUBLE,
                                          CALI_ATTR_ASVALUE |
                                          CALI_ATTR_AGGREGATABLE |
@@ -493,7 +507,9 @@ void KernelBase::print(std::ostream& os) const
   }
   os << "\t\t\t its_per_rep = " << its_per_rep << std::endl;
   os << "\t\t\t kernels_per_rep = " << kernels_per_rep << std::endl;
-  os << "\t\t\t bytes_per_rep = " << bytes_per_rep << std::endl;
+  os << "\t\t\t bytes_read_per_rep = " << bytes_read_per_rep << std::endl;
+  os << "\t\t\t bytes_written_per_rep = " << bytes_written_per_rep << std::endl;
+  os << "\t\t\t bytes_atomic_modify_written_per_rep = " << bytes_atomic_modify_written_per_rep << std::endl;
   os << "\t\t\t FLOPs_per_rep = " << FLOPs_per_rep << std::endl;
   os << "\t\t\t num_exec: " << std::endl;
   for (unsigned j = 0; j < NumVariants; ++j) {
@@ -548,6 +564,9 @@ void KernelBase::doOnceCaliMetaBegin(VariantID vid, size_t tune_idx)
     cali_set_double(Iters_Rep_attr,(double)getItsPerRep());
     cali_set_double(Kernels_Rep_attr,(double)getKernelsPerRep());
     cali_set_double(Bytes_Rep_attr,(double)getBytesPerRep());
+    cali_set_double(BytesRead_Rep_attr,(double)getBytesReadPerRep());
+    cali_set_double(BytesWritten_Rep_attr,(double)getBytesWrittenPerRep());
+    cali_set_double(BytesAtomicModifyWritten_Rep_attr,(double)getBytesAtomicModifyWrittenPerRep());
     cali_set_double(Flops_Rep_attr,(double)getFLOPsPerRep());
     cali_set_double(BlockSize_attr, getBlockSize());
     for (unsigned i = 0; i < FeatureID::NumFeatures; ++i) {
@@ -590,6 +609,9 @@ void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
           { "expr": "any(max#Iterations/Rep)", "as": "Iterations/Rep" },
           { "expr": "any(max#Kernels/Rep)", "as": "Kernels/Rep" },
           { "expr": "any(max#Bytes/Rep)", "as": "Bytes/Rep" },
+          { "expr": "any(max#BytesRead/Rep)", "as": "BytesRead/Rep" },
+          { "expr": "any(max#BytesWritten/Rep)", "as": "BytesWritten/Rep" },
+          { "expr": "any(max#BytesAtomicModifyWritten/Rep)", "as": "BytesAtomicModifyWritten/Rep" },
           { "expr": "any(max#Flops/Rep)", "as": "Flops/Rep" },
           { "expr": "any(max#BlockSize)", "as": "BlockSize" },
           { "expr": "any(max#Forall)", "as": "FeatureForall" },
@@ -613,6 +635,9 @@ void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
           { "expr": "any(any#max#Iterations/Rep)", "as": "Iterations/Rep" },
           { "expr": "any(any#max#Kernels/Rep)", "as": "Kernels/Rep" },
           { "expr": "any(any#max#Bytes/Rep)", "as": "Bytes/Rep" },
+          { "expr": "any(any#max#BytesRead/Rep)", "as": "BytesRead/Rep" },
+          { "expr": "any(any#max#BytesWritten/Rep)", "as": "BytesWritten/Rep" },
+          { "expr": "any(any#max#BytesAtomicModifyWritten/Rep)", "as": "BytesAtomicModifyWritten/Rep" },
           { "expr": "any(any#max#Flops/Rep)", "as": "Flops/Rep" },
           { "expr": "any(any#max#BlockSize)", "as": "BlockSize" },
           { "expr": "any(any#max#Forall)", "as": "FeatureForall" },

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -102,7 +102,9 @@ public:
   void setDefaultReps(Index_type reps) { default_reps = reps; }
   void setItsPerRep(Index_type its) { its_per_rep = its; };
   void setKernelsPerRep(Index_type nkerns) { kernels_per_rep = nkerns; };
-  void setBytesPerRep(Index_type bytes) { bytes_per_rep = bytes;}
+  void setBytesReadPerRep(Index_type bytes) { bytes_read_per_rep = bytes;}
+  void setBytesWrittenPerRep(Index_type bytes) { bytes_written_per_rep = bytes;}
+  void setBytesAtomicModifyWrittenPerRep(Index_type bytes) { bytes_atomic_modify_written_per_rep = bytes;}
   void setFLOPsPerRep(Index_type FLOPs) { FLOPs_per_rep = FLOPs; }
   void setBlockSize(Index_type size) { kernel_block_size = size; }
 
@@ -155,7 +157,10 @@ public:
   Index_type getDefaultReps() const { return default_reps; }
   Index_type getItsPerRep() const { return its_per_rep; };
   Index_type getKernelsPerRep() const { return kernels_per_rep; };
-  Index_type getBytesPerRep() const { return bytes_per_rep; }
+  Index_type getBytesPerRep() const { return bytes_read_per_rep + bytes_written_per_rep + 2*bytes_atomic_modify_written_per_rep; } // count atomic_modify_write operations as a read and a write to match previous counting
+  Index_type getBytesReadPerRep() const { return bytes_read_per_rep; }
+  Index_type getBytesWrittenPerRep() const { return bytes_written_per_rep; }
+  Index_type getBytesAtomicModifyWrittenPerRep() const { return bytes_atomic_modify_written_per_rep; }
   Index_type getFLOPsPerRep() const { return FLOPs_per_rep; }
   double getBlockSize() const { return kernel_block_size; }
 
@@ -549,7 +554,9 @@ private:
   //
   Index_type its_per_rep;
   Index_type kernels_per_rep;
-  Index_type bytes_per_rep;
+  Index_type bytes_read_per_rep;
+  Index_type bytes_written_per_rep;
+  Index_type bytes_atomic_modify_written_per_rep;
   Index_type FLOPs_per_rep;
   double kernel_block_size = nan(""); // Set default value for non GPU kernels
 
@@ -568,6 +575,9 @@ private:
   cali_id_t Iters_Rep_attr;
   cali_id_t Kernels_Rep_attr;
   cali_id_t Bytes_Rep_attr;
+  cali_id_t Bytes_Read_Rep_attr;
+  cali_id_t Bytes_Written_Rep_attr;
+  cali_id_t Bytes_AtomicModifyWritten_Rep_attr;
   cali_id_t Flops_Rep_attr;
   cali_id_t BlockSize_attr;
   std::map<std::string, cali_id_t> Feature_attrs;

--- a/src/lcals/DIFF_PREDICT.cpp
+++ b/src/lcals/DIFF_PREDICT.cpp
@@ -28,7 +28,9 @@ DIFF_PREDICT::DIFF_PREDICT(const RunParams& params)
   setItsPerRep( getActualProblemSize() );
 
   setKernelsPerRep(1);
-  setBytesPerRep( (10*sizeof(Real_type) + 10*sizeof(Real_type)) * getActualProblemSize());
+  setBytesReadPerRep( 10*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 10*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(9 * getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -31,8 +31,10 @@ EOS::EOS(const RunParams& params)
   setItsPerRep( getActualProblemSize() );
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) * getActualProblemSize() +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_array_length );
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() +
+                      1*sizeof(Real_type) * m_array_length );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(16 * getActualProblemSize());
 
   checksum_scale_factor = 0.0001 *

--- a/src/lcals/FIRST_DIFF.cpp
+++ b/src/lcals/FIRST_DIFF.cpp
@@ -29,10 +29,10 @@ FIRST_DIFF::FIRST_DIFF(const RunParams& params)
   m_N = getActualProblemSize()+1;
 
   setItsPerRep( getActualProblemSize() );
-  setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 0*sizeof(Real_type)) * getActualProblemSize() +
-                  (0*sizeof(Real_type) + 1*sizeof(Real_type)) * m_N );
+  setBytesReadPerRep( 1*sizeof(Real_type) * m_N );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/lcals/FIRST_MIN.cpp
+++ b/src/lcals/FIRST_MIN.cpp
@@ -33,9 +33,12 @@ FIRST_MIN::FIRST_MIN(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type ) + 1*sizeof(Real_type )) +
-                  (1*sizeof(Index_type) + 1*sizeof(Index_type)) +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N );
+  setBytesReadPerRep( 1*sizeof(Index_type) +
+                      1*sizeof(Real_type ) +
+                      1*sizeof(Real_type ) * m_N );
+  setBytesWrittenPerRep( 1*sizeof(Index_type) +
+                         1*sizeof(Real_type ) );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature(Forall);

--- a/src/lcals/FIRST_SUM.cpp
+++ b/src/lcals/FIRST_SUM.cpp
@@ -30,8 +30,9 @@ FIRST_SUM::FIRST_SUM(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * (m_N-1) +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N );
+  setBytesReadPerRep( 1*sizeof(Real_type ) * (m_N-1) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * m_N );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * (getActualProblemSize()-1));
 
   setUsesFeature(Forall);

--- a/src/lcals/GEN_LIN_RECUR.cpp
+++ b/src/lcals/GEN_LIN_RECUR.cpp
@@ -30,8 +30,11 @@ GEN_LIN_RECUR::GEN_LIN_RECUR(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(2);
-  setBytesPerRep( (2*sizeof(Real_type ) + 3*sizeof(Real_type )) * m_N +
-                  (2*sizeof(Real_type ) + 3*sizeof(Real_type )) * m_N );
+  setBytesReadPerRep( 3*sizeof(Real_type ) * m_N +
+                      3*sizeof(Real_type ) * m_N );
+  setBytesWrittenPerRep( 2*sizeof(Real_type ) * m_N +
+                         2*sizeof(Real_type ) * m_N );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep((3 +
                   3 ) * getActualProblemSize());
 

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -30,8 +30,10 @@ HYDRO_1D::HYDRO_1D(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type ) + 1*sizeof(Real_type )) * getActualProblemSize() +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * (getActualProblemSize()+1) );
+  setBytesReadPerRep( 1*sizeof(Real_type ) * getActualProblemSize() +
+                      1*sizeof(Real_type ) * (getActualProblemSize()+1) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(5 * getActualProblemSize());
 
   checksum_scale_factor = 0.001 *

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -40,11 +40,13 @@ HYDRO_2D::HYDRO_2D(const RunParams& params)
 
   setItsPerRep( 3 * getActualProblemSize() );
   setKernelsPerRep(3);
-  setBytesPerRep( (2*sizeof(Real_type ) + 0*sizeof(Real_type )) * (m_kn-2) * (m_jn-2) +
-                  (0*sizeof(Real_type ) + 4*sizeof(Real_type )) * m_array_length +
-                  (2*sizeof(Real_type ) + 0*sizeof(Real_type )) * (m_kn-2) * (m_jn-2) +
-                  (0*sizeof(Real_type ) + 4*sizeof(Real_type )) * m_array_length +
-                  (2*sizeof(Real_type ) + 4*sizeof(Real_type )) * (m_kn-2) * (m_jn-2) );
+  setBytesReadPerRep( 4*sizeof(Real_type ) * m_array_length +
+                      4*sizeof(Real_type ) * m_array_length +
+                      4*sizeof(Real_type ) * (m_kn-2) * (m_jn-2) );
+  setBytesWrittenPerRep( 2*sizeof(Real_type ) * (m_kn-2) * (m_jn-2) +
+                         2*sizeof(Real_type ) * (m_kn-2) * (m_jn-2) +
+                         2*sizeof(Real_type ) * (m_kn-2) * (m_jn-2) );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep((14 +
                   26 +
                   4  ) * (m_jn-2)*(m_kn-2));

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -33,7 +33,7 @@ HYDRO_2D::HYDRO_2D(const RunParams& params)
   setDefaultProblemSize(m_kn * m_jn);
   setDefaultReps(100);
 
-  m_jn = m_kn = std::sqrt(getTargetProblemSize());
+  m_jn = m_kn = std::sqrt(getTargetProblemSize()) + std::sqrt(2)-1;
   m_array_length = m_kn * m_jn;
 
   setActualProblemSize( getTargetProblemSize() );

--- a/src/lcals/INT_PREDICT.cpp
+++ b/src/lcals/INT_PREDICT.cpp
@@ -28,7 +28,9 @@ INT_PREDICT::INT_PREDICT(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type ) + 10*sizeof(Real_type )) * getActualProblemSize() );
+  setBytesReadPerRep( 10*sizeof(Real_type ) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(17 * getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/lcals/PLANCKIAN.cpp
+++ b/src/lcals/PLANCKIAN.cpp
@@ -28,7 +28,9 @@ PLANCKIAN::PLANCKIAN(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (2*sizeof(Real_type ) + 3*sizeof(Real_type )) * getActualProblemSize() );
+  setBytesReadPerRep( 3*sizeof(Real_type ) * getActualProblemSize() );
+  setBytesWrittenPerRep( 2*sizeof(Real_type ) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(4 * getActualProblemSize()); // 1 exp
 
   setUsesFeature(Forall);

--- a/src/lcals/TRIDIAG_ELIM.cpp
+++ b/src/lcals/TRIDIAG_ELIM.cpp
@@ -30,7 +30,9 @@ TRIDIAG_ELIM::TRIDIAG_ELIM(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type ) + 3*sizeof(Real_type )) * (m_N-1) );
+  setBytesReadPerRep( 3*sizeof(Real_type ) * (m_N-1) );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * (m_N-1) );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * (getActualProblemSize()-1));
 
   setUsesFeature(Forall);

--- a/src/lcals/TRIDIAG_ELIM.cpp
+++ b/src/lcals/TRIDIAG_ELIM.cpp
@@ -26,7 +26,7 @@ TRIDIAG_ELIM::TRIDIAG_ELIM(const RunParams& params)
 
   setActualProblemSize( getTargetProblemSize() );
 
-  m_N = getActualProblemSize();
+  m_N = getActualProblemSize() + 1;
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -44,13 +44,15 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
 
   setItsPerRep( m_ni*m_nj + m_ni*m_nl );
   setKernelsPerRep(2);
-  setBytesPerRep( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * m_ni * m_nj +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_ni * m_nk +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nj * m_nk +
+  setBytesReadPerRep( 1*sizeof(Real_type ) * m_ni * m_nk +
+                      1*sizeof(Real_type ) * m_nj * m_nk +
 
-                  (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * m_ni * m_nl +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_ni * m_nj +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nj * m_nl );
+                      1*sizeof(Real_type ) * m_ni * m_nj +
+                      1*sizeof(Real_type ) * m_nj * m_nl );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * m_ni * m_nj +
+
+                         1*sizeof(Real_type ) * m_ni * m_nl );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(3 * m_ni*m_nj*m_nk +
                  2 * m_ni*m_nj*m_nl );
 

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -31,7 +31,7 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
                                    ni_default*nl_default ) );
   setDefaultReps(2);
 
-  m_ni = std::sqrt( getTargetProblemSize() );
+  m_ni = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
   m_nj = m_ni;
   m_nk = Index_type(double(nk_default)/ni_default*m_ni);
   m_nl = m_ni;

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -31,9 +31,9 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
                                    ni_default*nl_default ) );
   setDefaultReps(2);
 
-  m_ni = std::sqrt( getTargetProblemSize() ) + 1;
+  m_ni = std::sqrt( getTargetProblemSize() );
   m_nj = m_ni;
-  m_nk = nk_default;
+  m_nk = Index_type(double(nk_default)/ni_default*m_ni);
   m_nl = m_ni;
 
   m_alpha = 1.5;

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -35,11 +35,11 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   setDefaultProblemSize( ni_default * nj_default );
   setDefaultReps(2);
 
-  m_ni = std::sqrt( getTargetProblemSize() ) + 1;
+  m_ni = std::sqrt( getTargetProblemSize() );
   m_nj = m_ni;
-  m_nk = nk_default;
+  m_nk = Index_type(double(nk_default)/ni_default*m_ni);
   m_nl = m_ni;
-  m_nm = nm_default;
+  m_nm = Index_type(double(nm_default)/ni_default*m_ni);
 
 
   setActualProblemSize( std::max( std::max( m_ni*m_nj, m_nj*m_nl ),

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -47,17 +47,20 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
 
   setItsPerRep( m_ni*m_nj + m_nj*m_nl + m_ni*m_nl );
   setKernelsPerRep(3);
-  setBytesPerRep( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * m_ni * m_nj +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_ni * m_nk +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nj * m_nk +
+  setBytesReadPerRep( 1*sizeof(Real_type ) * m_ni * m_nk +
+                      1*sizeof(Real_type ) * m_nj * m_nk +
 
-                  (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * m_nj * m_nl +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nj * m_nm +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nl * m_nm +
+                      1*sizeof(Real_type ) * m_nj * m_nm +
+                      1*sizeof(Real_type ) * m_nl * m_nm +
 
-                  (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * m_ni * m_nl +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_ni * m_nj +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nj * m_nl );
+                      1*sizeof(Real_type ) * m_ni * m_nj +
+                      1*sizeof(Real_type ) * m_nj * m_nl );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * m_ni * m_nj +
+
+                         1*sizeof(Real_type ) * m_nj * m_nl +
+
+                         1*sizeof(Real_type ) * m_ni * m_nl );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * m_ni*m_nj*m_nk +
                  2 * m_nj*m_nl*m_nm +
                  2 * m_ni*m_nj*m_nl );

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -35,7 +35,7 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   setDefaultProblemSize( ni_default * nj_default );
   setDefaultReps(2);
 
-  m_ni = std::sqrt( getTargetProblemSize() );
+  m_ni = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
   m_nj = m_ni;
   m_nk = Index_type(double(nk_default)/ni_default*m_ni);
   m_nl = m_ni;

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -34,8 +34,11 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
   setActualProblemSize( (m_n-2) * (m_n-2) );
 
   setKernelsPerRep( m_tsteps * 2 );
-  setBytesPerRep( m_tsteps * ( (3*sizeof(Real_type ) + 3*sizeof(Real_type )) * m_n * (m_n-2) +
-                               (3*sizeof(Real_type ) + 3*sizeof(Real_type )) * m_n * (m_n-2) ) );
+  setBytesReadPerRep((3*sizeof(Real_type ) * m_n * (m_n-2) +
+                      3*sizeof(Real_type ) * m_n * (m_n-2)) * m_tsteps  );
+  setBytesWrittenPerRep((3*sizeof(Real_type ) * m_n * (m_n-2) +
+                         3*sizeof(Real_type ) * m_n * (m_n-2)) * m_tsteps  );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep( m_tsteps * ( (15 + 2) * (m_n-2)*(m_n-2) +
                                (15 + 2) * (m_n-2)*(m_n-2) ) );
 

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -20,12 +20,12 @@ namespace polybench
 POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
   : KernelBase(rajaperf::Polybench_ADI, params)
 {
-  Index_type n_default = 1000;
+  Index_type n_default = 1002;
 
   setDefaultProblemSize( (n_default-2) * (n_default-2) );
   setDefaultReps(4);
 
-  m_n = std::sqrt( getTargetProblemSize() ) + 1;
+  m_n = std::sqrt( getTargetProblemSize() ) + 2;
   m_tsteps = 4;
 
   setItsPerRep( m_tsteps * ( (m_n-2) + (m_n-2) ) );

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -25,7 +25,7 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
   setDefaultProblemSize( (n_default-2) * (n_default-2) );
   setDefaultReps(4);
 
-  m_n = std::sqrt( getTargetProblemSize() ) + 2;
+  m_n = std::sqrt( getTargetProblemSize() ) + 2 + std::sqrt(2)-1;
   m_tsteps = 4;
 
   setItsPerRep( m_tsteps * ( (m_n-2) + (m_n-2) ) );

--- a/src/polybench/POLYBENCH_ATAX.cpp
+++ b/src/polybench/POLYBENCH_ATAX.cpp
@@ -26,7 +26,7 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(100);
 
-  m_N = std::sqrt( getTargetProblemSize() )+1;
+  m_N = std::sqrt( getTargetProblemSize() );
 
 
   setActualProblemSize( m_N * m_N );

--- a/src/polybench/POLYBENCH_ATAX.cpp
+++ b/src/polybench/POLYBENCH_ATAX.cpp
@@ -33,11 +33,14 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
 
   setItsPerRep( m_N + m_N );
   setKernelsPerRep(2);
-  setBytesPerRep( (2*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N * m_N +
+  setBytesReadPerRep( 1*sizeof(Real_type ) * m_N +
+                      1*sizeof(Real_type ) * m_N * m_N +
 
-                  (1*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N * m_N );
+                      1*sizeof(Real_type ) * m_N +
+                      1*sizeof(Real_type ) * m_N * m_N );
+  setBytesWrittenPerRep( 2*sizeof(Real_type ) * m_N +
+                         1*sizeof(Real_type ) * m_N);
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * m_N*m_N +
                  2 * m_N*m_N );
 

--- a/src/polybench/POLYBENCH_ATAX.cpp
+++ b/src/polybench/POLYBENCH_ATAX.cpp
@@ -26,7 +26,7 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(100);
 
-  m_N = std::sqrt( getTargetProblemSize() );
+  m_N = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
 
 
   setActualProblemSize( m_N * m_N );

--- a/src/polybench/POLYBENCH_FDTD_2D.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.cpp
@@ -31,7 +31,7 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
                                     nx_default * (ny_default-1) ) );
   setDefaultReps(8);
 
-  m_nx = std::sqrt( getTargetProblemSize() ) + 1;
+  m_nx = std::sqrt( getTargetProblemSize() ) + 1 + std::sqrt(2)-1;
   m_ny = m_nx;
   m_tsteps = 40;
 

--- a/src/polybench/POLYBENCH_FDTD_2D.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.cpp
@@ -43,18 +43,25 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
                              m_nx*(m_ny-1) +
                              (m_nx-1)*(m_ny-1) ) );
   setKernelsPerRep(m_tsteps * 4);
-  setBytesPerRep( m_tsteps * ( (0*sizeof(Real_type ) + 1*sizeof(Real_type )) +
-                               (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * m_ny +
+  setBytesReadPerRep((1*sizeof(Real_type ) +
 
-                               (1*sizeof(Real_type ) + 1*sizeof(Real_type )) * (m_nx-1) * m_ny +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nx * m_ny +
+                      1*sizeof(Real_type ) * (m_nx-1) * m_ny +
+                      1*sizeof(Real_type ) * m_nx * m_ny +
 
-                               (1*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nx * (m_ny-1) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nx * m_ny +
+                      1*sizeof(Real_type ) * m_nx * (m_ny-1) +
+                      1*sizeof(Real_type ) * m_nx * m_ny +
 
-                               (1*sizeof(Real_type ) + 1*sizeof(Real_type )) * (m_nx-1) * (m_ny-1) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * (m_nx-1) * m_ny +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nx * (m_ny-1) ) );
+                      1*sizeof(Real_type ) * (m_nx-1) * (m_ny-1) +
+                      1*sizeof(Real_type ) * (m_nx-1) * m_ny +
+                      1*sizeof(Real_type ) * m_nx * (m_ny-1)) * m_tsteps );
+  setBytesWrittenPerRep((1*sizeof(Real_type ) * m_ny +
+
+                         1*sizeof(Real_type ) * (m_nx-1) * m_ny +
+
+                         1*sizeof(Real_type ) * m_nx * (m_ny-1) +
+
+                         1*sizeof(Real_type ) * (m_nx-1) * (m_ny-1)) * m_tsteps );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep( m_tsteps * ( 0 * m_ny +
                                3 * (m_nx-1)*m_ny +
                                3 * m_nx*(m_ny-1) +

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
@@ -26,7 +26,7 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(8);
 
-  m_N = std::sqrt( getTargetProblemSize() );
+  m_N = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
 
 
   setActualProblemSize( m_N * m_N );

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
@@ -33,7 +33,9 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
 
   setItsPerRep( m_N*m_N );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N * m_N );
+  setBytesReadPerRep( 1*sizeof(Real_type ) * m_N * m_N );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * m_N * m_N );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * m_N*m_N*m_N );
 
   checksum_scale_factor = 1.0 *

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
@@ -26,7 +26,7 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(8);
 
-  m_N = std::sqrt( getTargetProblemSize() ) + 1;
+  m_N = std::sqrt( getTargetProblemSize() );
 
 
   setActualProblemSize( m_N * m_N );

--- a/src/polybench/POLYBENCH_GEMM.cpp
+++ b/src/polybench/POLYBENCH_GEMM.cpp
@@ -28,9 +28,9 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
   setDefaultProblemSize( ni_default * nj_default );
   setDefaultReps(4);
 
-  m_ni = std::sqrt( getTargetProblemSize() ) + 1;
+  m_ni = std::sqrt( getTargetProblemSize() );
   m_nj = m_ni;
-  m_nk = nk_default;
+  m_nk = Index_type(double(nk_default)/ni_default*m_ni);
 
   m_alpha = 0.62;
   m_beta = 1.002;

--- a/src/polybench/POLYBENCH_GEMM.cpp
+++ b/src/polybench/POLYBENCH_GEMM.cpp
@@ -28,7 +28,7 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
   setDefaultProblemSize( ni_default * nj_default );
   setDefaultReps(4);
 
-  m_ni = std::sqrt( getTargetProblemSize() );
+  m_ni = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
   m_nj = m_ni;
   m_nk = Index_type(double(nk_default)/ni_default*m_ni);
 

--- a/src/polybench/POLYBENCH_GEMM.cpp
+++ b/src/polybench/POLYBENCH_GEMM.cpp
@@ -40,9 +40,10 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
 
   setItsPerRep( m_ni * m_nj );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) * m_ni * m_nj +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_ni * m_nk +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_nj * m_nk );
+  setBytesReadPerRep( 1*sizeof(Real_type ) * m_ni * m_nk +
+                      1*sizeof(Real_type ) * m_nj * m_nk );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * m_ni * m_nj);
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep((1 +
                   3 * m_nk) * m_ni*m_nj);
 

--- a/src/polybench/POLYBENCH_GEMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMVER.cpp
@@ -39,16 +39,24 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
                 m_n +
                 m_n*m_n );
   setKernelsPerRep(4);
-  setBytesPerRep( (1*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_n * m_n +
-                  (0*sizeof(Real_type ) + 4*sizeof(Real_type )) * m_n +
+  setBytesReadPerRep( 1*sizeof(Real_type ) * m_n * m_n +
+                      4*sizeof(Real_type ) * m_n +
 
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_n * m_n +
-                  (1*sizeof(Real_type ) + 2*sizeof(Real_type )) * m_n +
+                      1*sizeof(Real_type ) * m_n * m_n +
+                      2*sizeof(Real_type ) * m_n +
 
-                  (1*sizeof(Real_type ) + 2*sizeof(Real_type )) * m_n +
+                      2*sizeof(Real_type ) * m_n +
 
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_n * m_n +
-                  (1*sizeof(Real_type ) + 2*sizeof(Real_type )) * m_n );
+                      1*sizeof(Real_type ) * m_n * m_n +
+                      2*sizeof(Real_type ) * m_n );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * m_n * m_n +
+
+                         1*sizeof(Real_type ) * m_n +
+
+                         1*sizeof(Real_type ) * m_n +
+
+                         1*sizeof(Real_type ) * m_n );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(4 * m_n*m_n +
                  3 * m_n*m_n +
                  1 * m_n +

--- a/src/polybench/POLYBENCH_GEMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMVER.cpp
@@ -26,7 +26,7 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
   setDefaultProblemSize( n_default * n_default );
   setDefaultReps(20);
 
-  m_n =  std::sqrt( getTargetProblemSize() ) + 1;
+  m_n =  std::sqrt( getTargetProblemSize() );
 
   m_alpha = 1.5;
   m_beta = 1.2;

--- a/src/polybench/POLYBENCH_GEMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMVER.cpp
@@ -26,7 +26,7 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
   setDefaultProblemSize( n_default * n_default );
   setDefaultReps(20);
 
-  m_n =  std::sqrt( getTargetProblemSize() );
+  m_n =  std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
 
   m_alpha = 1.5;
   m_beta = 1.2;

--- a/src/polybench/POLYBENCH_GESUMMV.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV.cpp
@@ -26,7 +26,7 @@ POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(120);
 
-  m_N = std::sqrt( getTargetProblemSize() );
+  m_N = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
 
   m_alpha = 0.62;
   m_beta = 1.002;

--- a/src/polybench/POLYBENCH_GESUMMV.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV.cpp
@@ -36,8 +36,10 @@ POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
 
   setItsPerRep( m_N );
   setKernelsPerRep(1);
-  setBytesPerRep( (2*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N +
-                  (0*sizeof(Real_type ) + 2*sizeof(Real_type )) * m_N * m_N );
+  setBytesReadPerRep( 1*sizeof(Real_type ) * m_N +
+                      2*sizeof(Real_type ) * m_N * m_N );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * m_N );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep((4 * m_N +
                   3 ) * m_N  );
 

--- a/src/polybench/POLYBENCH_GESUMMV.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV.cpp
@@ -26,7 +26,7 @@ POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(120);
 
-  m_N = std::sqrt( getTargetProblemSize() ) + 1;
+  m_N = std::sqrt( getTargetProblemSize() );
 
   m_alpha = 0.62;
   m_beta = 1.002;

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -22,12 +22,12 @@ namespace polybench
 POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_HEAT_3D, params)
 {
-  Index_type N_default = 100;
+  Index_type N_default = 102;
 
   setDefaultProblemSize( (N_default-2)*(N_default-2)*(N_default-2) );
   setDefaultReps(20);
 
-  m_N = std::cbrt( getTargetProblemSize() ) + 1;
+  m_N = std::cbrt( getTargetProblemSize() ) + 2;
   m_tsteps = 20;
 
 

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -27,7 +27,7 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
   setDefaultProblemSize( (N_default-2)*(N_default-2)*(N_default-2) );
   setDefaultReps(20);
 
-  m_N = std::cbrt( getTargetProblemSize() ) + 2;
+  m_N = std::cbrt( getTargetProblemSize() ) + 2 + std::cbrt(3)-1;
   m_tsteps = 20;
 
 

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -35,14 +35,13 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
 
   setItsPerRep( m_tsteps * ( 2 * getActualProblemSize() ) );
   setKernelsPerRep( m_tsteps * 2 );
-  setBytesPerRep( m_tsteps * ( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) *
-                               (m_N-2) * (m_N-2) * (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) *
-                               (m_N * m_N * m_N - 12*(m_N-2) - 8) +
-                               (1*sizeof(Real_type ) + 0*sizeof(Real_type )) *
-                               (m_N-2) * (m_N-2) * (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) *
-                               (m_N * m_N * m_N - 12*(m_N-2) - 8) ) );
+  setBytesReadPerRep((1*sizeof(Real_type ) * (m_N * m_N * m_N - 12*(m_N-2) - 8) +
+
+                      1*sizeof(Real_type ) * (m_N * m_N * m_N - 12*(m_N-2) - 8)) * m_tsteps);
+  setBytesWrittenPerRep((1*sizeof(Real_type ) * (m_N-2) * (m_N-2) * (m_N-2) +
+
+                         1*sizeof(Real_type ) * (m_N-2) * (m_N-2) * (m_N-2)) * m_tsteps);
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep( m_tsteps * ( 15 * (m_N-2) * (m_N-2) * (m_N-2) +
                                15 * (m_N-2) * (m_N-2) * (m_N-2) ) );
 

--- a/src/polybench/POLYBENCH_JACOBI_1D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.cpp
@@ -21,12 +21,12 @@ namespace polybench
 POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_JACOBI_1D, params)
 {
-  Index_type N_default = 1000000;
+  Index_type N_default = 1000002;
 
   setDefaultProblemSize( N_default-2 );
   setDefaultReps(100);
 
-  m_N = getTargetProblemSize();
+  m_N = getTargetProblemSize() + 2;
   m_tsteps = 16;
 
 

--- a/src/polybench/POLYBENCH_JACOBI_1D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.cpp
@@ -34,14 +34,13 @@ POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
 
   setItsPerRep( m_tsteps * ( 2 * getActualProblemSize() ) );
   setKernelsPerRep(m_tsteps * 2);
-  setBytesPerRep( m_tsteps * ( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) *
-                               (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) *
-                               m_N +
-                               (1*sizeof(Real_type ) + 0*sizeof(Real_type )) *
-                               (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) *
-                               m_N ) );
+  setBytesReadPerRep((1*sizeof(Real_type ) * m_N +
+
+                      1*sizeof(Real_type ) * m_N) * m_tsteps);
+  setBytesWrittenPerRep((1*sizeof(Real_type ) * (m_N-2) +
+
+                         1*sizeof(Real_type ) * (m_N-2)) * m_tsteps);
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep( m_tsteps * ( 3 * (m_N-2) +
                                3 * (m_N-2) ) );
 

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -34,14 +34,13 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
 
   setItsPerRep( m_tsteps * (2 * (m_N-2) * (m_N-2)) );
   setKernelsPerRep(2);
-  setBytesPerRep( m_tsteps * ( (1*sizeof(Real_type ) + 0*sizeof(Real_type )) *
-                               (m_N-2) * (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) *
-                               (m_N * m_N - 4) +
-                               (1*sizeof(Real_type ) + 0*sizeof(Real_type )) *
-                               (m_N-2) * (m_N-2) +
-                               (0*sizeof(Real_type ) + 1*sizeof(Real_type )) *
-                               (m_N * m_N  - 4) ) );
+  setBytesReadPerRep((1*sizeof(Real_type ) * (m_N * m_N - 4) +
+
+                      1*sizeof(Real_type ) * (m_N * m_N - 4)) * m_tsteps);
+  setBytesWrittenPerRep((1*sizeof(Real_type ) * (m_N-2) * (m_N-2) +
+
+                         1*sizeof(Real_type ) * (m_N-2) * (m_N-2)) * m_tsteps);
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep( m_tsteps * ( 5 * (m_N-2)*(m_N-2) +
                                5 * (m_N -2)*(m_N-2) ) );
 

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -26,7 +26,7 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
   setDefaultProblemSize( (N_default-2)*(N_default-2) );
   setDefaultReps(50);
 
-  m_N = std::sqrt( getTargetProblemSize() ) + 2;
+  m_N = std::sqrt( getTargetProblemSize() ) + 2 + std::sqrt(2)-1;
   m_tsteps = 40;
 
 

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -21,12 +21,12 @@ namespace polybench
 POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_JACOBI_2D, params)
 {
-  Index_type N_default = 1000;
+  Index_type N_default = 1002;
 
-  setDefaultProblemSize( N_default * N_default );
+  setDefaultProblemSize( (N_default-2)*(N_default-2) );
   setDefaultReps(50);
 
-  m_N = std::sqrt( getTargetProblemSize() ) + 1;
+  m_N = std::sqrt( getTargetProblemSize() ) + 2;
   m_tsteps = 40;
 
 

--- a/src/polybench/POLYBENCH_MVT.cpp
+++ b/src/polybench/POLYBENCH_MVT.cpp
@@ -26,7 +26,7 @@ POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(100);
 
-  m_N = std::sqrt( getTargetProblemSize() ) + 1;
+  m_N = std::sqrt( getTargetProblemSize() );
 
 
   setActualProblemSize( m_N * m_N );

--- a/src/polybench/POLYBENCH_MVT.cpp
+++ b/src/polybench/POLYBENCH_MVT.cpp
@@ -26,7 +26,7 @@ POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(100);
 
-  m_N = std::sqrt( getTargetProblemSize() );
+  m_N = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
 
 
   setActualProblemSize( m_N * m_N );

--- a/src/polybench/POLYBENCH_MVT.cpp
+++ b/src/polybench/POLYBENCH_MVT.cpp
@@ -33,10 +33,15 @@ POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
 
   setItsPerRep( 2 * m_N );
   setKernelsPerRep(2);
-  setBytesPerRep( (1*sizeof(Real_type ) + 2*sizeof(Real_type )) * m_N +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N * m_N +
-                  (1*sizeof(Real_type ) + 2*sizeof(Real_type )) * m_N +
-                  (0*sizeof(Real_type ) + 1*sizeof(Real_type )) * m_N * m_N );
+  setBytesReadPerRep( 2*sizeof(Real_type ) * m_N +
+                      1*sizeof(Real_type ) * m_N * m_N +
+
+                      2*sizeof(Real_type ) * m_N +
+                      1*sizeof(Real_type ) * m_N * m_N );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * m_N +
+
+                         1*sizeof(Real_type ) * m_N );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * m_N*m_N +
                  2 * m_N*m_N );
 

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -28,8 +28,9 @@ ADD::ADD(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) *
-                  getActualProblemSize() );
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature(Forall);

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -28,8 +28,9 @@ COPY::COPY(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) *
-                  getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
 
   setUsesFeature( Forall );

--- a/src/stream/DOT.cpp
+++ b/src/stream/DOT.cpp
@@ -28,9 +28,10 @@ DOT::DOT(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) +
-                  (0*sizeof(Real_type) + 2*sizeof(Real_type)) *
-                  getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) +
+                      2*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * getActualProblemSize());
 
   setUsesFeature( Forall );

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -28,8 +28,9 @@ MUL::MUL(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 1*sizeof(Real_type)) *
-                  getActualProblemSize() );
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * getActualProblemSize());
 
   setUsesFeature( Forall );

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -28,8 +28,9 @@ TRIAD::TRIAD(const RunParams& params)
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
-  setBytesPerRep( (1*sizeof(Real_type) + 2*sizeof(Real_type)) *
-                  getActualProblemSize() );
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() );
+  setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * getActualProblemSize());
 
   checksum_scale_factor = 0.001 *


### PR DESCRIPTION
# Split byte counters into reads and writes

This PR splits our current bytesPerRep counter into bytes read, bytes written, and bytes atomic modify written (atomicAdd with ignored return value). This will help us to understand performance on hardware where the total bandwidth is not the same as the sum of the read and write bandwidth. Note that the total bytes is still output with the same name in the same places and new counters are added to the end of tables to maintain compatibility with existing scripts as much as possible. Though some totals did change where errors in the counts were encountered.

This also messes with the way we decide the actual problem size from the target problem size to be closer to target problem size. It also fixes some cases where we had a zero or negative actual problem size when the target problem size was one. This also tweaks some reported problem sizes to be more consistent across kernels, for example using num_zones in app kernels instead of the number of iterations.

- This PR is a feature
- It does the following:
  - Modifies/refactors all of the bytes counters by splitting them into 3 categories
  - Fixes #457 
  - Adds split byte counts at the request of me
