### PR TITLE
Prevent Usage of CALI_CONFIG

### DIFF
--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -665,6 +665,19 @@ void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
   }
   )json";
 
+
+  // Check if CALI_CONFIG provided
+  const char* cali_config_env = std::getenv("CALI_CONFIG");
+  if (cali_config_env) {
+    std::string cali_config(cali_config_env);
+    std::cout << "CALI_CONFIG: " << cali_config << std::endl;
+    std::string err_str;
+    err_str = "setCaliperMgrVariantTuning: For the RAJA Performance Suite, do not set"
+      " CALI_CONFIG. Instead use the --add-to-spot-config and --add-to-cali-config"
+      " arguments to modify the Caliper configuration.";
+    throw std::invalid_argument(err_str);
+  }
+
   // Skip check if both empty
   if ((!addToSpotConfig.empty() || !addToCaliConfig.empty()) && !ran_spot_config_check) {
     cali::ConfigManager cm;


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following (modify list as needed):
  - Modifies the Caliper implementation in `src/common/KernelBase.cpp` to throw an error when `CALI_CONFIG` is used.

# Explanation

The `CALI_CONFIG` environment variable enables activating [one (or more) of Caliper's built-in performance profiling configurations](https://software.llnl.gov/Caliper/configuration.html#envvar-CALI_CONFIG). For the Caliper implementation in RAJAPerf, we manage the configuration separately for each [variant-tuning combination](https://github.com/LLNL/RAJAPerf/blob/83aed131f84eef2d6f81545570cf1fe596a52c62/src/common/KernelBase.cpp#L719). This means we generate a separate Caliper file for each variant-tuning combination. Allowing `CALI_CONFIG` to be set, means allowing usage such as `CALI_CONFIG="spot(output=my_file.cali)" raja-perf --variants Base_CUDA --tunings block_128 block 256`, resulting in 3 Caliper files `Base_CUDA-block_128.cali`, `Base_CUDA-block_256.cali`, and `my_file.cali`, which does not make sense.

We allow modification of the Caliper configuration through the `--add-to-spot-config` and `--add-to-cali-config` arguments, while this PR prevents the usage of `CALI_CONFIG` for RAJAPerf, limiting unintended behavior.