### PR TITLE
Fix optimization level on a few Caliper LC build scripts

### DIFF
--- a/scripts/lc-builds/toss4_clang-mpi_caliper.sh
+++ b/scripts/lc-builds/toss4_clang-mpi_caliper.sh
@@ -49,8 +49,6 @@ cmake \
   -DRAJA_PERFSUITE_USE_CALIPER=ON \
   -Dcaliper_DIR=${CALI_DIR} \
   -Dadiak_DIR=${ADIAK_DIR} \
-  -DCMAKE_C_FLAGS="-g -O0" \
-  -DCMAKE_CXX_FLAGS="-g -O0" \
   "$@" \
   ..
 

--- a/scripts/lc-builds/toss4_clang_caliper.sh
+++ b/scripts/lc-builds/toss4_clang_caliper.sh
@@ -48,8 +48,6 @@ cmake \
   -DRAJA_PERFSUITE_USE_CALIPER=ON \
   -Dcaliper_DIR=${CALI_DIR} \
   -Dadiak_DIR=${ADIAK_DIR} \
-  -DCMAKE_C_FLAGS="-g -O0" \
-  -DCMAKE_CXX_FLAGS="-g -O0" \
   "$@" \
   ..
 

--- a/scripts/lc-builds/toss4_gcc-mpi_caliper.sh
+++ b/scripts/lc-builds/toss4_gcc-mpi_caliper.sh
@@ -50,8 +50,6 @@ cmake \
   -DRAJA_PERFSUITE_USE_CALIPER=ON \
   -Dcaliper_DIR=${CALI_DIR} \
   -Dadiak_DIR=${ADIAK_DIR} \
-  -DCMAKE_C_FLAGS="-g -O0" \
-  -DCMAKE_CXX_FLAGS="-g -O0" \
   "$@" \
   ..
 

--- a/scripts/lc-builds/toss4_gcc_caliper.sh
+++ b/scripts/lc-builds/toss4_gcc_caliper.sh
@@ -48,8 +48,6 @@ cmake \
   -DRAJA_PERFSUITE_USE_CALIPER=ON \
   -Dcaliper_DIR=${CALI_DIR} \
   -Dadiak_DIR=${ADIAK_DIR} \
-  -DCMAKE_C_FLAGS="-g -O0" \
-  -DCMAKE_CXX_FLAGS="-g -O0" \
   "$@" \
   ..
 


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes a few LC build scripts which appear to configure the build without optimization and with debugging info. The host configs generate conflicting flags if configured in release mode. 
  - It seems that those settings (in the host configs) take precedence over these flags because they appear later in the compilation command. Nevertheless, I don't think the build scripts should have these flags. 

