### PR TITLE
Update cloud test checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is:
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen:
+
+**Compilers & Libraries (please complete the following information):**
+ - Compiler & version: [e.g. GCC 4.9.3]:
+ - CUDA version (if applicable):
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+
+Add any other context or information about the feature request here.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# Summary (Write a short headline summary of PR)
+# Summary
 
 - This PR is a (refactoring, bugfix, feature, something else)
 - It does the following (modify list as needed):

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,77 @@
+on: push
+name: Build
+jobs:
+  build_docker:
+    strategy:
+      matrix:
+        target: [gcc12, gcc13, clang13, clang15, rocm5.6, rocm5.6_desul, intel2024, intel2024_debug, intel2024_sycl]
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo docker image prune --all --force
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - uses: docker/setup-buildx-action@v3
+    - uses: docker/build-push-action@v6
+      with:
+        target: ${{ matrix.target }}
+  build_mac:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: threeal/cmake-action@v1.3.0
+        with:
+          build-dir: build
+          options:
+            CMAKE_CXX_STANDARD=14
+            ENABLE_OPENMP=Off
+            CMAKE_BUILD_TYPE=Release
+          run-build: true
+          build-args: '--parallel 16'
+      - uses: threeal/ctest-action@v1.1.0
+  build_windows:
+    strategy:
+      matrix:
+        shared: 
+## ====================================
+## Shared library build generated undefined symbol errors that are not
+## understood -RDH
+##      - args: 
+##          BUILD_SHARED_LIBS=On 
+##          CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=On
+        - args: BUILD_SHARED_LIBS=Off
+          
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+## ====================================
+## Config and build action
+      - uses: threeal/cmake-action@v1.3.0
+        with:
+          build-dir: build
+          options:
+            ENABLE_WARNINGS_AS_ERRORS=Off
+            BLT_CXX_STD=c++17
+            CMAKE_BUILD_TYPE=Release
+            PERFSUITE_RUN_SHORT_TEST=On
+            ${{ matrix.shared.args }}
+          run-build: true
+          build-args: '--parallel 16'
+## ====================================
+## Print the contents of the test directory in the build space (debugging)
+##    - run: | 
+##        dir -r D:\a\RAJA\RAJA\build\test
+## ====================================
+## Run tests action
+      - uses: threeal/ctest-action@v1.1.0
+        with:
+          build-config: Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,17 +15,7 @@ else()
   cmake_minimum_required(VERSION 3.20)
 endif()
 
-option(ENABLE_RAJA_SEQUENTIAL "Run sequential variants of RAJA kernels. Disable
-this, and all other variants, to run _only_ base variants." On)
 option(ENABLE_KOKKOS "Include Kokkos implementations of the kernels in the RAJA Perfsuite" Off)
-
-#
-# Note: the BLT build system is inheritted by RAJA and is initialized by RAJA
-#
-
-if (PERFSUITE_ENABLE_WARNINGS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
-endif()
 
 if (ENABLE_KOKKOS OR ENABLE_SYCL)
   set(CMAKE_CXX_STANDARD 17)
@@ -41,6 +31,13 @@ include(blt/SetupBLT.cmake)
 # Define RAJA PERFSUITE settings...
 #
 
+option(ENABLE_RAJA_SEQUENTIAL "Run sequential variants of RAJA kernels. Disable
+this, and all other variants, to run _only_ base variants." On)
+
+if (PERFSUITE_ENABLE_WARNINGS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
+endif()
+
 cmake_dependent_option(RAJA_PERFSUITE_ENABLE_TESTS "Enable RAJA Perf Suite Tests" On "ENABLE_TESTS" Off)
 
 if (ENABLE_TESTS)
@@ -49,6 +46,8 @@ if (ENABLE_TESTS)
   set(CAMP_ENABLE_TESTS Off CACHE BOOL "")
 
 endif()
+
+option(PERFSUITE_RUN_SHORT_TEST "Shorter test run to avoid timeout in some CI cases." Off)
 
 cmake_dependent_option(RAJA_PERFSUITE_ENABLE_MPI "Build with MPI" On "ENABLE_MPI" Off)
 if (RAJA_PERFSUITE_ENABLE_MPI)
@@ -132,9 +131,14 @@ set(CAMP_ENABLE_TESTS Off CACHE BOOL "")
 if (ENABLE_RAJA_SEQUENTIAL)
   add_definitions(-DRUN_RAJA_SEQ)
 endif ()
+
 if (ENABLE_OPENMP)
   add_definitions(-DRUN_OPENMP)
 endif ()
+
+if (PERFSUITE_RUN_SHORT_TEST)
+  add_definitions(-DRUN_RAJAPERF_SHORT_TEST)
+endif()
 
 set(RAJA_PERFSUITE_VERSION_MAJOR 2024)
 set(RAJA_PERFSUITE_VERSION_MINOR 07)

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,7 +120,7 @@ ENV GTEST_COLOR=1
 ENV HCC_AMDGPU_TARGET=gfx900
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-5.6.1/bin/amdclang++ -DENABLE_HIP=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-5.6.1/bin/amdclang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_HIP=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
     make -j 6
 
 # TODO: We should switch to ROCm 6 -- where to get an image??
@@ -129,7 +129,7 @@ ENV GTEST_COLOR=1
 ENV HCC_AMDGPU_TARGET=gfx900
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-5.6.1/bin/amdclang++ -DENABLE_HIP=On -DRAJA_ENABLE_DESUL_ATOMICS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-5.6.1/bin/amdclang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_HIP=On -DRAJA_ENABLE_DESUL_ATOMICS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
     make -j 6
 
 ## ROCm 6 image is broken
@@ -138,7 +138,7 @@ ENV GTEST_COLOR=1
 ENV HCC_AMDGPU_TARGET=gfx900
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-6.0.2/bin/amdclang++ -DENABLE_HIP=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-6.0.2/bin/amdclang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_HIP=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
     make -j 6
 
 ## ROCm 6 image is broken
@@ -147,7 +147,7 @@ ENV GTEST_COLOR=1
 ENV HCC_AMDGPU_TARGET=gfx900
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-6.0.2/bin/amdclang++ -DENABLE_HIP=On -DRAJA_ENABLE_DESUL_ATOMICS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-6.0.2/bin/amdclang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_HIP=On -DRAJA_ENABLE_DESUL_ATOMICS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
     make -j 6
 
 FROM ghcr.io/llnl/radiuss:intel-2024.0-ubuntu-20.04 AS intel2024_sycl

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,118 +5,155 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 ###############################################################################
 
-FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-7.3.0 AS gcc7.3.0
+##
+## Note that we build with 'make -j 16' on GitHub Actions and
+## with 'make -j 6' on Azure. This is reflected in the 'make' commands below.
+## This seems to work best for throughput.
+##
+## Also, we only check builds for GPU configurations (CUDA, HIP, SYCL) since
+## we do not have clouds resources to run tests for those.
+##
+
+FROM ghcr.io/llnl/radiuss:gcc-11-ubuntu-22.04 AS gcc11
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_CXX_COMPILER=g++ -DRAJA_ENABLE_WARNINGS=On -DENABLE_OPENMP=On .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DRAJA_ENABLE_WARNINGS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=On -DENABLE_OPENMP=On .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure && \
-    cd .. && rm -rf build
+    ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-8.1.0 AS gcc8.1.0
+FROM ghcr.io/llnl/radiuss:gcc-12-ubuntu-22.04 AS gcc12
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_CXX_COMPILER=g++ -DRAJA_ENABLE_WARNINGS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=On -DENABLE_OPENMP=On .. && \
-    make -j 6 &&\
-    ctest -T test --output-on-failure && \
-    cd .. && rm -rf build
+RUN cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DRAJA_ENABLE_WARNINGS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=On -DENABLE_OPENMP=On .. && \
+    make -j 16 &&\
+    ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-9.4.0 AS gcc9.4.0
+FROM ghcr.io/llnl/radiuss:gcc-12-ubuntu-22.04 AS gcc12_debug
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_CXX_COMPILER=g++ -DRAJA_ENABLE_WARNINGS=On -DENABLE_OPENMP=On .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Debug -DRAJA_ENABLE_WARNINGS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=On -DENABLE_OPENMP=On -DPERFSUITE_RUN_SHORT_TEST=On .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure && \
-    cd .. && rm -rf build
+    ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/gcc-ubuntu-20.04:gcc-11.2.0 AS gcc11.2.0
+FROM ghcr.io/llnl/radiuss:gcc-12-ubuntu-22.04 AS gcc12_desul
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_COMPILER=g++ -DRAJA_ENABLE_WARNINGS=On -DENABLE_OPENMP=On .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DRAJA_ENABLE_WARNINGS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=On -DENABLE_OPENMP=On -DRAJA_ENABLE_DESUL_ATOMICS=On .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure && \
-    cd .. && rm -rf build
+    ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-11.0.0 AS clang11.0.0
+FROM ghcr.io/llnl/radiuss:gcc-13-ubuntu-22.04 AS gcc13
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN . /opt/spack/share/spack/setup-env.sh && \
-    export LD_LIBRARY_PATH=/opt/view/lib:$LD_LIBRARY_PATH && \
-    cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=On .. && \
-    make -j 6 &&\
-    ctest -T test --output-on-failure && \
-    cd .. && rm -rf build
+RUN cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DRAJA_ENABLE_WARNINGS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=On -DENABLE_OPENMP=On .. && \
+    make -j 16 &&\
+    ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/clang-ubuntu-20.04:llvm-11.0.0 AS clang11.0.0-debug
+FROM ghcr.io/llnl/radiuss:clang-13-ubuntu-22.04 AS clang13
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN . /opt/spack/share/spack/setup-env.sh && \
-    export LD_LIBRARY_PATH=/opt/view/lib:$LD_LIBRARY_PATH && \
-    cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENMP=On .. && \
-    make -j 6 &&\
-    ctest -T test --output-on-failure && \
-    cd .. && rm -rf build
+RUN cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=On .. && \
+    make -j 16 &&\
+    ctest -T test --output-on-failure
 
-FROM ghcr.io/rse-ops/clang-ubuntu-22.04:llvm-13.0.0 AS clang13.0.0
+FROM ghcr.io/llnl/radiuss:clang-14-ubuntu-22.04 AS clang14_debug
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN . /opt/spack/share/spack/setup-env.sh && \
-    export LD_LIBRARY_PATH=/opt/view/lib:$LD_LIBRARY_PATH && \
-    cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=On .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug  -DENABLE_OPENMP=On -DPERFSUITE_RUN_SHORT_TEST=On .. && \
     make -j 6 &&\
-    ctest -T test --output-on-failure && \
-    cd .. && rm -rf build
+    ctest -T test --output-on-failure
 
-##FROM ghcr.io/rse-ops/cuda:cuda-10.1.243-ubuntu-18.04 AS nvcc10.1.243
-##ENV GTEST_COLOR=1
-##COPY . /home/raja/workspace
-##WORKDIR /home/raja/workspace/build
-##RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
-##    cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
-##    make -j 4 && \
-##    cd .. && rm -rf build
-
-##FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc11.1.1
-##ENV GTEST_COLOR=1
-##COPY . /home/raja/workspace
-##WORKDIR /home/raja/workspace/build
-##RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
-##    cmake -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
-##    make -j 4 && \
-##    cd .. && rm -rf build
-
-##FROM ghcr.io/rse-ops/cuda-ubuntu-20.04:cuda-11.1.1 AS nvcc11.1.1-debug
-##ENV GTEST_COLOR=1
-##COPY . /home/raja/workspace
-##WORKDIR /home/raja/workspace/build
-##RUN . /opt/spack/share/spack/setup-env.sh && spack load cuda && \
-##    cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++ -DENABLE_CUDA=On -DCMAKE_CUDA_STANDARD=14 -DCMAKE_CUDA_ARCHITECTURES=70 -DENABLE_OPENMP=On .. && \
-##    make -j 4 && \
-##    cd .. && rm -rf build
-
-##FROM ghcr.io/rse-ops/hip-ubuntu-20.04:hip-5.1.3 AS hip5.1.3
-##ENV GTEST_COLOR=1
-##ENV HCC_AMDGPU_TARGET=gfx900
-##COPY . /home/raja/workspace
-##WORKDIR /home/raja/workspace/build
-##RUN . /opt/spack/share/spack/setup-env.sh && spack load hip llvm-amdgpu && \
-##    cmake -DCMAKE_CXX_COMPILER=clang++ -DHIP_PATH=/opt -DENABLE_HIP=On -DENABLE_CUDA=Off -DENABLE_OPENMP=Off -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off -DBLT_EXPORT_THIRDPARTY=On .. && \
-##    make -j 6 && \
-##    cd .. && rm -rf build
-
-FROM ghcr.io/rse-ops/intel-ubuntu-23.04:intel-2023.2.1 AS sycl
+FROM ghcr.io/llnl/radiuss:clang-15-ubuntu-22.04 AS clang15
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN /bin/bash -c "source /opt/view/setvars.sh && \
-    cmake -DCMAKE_CXX_COMPILER=dpcpp -DENABLE_SYCL=On -DENABLE_OPENMP=Off -DENABLE_ALL_WARNINGS=Off -DBLT_CXX_STD=c++17 -DENABLE_TESTS=On .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=On .. && \
+    make -j 16 &&\
+    ctest -T test --output-on-failure
+
+FROM ghcr.io/llnl/radiuss:clang-15-ubuntu-22.04 AS clang15_desul
+ENV GTEST_COLOR=1
+COPY . /home/raja/workspace
+WORKDIR /home/raja/workspace/build
+RUN cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=On -DRAJA_ENABLE_DESUL_ATOMICS=On .. && \
     make -j 6 &&\
-    ./bin/raja-perf.exe --checkrun --exclude-variants Base_SYCL RAJA_SYCL -sp" && \
-    cd .. && rm -rf build
+    ctest -T test --output-on-failure
+
+## TODO: Investigate checksum errors with intel compiler
+##       Check compile, but don't run tests
+FROM ghcr.io/llnl/radiuss:ubuntu-20.04-intel-2024.0 AS intel2024
+ENV GTEST_COLOR=1
+COPY . /home/raja/workspace
+WORKDIR /home/raja/workspace/build
+RUN /bin/bash -c "source /opt/intel/oneapi/setvars.sh 2>&1 > /dev/null && \
+    cmake -DCMAKE_CXX_COMPILER=icpx -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=On .. && \
+    make -j 16"
+##  make -j 16 &&\
+##  ctest -T test --output-on-failure"
+
+## TODO: Investigate checksum errors with intel compiler
+##       Check compile, but don't run tests
+FROM ghcr.io/llnl/radiuss:ubuntu-20.04-intel-2024.0 AS intel2024_debug
+ENV GTEST_COLOR=1
+COPY . /home/raja/workspace
+WORKDIR /home/raja/workspace/build
+RUN /bin/bash -c "source /opt/intel/oneapi/setvars.sh 2>&1 > /dev/null && \
+    cmake -DCMAKE_CXX_COMPILER=icpx -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENMP=On .. && \
+    make -j 16"
+##  make -j 16 &&\
+##  ctest -T test --output-on-failure"
+
+##
+## Need to find a viable cuda image to test...
+##
+
+# TODO: We should switch to ROCm 6 -- where to get an image??
+FROM ghcr.io/llnl/radiuss:ubuntu-20.04-hip-5.6.1 AS rocm5.6
+ENV GTEST_COLOR=1
+ENV HCC_AMDGPU_TARGET=gfx900
+COPY . /home/raja/workspace
+WORKDIR /home/raja/workspace/build
+RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-5.6.1/bin/amdclang++ -DENABLE_HIP=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
+    make -j 6
+
+# TODO: We should switch to ROCm 6 -- where to get an image??
+FROM ghcr.io/llnl/radiuss:ubuntu-20.04-hip-5.6.1 AS rocm5.6_desul
+ENV GTEST_COLOR=1
+ENV HCC_AMDGPU_TARGET=gfx900
+COPY . /home/raja/workspace
+WORKDIR /home/raja/workspace/build
+RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-5.6.1/bin/amdclang++ -DENABLE_HIP=On -DRAJA_ENABLE_DESUL_ATOMICS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
+    make -j 6
+
+## ROCm 6 image is broken
+FROM ghcr.io/llnl/radiuss:hip-6.0.2-ubuntu-20.04 AS rocm6.0
+ENV GTEST_COLOR=1
+ENV HCC_AMDGPU_TARGET=gfx900
+COPY . /home/raja/workspace
+WORKDIR /home/raja/workspace/build
+RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-6.0.2/bin/amdclang++ -DENABLE_HIP=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
+    make -j 6
+
+## ROCm 6 image is broken
+FROM ghcr.io/llnl/radiuss:hip-6.0.2-ubuntu-20.04 AS rocm6.0_desul
+ENV GTEST_COLOR=1
+ENV HCC_AMDGPU_TARGET=gfx900
+COPY . /home/raja/workspace
+WORKDIR /home/raja/workspace/build
+RUN cmake -DCMAKE_CXX_COMPILER=/opt/rocm-6.0.2/bin/amdclang++ -DENABLE_HIP=On -DRAJA_ENABLE_DESUL_ATOMICS=On -DRAJA_ENABLE_WARNINGS_AS_ERRORS=Off .. && \
+    make -j 6
+
+FROM ghcr.io/llnl/radiuss:intel-2024.0-ubuntu-20.04 AS intel2024_sycl
+ENV GTEST_COLOR=1
+COPY . /home/raja/workspace
+WORKDIR /home/raja/workspace/build
+RUN /bin/bash -c "source /opt/intel/oneapi/setvars.sh 2>&1 > /dev/null && \
+    cmake -DCMAKE_CXX_COMPILER=dpcpp -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=Off -DRAJA_ENABLE_SYCL=On -DBLT_CXX_STD=c++17 -DRAJA_ENABLE_DESUL_ATOMICS=On .. && \
+    make -j 16"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,31 +33,17 @@ jobs:
 - job: Docker
   timeoutInMinutes: 360
   strategy:
-    matrix: 
-      gcc7.3.0:
-        docker_target: gcc7.3.0
-      gcc8.1.0:
-        docker_target: gcc8.1.0
-      gcc9.4.0:
-        docker_target: gcc9.4.0
-      gcc11.2.0:
-        docker_target: gcc11.2.0
-      clang11.0.0:
-        docker_target: clang11.0.0
-##      clang11.0.0-debug:
-##        docker_target: clang11.0.0-debug
-      clang13.0.0:
-        docker_target: clang13.0.0
-##      nvcc10.1.243:
-##        docker_target: nvcc10.1.243
-##      nvcc11.1.1:
-##        docker_target: nvcc11.1.1
-##      nvcc11.1.1-debug:
-##        docker_target: nvcc11.1.1-debug
-##      hip5.1.3:
-##        docker_target: hip5.1.3
-      sycl:
-        docker_target: sycl
+    matrix:
+      gcc11:
+        docker_target: gcc11
+      gcc12_debug:
+        docker_target: gcc12_debug
+      gcc12_desul:
+        docker_target: gcc12_desul
+      clang14_debug:
+        docker_target: clang14_debug
+      clang15_desul:
+        docker_target: clang15_desul
   pool:
     vmImage: 'ubuntu-latest'
   variables:

--- a/test/test-raja-perf-suite.cpp
+++ b/test/test-raja-perf-suite.cpp
@@ -55,7 +55,11 @@ TEST(ShortSuiteTest, Basic)
   std::vector< std::string > sargv{};
   sargv.emplace_back(std::string("dummy "));  // for executable name
   sargv.emplace_back(std::string("--checkrun"));
+#if defined(RUN_RAJAPERF_SHORT_TEST)
+  sargv.emplace_back(std::string("1"));
+#else
   sargv.emplace_back(std::string("3"));
+#endif
   sargv.emplace_back(std::string("--show-progress"));
   sargv.emplace_back(std::string("--disable-warmup"));
 
@@ -66,10 +70,21 @@ TEST(ShortSuiteTest, Basic)
   sargv.emplace_back(std::string("HALO_PACKING_FUSED"));
 #endif
 
-#if (defined(RAJA_COMPILER_CLANG) && __clang_major__ == 11)
+#if !defined(_WIN32)
+
+#if ( (defined(RAJA_COMPILER_CLANG) && __clang_major__ == 11) || \
+      defined(RUN_RAJAPERF_SHORT_TEST) )
   sargv.emplace_back(std::string("--exclude-kernels"));
+#if (defined(RAJA_COMPILER_CLANG) && __clang_major__ == 11)  
   sargv.emplace_back(std::string("FIRST_MIN"));
 #endif
+#if defined(RUN_RAJAPERF_SHORT_TEST)
+  sargv.emplace_back(std::string("Polybench"));
+#endif
+#endif
+
+#endif // !defined(_WIN32)
+
 
   char *unit_test = getenv("RAJA_PERFSUITE_UNIT_TEST");
   if (unit_test != NULL) {


### PR DESCRIPTION
# Summary

- This PR adds GitHub Actions testing and splits test workload between Azure and GH Actions.
- Updates Dockerfile and use newer RADIUSS images which replace rse-ops images which are no longer maintained
- Add short test option to prevent timeout in some debug tests.
- Also add new issue templates.