### PR TITLE
Change Default Tuning Names

### DIFF
--- a/src/algorithm/HISTOGRAM-Cuda.cpp
+++ b/src/algorithm/HISTOGRAM-Cuda.cpp
@@ -280,6 +280,23 @@ void HISTOGRAM::runCudaVariant(VariantID vid, size_t tune_idx)
 
         seq_for(gpu_mapping::reducer_helpers{}, [&](auto mapping_helper) {
 
+          if (camp::size<cuda_atomic_global_replications_type>::value == 0 &&
+              camp::size<cuda_atomic_shared_replications_type>::value == 0 ) {
+
+            if (tune_idx == t) {
+
+              setBlockSize(block_size);
+              runCudaVariantAtomicRuntime<decltype(block_size)::value,
+                                          default_cuda_atomic_global_replication,
+                                          default_cuda_atomic_shared_replication,
+                                          decltype(mapping_helper)>(vid);
+
+            }
+
+            t += 1;
+
+          }
+
           seq_for(cuda_atomic_global_replications_type{}, [&](auto global_replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
@@ -335,6 +352,15 @@ void HISTOGRAM::setCudaTuningDefinitions(VariantID vid)
           run_params.validGPUBlockSize(block_size)) {
 
         seq_for(gpu_mapping::reducer_helpers{}, [&](auto mapping_helper) {
+
+          if (camp::size<cuda_atomic_global_replications_type>::value == 0 &&
+              camp::size<cuda_atomic_shared_replications_type>::value == 0 ) {
+
+            addVariantTuningName(vid, "atomic_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      std::to_string(block_size));
+
+          }
 
           seq_for(cuda_atomic_global_replications_type{}, [&](auto global_replication) {
 

--- a/src/algorithm/HISTOGRAM-Hip.cpp
+++ b/src/algorithm/HISTOGRAM-Hip.cpp
@@ -309,6 +309,23 @@ void HISTOGRAM::runHipVariant(VariantID vid, size_t tune_idx)
 
         seq_for(gpu_mapping::reducer_helpers{}, [&](auto mapping_helper) {
 
+          if (camp::size<hip_atomic_global_replications_type>::value == 0 &&
+              camp::size<hip_atomic_shared_replications_type>::value == 0 ) {
+
+            if (tune_idx == t) {
+
+              setBlockSize(block_size);
+              runHipVariantAtomicRuntime<decltype(block_size)::value,
+                                          default_hip_atomic_global_replication,
+                                          default_hip_atomic_shared_replication,
+                                          decltype(mapping_helper)>(vid);
+
+            }
+
+            t += 1;
+
+          }
+
           seq_for(hip_atomic_global_replications_type{}, [&](auto global_replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
@@ -364,6 +381,15 @@ void HISTOGRAM::setHipTuningDefinitions(VariantID vid)
           run_params.validGPUBlockSize(block_size)) {
 
         seq_for(gpu_mapping::reducer_helpers{}, [&](auto mapping_helper) {
+
+          if (camp::size<hip_atomic_global_replications_type>::value == 0 &&
+              camp::size<hip_atomic_shared_replications_type>::value == 0 ) {
+
+            addVariantTuningName(vid, "atomic_"+
+                                      decltype(mapping_helper)::get_name()+"_"+
+                                      std::to_string(block_size));
+
+          }
 
           seq_for(hip_atomic_global_replications_type{}, [&](auto global_replication) {
 

--- a/src/algorithm/HISTOGRAM.hpp
+++ b/src/algorithm/HISTOGRAM.hpp
@@ -125,13 +125,13 @@ private:
 
   static const size_t default_cuda_atomic_global_replication = 2;
   static const size_t default_cuda_atomic_shared_replication = 16;
-  using cuda_atomic_global_replications_type = integer::make_atomic_replication_list_type<default_cuda_atomic_global_replication>;
-  using cuda_atomic_shared_replications_type = integer::make_atomic_replication_list_type<default_cuda_atomic_shared_replication>;
+  using cuda_atomic_global_replications_type = integer::make_atomic_replication_list_type<0>; // default list is empty
+  using cuda_atomic_shared_replications_type = integer::make_atomic_replication_list_type<0>; // default list is empty
 
   static const size_t default_hip_atomic_global_replication = 32;
   static const size_t default_hip_atomic_shared_replication = 4;
-  using hip_atomic_global_replications_type = integer::make_atomic_replication_list_type<default_hip_atomic_global_replication>;
-  using hip_atomic_shared_replications_type = integer::make_atomic_replication_list_type<default_hip_atomic_shared_replication>;
+  using hip_atomic_global_replications_type = integer::make_atomic_replication_list_type<0>; // default list is empty
+  using hip_atomic_shared_replications_type = integer::make_atomic_replication_list_type<0>; // default list is empty
 
   Index_type m_num_bins;
   Index_ptr m_bins;

--- a/src/basic/INDEXLIST-Cuda.cpp
+++ b/src/basic/INDEXLIST-Cuda.cpp
@@ -24,7 +24,7 @@ namespace basic
 
 template < size_t block_size >
 using cuda_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
-    detail::cuda::grid_scan_default_items_per_thread<Index_type, block_size, RAJA_PERFSUITE_TUNING_CUDA_ARCH>::value,
+    detail::cuda::grid_scan_max_items_per_thread<Index_type, block_size>::value+1,
     integer::LessEqual<detail::cuda::grid_scan_max_items_per_thread<Index_type, block_size>::value>>;
 
 
@@ -142,7 +142,24 @@ void INDEXLIST::runCudaVariant(VariantID vid, size_t tune_idx)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        seq_for(cuda_items_per_thread_type<block_size>{}, [&](auto items_per_thread) {
+        using cuda_items_per_thread = cuda_items_per_thread_type<block_size>;
+
+        if (camp::size<cuda_items_per_thread>::value == 0) {
+
+          if (tune_idx == t) {
+
+            runCudaVariantImpl<decltype(block_size)::value,
+                               detail::cuda::grid_scan_default_items_per_thread<
+                                  Real_type, block_size, RAJA_PERFSUITE_TUNING_CUDA_ARCH>::value
+                               >(vid);
+
+          }
+
+          t += 1;
+
+        }
+
+        seq_for(cuda_items_per_thread{}, [&](auto items_per_thread) {
 
           if (run_params.numValidItemsPerThread() == 0u ||
               run_params.validItemsPerThread(block_size)) {
@@ -179,13 +196,21 @@ void INDEXLIST::setCudaTuningDefinitions(VariantID vid)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        seq_for(cuda_items_per_thread_type<block_size>{}, [&](auto items_per_thread) {
+        using cuda_items_per_thread = cuda_items_per_thread_type<block_size>;
+
+        if (camp::size<cuda_items_per_thread>::value == 0) {
+
+          addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        }
+
+        seq_for(cuda_items_per_thread{}, [&](auto items_per_thread) {
 
           if (run_params.numValidItemsPerThread() == 0u ||
               run_params.validItemsPerThread(block_size)) {
 
-            addVariantTuningName(vid, "block_"+std::to_string(block_size)+
-                                      "_itemsPerThread_"+std::to_string(items_per_thread));
+            addVariantTuningName(vid, "itemsPerThread<"+std::to_string(items_per_thread)+">_"
+                                      "block_"+std::to_string(block_size));
 
           }
 

--- a/src/basic/INDEXLIST-Hip.cpp
+++ b/src/basic/INDEXLIST-Hip.cpp
@@ -24,7 +24,7 @@ namespace basic
 
 template < size_t block_size >
 using hip_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
-    detail::hip::grid_scan_default_items_per_thread<Index_type, block_size, RAJA_PERFSUITE_TUNING_HIP_ARCH>::value,
+    detail::hip::grid_scan_max_items_per_thread<Index_type, block_size>::value+1,
     integer::LessEqual<detail::hip::grid_scan_max_items_per_thread<Index_type, block_size>::value>>;
 
 
@@ -142,7 +142,24 @@ void INDEXLIST::runHipVariant(VariantID vid, size_t tune_idx)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        seq_for(hip_items_per_thread_type<block_size>{}, [&](auto items_per_thread) {
+        using hip_items_per_thread = hip_items_per_thread_type<block_size>;
+
+        if (camp::size<hip_items_per_thread>::value == 0) {
+
+          if (tune_idx == t) {
+
+            runHipVariantImpl<decltype(block_size)::value,
+                               detail::hip::grid_scan_default_items_per_thread<
+                                  Real_type, block_size, RAJA_PERFSUITE_TUNING_HIP_ARCH>::value
+                               >(vid);
+
+          }
+
+          t += 1;
+
+        }
+
+        seq_for(hip_items_per_thread{}, [&](auto items_per_thread) {
 
           if (run_params.numValidItemsPerThread() == 0u ||
               run_params.validItemsPerThread(block_size)) {
@@ -179,13 +196,21 @@ void INDEXLIST::setHipTuningDefinitions(VariantID vid)
       if (run_params.numValidGPUBlockSize() == 0u ||
           run_params.validGPUBlockSize(block_size)) {
 
-        seq_for(hip_items_per_thread_type<block_size>{}, [&](auto items_per_thread) {
+        using hip_items_per_thread = hip_items_per_thread_type<block_size>;
+
+        if (camp::size<hip_items_per_thread>::value == 0) {
+
+          addVariantTuningName(vid, "block_"+std::to_string(block_size));
+
+        }
+
+        seq_for(hip_items_per_thread{}, [&](auto items_per_thread) {
 
           if (run_params.numValidItemsPerThread() == 0u ||
               run_params.validItemsPerThread(block_size)) {
 
-            addVariantTuningName(vid, "block_"+std::to_string(block_size)+
-                                      "_itemsPerThread_"+std::to_string(items_per_thread));
+              addVariantTuningName(vid, "itemsPerThread<"+std::to_string(items_per_thread)+">_"
+                                        "block_"+std::to_string(block_size));
 
           }
 

--- a/src/basic/MULTI_REDUCE-Cuda.cpp
+++ b/src/basic/MULTI_REDUCE-Cuda.cpp
@@ -195,6 +195,23 @@ void MULTI_REDUCE::runCudaVariant(VariantID vid, size_t tune_idx)
 
         seq_for(gpu_mapping::reducer_helpers{}, [&](auto mapping_helper) {
 
+          if (camp::size<cuda_atomic_global_replications_type>::value == 0 &&
+              camp::size<cuda_atomic_shared_replications_type>::value == 0 ) {
+
+            if (tune_idx == t) {
+
+              setBlockSize(block_size);
+              runCudaVariantAtomicRuntime<decltype(block_size)::value,
+                                          default_cuda_atomic_global_replication,
+                                          default_cuda_atomic_shared_replication,
+                                          decltype(mapping_helper)>(vid);
+
+            }
+
+            t += 1;
+
+          }
+
           seq_for(cuda_atomic_global_replications_type{}, [&](auto global_replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
@@ -242,6 +259,15 @@ void MULTI_REDUCE::setCudaTuningDefinitions(VariantID vid)
         run_params.validGPUBlockSize(block_size)) {
 
       seq_for(gpu_mapping::reducer_helpers{}, [&](auto mapping_helper) {
+
+        if (camp::size<cuda_atomic_global_replications_type>::value == 0 &&
+            camp::size<cuda_atomic_shared_replications_type>::value == 0 ) {
+
+          addVariantTuningName(vid, "atomic_"+
+                                    decltype(mapping_helper)::get_name()+"_"+
+                                    std::to_string(block_size));
+
+        }
 
         seq_for(cuda_atomic_global_replications_type{}, [&](auto global_replication) {
 

--- a/src/basic/MULTI_REDUCE-Hip.cpp
+++ b/src/basic/MULTI_REDUCE-Hip.cpp
@@ -195,6 +195,23 @@ void MULTI_REDUCE::runHipVariant(VariantID vid, size_t tune_idx)
 
         seq_for(gpu_mapping::reducer_helpers{}, [&](auto mapping_helper) {
 
+          if (camp::size<hip_atomic_global_replications_type>::value == 0 &&
+              camp::size<hip_atomic_shared_replications_type>::value == 0 ) {
+
+            if (tune_idx == t) {
+
+              setBlockSize(block_size);
+              runHipVariantAtomicRuntime<decltype(block_size)::value,
+                                          default_hip_atomic_global_replication,
+                                          default_hip_atomic_shared_replication,
+                                          decltype(mapping_helper)>(vid);
+
+            }
+
+            t += 1;
+
+          }
+
           seq_for(hip_atomic_global_replications_type{}, [&](auto global_replication) {
 
             if (run_params.numValidAtomicReplication() == 0u ||
@@ -242,6 +259,15 @@ void MULTI_REDUCE::setHipTuningDefinitions(VariantID vid)
         run_params.validGPUBlockSize(block_size)) {
 
       seq_for(gpu_mapping::reducer_helpers{}, [&](auto mapping_helper) {
+
+        if (camp::size<hip_atomic_global_replications_type>::value == 0 &&
+            camp::size<hip_atomic_shared_replications_type>::value == 0 ) {
+
+          addVariantTuningName(vid, "atomic_"+
+                                    decltype(mapping_helper)::get_name()+"_"+
+                                    std::to_string(block_size));
+
+        }
 
         seq_for(hip_atomic_global_replications_type{}, [&](auto global_replication) {
 

--- a/src/basic/MULTI_REDUCE.hpp
+++ b/src/basic/MULTI_REDUCE.hpp
@@ -117,13 +117,13 @@ private:
 
   static const size_t default_cuda_atomic_global_replication = 2;
   static const size_t default_cuda_atomic_shared_replication = 16;
-  using cuda_atomic_global_replications_type = integer::make_atomic_replication_list_type<default_cuda_atomic_global_replication>;
-  using cuda_atomic_shared_replications_type = integer::make_atomic_replication_list_type<default_cuda_atomic_shared_replication>;
+  using cuda_atomic_global_replications_type = integer::make_atomic_replication_list_type<0>; // default list is empty
+  using cuda_atomic_shared_replications_type = integer::make_atomic_replication_list_type<0>; // default list is empty
 
   static const size_t default_hip_atomic_global_replication = 32;
   static const size_t default_hip_atomic_shared_replication = 4;
-  using hip_atomic_global_replications_type = integer::make_atomic_replication_list_type<default_hip_atomic_global_replication>;
-  using hip_atomic_shared_replications_type = integer::make_atomic_replication_list_type<default_hip_atomic_shared_replication>;
+  using hip_atomic_global_replications_type = integer::make_atomic_replication_list_type<0>; // default list is empty
+  using hip_atomic_shared_replications_type = integer::make_atomic_replication_list_type<0>; // default list is empty
 
   Index_type m_num_bins;
   Index_ptr m_bins;

--- a/src/common/GPUUtils.hpp
+++ b/src/common/GPUUtils.hpp
@@ -156,7 +156,7 @@ using make_gpu_block_size_list_type =
 // If atomic_replications from the configuration is not empty it is those atomic_replications,
 // otherwise it is a list containing just default_atomic_replication.
 // Invalid entries are removed according to validity_checker in either case.
-template < size_t default_atomic_replication, typename validity_checker = AllowAny >
+template < size_t default_atomic_replication, typename validity_checker = PositiveOnly >
 using make_atomic_replication_list_type =
       typename detail::remove_invalid<validity_checker,
         typename std::conditional< (camp::size<rajaperf::configuration::atomic_replications>::value > 0),
@@ -169,7 +169,7 @@ using make_atomic_replication_list_type =
 // If gpu_items_per_thread from the configuration is not empty it is those gpu_items_per_thread,
 // otherwise it is a list containing just default_gpu_items_per_thread.
 // Invalid entries are removed according to validity_checker in either case.
-template < size_t default_gpu_items_per_thread, typename validity_checker = AllowAny >
+template < size_t default_gpu_items_per_thread, typename validity_checker = PositiveOnly >
 using make_gpu_items_per_thread_list_type =
       typename detail::remove_invalid<validity_checker,
         typename std::conditional< (camp::size<rajaperf::configuration::gpu_items_per_thread>::value > 0),

--- a/src/rajaperf_config.hpp.in
+++ b/src/rajaperf_config.hpp.in
@@ -156,7 +156,7 @@ template <typename Func, typename... Ts>
 inline void seq_for(camp::list<Ts...> const&, Func&& func)
 {
   // braced init lists are evaluated in order
-  int seq_unused_array[] = {(func(Ts{}), 0)...};
+  int seq_unused_array[] = {0, (func(Ts{}), 0)...};
   RAJAPERF_UNUSED_VAR(seq_unused_array);
 }
 


### PR DESCRIPTION
# Change Default Tuning Names

They are now more consistent between backends as the specific tuning parameters are not part of the name.

- This PR is a bugfix
- It does the following
  - Fixes part of #463
