### PR TITLE
Bugfix/rhornung67/fir memory issue

### DIFF
--- a/scripts/lc-builds/corona_sycl.sh
+++ b/scripts/lc-builds/corona_sycl.sh
@@ -38,7 +38,7 @@ DATE=$(printf '%(%Y-%m-%d)T\n' -1)
 export PATH=${SYCL_PATH}/bin:$PATH
 export LD_LIBRARY_PATH=${SYCL_PATH}/lib:${SYCL_PATH}/lib64:$LD_LIBRARY_PATH
 
-module load cmake/3.24.2
+module load cmake/3.23.1
 
 cmake \
   -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \

--- a/src/apps/FIR-Sycl.cpp
+++ b/src/apps/FIR-Sycl.cpp
@@ -25,15 +25,10 @@ namespace apps
 #define FIR_DATA_SETUP_SYCL \
   Real_ptr coeff; \
 \
-  allocAndInitSyclDeviceData(in, m_in, getActualProblemSize(), qu); \
-  allocAndInitSyclDeviceData(out, m_out, getActualProblemSize(), qu); \
   Real_ptr tcoeff = &coeff_array[0]; \
   allocAndInitSyclDeviceData(coeff, tcoeff, FIR_COEFFLEN, qu);
 
 #define FIR_DATA_TEARDOWN_SYCL \
-  getSyclDeviceData(m_out, out, getActualProblemSize(), qu); \
-  deallocSyclDeviceData(in, qu); \
-  deallocSyclDeviceData(out, qu); \
   deallocSyclDeviceData(coeff, qu);
 
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix.
- It fixes the CMake version in the SYCL build script. What was there does not exist on corona.
- Fixes device memory issue in SYCL variants of FIR kernel so now tests pass.