### PR TITLE
Remove old reduction "tuning" from OpenMP Target variants

### DIFF
--- a/src/algorithm/ATOMIC.hpp
+++ b/src/algorithm/ATOMIC.hpp
@@ -74,24 +74,28 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void setOpenMPTargetTuningDefinitions(VariantID vid);
 
   template < size_t replication >
   void runSeqVariantReplicate(VariantID vid);
+
   template < size_t replication >
   void runOpenMPVariantReplicate(VariantID vid);
+
   template < size_t block_size, size_t replication >
   void runCudaVariantReplicateGlobal(VariantID vid);
   template < size_t block_size, size_t replication >
   void runHipVariantReplicateGlobal(VariantID vid);
   template < size_t block_size, size_t replication >
+
   void runCudaVariantReplicateWarp(VariantID vid);
   template < size_t block_size, size_t replication >
   void runHipVariantReplicateWarp(VariantID vid);
+
   template < size_t block_size, size_t replication >
   void runCudaVariantReplicateBlock(VariantID vid);
   template < size_t block_size, size_t replication >
   void runHipVariantReplicateBlock(VariantID vid);
+
   template < size_t replication >
   void runOpenMPTargetVariantReplicate(VariantID vid);
 

--- a/src/algorithm/HISTOGRAM.hpp
+++ b/src/algorithm/HISTOGRAM.hpp
@@ -105,6 +105,7 @@ public:
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+
   void runCudaVariantLibrary(VariantID vid);
   void runHipVariantLibrary(VariantID vid);
 

--- a/src/algorithm/MEMCPY.hpp
+++ b/src/algorithm/MEMCPY.hpp
@@ -58,6 +58,7 @@ public:
   void setSeqTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+
   void runSeqVariantDefault(VariantID vid);
   void runSeqVariantLibrary(VariantID vid);
 

--- a/src/algorithm/MEMSET.hpp
+++ b/src/algorithm/MEMSET.hpp
@@ -58,6 +58,7 @@ public:
   void setSeqTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+
   void runSeqVariantDefault(VariantID vid);
   void runSeqVariantLibrary(VariantID vid);
 

--- a/src/algorithm/REDUCE_SUM-OMPTarget.cpp
+++ b/src/algorithm/REDUCE_SUM-OMPTarget.cpp
@@ -27,7 +27,7 @@ namespace algorithm
   const size_t threads_per_team = 256;
 
 
-void REDUCE_SUM::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
+void REDUCE_SUM::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;

--- a/src/algorithm/REDUCE_SUM-OMPTarget.cpp
+++ b/src/algorithm/REDUCE_SUM-OMPTarget.cpp
@@ -56,60 +56,28 @@ void REDUCE_SUM::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    if (tune_idx == 0) {
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      Real_type tsum = m_sum_init;
 
-        RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> sum(m_sum_init);
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tsum),
+        [=] (Index_type i, Real_type& sum) {
+          REDUCE_SUM_BODY;
+        }
+      );
 
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-          RAJA::RangeSegment(ibegin, iend),
-          [=](Index_type i) {
-            REDUCE_SUM_BODY;
-        });
+      m_sum = static_cast<Real_type>(tsum);
 
-        m_sum = sum.get();
-
-      }
-      stopTimer();
-
-    } else if (tune_idx == 1) {
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        Real_type tsum = m_sum_init;
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-          RAJA::RangeSegment(ibegin, iend),
-          RAJA::expt::Reduce<RAJA::operators::plus>(&tsum),
-          [=] (Index_type i, Real_type& sum) {
-            REDUCE_SUM_BODY;
-          }
-        );
-
-        m_sum = static_cast<Real_type>(tsum);
-
-      }
-      stopTimer();
-
-    } else {
-      getCout() << "\n  REDUCE_SUM : Unknown OMP Target tuning index = " << tune_idx << std::endl;
     }
+    stopTimer();
 
   } else {
     getCout() << "\n  REDUCE_SUM : Unknown OMP Target variant id = " << vid << std::endl;
   }
 
-}
-
-void REDUCE_SUM::setOpenMPTargetTuningDefinitions(VariantID vid)
-{
-  addVariantTuningName(vid, "default");
-  if (vid == RAJA_OpenMPTarget) {
-    addVariantTuningName(vid, "new");
-  }
 }
 
 } // end namespace algorithm

--- a/src/algorithm/REDUCE_SUM.hpp
+++ b/src/algorithm/REDUCE_SUM.hpp
@@ -64,7 +64,6 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void setOpenMPTargetTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);
 
   void runCudaVariantCub(VariantID vid);

--- a/src/algorithm/SCAN.hpp
+++ b/src/algorithm/SCAN.hpp
@@ -65,8 +65,10 @@ public:
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+
   void runCudaVariantLibrary(VariantID vid);
   void runHipVariantLibrary(VariantID vid);
+
   template < size_t block_size, size_t items_per_thread >
   void runCudaVariantImpl(VariantID vid);
   template < size_t block_size, size_t items_per_thread >

--- a/src/apps/EDGE3D-OMP.cpp
+++ b/src/apps/EDGE3D-OMP.cpp
@@ -58,8 +58,6 @@ void EDGE3D::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        auto edge3d_lam = [=](Index_type i) { EDGE3D_BODY; };
-
         #pragma omp parallel for
         for (Index_type i = ibegin ; i < iend ; ++i ) {
           edge3d_lam(i);
@@ -86,7 +84,7 @@ void EDGE3D::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
     }
 
     default : {
-      getCout() << "\n  EDGE3D : Unknown variant id = " << vid << std::endl;
+      getCout() << "\n  EDGE3D : Unknown OpenMP variant id = " << vid << std::endl;
     }
 
   }

--- a/src/apps/EDGE3D.cpp
+++ b/src/apps/EDGE3D.cpp
@@ -58,7 +58,7 @@ EDGE3D::EDGE3D(const RunParams& params)
 
   setFLOPsPerRep(number_of_elements * flops_per_element);
 
-  checksum_scale_factor = 0.001 *
+  m_checksum_scale_factor = 0.001 *
               ( static_cast<Checksum_type>(getDefaultProblemSize()) /
                                            getActualProblemSize() );
 
@@ -116,7 +116,7 @@ void EDGE3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 
 void EDGE3D::updateChecksum(VariantID vid, size_t tune_idx)
 {
-  checksum[vid][tune_idx] += calcChecksum(m_sum, m_array_length, checksum_scale_factor, vid  );
+  checksum[vid][tune_idx] += calcChecksum(m_sum, m_array_length, m_checksum_scale_factor, vid  );
 }
 
 void EDGE3D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/src/apps/EDGE3D.hpp
+++ b/src/apps/EDGE3D.hpp
@@ -441,6 +441,8 @@ private:
 
   ADomain* m_domain;
   Index_type m_array_length;
+
+  Real_type m_checksum_scale_factor;
 };
 
 } // end namespace apps

--- a/src/apps/PRESSURE.hpp
+++ b/src/apps/PRESSURE.hpp
@@ -82,7 +82,6 @@ public:
   void runCudaVariantImpl(VariantID vid);
   template < size_t block_size >
   void runHipVariantImpl(VariantID vid);
-
   template < size_t work_group_size >
   void runSyclVariantImpl(VariantID vid);
 

--- a/src/basic/MULTI_REDUCE.hpp
+++ b/src/basic/MULTI_REDUCE.hpp
@@ -100,6 +100,7 @@ public:
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+
   template < Index_type block_size,
              Index_type preferred_global_replication,
              Index_type preferred_shared_replication,

--- a/src/basic/PI_REDUCE-OMPTarget.cpp
+++ b/src/basic/PI_REDUCE-OMPTarget.cpp
@@ -27,7 +27,7 @@ namespace basic
   const size_t threads_per_team = 256;
 
 
-void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
+void PI_REDUCE::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -62,7 +62,6 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void setOpenMPTargetTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >

--- a/src/basic/REDUCE3_INT-OMPTarget.cpp
+++ b/src/basic/REDUCE3_INT-OMPTarget.cpp
@@ -27,7 +27,7 @@ namespace basic
   const size_t threads_per_team = 256;
 
 
-void REDUCE3_INT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
+void REDUCE3_INT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;

--- a/src/basic/REDUCE3_INT-OMPTarget.cpp
+++ b/src/basic/REDUCE3_INT-OMPTarget.cpp
@@ -62,67 +62,32 @@ void REDUCE3_INT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    if (tune_idx == 0) {
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      Int_type tvsum = m_vsum_init;
+      Int_type tvmin = m_vmin_init;
+      Int_type tvmax = m_vmax_init;
 
-        RAJA::ReduceSum<RAJA::omp_target_reduce, Int_type> vsum(m_vsum_init);
-        RAJA::ReduceMin<RAJA::omp_target_reduce, Int_type> vmin(m_vmin_init);
-        RAJA::ReduceMax<RAJA::omp_target_reduce, Int_type> vmax(m_vmax_init);
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tvsum),
+        RAJA::expt::Reduce<RAJA::operators::minimum>(&tvmin),
+        RAJA::expt::Reduce<RAJA::operators::maximum>(&tvmax),
+        [=](Index_type i, Int_type& vsum, Int_type& vmin, Int_type& vmax) {
+          REDUCE3_INT_BODY;
+        }
+      );
 
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          REDUCE3_INT_BODY_RAJA;
-        });
+      m_vsum += static_cast<Int_type>(tvsum);
+      m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(tvmin));
+      m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(tvmax));
 
-        m_vsum += static_cast<Int_type>(vsum.get());
-        m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(vmin.get()));
-        m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(vmax.get()));
-
-      }
-      stopTimer();
-
-    } else if (tune_idx == 1) {
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        Int_type tvsum = m_vsum_init;
-        Int_type tvmin = m_vmin_init;
-        Int_type tvmax = m_vmax_init;
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-          RAJA::RangeSegment(ibegin, iend),
-          RAJA::expt::Reduce<RAJA::operators::plus>(&tvsum),
-          RAJA::expt::Reduce<RAJA::operators::minimum>(&tvmin),
-          RAJA::expt::Reduce<RAJA::operators::maximum>(&tvmax),
-          [=](Index_type i, Int_type& vsum, Int_type& vmin, Int_type& vmax) {
-            REDUCE3_INT_BODY;
-          }
-        );
-
-        m_vsum += static_cast<Int_type>(tvsum);
-        m_vmin = RAJA_MIN(m_vmin, static_cast<Int_type>(tvmin));
-        m_vmax = RAJA_MAX(m_vmax, static_cast<Int_type>(tvmax));
-
-      }
-      stopTimer();
-
-    } else {
-      getCout() << "\n  REDUCE3_INT : Unknown OMP Target tuning index = " << tune_idx << std::endl;
     }
+    stopTimer();
 
   } else {
      getCout() << "\n  REDUCE3_INT : Unknown OMP Target variant id = " << vid << std::endl;
-  }
-}
-
-void REDUCE3_INT::setOpenMPTargetTuningDefinitions(VariantID vid)
-{
-  addVariantTuningName(vid, "default");
-  if (vid == RAJA_OpenMPTarget) {
-    addVariantTuningName(vid, "new");
   }
 }
 

--- a/src/basic/REDUCE3_INT.hpp
+++ b/src/basic/REDUCE3_INT.hpp
@@ -78,7 +78,6 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void setOpenMPTargetTuningDefinitions(VariantID vid); 
   void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >

--- a/src/basic/REDUCE_STRUCT-OMPTarget.cpp
+++ b/src/basic/REDUCE_STRUCT-OMPTarget.cpp
@@ -27,7 +27,7 @@ namespace basic
   const size_t threads_per_team = 256;
 
 
-void REDUCE_STRUCT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
+void REDUCE_STRUCT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;

--- a/src/basic/REDUCE_STRUCT-OMPTarget.cpp
+++ b/src/basic/REDUCE_STRUCT-OMPTarget.cpp
@@ -83,76 +83,41 @@ void REDUCE_STRUCT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 
     case RAJA_OpenMPTarget : {
 
-      if (tune_idx == 0) {
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        startTimer();
-        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+        Real_type txsum = m_init_sum;
+        Real_type tysum = m_init_sum;
+        Real_type txmin = m_init_min;
+        Real_type tymin = m_init_min;
+        Real_type txmax = m_init_max;
+        Real_type tymax = m_init_max;
 
-          RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> xsum(m_init_sum);
-          RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> ysum(m_init_sum);
-          RAJA::ReduceMin<RAJA::omp_target_reduce, Real_type> xmin(m_init_min);
-          RAJA::ReduceMin<RAJA::omp_target_reduce, Real_type> ymin(m_init_min);
-          RAJA::ReduceMax<RAJA::omp_target_reduce, Real_type> xmax(m_init_max);
-          RAJA::ReduceMax<RAJA::omp_target_reduce, Real_type> ymax(m_init_max);
+        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+          RAJA::RangeSegment(ibegin, iend),
+          RAJA::expt::Reduce<RAJA::operators::plus>(&txsum),
+          RAJA::expt::Reduce<RAJA::operators::plus>(&tysum),
+          RAJA::expt::Reduce<RAJA::operators::minimum>(&txmin),
+          RAJA::expt::Reduce<RAJA::operators::minimum>(&tymin),
+          RAJA::expt::Reduce<RAJA::operators::maximum>(&txmax),
+          RAJA::expt::Reduce<RAJA::operators::maximum>(&tymax),
+          [=](Index_type i, Real_type& xsum, Real_type& ysum,
+                            Real_type& xmin, Real_type& ymin,
+                            Real_type& xmax, Real_type& ymax) {
+            REDUCE_STRUCT_BODY;
+          }
+        );
 
-          RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-            RAJA::RangeSegment(ibegin, iend),
-            [=](Index_type i) {
-              REDUCE_STRUCT_BODY_RAJA;
-          });
+        points.SetCenter(static_cast<Real_type>(txsum)/(points.N),
+                         static_cast<Real_type>(tysum)/(points.N));
+        points.SetXMin(static_cast<Real_type>(txmin));
+        points.SetXMax(static_cast<Real_type>(txmax));
+        points.SetYMin(static_cast<Real_type>(tymin));
+        points.SetYMax(static_cast<Real_type>(tymax));
+        m_points = points;
 
-          points.SetCenter(xsum.get()/(points.N),
-                           ysum.get()/(points.N));
-          points.SetXMin(xmin.get());
-          points.SetXMax(xmax.get());
-          points.SetYMin(ymin.get());
-          points.SetYMax(ymax.get());
-          m_points = points;
-
-        }
-        stopTimer();
-
-      } else if (tune_idx == 1) {
-
-        startTimer();
-        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-          Real_type txsum = m_init_sum;
-          Real_type tysum = m_init_sum;
-          Real_type txmin = m_init_min;
-          Real_type tymin = m_init_min;
-          Real_type txmax = m_init_max;
-          Real_type tymax = m_init_max;
-
-          RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-            RAJA::RangeSegment(ibegin, iend),
-            RAJA::expt::Reduce<RAJA::operators::plus>(&txsum),
-            RAJA::expt::Reduce<RAJA::operators::plus>(&tysum),
-            RAJA::expt::Reduce<RAJA::operators::minimum>(&txmin),
-            RAJA::expt::Reduce<RAJA::operators::minimum>(&tymin),
-            RAJA::expt::Reduce<RAJA::operators::maximum>(&txmax),
-            RAJA::expt::Reduce<RAJA::operators::maximum>(&tymax),
-            [=](Index_type i, Real_type& xsum, Real_type& ysum,
-                              Real_type& xmin, Real_type& ymin,
-                              Real_type& xmax, Real_type& ymax) {
-              REDUCE_STRUCT_BODY;
-            }
-          );
-
-          points.SetCenter(static_cast<Real_type>(txsum)/(points.N),
-                           static_cast<Real_type>(tysum)/(points.N));
-          points.SetXMin(static_cast<Real_type>(txmin));
-          points.SetXMax(static_cast<Real_type>(txmax));
-          points.SetYMin(static_cast<Real_type>(tymin));
-          points.SetYMax(static_cast<Real_type>(tymax));
-          m_points = points;
-
-        }
-        stopTimer();
-
-      } else {
-        getCout() << "\n  REDUCE_STRUCT : Unknown OMP Target tuning index = " << tune_idx << std::endl;
       }
+      stopTimer();
 
       break;
     }
@@ -161,14 +126,6 @@ void REDUCE_STRUCT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
      getCout() << "\n  REDUCE_STRUCT : Unknown OMP Target variant id = " << vid << std::endl;
   }
 
-}
-
-void REDUCE_STRUCT::setOpenMPTargetTuningDefinitions(VariantID vid)
-{
-  addVariantTuningName(vid, "default");
-  if (vid == RAJA_OpenMPTarget) {
-    addVariantTuningName(vid, "new");
-  }
 }
 
 } // end namespace basic

--- a/src/basic/REDUCE_STRUCT.hpp
+++ b/src/basic/REDUCE_STRUCT.hpp
@@ -91,7 +91,6 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void setOpenMPTargetTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >
   void runCudaVariantBase(VariantID vid);

--- a/src/basic/TRAP_INT-OMPTarget.cpp
+++ b/src/basic/TRAP_INT-OMPTarget.cpp
@@ -29,7 +29,7 @@ namespace basic
   const size_t threads_per_team = 256;
 
 
-void TRAP_INT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
+void TRAP_INT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;

--- a/src/basic/TRAP_INT-OMPTarget.cpp
+++ b/src/basic/TRAP_INT-OMPTarget.cpp
@@ -63,57 +63,26 @@ void TRAP_INT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    if (tune_idx == 0) {
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      Real_type tsumx = m_sumx_init;
 
-        RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> sumx(m_sumx_init);
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::plus>(&tsumx),
+        [=] (Index_type i, Real_type& sumx) {
           TRAP_INT_BODY;
-        });
+        }
+      );
 
-        m_sumx += static_cast<Real_type>(sumx.get()) * h;
+      m_sumx += static_cast<Real_type>(tsumx) * h;
 
-      }
-      stopTimer();
-
-    } else if (tune_idx == 1) {
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        Real_type tsumx = m_sumx_init;
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-          RAJA::RangeSegment(ibegin, iend),
-          RAJA::expt::Reduce<RAJA::operators::plus>(&tsumx),
-          [=] (Index_type i, Real_type& sumx) {
-            TRAP_INT_BODY;
-          }
-        );
-
-        m_sumx += static_cast<Real_type>(tsumx) * h;
-
-      }
-      stopTimer();
-
-    } else {
-      getCout() << "\n  TRAP_INT : Unknown OMP Target tuning index = " << tune_idx << std::endl;
     }
+    stopTimer();
 
   } else {
      getCout() << "\n  TRAP_INT : Unknown OMP Target variant id = " << vid << std::endl;
-  }
-}
-
-void TRAP_INT::setOpenMPTargetTuningDefinitions(VariantID vid)
-{
-  addVariantTuningName(vid, "default");
-  if (vid == RAJA_OpenMPTarget) {
-    addVariantTuningName(vid, "new");
   }
 }
 

--- a/src/basic/TRAP_INT.hpp
+++ b/src/basic/TRAP_INT.hpp
@@ -75,7 +75,6 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void setOpenMPTargetTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >

--- a/src/comm/HALO_EXCHANGE.hpp
+++ b/src/comm/HALO_EXCHANGE.hpp
@@ -115,6 +115,7 @@ public:
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+
   template < size_t block_size >
   void runCudaVariantImpl(VariantID vid);
   template < size_t block_size >

--- a/src/comm/HALO_EXCHANGE_FUSED.hpp
+++ b/src/comm/HALO_EXCHANGE_FUSED.hpp
@@ -161,7 +161,6 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void setOpenMPTargetTuningDefinitions(VariantID vid);
 
   void runSeqVariantDirect(VariantID vid);
   void runOpenMPVariantDirect(VariantID vid);

--- a/src/comm/HALO_EXCHANGE_FUSED.hpp
+++ b/src/comm/HALO_EXCHANGE_FUSED.hpp
@@ -161,6 +161,7 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid);
 
   void runSeqVariantDirect(VariantID vid);
   void runOpenMPVariantDirect(VariantID vid);

--- a/src/comm/HALO_PACKING_FUSED.hpp
+++ b/src/comm/HALO_PACKING_FUSED.hpp
@@ -139,6 +139,7 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid);
 
   void runSeqVariantDirect(VariantID vid);
   void runOpenMPVariantDirect(VariantID vid);

--- a/src/comm/HALO_PACKING_FUSED.hpp
+++ b/src/comm/HALO_PACKING_FUSED.hpp
@@ -139,7 +139,6 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void setOpenMPTargetTuningDefinitions(VariantID vid);
 
   void runSeqVariantDirect(VariantID vid);
   void runOpenMPVariantDirect(VariantID vid);

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -302,8 +302,8 @@ static const std::string VariantNames [] =
   std::string("Lambda_OpenMP"),
   std::string("RAJA_OpenMP"),
 
-  std::string("Base_OMPTarget"),
-  std::string("RAJA_OMPTarget"),
+  std::string("Base_OpenMPTarget"),
+  std::string("RAJA_OpenMPTarget"),
 
   std::string("Base_CUDA"),
   std::string("Lambda_CUDA"),

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -2410,7 +2410,7 @@ void RunParams::processVariantInput()
   
       // Assemble invalid input items for output message.
       if ( !found_it ) {
-         invalid_variant_input.push_back(variant_input[it]);
+        invalid_variant_input.push_back(variant_input[it]);
       } 
 
     }

--- a/src/lcals/FIRST_MIN-OMPTarget.cpp
+++ b/src/lcals/FIRST_MIN-OMPTarget.cpp
@@ -27,7 +27,7 @@ namespace lcals
   const size_t threads_per_team = 256;
 
 
-void FIRST_MIN::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
+void FIRST_MIN::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;

--- a/src/lcals/FIRST_MIN-OMPTarget.cpp
+++ b/src/lcals/FIRST_MIN-OMPTarget.cpp
@@ -60,62 +60,30 @@ void FIRST_MIN::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 
   } else if ( vid == RAJA_OpenMPTarget ) {
 
-    if (tune_idx == 0) {
+    using VL_TYPE = RAJA::expt::ValLoc<Real_type>;
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::ReduceMinLoc<RAJA::omp_target_reduce, Real_type, Index_type> loc(
-                                                    m_xmin_init, m_initloc);
+      VL_TYPE tloc(m_xmin_init, m_initloc);
 
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
-          FIRST_MIN_BODY_RAJA;
-        });
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+        RAJA::RangeSegment(ibegin, iend),
+        RAJA::expt::Reduce<RAJA::operators::minimum>(&tloc),
+        [=](Index_type i, VL_TYPE& loc) {
+          loc.min(x[i], i);
+        }
+      );
 
-        m_minloc = loc.getLoc();
+      m_minloc = static_cast<Index_type>(tloc.getLoc());
 
-      }
-      stopTimer();
-
-    } else if (tune_idx == 1) {
-
-      using VL_TYPE = RAJA::expt::ValLoc<Real_type>;
-
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-        VL_TYPE tloc(m_xmin_init, m_initloc);
-
-        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-          RAJA::RangeSegment(ibegin, iend),
-          RAJA::expt::Reduce<RAJA::operators::minimum>(&tloc),
-          [=](Index_type i, VL_TYPE& loc) {
-            loc.min(x[i], i);
-          }
-        );
-
-        m_minloc = static_cast<Index_type>(tloc.getLoc());
-
-      }
-      stopTimer();
-
-    } else {
-      getCout() << "\n  FIRST_MIN : Unknown OMP Target tuning index = " << tune_idx << std::endl;
     }
+    stopTimer();
 
   } else {
      getCout() << "\n  FIRST_MIN : Unknown OMP Target variant id = " << vid << std::endl;
   }
 
-}
-
-void FIRST_MIN::setOpenMPTargetTuningDefinitions(VariantID vid)
-{
-  addVariantTuningName(vid, "default");
-  if (vid == RAJA_OpenMPTarget) {
-    addVariantTuningName(vid, "new");
-  }
 }
 
 } // end namespace lcals

--- a/src/lcals/FIRST_MIN.hpp
+++ b/src/lcals/FIRST_MIN.hpp
@@ -87,7 +87,6 @@ public:
   void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void setOpenMPTargetTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid); 
 
   template < size_t block_size, typename MappingHelper >

--- a/src/stream/DOT-OMPTarget.cpp
+++ b/src/stream/DOT-OMPTarget.cpp
@@ -26,7 +26,7 @@ namespace stream
   //
   const size_t threads_per_team = 256;
 
-void DOT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
+void DOT::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;

--- a/src/stream/DOT-OMPTarget.cpp
+++ b/src/stream/DOT-OMPTarget.cpp
@@ -60,46 +60,23 @@ void DOT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 
     case RAJA_OpenMPTarget : {
 
-      if (tune_idx == 0) {
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        startTimer();
-        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+        Real_type tdot = m_dot_init;
 
-          RAJA::ReduceSum<RAJA::omp_target_reduce, Real_type> dot(m_dot_init);
-
-          RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-            RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
+        RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
+          RAJA::RangeSegment(ibegin, iend),
+          RAJA::expt::Reduce<RAJA::operators::plus>(&tdot),
+          [=] (Index_type i, Real_type& dot) {
             DOT_BODY;
-          });
+          }
+        );
 
-          m_dot += static_cast<Real_type>(dot.get());
+        m_dot += static_cast<Real_type>(tdot);
 
-        }
-        stopTimer();
-
-      } else if (tune_idx == 1) {
-
-        startTimer();
-        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
-
-          Real_type tdot = m_dot_init;
-
-          RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>(
-            RAJA::RangeSegment(ibegin, iend),
-            RAJA::expt::Reduce<RAJA::operators::plus>(&tdot),
-            [=] (Index_type i, Real_type& dot) {
-              DOT_BODY;
-            }
-          );
-
-          m_dot += static_cast<Real_type>(tdot);
-
-        }
-        stopTimer();
-
-      } else {
-        getCout() << "\n  DOT : Unknown OMP Target tuning index = " << tune_idx << std::endl;
       }
+      stopTimer();
 
       break;
     }
@@ -110,14 +87,6 @@ void DOT::runOpenMPTargetVariant(VariantID vid, size_t tune_idx)
 
   }
 
-}
-
-void DOT::setOpenMPTargetTuningDefinitions(VariantID vid)
-{
-  addVariantTuningName(vid, "default");
-  if (vid == RAJA_OpenMPTarget) {
-    addVariantTuningName(vid, "new");
-  }
 }
 
 } // end namespace stream

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -56,10 +56,8 @@ public:
   void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setSeqTuningDefinitions(VariantID vid);
-  void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
-  void setOpenMPTargetTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size, typename MappingHelper >

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -56,6 +56,7 @@ public:
   void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setSeqTuningDefinitions(VariantID vid);
+  void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);


### PR DESCRIPTION
# Summary

- This PR removes the old reductions from OpenMP Target variants of kernels with reductions.
- It also removes declarations of tuning methods in kernel class headers when those methods are unimplemented.
- Lastly, is contains some minor changes for code consistency, cleanup, etc.