### PR TITLE
Add Warmup Kernels Option

### DIFF
--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -1315,6 +1315,15 @@ void RunParams::printHelpMessage(std::ostream& str) const
 
   str << "\t --disable-warmup (disable warmup kernels) [Default is run warmup kernels that are relevant to kernels selected to run]\n\n";
 
+  str << "\t --warmup-kernels, -wk <space-separated strings> [Default is run warmup kernels that are relevant to kernels selected to run]\n"
+      << "\t      (names of individual kernels and/or groups of kernels to warmup)\n"
+      << "\t      See '--print-kernels'/'-pk' option for list of valid kernel and group names.\n"
+      << "\t      Kernel names are listed as <group name>_<kernel name>.\n";
+  str << "\t\t Examples...\n"
+      << "\t\t --warmup-kernels Polybench (warmup all kernels in Polybench group)\n"
+      << "\t\t -wk INIT3 MULADDSUB (warmup INIT3 and MULADDSUB kernels)\n"
+      << "\t\t -wk INIT3 Apps (warmup INIT3 kernel and all kernels in Apps group)\n\n";
+
   str << "\t --kernels, -k <space-separated strings> [Default is run all]\n"
       << "\t      (names of individual kernels and/or groups of kernels to run)\n"
       << "\t      See '--print-kernels'/'-pk' option for list of valid kernel and group names.\n"

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -2042,7 +2042,7 @@ void RunParams::processKernelInput()
 
       // Assemble invalid input for output message.
       if ( !found_it ) {
-        invalid_kernel_input.push_back(*it);
+        invalid_warmup_kernel_input.push_back(*it);
       }
 
     } // iterate over kernel name input

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -252,6 +252,7 @@ public:
 
   bool getDisableWarmup() const { return disable_warmup; }
 
+  const std::set<KernelID>& getWarmupKernelIDsToRun() const { return run_warmup_kernels; }
   const std::set<KernelID>& getKernelIDsToRun() const { return run_kernels; }
   const std::set<VariantID>& getVariantIDsToRun() const { return run_variants; }
   VariantID getReferenceVariantID() const { return reference_vid; }
@@ -360,6 +361,8 @@ private:
   // Arrays to hold input strings for valid/invalid input. Helpful for
   // debugging command line args.
   //
+  std::vector<std::string> warmup_kernel_input;
+  std::vector<std::string> invalid_warmup_kernel_input;
   std::vector<std::string> kernel_input;
   std::vector<std::string> invalid_kernel_input;
   std::vector<std::string> exclude_kernel_input;
@@ -390,6 +393,7 @@ private:
 
   bool disable_warmup;
 
+  std::set<KernelID>  run_warmup_kernels;
   std::set<KernelID>  run_kernels;
   std::set<VariantID> run_variants;
 


### PR DESCRIPTION
# Add Warmup Kernels Option

This allows people to specify a specific set of kernels to run during warmup. When this argument is used it overrides the default behavior of picking kernels based on the features used.

- This PR is a feature
- It does the following:
  - Fixes #467 
  - Adds user specified warmup kernels at the request of people working with @pearce8 
