### PR TITLE
Add empty kernel

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,9 @@ blt_add_executable(
   basic/DAXPY_ATOMIC.cpp
   basic/DAXPY_ATOMIC-Seq.cpp
   basic/DAXPY_ATOMIC-OMPTarget.cpp
+  basic/EMPTY.cpp
+  basic/EMPTY-Seq.cpp
+  basic/EMPTY-OMPTarget.cpp
   basic/IF_QUAD.cpp
   basic/IF_QUAD-Seq.cpp
   basic/IF_QUAD-OMPTarget.cpp

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -35,6 +35,13 @@ blt_add_library(
           DAXPY_ATOMIC-Cuda.cpp
           DAXPY_ATOMIC-OMP.cpp
           DAXPY_ATOMIC-OMPTarget.cpp
+          EMPTY.cpp
+          EMPTY-Seq.cpp
+          EMPTY-Hip.cpp
+          EMPTY-Cuda.cpp
+          EMPTY-OMP.cpp
+          EMPTY-OMPTarget.cpp
+          EMPTY-Sycl.cpp
           IF_QUAD.cpp
           IF_QUAD-Seq.cpp
           IF_QUAD-Hip.cpp

--- a/src/basic/EMPTY-Cuda.cpp
+++ b/src/basic/EMPTY-Cuda.cpp
@@ -64,7 +64,7 @@ void EMPTY::runCudaVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      auto empty_lambda = [=] __device__ (Index_type RAJA_UNUSED_ARG(i)) {
+      auto empty_lambda = [=] __device__ (Index_type i) {
         EMPTY_BODY;
       }; 
 
@@ -86,7 +86,7 @@ void EMPTY::runCudaVariantImpl(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >( res,
-        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type RAJA_UNUSED_ARG(i)) {
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
         EMPTY_BODY;
       });
 

--- a/src/basic/EMPTY-Cuda.cpp
+++ b/src/basic/EMPTY-Cuda.cpp
@@ -25,14 +25,25 @@ template < size_t block_size >
 __launch_bounds__(block_size)
 __global__ void empty(Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     EMPTY_BODY;
-   }
+  Index_type i = blockIdx.x * block_size + threadIdx.x;
+  if (i < iend) {
+    EMPTY_BODY;
+  }
+}
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void empty_grid_stride(Index_type iend)
+{
+  Index_type i = blockIdx.x * block_size + threadIdx.x;
+  Index_type grid_stride = gridDim.x * block_size;
+  for ( ; i < iend; i += grid_stride) {
+    EMPTY_BODY;
+  }
 }
 
 
-template < size_t block_size >
+template < size_t block_size, typename MappingHelper >
 void EMPTY::runCudaVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
@@ -45,13 +56,21 @@ void EMPTY::runCudaVariantImpl(VariantID vid)
 
   if ( vid == Base_CUDA ) {
 
+    auto func = MappingHelper::direct
+        ? &empty<block_size>
+        : &empty_grid_stride<block_size>;
+
+    constexpr size_t shmem = 0;
+    const size_t max_grid_size = RAJAPERF_CUDA_GET_MAX_BLOCKS(
+        MappingHelper, func, block_size, shmem);
+
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      constexpr size_t shmem = 0;
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
 
-      RPlaunchCudaKernel( (empty<block_size>),
+      RPlaunchCudaKernel( func,
                           grid_size, block_size,
                           shmem, res.get_stream(),
                           iend );
@@ -61,18 +80,25 @@ void EMPTY::runCudaVariantImpl(VariantID vid)
 
   } else if ( vid == Lambda_CUDA ) {
 
+    auto empty_lambda = [=] __device__ (Index_type i) {
+      EMPTY_BODY;
+    };
+
+    auto func = MappingHelper::direct
+        ? &lambda_cuda_forall<block_size, decltype(empty_lambda)>
+        : &lambda_cuda_forall_grid_stride<block_size, decltype(empty_lambda)>;
+
+    constexpr size_t shmem = 0;
+    const size_t max_grid_size = RAJAPERF_CUDA_GET_MAX_BLOCKS(
+        MappingHelper, func, block_size, shmem);
+
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      auto empty_lambda = [=] __device__ (Index_type i) {
-        EMPTY_BODY;
-      }; 
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      constexpr size_t shmem = 0;
-
-      RPlaunchCudaKernel( (lambda_cuda_forall<block_size, 
-                                              decltype(empty_lambda)>),
+      RPlaunchCudaKernel( func,
                           grid_size, block_size,
                           shmem, res.get_stream(),
                           ibegin, iend, empty_lambda );
@@ -82,10 +108,14 @@ void EMPTY::runCudaVariantImpl(VariantID vid)
 
   } else if ( vid == RAJA_CUDA ) {
 
+    using exec_policy = std::conditional_t<MappingHelper::direct,
+        RAJA::cuda_exec<block_size, true /*async*/>,
+        RAJA::cuda_exec_occ_calc<block_size, true /*async*/>>;
+
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >( res,
+      RAJA::forall< exec_policy >( res,
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
         EMPTY_BODY;
       });
@@ -98,7 +128,55 @@ void EMPTY::runCudaVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(EMPTY, Cuda)
+void EMPTY::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      seq_for(gpu_mapping::forall_helpers{}, [&](auto mapping_helper) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runCudaVariantImpl<decltype(block_size){},
+                             decltype(mapping_helper)>(vid);
+
+        }
+
+        t += 1;
+
+      });
+
+    }
+
+  });
+
+}
+
+void EMPTY::setCudaTuningDefinitions(VariantID vid)
+{
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      seq_for(gpu_mapping::forall_helpers{}, [&](auto mapping_helper) {
+
+          addVariantTuningName(vid, decltype(mapping_helper)::get_name()+"_"+
+                                    std::to_string(block_size));
+
+      });
+
+    }
+
+  });
+
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/EMPTY-Cuda.cpp
+++ b/src/basic/EMPTY-Cuda.cpp
@@ -1,0 +1,106 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-25, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "EMPTY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void empty(Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     EMPTY_BODY;
+   }
+}
+
+
+template < size_t block_size >
+void EMPTY::runCudaVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  EMPTY_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchCudaKernel( (empty<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          iend );
+
+    }
+    stopTimer();
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto empty_lambda = [=] __device__ (Index_type RAJA_UNUSED_ARG(i)) {
+        EMPTY_BODY;
+      }; 
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size, 
+                                              decltype(empty_lambda)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend, empty_lambda );
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::cuda_exec<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type RAJA_UNUSED_ARG(i)) {
+        EMPTY_BODY;
+      });
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  EMPTY : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(EMPTY, Cuda)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/basic/EMPTY-Hip.cpp
+++ b/src/basic/EMPTY-Hip.cpp
@@ -64,7 +64,7 @@ void EMPTY::runHipVariantImpl(VariantID vid)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      auto empty_lambda = [=] __device__ (Index_type RAJA_UNUSED_ARG(i)) {
+      auto empty_lambda = [=] __device__ (Index_type i) {
         EMPTY_BODY;
       };
 
@@ -86,7 +86,7 @@ void EMPTY::runHipVariantImpl(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >( res,
-        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type RAJA_UNUSED_ARG(i)) {
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
         EMPTY_BODY;
       });
 

--- a/src/basic/EMPTY-Hip.cpp
+++ b/src/basic/EMPTY-Hip.cpp
@@ -25,14 +25,25 @@ template < size_t block_size >
 __launch_bounds__(block_size)
 __global__ void empty(Index_type iend)
 {
-   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
-   if (i < iend) {
-     EMPTY_BODY;
-   }
+  Index_type i = blockIdx.x * block_size + threadIdx.x;
+  if (i < iend) {
+    EMPTY_BODY;
+  }
+}
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void empty_grid_stride(Index_type iend)
+{
+  Index_type i = blockIdx.x * block_size + threadIdx.x;
+  Index_type grid_stride = gridDim.x * block_size;
+  for ( ; i < iend; i += grid_stride) {
+    EMPTY_BODY;
+  }
 }
 
 
-template < size_t block_size >
+template < size_t block_size, typename MappingHelper >
 void EMPTY::runHipVariantImpl(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
@@ -45,13 +56,21 @@ void EMPTY::runHipVariantImpl(VariantID vid)
 
   if ( vid == Base_HIP ) {
 
+    auto func = MappingHelper::direct
+        ? &empty<block_size>
+        : &empty_grid_stride<block_size>;
+
+    constexpr size_t shmem = 0;
+    const size_t max_grid_size = RAJAPERF_HIP_GET_MAX_BLOCKS(
+        MappingHelper, func, block_size, shmem);
+
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      constexpr size_t shmem = 0;
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
 
-      RPlaunchHipKernel( (empty<block_size>),
+      RPlaunchHipKernel( func,
                          grid_size, block_size,
                          shmem, res.get_stream(),
                          iend );
@@ -61,18 +80,25 @@ void EMPTY::runHipVariantImpl(VariantID vid)
 
   } else if ( vid == Lambda_HIP ) {
 
+    auto empty_lambda = [=] __device__ (Index_type i) {
+      EMPTY_BODY;
+    };
+
+    auto func = MappingHelper::direct
+        ? &lambda_hip_forall<block_size, decltype(empty_lambda)>
+        : &lambda_hip_forall_grid_stride<block_size, decltype(empty_lambda)>;
+
+    constexpr size_t shmem = 0;
+    const size_t max_grid_size = RAJAPERF_HIP_GET_MAX_BLOCKS(
+        MappingHelper, func, block_size, shmem);
+
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      auto empty_lambda = [=] __device__ (Index_type i) {
-        EMPTY_BODY;
-      };
+      const size_t normal_grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      const size_t grid_size = std::min(normal_grid_size, max_grid_size);
 
-      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
-      constexpr size_t shmem = 0;
-
-      RPlaunchHipKernel( (lambda_hip_forall<block_size,
-                                            decltype(empty_lambda)>),
+      RPlaunchHipKernel( func,
                          grid_size, block_size,
                          shmem, res.get_stream(),
                          ibegin, iend, empty_lambda );
@@ -82,10 +108,14 @@ void EMPTY::runHipVariantImpl(VariantID vid)
 
   } else if ( vid == RAJA_HIP ) {
 
+    using exec_policy = std::conditional_t<MappingHelper::direct,
+        RAJA::hip_exec<block_size, true /*async*/>,
+        RAJA::hip_exec_occ_calc<block_size, true /*async*/>>;
+
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >( res,
+      RAJA::forall< exec_policy >( res,
         RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type i) {
         EMPTY_BODY;
       });
@@ -98,7 +128,55 @@ void EMPTY::runHipVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(EMPTY, Hip)
+void EMPTY::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      seq_for(gpu_mapping::forall_helpers{}, [&](auto mapping_helper) {
+
+        if (tune_idx == t) {
+
+          setBlockSize(block_size);
+          runHipVariantImpl<decltype(block_size){},
+                             decltype(mapping_helper)>(vid);
+
+        }
+
+        t += 1;
+
+      });
+
+    }
+
+  });
+
+}
+
+void EMPTY::setHipTuningDefinitions(VariantID vid)
+{
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      seq_for(gpu_mapping::forall_helpers{}, [&](auto mapping_helper) {
+
+          addVariantTuningName(vid, decltype(mapping_helper)::get_name()+"_"+
+                                    std::to_string(block_size));
+
+      });
+
+    }
+
+  });
+
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/EMPTY-Hip.cpp
+++ b/src/basic/EMPTY-Hip.cpp
@@ -1,0 +1,106 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-25, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "EMPTY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+#include "common/HipDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void empty(Index_type iend)
+{
+   Index_type i = blockIdx.x * blockDim.x + threadIdx.x;
+   if (i < iend) {
+     EMPTY_BODY;
+   }
+}
+
+
+template < size_t block_size >
+void EMPTY::runHipVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  EMPTY_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchHipKernel( (empty<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         iend );
+
+    }
+    stopTimer();
+
+  } else if ( vid == Lambda_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      auto empty_lambda = [=] __device__ (Index_type RAJA_UNUSED_ARG(i)) {
+        EMPTY_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(empty_lambda)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, empty_lambda );
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_HIP ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::hip_exec<block_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] __device__ (Index_type RAJA_UNUSED_ARG(i)) {
+        EMPTY_BODY;
+      });
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  EMPTY : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(EMPTY, Hip)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_HIP

--- a/src/basic/EMPTY-OMP.cpp
+++ b/src/basic/EMPTY-OMP.cpp
@@ -1,0 +1,99 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-25, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "EMPTY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+
+void EMPTY::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  EMPTY_DATA_SETUP;
+
+  switch ( vid ) {
+
+    case Base_OpenMP : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          EMPTY_BODY;
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case Lambda_OpenMP : {
+
+      auto empty_lam = [=](Index_type RAJA_UNUSED_ARG(i)) {
+                         EMPTY_BODY;
+                       };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        #pragma omp parallel for
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          empty_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_OpenMP : {
+
+      auto res{getHostResource()};
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::forall<RAJA::omp_parallel_for_exec>( res,
+          RAJA::RangeSegment(ibegin, iend), [=](Index_type RAJA_UNUSED_ARG(i)) {
+          EMPTY_BODY;
+        });
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    default : {
+      getCout() << "\n  EMPTY : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/EMPTY-OMP.cpp
+++ b/src/basic/EMPTY-OMP.cpp
@@ -48,7 +48,7 @@ void EMPTY::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx)
 
     case Lambda_OpenMP : {
 
-      auto empty_lam = [=](Index_type RAJA_UNUSED_ARG(i)) {
+      auto empty_lam = [=](Index_type i) {
                          EMPTY_BODY;
                        };
 
@@ -74,7 +74,7 @@ void EMPTY::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         RAJA::forall<RAJA::omp_parallel_for_exec>( res,
-          RAJA::RangeSegment(ibegin, iend), [=](Index_type RAJA_UNUSED_ARG(i)) {
+          RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
           EMPTY_BODY;
         });
 

--- a/src/basic/EMPTY-OMPTarget.cpp
+++ b/src/basic/EMPTY-OMPTarget.cpp
@@ -40,7 +40,7 @@ void EMPTY::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tun
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      #pragma omp target is_device_ptr(x, y) device( did )
+      #pragma omp target device( did )
       #pragma omp teams distribute parallel for thread_limit(threads_per_team) schedule(static, 1)
       for (Index_type i = ibegin; i < iend; ++i ) {
         EMPTY_BODY;

--- a/src/basic/EMPTY-OMPTarget.cpp
+++ b/src/basic/EMPTY-OMPTarget.cpp
@@ -1,0 +1,75 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-25, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "EMPTY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_TARGET_OPENMP)
+
+#include "common/OpenMPTargetDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+  //
+  // Define threads per team for target execution
+  //
+  const size_t threads_per_team = 256;
+
+
+void EMPTY::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  EMPTY_DATA_SETUP;
+
+  if ( vid == Base_OpenMPTarget ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      #pragma omp target is_device_ptr(x, y) device( did )
+      #pragma omp teams distribute parallel for thread_limit(threads_per_team) schedule(static, 1)
+      for (Index_type i = ibegin; i < iend; ++i ) {
+        EMPTY_BODY;
+      }
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_OpenMPTarget ) {
+
+    auto res{getOmpTargetResource()};
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>( res,
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type RAJA_UNUSED_ARG(i)) {
+        EMPTY_BODY;
+      });
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  EMPTY : Unknown OMP Target variant id = " << vid << std::endl;
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_TARGET_OPENMP

--- a/src/basic/EMPTY-OMPTarget.cpp
+++ b/src/basic/EMPTY-OMPTarget.cpp
@@ -57,7 +57,7 @@ void EMPTY::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tun
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       RAJA::forall<RAJA::omp_target_parallel_for_exec<threads_per_team>>( res,
-        RAJA::RangeSegment(ibegin, iend), [=](Index_type RAJA_UNUSED_ARG(i)) {
+        RAJA::RangeSegment(ibegin, iend), [=](Index_type i) {
         EMPTY_BODY;
       });
 

--- a/src/basic/EMPTY-Seq.cpp
+++ b/src/basic/EMPTY-Seq.cpp
@@ -1,0 +1,95 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-25, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "EMPTY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+
+void EMPTY::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  EMPTY_DATA_SETUP;
+
+  switch ( vid ) {
+
+    case Base_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          EMPTY_BODY;
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+#if defined(RUN_RAJA_SEQ)
+    case Lambda_Seq : {
+
+      auto empty_lam = [=](Index_type RAJA_UNUSED_ARG(i)) {
+                     EMPTY_BODY;
+                   };
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        for (Index_type i = ibegin; i < iend; ++i ) {
+          empty_lam(i);
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_Seq : {
+
+      auto res{getHostResource()};
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::forall<RAJA::seq_exec>( res,
+          RAJA::RangeSegment(ibegin, iend),
+          [=](Index_type RAJA_UNUSED_ARG(i)) {
+            EMPTY_BODY;
+        });
+
+      }
+      stopTimer();
+
+      break;
+    }
+#endif
+
+    default : {
+      getCout() << "\n  EMPTY : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/EMPTY-Seq.cpp
+++ b/src/basic/EMPTY-Seq.cpp
@@ -46,7 +46,7 @@ void EMPTY::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 #if defined(RUN_RAJA_SEQ)
     case Lambda_Seq : {
 
-      auto empty_lam = [=](Index_type RAJA_UNUSED_ARG(i)) {
+      auto empty_lam = [=](Index_type i) {
                      EMPTY_BODY;
                    };
 
@@ -72,7 +72,7 @@ void EMPTY::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 
         RAJA::forall<RAJA::seq_exec>( res,
           RAJA::RangeSegment(ibegin, iend),
-          [=](Index_type RAJA_UNUSED_ARG(i)) {
+          [=](Index_type i) {
             EMPTY_BODY;
         });
 

--- a/src/basic/EMPTY-Sycl.cpp
+++ b/src/basic/EMPTY-Sycl.cpp
@@ -61,7 +61,7 @@ void EMPTY::runSyclVariantImpl(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       RAJA::forall< RAJA::sycl_exec<work_group_size, true /*async*/> >( res,
-        RAJA::RangeSegment(ibegin, iend), [=] (Index_type RAJA_UNUSED_ARG(i)) {
+        RAJA::RangeSegment(ibegin, iend), [=] (Index_type i) {
         EMPTY_BODY;
       });
 

--- a/src/basic/EMPTY-Sycl.cpp
+++ b/src/basic/EMPTY-Sycl.cpp
@@ -1,0 +1,82 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-25, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "EMPTY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_SYCL)
+
+#include "common/SyclDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+template <size_t work_group_size >
+void EMPTY::runSyclVariantImpl(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
+  EMPTY_DATA_SETUP;
+
+  if ( vid == Base_SYCL ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
+
+      qu->submit([&] (sycl::handler& h) {
+        h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
+                       [=] (sycl::nd_item<1> item ) {
+
+          Index_type i = item.get_global_id(0);
+          if (i < iend) {
+            EMPTY_BODY;
+          }
+
+        });
+      });
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_SYCL ) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+      RAJA::forall< RAJA::sycl_exec<work_group_size, true /*async*/> >( res,
+        RAJA::RangeSegment(ibegin, iend), [=] (Index_type RAJA_UNUSED_ARG(i)) {
+        EMPTY_BODY;
+      });
+
+    }
+    stopTimer();
+
+  } else {
+     std::cout << "\n  EMPTY : Unknown Sycl variant id = " << vid << std::endl;
+  }
+
+}
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(EMPTY, Sycl)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+
+#endif  // RAJA_ENABLE_SYCL

--- a/src/basic/EMPTY.cpp
+++ b/src/basic/EMPTY.cpp
@@ -1,0 +1,77 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-25, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "EMPTY.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
+namespace rajaperf
+{
+namespace basic
+{
+
+
+EMPTY::EMPTY(const RunParams& params)
+  : KernelBase(rajaperf::Basic_EMPTY, params)
+{
+  setDefaultProblemSize(1000000);
+  setDefaultReps(1000);
+
+  setActualProblemSize( getTargetProblemSize() );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep( 1 );
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep( 0 );
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  setVariantDefined( Base_Seq );
+  setVariantDefined( Lambda_Seq );
+  setVariantDefined( RAJA_Seq );
+
+  setVariantDefined( Base_OpenMP );
+  setVariantDefined( Lambda_OpenMP );
+  setVariantDefined( RAJA_OpenMP );
+
+  setVariantDefined( Base_OpenMPTarget );
+  setVariantDefined( RAJA_OpenMPTarget );
+
+  setVariantDefined( Base_CUDA );
+  setVariantDefined( Lambda_CUDA );
+  setVariantDefined( RAJA_CUDA );
+
+  setVariantDefined( Base_HIP );
+  setVariantDefined( Lambda_HIP );
+  setVariantDefined( RAJA_HIP );
+}
+
+EMPTY::~EMPTY()
+{
+}
+
+void EMPTY::setUp(VariantID RAJAPERF_UNUSED_ARG(vid), size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+}
+
+void EMPTY::updateChecksum(VariantID RAJAPERF_UNUSED_ARG(vid), size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+}
+
+void EMPTY::tearDown(VariantID RAJAPERF_UNUSED_ARG(vid), size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/EMPTY.hpp
+++ b/src/basic/EMPTY.hpp
@@ -1,0 +1,72 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-25, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/LICENSE file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// EMPTY kernel reference implementation:
+///
+/// for (Index_type i = ibegin; i < iend; ++i ) {
+///   y[i] += a * x[i] ;
+/// }
+///
+
+#ifndef RAJAPerf_Basic_EMPTY_HPP
+#define RAJAPerf_Basic_EMPTY_HPP
+
+#define EMPTY_DATA_SETUP
+
+#if defined(RAJA_COMPILER_MSVC)
+#define EMPTY_BODY __asm { } ;
+#else
+#define EMPTY_BODY asm volatile ( "" ::: "memory" ) ;
+#endif
+
+
+#include "common/KernelBase.hpp"
+
+namespace rajaperf
+{
+class RunParams;
+
+namespace basic
+{
+
+class EMPTY : public KernelBase
+{
+public:
+
+  EMPTY(const RunParams& params);
+
+  ~EMPTY();
+
+  void setUp(VariantID vid, size_t tune_idx);
+  void updateChecksum(VariantID vid, size_t tune_idx);
+  void tearDown(VariantID vid, size_t tune_idx);
+
+  void runSeqVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPVariant(VariantID vid, size_t tune_idx);
+  void runCudaVariant(VariantID vid, size_t tune_idx);
+  void runHipVariant(VariantID vid, size_t tune_idx);
+  void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+
+  void setCudaTuningDefinitions(VariantID vid);
+  void setHipTuningDefinitions(VariantID vid);
+
+  template < size_t block_size >
+  void runCudaVariantImpl(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantImpl(VariantID vid);
+
+private:
+  static const size_t default_gpu_block_size = 256;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size>;
+};
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/basic/EMPTY.hpp
+++ b/src/basic/EMPTY.hpp
@@ -10,7 +10,7 @@
 /// EMPTY kernel reference implementation:
 ///
 /// for (Index_type i = ibegin; i < iend; ++i ) {
-///   y[i] += a * x[i] ;
+///
 /// }
 ///
 
@@ -19,10 +19,14 @@
 
 #define EMPTY_DATA_SETUP
 
+// Add something that will stop the loop from being optimized out
+// while adding as little overhead as possible.
 #if defined(_WIN32) || defined(_WIN64)
-#define EMPTY_BODY __asm { } ;
+// Generate a loop with one write to the stack.
+#define EMPTY_BODY volatile auto unused = i; RAJA_UNUSED_VAR( unused ) ;
 #else
-#define EMPTY_BODY asm volatile ( "" ::: "memory" ) ;
+// Generate an empty loop.
+#define EMPTY_BODY asm volatile ( "" ) ; RAJA_UNUSED_VAR( i ) ;
 #endif
 
 

--- a/src/basic/EMPTY.hpp
+++ b/src/basic/EMPTY.hpp
@@ -52,14 +52,18 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
+  void runSyclVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size >
   void runCudaVariantImpl(VariantID vid);
   template < size_t block_size >
   void runHipVariantImpl(VariantID vid);
+  template < size_t work_group_size >
+  void runSyclVariantImpl(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/basic/EMPTY.hpp
+++ b/src/basic/EMPTY.hpp
@@ -19,7 +19,7 @@
 
 #define EMPTY_DATA_SETUP
 
-#if defined(RAJA_COMPILER_MSVC)
+#if defined(_WIN32) || defined(_WIN64)
 #define EMPTY_BODY __asm { } ;
 #else
 #define EMPTY_BODY asm volatile ( "" ::: "memory" ) ;

--- a/src/basic/EMPTY.hpp
+++ b/src/basic/EMPTY.hpp
@@ -62,9 +62,9 @@ public:
   void setHipTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);
 
-  template < size_t block_size >
+  template < size_t block_size, typename MappingHelper >
   void runCudaVariantImpl(VariantID vid);
-  template < size_t block_size >
+  template < size_t block_size, typename MappingHelper >
   void runHipVariantImpl(VariantID vid);
   template < size_t work_group_size >
   void runSyclVariantImpl(VariantID vid);

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -92,6 +92,30 @@ __global__ void lambda_cuda_forall(Index_type ibegin, Index_type iend, Lambda bo
 }
 
 /*!
+ * \brief Grid stride forall cuda kernel that runs a lambda.
+ */
+template < typename Lambda >
+__global__ void lambda_cuda_forall_grid_stride(Index_type ibegin, Index_type iend, Lambda body)
+{
+  Index_type i = ibegin + blockIdx.x * blockDim.x + threadIdx.x;
+  Index_type grid_stride = gridDim.x * blockDim.x;
+  for ( ; i < iend; i += grid_stride ) {
+    body(i);
+  }
+}
+///
+template < size_t block_size, typename Lambda >
+__launch_bounds__(block_size)
+__global__ void lambda_cuda_forall_grid_stride(Index_type ibegin, Index_type iend, Lambda body)
+{
+  Index_type i = ibegin + blockIdx.x * block_size + threadIdx.x;
+  Index_type grid_stride = gridDim.x * block_size;
+  for ( ; i < iend; i += grid_stride ) {
+    body(i);
+  }
+}
+
+/*!
  * \brief Simple cuda kernel that runs a lambda.
  */
 template < typename Lambda >

--- a/src/common/GPUUtils.hpp
+++ b/src/common/GPUUtils.hpp
@@ -220,6 +220,10 @@ struct global_loop_occupancy_grid_stride_helper
   static std::string get_name() { return "occgs"; }
 };
 
+using forall_helpers = camp::list<
+    global_direct_helper,
+    global_loop_occupancy_grid_stride_helper >;
+
 using reducer_helpers = camp::list<
     global_direct_helper,
     global_loop_occupancy_grid_stride_helper >;

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -79,6 +79,30 @@ __global__ void lambda_hip_forall(Index_type ibegin, Index_type iend, Lambda bod
 }
 
 /*!
+ * \brief Grid stride forall hip kernel that runs a lambda.
+ */
+template < typename Lambda >
+__global__ void lambda_hip_forall_grid_stride(Index_type ibegin, Index_type iend, Lambda body)
+{
+  Index_type i = ibegin + blockIdx.x * blockDim.x + threadIdx.x;
+  Index_type grid_stride = gridDim.x * blockDim.x;
+  for ( ; i < iend; i += grid_stride) {
+    body(i);
+  }
+}
+///
+template < size_t block_size, typename Lambda >
+__launch_bounds__(block_size)
+__global__ void lambda_hip_forall_grid_stride(Index_type ibegin, Index_type iend, Lambda body)
+{
+  Index_type i = ibegin + blockIdx.x * block_size + threadIdx.x;
+  Index_type grid_stride = gridDim.x * block_size;
+  for ( ; i < iend; i += grid_stride) {
+    body(i);
+  }
+}
+
+/*!
  * \brief Simple hip kernel that runs a lambda.
  */
 template < typename Lambda >

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -21,6 +21,7 @@
 #include "basic/COPY8.hpp"
 #include "basic/DAXPY.hpp"
 #include "basic/DAXPY_ATOMIC.hpp"
+#include "basic/EMPTY.hpp"
 #include "basic/IF_QUAD.hpp"
 #include "basic/INDEXLIST.hpp"
 #include "basic/INDEXLIST_3LOOP.hpp"
@@ -175,6 +176,7 @@ static const std::string KernelNames [] =
   std::string("Basic_COPY8"),
   std::string("Basic_DAXPY"),
   std::string("Basic_DAXPY_ATOMIC"),
+  std::string("Basic_EMPTY"),
   std::string("Basic_IF_QUAD"),
   std::string("Basic_INDEXLIST"),
   std::string("Basic_INDEXLIST_3LOOP"),
@@ -809,6 +811,10 @@ KernelBase* getKernelObject(KernelID kid,
     }
     case Basic_DAXPY_ATOMIC : {
        kernel = new basic::DAXPY_ATOMIC(run_params);
+       break;
+    }
+    case Basic_EMPTY : {
+       kernel = new basic::EMPTY(run_params);
        break;
     }
     case Basic_IF_QUAD : {

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -81,6 +81,7 @@ enum KernelID {
   Basic_COPY8,
   Basic_DAXPY,
   Basic_DAXPY_ATOMIC,
+  Basic_EMPTY,
   Basic_IF_QUAD,
   Basic_INDEXLIST,
   Basic_INDEXLIST_3LOOP,


### PR DESCRIPTION
Add a kernel that does nothing inside of the loop to try have a way to get the minimal cost of running a loop.

Uses an empty asm statement to convince the compiler to generate code for loops even though they do nothing.

# Summary

- This PR is a feature
- It does the following:
  - Adds empty kernel at the request of myself
