### PR TITLE
Improve how copies are handled

### DIFF
--- a/src/algorithm/ATOMIC.hpp
+++ b/src/algorithm/ATOMIC.hpp
@@ -25,10 +25,19 @@
 
 #define ATOMIC_DATA_TEARDOWN(replication) \
   { \
-    auto reset_atomic = scopedMoveData(atomic, replication, vid); \
+    Real_ptr atomic_host = atomic; \
+    DataSpace ds = getDataSpace(vid); \
+    DataSpace hds = rajaperf::hostCopyDataSpace(ds); \
+    if (ds != hds) { \
+      rajaperf::allocData(hds, atomic_host, replication, getDataAlignment()); \
+      rajaperf::copyData(hds, atomic_host, ds, atomic, replication); \
+    } \
     m_final = init; \
     for (size_t r = 0; r < replication; ++r ) { \
       m_final += atomic[r]; \
+    } \
+    if (ds != hds) { \
+      rajaperf::deallocData(hds, atomic_host); \
     } \
   } \
   deallocData(atomic, vid);

--- a/src/algorithm/HISTOGRAM.cpp
+++ b/src/algorithm/HISTOGRAM.cpp
@@ -70,9 +70,8 @@ HISTOGRAM::~HISTOGRAM()
 
 void HISTOGRAM::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  allocData(m_bins, getActualProblemSize(), vid);
   {
-    auto reset_bins = scopedMoveData(m_bins, getActualProblemSize(), vid);
+    auto reset_bins = allocDataForSeqInit(m_bins, getActualProblemSize(), vid);
 
     const bool init_random_per_iterate =
         (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::Random);

--- a/src/algorithm/HISTOGRAM.cpp
+++ b/src/algorithm/HISTOGRAM.cpp
@@ -70,65 +70,63 @@ HISTOGRAM::~HISTOGRAM()
 
 void HISTOGRAM::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  {
-    auto reset_bins = allocDataForSeqInit(m_bins, getActualProblemSize(), vid);
+  auto reset_bins = allocDataForInit(m_bins, getActualProblemSize(), vid);
 
-    const bool init_random_per_iterate =
-        (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::Random);
-    const bool init_random_sizes =
-        (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::RunsRandomSizes);
-    const bool init_even_sizes =
-        (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::RunsEvenSizes);
-    const bool init_all_one =
-        (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::Single);
+  const bool init_random_per_iterate =
+      (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::Random);
+  const bool init_random_sizes =
+      (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::RunsRandomSizes);
+  const bool init_even_sizes =
+      (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::RunsEvenSizes);
+  const bool init_all_one =
+      (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::Single);
 
-    if (init_even_sizes || init_random_sizes || init_all_one) {
-      Real_ptr data = nullptr;
-      if (init_even_sizes) {
-        allocData(data, m_num_bins, Base_Seq);
-        for (Index_type b = 0; b < m_num_bins; ++b) {
-          data[b] = static_cast<Real_type>(b+1) / m_num_bins;
-        }
-      } else if (init_random_sizes) {
-        allocAndInitDataRandValue(data, m_num_bins, Base_Seq);
-        std::sort(data, data+m_num_bins);
-      } else if (init_all_one) {
-        allocData(data, m_num_bins, Base_Seq);
-        for (Index_type b = 0; b < m_num_bins; ++b) {
-          data[b] = static_cast<Real_type>(0);
-        }
+  if (init_even_sizes || init_random_sizes || init_all_one) {
+    Real_ptr data = nullptr;
+    if (init_even_sizes) {
+      allocData(data, m_num_bins, Base_Seq);
+      for (Index_type b = 0; b < m_num_bins; ++b) {
+        data[b] = static_cast<Real_type>(b+1) / m_num_bins;
       }
-
-      Index_type actual_prob_size = getActualProblemSize();
-      Index_type bin = 0;
-      for (Index_type i = 0; i < actual_prob_size; ++i) {
-        Real_type pos = static_cast<Real_type>(i) / actual_prob_size;
-        while (bin+1 < m_num_bins && pos >= data[bin]) {
-          bin += 1;
-        }
-        m_bins[i] = bin;
+    } else if (init_random_sizes) {
+      allocAndInitDataRandValue(data, m_num_bins, Base_Seq);
+      std::sort(data, data+m_num_bins);
+    } else if (init_all_one) {
+      allocData(data, m_num_bins, Base_Seq);
+      for (Index_type b = 0; b < m_num_bins; ++b) {
+        data[b] = static_cast<Real_type>(0);
       }
-
-      deallocData(data, Base_Seq);
-
-    } else if (init_random_per_iterate) {
-      Real_ptr data;
-      allocAndInitDataRandValue(data, getActualProblemSize(), Base_Seq);
-
-      for (Index_type i = 0; i < getActualProblemSize(); ++i) {
-        m_bins[i] = static_cast<Index_type>(data[i] * m_num_bins);
-        if (m_bins[i] >= m_num_bins) {
-          m_bins[i] = m_num_bins - 1;
-        }
-        if (m_bins[i] < 0) {
-          m_bins[i] = 0;
-        }
-      }
-
-      deallocData(data, Base_Seq);
-    } else {
-      throw 1;
     }
+
+    Index_type actual_prob_size = getActualProblemSize();
+    Index_type bin = 0;
+    for (Index_type i = 0; i < actual_prob_size; ++i) {
+      Real_type pos = static_cast<Real_type>(i) / actual_prob_size;
+      while (bin+1 < m_num_bins && pos >= data[bin]) {
+        bin += 1;
+      }
+      m_bins[i] = bin;
+    }
+
+    deallocData(data, Base_Seq);
+
+  } else if (init_random_per_iterate) {
+    Real_ptr data;
+    allocAndInitDataRandValue(data, getActualProblemSize(), Base_Seq);
+
+    for (Index_type i = 0; i < getActualProblemSize(); ++i) {
+      m_bins[i] = static_cast<Index_type>(data[i] * m_num_bins);
+      if (m_bins[i] >= m_num_bins) {
+        m_bins[i] = m_num_bins - 1;
+      }
+      if (m_bins[i] < 0) {
+        m_bins[i] = 0;
+      }
+    }
+
+    deallocData(data, Base_Seq);
+  } else {
+    throw 1;
   }
 
   m_counts_init.resize(m_num_bins, 0);

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -77,17 +77,15 @@ DEL_DOT_VEC_2D::~DEL_DOT_VEC_2D()
 
 void DEL_DOT_VEC_2D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  {
-    auto reset_x = allocAndInitDataConstForSeqInit(m_x, m_array_length, 0.0, vid);
-    auto reset_y = allocAndInitDataConstForSeqInit(m_y, m_array_length, 0.0, vid);
-    auto reset_rz = allocAndInitDataConstForSeqInit(m_real_zones, m_domain->n_real_zones,
-                        static_cast<Index_type>(-1), vid);
+  auto reset_x = allocAndInitDataConstForInit(m_x, m_array_length, 0.0, vid);
+  auto reset_y = allocAndInitDataConstForInit(m_y, m_array_length, 0.0, vid);
+  auto reset_rz = allocAndInitDataConstForInit(m_real_zones, m_domain->n_real_zones,
+                      static_cast<Index_type>(-1), vid);
 
-    Real_type dx = 0.2;
-    Real_type dy = 0.1;
-    setMeshPositions_2d(m_x, dx, m_y, dy, *m_domain);
-    setRealZones_2d(m_real_zones, *m_domain);
-  }
+  Real_type dx = 0.2;
+  Real_type dy = 0.1;
+  setMeshPositions_2d(m_x, dx, m_y, dy, *m_domain);
+  setRealZones_2d(m_real_zones, *m_domain);
 
   allocAndInitData(m_xdot, m_array_length, vid);
   allocAndInitData(m_ydot, m_array_length, vid);

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -77,15 +77,11 @@ DEL_DOT_VEC_2D::~DEL_DOT_VEC_2D()
 
 void DEL_DOT_VEC_2D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  allocAndInitDataConst(m_x, m_array_length, 0.0, vid);
-  allocAndInitDataConst(m_y, m_array_length, 0.0, vid);
-  allocAndInitDataConst(m_real_zones, m_domain->n_real_zones,
-                        static_cast<Index_type>(-1), vid);
-
   {
-    auto reset_x = scopedMoveData(m_x, m_array_length, vid);
-    auto reset_y = scopedMoveData(m_y, m_array_length, vid);
-    auto reset_rz = scopedMoveData(m_real_zones, m_domain->n_real_zones, vid);
+    auto reset_x = allocAndInitDataConstForSeqInit(m_x, m_array_length, 0.0, vid);
+    auto reset_y = allocAndInitDataConstForSeqInit(m_y, m_array_length, 0.0, vid);
+    auto reset_rz = allocAndInitDataConstForSeqInit(m_real_zones, m_domain->n_real_zones,
+                        static_cast<Index_type>(-1), vid);
 
     Real_type dx = 0.2;
     Real_type dy = 0.1;

--- a/src/apps/EDGE3D.cpp
+++ b/src/apps/EDGE3D.cpp
@@ -96,14 +96,10 @@ EDGE3D::~EDGE3D()
 
 void EDGE3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  allocAndInitDataConst(m_x, m_array_length, Real_type(0.0), vid);
-  allocAndInitDataConst(m_y, m_array_length, Real_type(0.0), vid);
-  allocAndInitDataConst(m_z, m_array_length, Real_type(0.0), vid);
-
   {
-    auto reset_x = scopedMoveData(m_x, m_array_length, vid);
-    auto reset_y = scopedMoveData(m_y, m_array_length, vid);
-    auto reset_z = scopedMoveData(m_z, m_array_length, vid);
+    auto reset_x = allocAndInitDataConstForSeqInit(m_x, m_array_length, Real_type(0.0), vid);
+    auto reset_y = allocAndInitDataConstForSeqInit(m_y, m_array_length, Real_type(0.0), vid);
+    auto reset_z = allocAndInitDataConstForSeqInit(m_z, m_array_length, Real_type(0.0), vid);
 
     Real_type dx = 0.3;
     Real_type dy = 0.2;

--- a/src/apps/EDGE3D.cpp
+++ b/src/apps/EDGE3D.cpp
@@ -96,16 +96,14 @@ EDGE3D::~EDGE3D()
 
 void EDGE3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  {
-    auto reset_x = allocAndInitDataConstForSeqInit(m_x, m_array_length, Real_type(0.0), vid);
-    auto reset_y = allocAndInitDataConstForSeqInit(m_y, m_array_length, Real_type(0.0), vid);
-    auto reset_z = allocAndInitDataConstForSeqInit(m_z, m_array_length, Real_type(0.0), vid);
+  auto reset_x = allocAndInitDataConstForInit(m_x, m_array_length, Real_type(0.0), vid);
+  auto reset_y = allocAndInitDataConstForInit(m_y, m_array_length, Real_type(0.0), vid);
+  auto reset_z = allocAndInitDataConstForInit(m_z, m_array_length, Real_type(0.0), vid);
 
-    Real_type dx = 0.3;
-    Real_type dy = 0.2;
-    Real_type dz = 0.1;
-    setMeshPositions_3d(m_x, dx, m_y, dy, m_z, dz, *m_domain);
-  }
+  Real_type dx = 0.3;
+  Real_type dy = 0.2;
+  Real_type dz = 0.1;
+  setMeshPositions_3d(m_x, dx, m_y, dy, m_z, dz, *m_domain);
 
   allocAndInitDataConst(m_sum, m_array_length, Real_type(0.0), vid);
 }

--- a/src/apps/MATVEC_3D_STENCIL.cpp
+++ b/src/apps/MATVEC_3D_STENCIL.cpp
@@ -146,13 +146,10 @@ void MATVEC_3D_STENCIL::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
   m_matrix.ufc = m_matrix.dbc     + m_domain->jp + m_domain->kp ;
   m_matrix.ufr = m_matrix.dbl + 1 + m_domain->jp + m_domain->kp ;
 
-  {
-    auto reset_rz = allocAndInitDataConstForSeqInit(m_real_zones, m_domain->n_real_zones,
-                        static_cast<Index_type>(-1), vid);
+  auto reset_rz = allocAndInitDataConstForInit(m_real_zones, m_domain->n_real_zones,
+                      static_cast<Index_type>(-1), vid);
 
-    setRealZones_3d(m_real_zones, *m_domain);
-  }
-
+  setRealZones_3d(m_real_zones, *m_domain);
 }
 
 void MATVEC_3D_STENCIL::updateChecksum(VariantID vid, size_t tune_idx)

--- a/src/apps/MATVEC_3D_STENCIL.cpp
+++ b/src/apps/MATVEC_3D_STENCIL.cpp
@@ -146,11 +146,9 @@ void MATVEC_3D_STENCIL::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
   m_matrix.ufc = m_matrix.dbc     + m_domain->jp + m_domain->kp ;
   m_matrix.ufr = m_matrix.dbl + 1 + m_domain->jp + m_domain->kp ;
 
-  allocAndInitDataConst(m_real_zones, m_domain->n_real_zones,
-                        static_cast<Index_type>(-1), vid);
-
   {
-    auto reset_rz = scopedMoveData(m_real_zones, m_domain->n_real_zones, vid);
+    auto reset_rz = allocAndInitDataConstForSeqInit(m_real_zones, m_domain->n_real_zones,
+                        static_cast<Index_type>(-1), vid);
 
     setRealZones_3d(m_real_zones, *m_domain);
   }

--- a/src/apps/NODAL_ACCUMULATION_3D.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D.cpp
@@ -82,11 +82,10 @@ void NODAL_ACCUMULATION_3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
 {
   allocAndInitDataConst(m_x, m_nodal_array_length, 0.0, vid);
   allocAndInitDataConst(m_vol, m_zonal_array_length, 1.0, vid);
-  allocAndInitDataConst(m_real_zones, m_domain->n_real_zones,
-                        static_cast<Index_type>(-1), vid);
 
   {
-    auto reset_rz = scopedMoveData(m_real_zones, m_domain->n_real_zones, vid);
+    auto reset_rz = allocAndInitDataConstForSeqInit(m_real_zones, m_domain->n_real_zones,
+                        static_cast<Index_type>(-1), vid);
 
     setRealZones_3d(m_real_zones, *m_domain);
   }

--- a/src/apps/NODAL_ACCUMULATION_3D.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D.cpp
@@ -83,12 +83,10 @@ void NODAL_ACCUMULATION_3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
   allocAndInitDataConst(m_x, m_nodal_array_length, 0.0, vid);
   allocAndInitDataConst(m_vol, m_zonal_array_length, 1.0, vid);
 
-  {
-    auto reset_rz = allocAndInitDataConstForSeqInit(m_real_zones, m_domain->n_real_zones,
-                        static_cast<Index_type>(-1), vid);
+  auto reset_rz = allocAndInitDataConstForInit(m_real_zones, m_domain->n_real_zones,
+                                                  static_cast<Index_type>(-1), vid);
 
-    setRealZones_3d(m_real_zones, *m_domain);
-  }
+  setRealZones_3d(m_real_zones, *m_domain);
 }
 
 void NODAL_ACCUMULATION_3D::updateChecksum(VariantID vid, size_t tune_idx)

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -79,14 +79,10 @@ VOL3D::~VOL3D()
 
 void VOL3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  allocAndInitDataConst(m_x, m_array_length, 0.0, vid);
-  allocAndInitDataConst(m_y, m_array_length, 0.0, vid);
-  allocAndInitDataConst(m_z, m_array_length, 0.0, vid);
-
   {
-    auto reset_x = scopedMoveData(m_x, m_array_length, vid);
-    auto reset_y = scopedMoveData(m_y, m_array_length, vid);
-    auto reset_z = scopedMoveData(m_z, m_array_length, vid);
+    auto reset_x = allocAndInitDataConstForSeqInit(m_x, m_array_length, 0.0, vid);
+    auto reset_y = allocAndInitDataConstForSeqInit(m_y, m_array_length, 0.0, vid);
+    auto reset_z = allocAndInitDataConstForSeqInit(m_z, m_array_length, 0.0, vid);
 
     Real_type dx = 0.3;
     Real_type dy = 0.2;

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -79,16 +79,14 @@ VOL3D::~VOL3D()
 
 void VOL3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  {
-    auto reset_x = allocAndInitDataConstForSeqInit(m_x, m_array_length, 0.0, vid);
-    auto reset_y = allocAndInitDataConstForSeqInit(m_y, m_array_length, 0.0, vid);
-    auto reset_z = allocAndInitDataConstForSeqInit(m_z, m_array_length, 0.0, vid);
+  auto reset_x = allocAndInitDataConstForInit(m_x, m_array_length, 0.0, vid);
+  auto reset_y = allocAndInitDataConstForInit(m_y, m_array_length, 0.0, vid);
+  auto reset_z = allocAndInitDataConstForInit(m_z, m_array_length, 0.0, vid);
 
-    Real_type dx = 0.3;
-    Real_type dy = 0.2;
-    Real_type dz = 0.1;
-    setMeshPositions_3d(m_x, dx, m_y, dy, m_z, dz, *m_domain);
-  }
+  Real_type dx = 0.3;
+  Real_type dy = 0.2;
+  Real_type dz = 0.1;
+  setMeshPositions_3d(m_x, dx, m_y, dy, m_z, dz, *m_domain);
 
   allocAndInitDataConst(m_vol, m_array_length, 0.0, vid);
 

--- a/src/apps/ZONAL_ACCUMULATION_3D.cpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D.cpp
@@ -83,11 +83,10 @@ void ZONAL_ACCUMULATION_3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
 {
   allocAndInitDataConst(m_x, m_nodal_array_length, 1.0, vid);
   allocAndInitDataConst(m_vol, m_zonal_array_length, 0.0, vid);
-  allocAndInitDataConst(m_real_zones, m_domain->n_real_zones,
-                        static_cast<Index_type>(-1), vid);
 
   {
-    auto reset_rz = scopedMoveData(m_real_zones, m_domain->n_real_zones, vid);
+    auto reset_rz = allocAndInitDataConstForSeqInit(m_real_zones, m_domain->n_real_zones,
+                        static_cast<Index_type>(-1), vid);
 
     setRealZones_3d(m_real_zones, *m_domain);
   }

--- a/src/apps/ZONAL_ACCUMULATION_3D.cpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D.cpp
@@ -84,12 +84,10 @@ void ZONAL_ACCUMULATION_3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
   allocAndInitDataConst(m_x, m_nodal_array_length, 1.0, vid);
   allocAndInitDataConst(m_vol, m_zonal_array_length, 0.0, vid);
 
-  {
-    auto reset_rz = allocAndInitDataConstForSeqInit(m_real_zones, m_domain->n_real_zones,
-                        static_cast<Index_type>(-1), vid);
+  auto reset_rz = allocAndInitDataConstForInit(m_real_zones, m_domain->n_real_zones,
+                                                  static_cast<Index_type>(-1), vid);
 
-    setRealZones_3d(m_real_zones, *m_domain);
-  }
+  setRealZones_3d(m_real_zones, *m_domain);
 }
 
 void ZONAL_ACCUMULATION_3D::updateChecksum(VariantID vid, size_t tune_idx)

--- a/src/basic/MULTI_REDUCE.cpp
+++ b/src/basic/MULTI_REDUCE.cpp
@@ -71,10 +71,9 @@ MULTI_REDUCE::~MULTI_REDUCE()
 
 void MULTI_REDUCE::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  allocData(m_bins, getActualProblemSize(), vid);
   allocAndInitDataRandValue(m_data, getActualProblemSize(), vid);
   {
-    auto reset_bins = scopedMoveData(m_bins, getActualProblemSize(), vid);
+    auto reset_bins = allocDataForSeqInit(m_bins, getActualProblemSize(), vid);
 
     const bool init_random_per_iterate =
         (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::Random);

--- a/src/basic/MULTI_REDUCE.cpp
+++ b/src/basic/MULTI_REDUCE.cpp
@@ -72,65 +72,63 @@ MULTI_REDUCE::~MULTI_REDUCE()
 void MULTI_REDUCE::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   allocAndInitDataRandValue(m_data, getActualProblemSize(), vid);
-  {
-    auto reset_bins = allocDataForSeqInit(m_bins, getActualProblemSize(), vid);
+  auto reset_bins = allocDataForInit(m_bins, getActualProblemSize(), vid);
 
-    const bool init_random_per_iterate =
-        (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::Random);
-    const bool init_random_sizes =
-        (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::RunsRandomSizes);
-    const bool init_even_sizes =
-        (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::RunsEvenSizes);
-    const bool init_all_one =
-        (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::Single);
+  const bool init_random_per_iterate =
+      (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::Random);
+  const bool init_random_sizes =
+      (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::RunsRandomSizes);
+  const bool init_even_sizes =
+      (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::RunsEvenSizes);
+  const bool init_all_one =
+      (m_bin_assignment_algorithm == RunParams::BinAssignmentAlgorithm::Single);
 
-    if (init_even_sizes || init_random_sizes || init_all_one) {
-      Real_ptr data = nullptr;
-      if (init_even_sizes) {
-        allocData(data, m_num_bins, Base_Seq);
-        for (Index_type b = 0; b < m_num_bins; ++b) {
-          data[b] = static_cast<Real_type>(b+1) / m_num_bins;
-        }
-      } else if (init_random_sizes) {
-        allocAndInitDataRandValue(data, m_num_bins, Base_Seq);
-        std::sort(data, data+m_num_bins);
-      } else if (init_all_one) {
-        allocData(data, m_num_bins, Base_Seq);
-        for (Index_type b = 0; b < m_num_bins; ++b) {
-          data[b] = static_cast<Real_type>(0);
-        }
+  if (init_even_sizes || init_random_sizes || init_all_one) {
+    Real_ptr data = nullptr;
+    if (init_even_sizes) {
+      allocData(data, m_num_bins, Base_Seq);
+      for (Index_type b = 0; b < m_num_bins; ++b) {
+        data[b] = static_cast<Real_type>(b+1) / m_num_bins;
       }
-
-      Index_type actual_prob_size = getActualProblemSize();
-      Index_type bin = 0;
-      for (Index_type i = 0; i < actual_prob_size; ++i) {
-        Real_type pos = static_cast<Real_type>(i) / actual_prob_size;
-        while (bin+1 < m_num_bins && pos >= data[bin]) {
-          bin += 1;
-        }
-        m_bins[i] = bin;
+    } else if (init_random_sizes) {
+      allocAndInitDataRandValue(data, m_num_bins, Base_Seq);
+      std::sort(data, data+m_num_bins);
+    } else if (init_all_one) {
+      allocData(data, m_num_bins, Base_Seq);
+      for (Index_type b = 0; b < m_num_bins; ++b) {
+        data[b] = static_cast<Real_type>(0);
       }
-
-      deallocData(data, Base_Seq);
-
-    } else if (init_random_per_iterate) {
-      Real_ptr data;
-      allocAndInitDataRandValue(data, getActualProblemSize(), Base_Seq);
-
-      for (Index_type i = 0; i < getActualProblemSize(); ++i) {
-        m_bins[i] = static_cast<Index_type>(data[i] * m_num_bins);
-        if (m_bins[i] >= m_num_bins) {
-          m_bins[i] = m_num_bins - 1;
-        }
-        if (m_bins[i] < 0) {
-          m_bins[i] = 0;
-        }
-      }
-
-      deallocData(data, Base_Seq);
-    } else {
-      throw 1;
     }
+
+    Index_type actual_prob_size = getActualProblemSize();
+    Index_type bin = 0;
+    for (Index_type i = 0; i < actual_prob_size; ++i) {
+      Real_type pos = static_cast<Real_type>(i) / actual_prob_size;
+      while (bin+1 < m_num_bins && pos >= data[bin]) {
+        bin += 1;
+      }
+      m_bins[i] = bin;
+    }
+
+    deallocData(data, Base_Seq);
+
+  } else if (init_random_per_iterate) {
+    Real_ptr data;
+    allocAndInitDataRandValue(data, getActualProblemSize(), Base_Seq);
+
+    for (Index_type i = 0; i < getActualProblemSize(); ++i) {
+      m_bins[i] = static_cast<Index_type>(data[i] * m_num_bins);
+      if (m_bins[i] >= m_num_bins) {
+        m_bins[i] = m_num_bins - 1;
+      }
+      if (m_bins[i] < 0) {
+        m_bins[i] = 0;
+      }
+    }
+
+    deallocData(data, Base_Seq);
+  } else {
+    throw 1;
   }
 
   m_values_init.resize(m_num_bins, 0.0);

--- a/src/basic/REDUCE_STRUCT.cpp
+++ b/src/basic/REDUCE_STRUCT.cpp
@@ -71,12 +71,10 @@ void REDUCE_STRUCT::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
   m_init_sum = 0.0;
   m_init_min = std::numeric_limits<Real_type>::max();
   m_init_max = std::numeric_limits<Real_type>::lowest();
-  allocAndInitData(m_x, getActualProblemSize(), vid);
-  allocAndInitData(m_y, getActualProblemSize(), vid);
 
   {
-    auto reset_x = scopedMoveData(m_x, getActualProblemSize(), vid);
-    auto reset_y = scopedMoveData(m_y, getActualProblemSize(), vid);
+    auto reset_x = allocAndInitDataForSeqInit(m_x, getActualProblemSize(), vid);
+    auto reset_y = allocAndInitDataForSeqInit(m_y, getActualProblemSize(), vid);
 
     Real_type dx = Lx/(Real_type)(getActualProblemSize());
     Real_type dy = Ly/(Real_type)(getActualProblemSize());

--- a/src/basic/REDUCE_STRUCT.cpp
+++ b/src/basic/REDUCE_STRUCT.cpp
@@ -72,16 +72,14 @@ void REDUCE_STRUCT::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
   m_init_min = std::numeric_limits<Real_type>::max();
   m_init_max = std::numeric_limits<Real_type>::lowest();
 
-  {
-    auto reset_x = allocAndInitDataForSeqInit(m_x, getActualProblemSize(), vid);
-    auto reset_y = allocAndInitDataForSeqInit(m_y, getActualProblemSize(), vid);
+  auto reset_x = allocAndInitDataForInit(m_x, getActualProblemSize(), vid);
+  auto reset_y = allocAndInitDataForInit(m_y, getActualProblemSize(), vid);
 
-    Real_type dx = Lx/(Real_type)(getActualProblemSize());
-    Real_type dy = Ly/(Real_type)(getActualProblemSize());
-    for (int i=0;i<getActualProblemSize();i++){ \
-      m_x[i] = i*dx;
-      m_y[i] = i*dy;
-    }
+  Real_type dx = Lx/(Real_type)(getActualProblemSize());
+  Real_type dy = Ly/(Real_type)(getActualProblemSize());
+  for (int i=0;i<getActualProblemSize();i++){ \
+    m_x[i] = i*dx;
+    m_y[i] = i*dy;
   }
 }
 

--- a/src/comm/HALO_EXCHANGE-Cuda.cpp
+++ b/src/comm/HALO_EXCHANGE-Cuda.cpp
@@ -83,9 +83,9 @@ void HALO_EXCHANGE::runCudaVariantImpl(VariantID vid)
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          cudaErrchk( cudaMemcpyAsync(send_buffers[l], pack_buffers[l],
+                                      len*num_vars*sizeof(Real_type),
+                                      cudaMemcpyDefault, res.get_stream()) );
         }
 
         cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
@@ -101,9 +101,9 @@ void HALO_EXCHANGE::runCudaVariantImpl(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          cudaErrchk( cudaMemcpyAsync(unpack_buffers[l], recv_buffers[l],
+                                      len*num_vars*sizeof(Real_type),
+                                      cudaMemcpyDefault, res.get_stream()) );
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -154,9 +154,7 @@ void HALO_EXCHANGE::runCudaVariantImpl(VariantID vid)
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         res.wait();
@@ -172,9 +170,7 @@ void HALO_EXCHANGE::runCudaVariantImpl(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_EXCHANGE-Hip.cpp
+++ b/src/comm/HALO_EXCHANGE-Hip.cpp
@@ -83,9 +83,9 @@ void HALO_EXCHANGE::runHipVariantImpl(VariantID vid)
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          hipErrchk( hipMemcpyAsync(send_buffers[l], pack_buffers[l],
+                                    len*num_vars*sizeof(Real_type),
+                                    hipMemcpyDefault, res.get_stream()) );
         }
 
         hipErrchk( hipStreamSynchronize( res.get_stream() ) );
@@ -101,9 +101,9 @@ void HALO_EXCHANGE::runHipVariantImpl(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          hipErrchk( hipMemcpyAsync(unpack_buffers[l], recv_buffers[l],
+                                    len*num_vars*sizeof(Real_type),
+                                    hipMemcpyDefault, res.get_stream()) );
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -154,9 +154,7 @@ void HALO_EXCHANGE::runHipVariantImpl(VariantID vid)
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         res.wait();
@@ -172,9 +170,7 @@ void HALO_EXCHANGE::runHipVariantImpl(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_EXCHANGE-OMP.cpp
+++ b/src/comm/HALO_EXCHANGE-OMP.cpp
@@ -55,9 +55,7 @@ void HALO_EXCHANGE::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           MPI_Isend(send_buffers[l], len*num_vars, Real_MPI_type,
@@ -72,9 +70,7 @@ void HALO_EXCHANGE::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -123,9 +119,7 @@ void HALO_EXCHANGE::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           MPI_Isend(send_buffers[l], len*num_vars, Real_MPI_type,
@@ -140,9 +134,7 @@ void HALO_EXCHANGE::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -197,9 +189,7 @@ void HALO_EXCHANGE::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           MPI_Isend(send_buffers[l], len*num_vars, Real_MPI_type,
@@ -214,9 +204,7 @@ void HALO_EXCHANGE::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_EXCHANGE-OMPTarget.cpp
+++ b/src/comm/HALO_EXCHANGE-OMPTarget.cpp
@@ -59,9 +59,9 @@ void HALO_EXCHANGE::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          omp_target_memcpy(send_buffers[l], pack_buffers[l],
+                            len*num_vars*sizeof(Real_type),
+                            0, 0, did, hid);
         }
 
         MPI_Isend(send_buffers[l], len*num_vars, Real_MPI_type,
@@ -76,9 +76,9 @@ void HALO_EXCHANGE::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          omp_target_memcpy(unpack_buffers[l], recv_buffers[l],
+                            len*num_vars*sizeof(Real_type),
+                            0, 0, hid, did);
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -128,9 +128,7 @@ void HALO_EXCHANGE::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         MPI_Isend(send_buffers[l], len*num_vars, Real_MPI_type,
@@ -145,9 +143,7 @@ void HALO_EXCHANGE::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_EXCHANGE-Seq.cpp
+++ b/src/comm/HALO_EXCHANGE-Seq.cpp
@@ -52,9 +52,7 @@ void HALO_EXCHANGE::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           MPI_Isend(send_buffers[l], len*num_vars, Real_MPI_type,
@@ -69,9 +67,7 @@ void HALO_EXCHANGE::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -119,9 +115,7 @@ void HALO_EXCHANGE::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           MPI_Isend(send_buffers[l], len*num_vars, Real_MPI_type,
@@ -136,9 +130,7 @@ void HALO_EXCHANGE::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -192,9 +184,7 @@ void HALO_EXCHANGE::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           MPI_Isend(send_buffers[l], len*num_vars, Real_MPI_type,
@@ -209,9 +199,7 @@ void HALO_EXCHANGE::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_EXCHANGE.cpp
+++ b/src/comm/HALO_EXCHANGE.cpp
@@ -81,8 +81,7 @@ void HALO_EXCHANGE::setUp(VariantID vid, size_t tune_idx)
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
-    allocAndInitData(m_vars[v], m_var_size, vid);
-    auto reset_var = scopedMoveData(m_vars[v], m_var_size, vid);
+    auto reset_var = allocAndInitDataForSeqInit(m_vars[v], m_var_size, vid);
 
     Real_ptr var = m_vars[v];
 

--- a/src/comm/HALO_EXCHANGE.cpp
+++ b/src/comm/HALO_EXCHANGE.cpp
@@ -81,7 +81,7 @@ void HALO_EXCHANGE::setUp(VariantID vid, size_t tune_idx)
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
-    auto reset_var = allocAndInitDataForSeqInit(m_vars[v], m_var_size, vid);
+    auto reset_var = allocAndInitDataForInit(m_vars[v], m_var_size, vid);
 
     Real_ptr var = m_vars[v];
 

--- a/src/comm/HALO_EXCHANGE_FUSED-Cuda.cpp
+++ b/src/comm/HALO_EXCHANGE_FUSED-Cuda.cpp
@@ -143,9 +143,9 @@ void HALO_EXCHANGE_FUSED::runCudaVariantDirect(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          cudaErrchk( cudaMemcpyAsync(send_buffers[l], pack_buffers[l],
+                                      len*num_vars*sizeof(Real_type),
+                                      cudaMemcpyDefault, res.get_stream()) );
         }
       }
       cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
@@ -165,9 +165,9 @@ void HALO_EXCHANGE_FUSED::runCudaVariantDirect(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          cudaErrchk( cudaMemcpyAsync(unpack_buffers[l], recv_buffers[l],
+                                      len*num_vars*sizeof(Real_type),
+                                      cudaMemcpyDefault, res.get_stream()) );
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -277,9 +277,7 @@ void HALO_EXCHANGE_FUSED::runCudaVariantWorkGroup(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
       }
       res.wait();
@@ -296,9 +294,7 @@ void HALO_EXCHANGE_FUSED::runCudaVariantWorkGroup(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_EXCHANGE_FUSED-Hip.cpp
+++ b/src/comm/HALO_EXCHANGE_FUSED-Hip.cpp
@@ -143,9 +143,9 @@ void HALO_EXCHANGE_FUSED::runHipVariantDirect(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          hipErrchk( hipMemcpyAsync(send_buffers[l], pack_buffers[l],
+                                    len*num_vars*sizeof(Real_type),
+                                    hipMemcpyDefault, res.get_stream()) );
         }
       }
       hipErrchk( hipStreamSynchronize( res.get_stream() ) );
@@ -165,9 +165,9 @@ void HALO_EXCHANGE_FUSED::runHipVariantDirect(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          hipErrchk( hipMemcpyAsync(unpack_buffers[l], recv_buffers[l],
+                                    len*num_vars*sizeof(Real_type),
+                                    hipMemcpyDefault, res.get_stream()) );
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -277,9 +277,7 @@ void HALO_EXCHANGE_FUSED::runHipVariantWorkGroup(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
       }
       res.wait();
@@ -296,9 +294,7 @@ void HALO_EXCHANGE_FUSED::runHipVariantWorkGroup(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_EXCHANGE_FUSED-OMP.cpp
+++ b/src/comm/HALO_EXCHANGE_FUSED-OMP.cpp
@@ -88,9 +88,7 @@ void HALO_EXCHANGE_FUSED::runOpenMPVariantDirect(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
         for (Index_type l = 0; l < num_neighbors; ++l) {
@@ -108,9 +106,7 @@ void HALO_EXCHANGE_FUSED::runOpenMPVariantDirect(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -214,9 +210,7 @@ void HALO_EXCHANGE_FUSED::runOpenMPVariantDirect(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
         for (Index_type l = 0; l < num_neighbors; ++l) {
@@ -234,9 +228,7 @@ void HALO_EXCHANGE_FUSED::runOpenMPVariantDirect(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -370,9 +362,7 @@ void HALO_EXCHANGE_FUSED::runOpenMPVariantWorkGroup(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
         for (Index_type l = 0; l < num_neighbors; ++l) {
@@ -388,9 +378,7 @@ void HALO_EXCHANGE_FUSED::runOpenMPVariantWorkGroup(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_EXCHANGE_FUSED-OMPTarget.cpp
+++ b/src/comm/HALO_EXCHANGE_FUSED-OMPTarget.cpp
@@ -120,9 +120,9 @@ void HALO_EXCHANGE_FUSED::runOpenMPTargetVariantDirect(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          omp_target_memcpy(send_buffers[l], pack_buffers[l],
+                            len*num_vars*sizeof(Real_type),
+                            0, 0, did, hid);
         }
       }
       for (Index_type l = 0; l < num_neighbors; ++l) {
@@ -141,9 +141,9 @@ void HALO_EXCHANGE_FUSED::runOpenMPTargetVariantDirect(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          omp_target_memcpy(unpack_buffers[l], recv_buffers[l],
+                            len*num_vars*sizeof(Real_type),
+                            0, 0, hid, did);
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -260,9 +260,7 @@ void HALO_EXCHANGE_FUSED::runOpenMPTargetVariantWorkGroup(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
       }
       for (Index_type l = 0; l < num_neighbors; ++l) {
@@ -278,9 +276,7 @@ void HALO_EXCHANGE_FUSED::runOpenMPTargetVariantWorkGroup(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_EXCHANGE_FUSED-Seq.cpp
+++ b/src/comm/HALO_EXCHANGE_FUSED-Seq.cpp
@@ -67,9 +67,7 @@ void HALO_EXCHANGE_FUSED::runSeqVariantDirect(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
         for (Index_type l = 0; l < num_neighbors; ++l) {
@@ -87,9 +85,7 @@ void HALO_EXCHANGE_FUSED::runSeqVariantDirect(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -158,9 +154,7 @@ void HALO_EXCHANGE_FUSED::runSeqVariantDirect(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
         for (Index_type l = 0; l < num_neighbors; ++l) {
@@ -178,9 +172,7 @@ void HALO_EXCHANGE_FUSED::runSeqVariantDirect(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -294,9 +286,7 @@ void HALO_EXCHANGE_FUSED::runSeqVariantWorkGroup(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
         for (Index_type l = 0; l < num_neighbors; ++l) {
@@ -312,9 +302,7 @@ void HALO_EXCHANGE_FUSED::runSeqVariantWorkGroup(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_EXCHANGE_FUSED.cpp
+++ b/src/comm/HALO_EXCHANGE_FUSED.cpp
@@ -81,8 +81,7 @@ void HALO_EXCHANGE_FUSED::setUp(VariantID vid, size_t tune_idx)
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
-    allocAndInitData(m_vars[v], m_var_size, vid);
-    auto reset_var = scopedMoveData(m_vars[v], m_var_size, vid);
+    auto reset_var = allocAndInitDataForSeqInit(m_vars[v], m_var_size, vid);
 
     Real_ptr var = m_vars[v];
 

--- a/src/comm/HALO_EXCHANGE_FUSED.cpp
+++ b/src/comm/HALO_EXCHANGE_FUSED.cpp
@@ -81,7 +81,7 @@ void HALO_EXCHANGE_FUSED::setUp(VariantID vid, size_t tune_idx)
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
-    auto reset_var = allocAndInitDataForSeqInit(m_vars[v], m_var_size, vid);
+    auto reset_var = allocAndInitDataForInit(m_vars[v], m_var_size, vid);
 
     Real_ptr var = m_vars[v];
 

--- a/src/comm/HALO_PACKING-Cuda.cpp
+++ b/src/comm/HALO_PACKING-Cuda.cpp
@@ -77,9 +77,9 @@ void HALO_PACKING::runCudaVariantImpl(VariantID vid)
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          cudaErrchk( cudaMemcpyAsync(send_buffers[l], pack_buffers[l],
+                                      len*num_vars*sizeof(Real_type),
+                                      cudaMemcpyDefault, res.get_stream()) );
         }
 
         cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
@@ -90,9 +90,9 @@ void HALO_PACKING::runCudaVariantImpl(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          cudaErrchk( cudaMemcpyAsync(unpack_buffers[l], recv_buffers[l],
+                                      len*num_vars*sizeof(Real_type),
+                                      cudaMemcpyDefault, res.get_stream()) );
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -135,9 +135,7 @@ void HALO_PACKING::runCudaVariantImpl(VariantID vid)
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         res.wait();
@@ -148,9 +146,7 @@ void HALO_PACKING::runCudaVariantImpl(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_PACKING-Hip.cpp
+++ b/src/comm/HALO_PACKING-Hip.cpp
@@ -77,9 +77,9 @@ void HALO_PACKING::runHipVariantImpl(VariantID vid)
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          hipErrchk( hipMemcpyAsync(send_buffers[l], pack_buffers[l],
+                                    len*num_vars*sizeof(Real_type),
+                                    hipMemcpyDefault, res.get_stream()) );
         }
 
         hipErrchk( hipStreamSynchronize( res.get_stream() ) );
@@ -90,9 +90,9 @@ void HALO_PACKING::runHipVariantImpl(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          hipErrchk( hipMemcpyAsync(unpack_buffers[l], recv_buffers[l],
+                                    len*num_vars*sizeof(Real_type),
+                                    hipMemcpyDefault, res.get_stream()) );
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -135,9 +135,7 @@ void HALO_PACKING::runHipVariantImpl(VariantID vid)
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         res.wait();
@@ -148,9 +146,7 @@ void HALO_PACKING::runHipVariantImpl(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_PACKING-OMP.cpp
+++ b/src/comm/HALO_PACKING-OMP.cpp
@@ -47,9 +47,7 @@ void HALO_PACKING::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -58,9 +56,7 @@ void HALO_PACKING::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -101,9 +97,7 @@ void HALO_PACKING::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -112,9 +106,7 @@ void HALO_PACKING::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -161,9 +153,7 @@ void HALO_PACKING::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -172,9 +162,7 @@ void HALO_PACKING::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_PACKING-OMPTarget.cpp
+++ b/src/comm/HALO_PACKING-OMPTarget.cpp
@@ -53,9 +53,9 @@ void HALO_PACKING::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          omp_target_memcpy(send_buffers[l], pack_buffers[l],
+                            len*num_vars*sizeof(Real_type),
+                            0, 0, did, hid);
         }
       }
 
@@ -64,9 +64,9 @@ void HALO_PACKING::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          omp_target_memcpy(unpack_buffers[l], recv_buffers[l],
+                            len*num_vars*sizeof(Real_type),
+                            0, 0, hid, did);
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -108,9 +108,7 @@ void HALO_PACKING::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_
         }
 
         if (separate_buffers) {
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
       }
 
@@ -119,9 +117,7 @@ void HALO_PACKING::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_PACKING-Seq.cpp
+++ b/src/comm/HALO_PACKING-Seq.cpp
@@ -45,9 +45,7 @@ void HALO_PACKING::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -56,9 +54,7 @@ void HALO_PACKING::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -98,9 +94,7 @@ void HALO_PACKING::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -109,9 +103,7 @@ void HALO_PACKING::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -157,9 +149,7 @@ void HALO_PACKING::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
           }
 
           if (separate_buffers) {
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -168,9 +158,7 @@ void HALO_PACKING::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_PACKING.cpp
+++ b/src/comm/HALO_PACKING.cpp
@@ -70,8 +70,7 @@ void HALO_PACKING::setUp(VariantID vid, size_t tune_idx)
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
-    allocAndInitData(m_vars[v], m_var_size, vid);
-    auto reset_var = scopedMoveData(m_vars[v], m_var_size, vid);
+    auto reset_var = allocDataForSeqInit(m_vars[v], m_var_size, vid);
 
     Real_ptr var = m_vars[v];
 

--- a/src/comm/HALO_PACKING.cpp
+++ b/src/comm/HALO_PACKING.cpp
@@ -70,7 +70,7 @@ void HALO_PACKING::setUp(VariantID vid, size_t tune_idx)
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
-    auto reset_var = allocDataForSeqInit(m_vars[v], m_var_size, vid);
+    auto reset_var = allocAndInitDataForInit(m_vars[v], m_var_size, vid);
 
     Real_ptr var = m_vars[v];
 

--- a/src/comm/HALO_PACKING_FUSED-Cuda.cpp
+++ b/src/comm/HALO_PACKING_FUSED-Cuda.cpp
@@ -141,9 +141,9 @@ void HALO_PACKING_FUSED::runCudaVariantDirect(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          cudaErrchk( cudaMemcpyAsync(send_buffers[l], pack_buffers[l],
+                                      len*num_vars*sizeof(Real_type),
+                                      cudaMemcpyDefault, res.get_stream()) );
         }
       }
       cudaErrchk( cudaStreamSynchronize( res.get_stream() ) );
@@ -156,9 +156,9 @@ void HALO_PACKING_FUSED::runCudaVariantDirect(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          cudaErrchk( cudaMemcpyAsync(unpack_buffers[l], recv_buffers[l],
+                                      len*num_vars*sizeof(Real_type),
+                                      cudaMemcpyDefault, res.get_stream()) );
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -262,9 +262,7 @@ void HALO_PACKING_FUSED::runCudaVariantWorkGroup(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
       }
       res.wait();
@@ -274,9 +272,7 @@ void HALO_PACKING_FUSED::runCudaVariantWorkGroup(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_PACKING_FUSED-Hip.cpp
+++ b/src/comm/HALO_PACKING_FUSED-Hip.cpp
@@ -141,9 +141,9 @@ void HALO_PACKING_FUSED::runHipVariantDirect(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          hipErrchk( hipMemcpyAsync(send_buffers[l], pack_buffers[l],
+                                    len*num_vars*sizeof(Real_type),
+                                    hipMemcpyDefault, res.get_stream()) );
         }
       }
       hipErrchk( hipStreamSynchronize( res.get_stream() ) );
@@ -156,9 +156,9 @@ void HALO_PACKING_FUSED::runHipVariantDirect(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          hipErrchk( hipMemcpyAsync(unpack_buffers[l], recv_buffers[l],
+                                    len*num_vars*sizeof(Real_type),
+                                    hipMemcpyDefault, res.get_stream()) );
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -262,9 +262,7 @@ void HALO_PACKING_FUSED::runHipVariantWorkGroup(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
       }
       res.wait();
@@ -274,9 +272,7 @@ void HALO_PACKING_FUSED::runHipVariantWorkGroup(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_PACKING_FUSED-OMP.cpp
+++ b/src/comm/HALO_PACKING_FUSED-OMP.cpp
@@ -80,9 +80,7 @@ void HALO_PACKING_FUSED::runOpenMPVariantDirect(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -93,9 +91,7 @@ void HALO_PACKING_FUSED::runOpenMPVariantDirect(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -191,9 +187,7 @@ void HALO_PACKING_FUSED::runOpenMPVariantDirect(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -204,9 +198,7 @@ void HALO_PACKING_FUSED::runOpenMPVariantDirect(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -332,9 +324,7 @@ void HALO_PACKING_FUSED::runOpenMPVariantWorkGroup(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -343,9 +333,7 @@ void HALO_PACKING_FUSED::runOpenMPVariantWorkGroup(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_PACKING_FUSED-OMPTarget.cpp
+++ b/src/comm/HALO_PACKING_FUSED-OMPTarget.cpp
@@ -114,9 +114,9 @@ void HALO_PACKING_FUSED::runOpenMPTargetVariantDirect(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          omp_target_memcpy(send_buffers[l], pack_buffers[l],
+                            len*num_vars*sizeof(Real_type),
+                            0, 0, did, hid);
         }
       }
 
@@ -128,9 +128,9 @@ void HALO_PACKING_FUSED::runOpenMPTargetVariantDirect(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          omp_target_memcpy(unpack_buffers[l], recv_buffers[l],
+                            len*num_vars*sizeof(Real_type),
+                            0, 0, hid, did);
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {
@@ -239,9 +239,7 @@ void HALO_PACKING_FUSED::runOpenMPTargetVariantWorkGroup(VariantID vid)
       if (separate_buffers) {
         for (Index_type l = 0; l < num_neighbors; ++l) {
           Index_type len = pack_index_list_lengths[l];
-          copyData(DataSpace::Host, send_buffers[l],
-                   dataSpace, pack_buffers[l],
-                   len*num_vars);
+          res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
         }
       }
 
@@ -250,9 +248,7 @@ void HALO_PACKING_FUSED::runOpenMPTargetVariantWorkGroup(VariantID vid)
         Int_ptr list = unpack_index_lists[l];
         Index_type len = unpack_index_list_lengths[l];
         if (separate_buffers) {
-          copyData(dataSpace, unpack_buffers[l],
-                   DataSpace::Host, recv_buffers[l],
-                   len*num_vars);
+          res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
         }
 
         for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_PACKING_FUSED-Seq.cpp
+++ b/src/comm/HALO_PACKING_FUSED-Seq.cpp
@@ -59,9 +59,7 @@ void HALO_PACKING_FUSED::runSeqVariantDirect(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -72,9 +70,7 @@ void HALO_PACKING_FUSED::runSeqVariantDirect(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -135,9 +131,7 @@ void HALO_PACKING_FUSED::runSeqVariantDirect(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -148,9 +142,7 @@ void HALO_PACKING_FUSED::runSeqVariantDirect(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {
@@ -256,9 +248,7 @@ void HALO_PACKING_FUSED::runSeqVariantWorkGroup(VariantID vid)
         if (separate_buffers) {
           for (Index_type l = 0; l < num_neighbors; ++l) {
             Index_type len = pack_index_list_lengths[l];
-            copyData(DataSpace::Host, send_buffers[l],
-                     dataSpace, pack_buffers[l],
-                     len*num_vars);
+            res.memcpy(send_buffers[l], pack_buffers[l], len*num_vars*sizeof(Real_type));
           }
         }
 
@@ -267,9 +257,7 @@ void HALO_PACKING_FUSED::runSeqVariantWorkGroup(VariantID vid)
           Int_ptr list = unpack_index_lists[l];
           Index_type len = unpack_index_list_lengths[l];
           if (separate_buffers) {
-            copyData(dataSpace, unpack_buffers[l],
-                     DataSpace::Host, recv_buffers[l],
-                     len*num_vars);
+            res.memcpy(unpack_buffers[l], recv_buffers[l], len*num_vars*sizeof(Real_type));
           }
 
           for (Index_type v = 0; v < num_vars; ++v) {

--- a/src/comm/HALO_PACKING_FUSED.cpp
+++ b/src/comm/HALO_PACKING_FUSED.cpp
@@ -70,8 +70,7 @@ void HALO_PACKING_FUSED::setUp(VariantID vid, size_t tune_idx)
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
-    allocAndInitData(m_vars[v], m_var_size, vid);
-    auto reset_var = scopedMoveData(m_vars[v], m_var_size, vid);
+    auto reset_var = allocAndInitDataForSeqInit(m_vars[v], m_var_size, vid);
 
     Real_ptr var = m_vars[v];
 

--- a/src/comm/HALO_PACKING_FUSED.cpp
+++ b/src/comm/HALO_PACKING_FUSED.cpp
@@ -70,7 +70,7 @@ void HALO_PACKING_FUSED::setUp(VariantID vid, size_t tune_idx)
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
-    auto reset_var = allocAndInitDataForSeqInit(m_vars[v], m_var_size, vid);
+    auto reset_var = allocAndInitDataForInit(m_vars[v], m_var_size, vid);
 
     Real_ptr var = m_vars[v];
 

--- a/src/comm/HALO_base.cpp
+++ b/src/comm/HALO_base.cpp
@@ -233,8 +233,7 @@ void HALO_base::create_lists(
                                    (extent.j_max - extent.j_min) *
                                    (extent.k_max - extent.k_min) ;
 
-      allocAndInitData(pack_index_lists[l], pack_index_list_lengths[l], vid);
-      auto reset_list = scopedMoveData(pack_index_lists[l], pack_index_list_lengths[l], vid);
+      auto reset_list = allocAndInitDataForSeqInit(pack_index_lists[l], pack_index_list_lengths[l], vid);
 
       Int_ptr pack_list = pack_index_lists[l];
 
@@ -266,8 +265,7 @@ void HALO_base::create_lists(
                                      (extent.j_max - extent.j_min) *
                                      (extent.k_max - extent.k_min) ;
 
-      allocAndInitData(unpack_index_lists[l], unpack_index_list_lengths[l], vid);
-      auto reset_list = scopedMoveData(unpack_index_lists[l], unpack_index_list_lengths[l], vid);
+      auto reset_list = allocAndInitDataForSeqInit(unpack_index_lists[l], unpack_index_list_lengths[l], vid);
 
       Int_ptr unpack_list = unpack_index_lists[l];
 

--- a/src/comm/HALO_base.cpp
+++ b/src/comm/HALO_base.cpp
@@ -233,7 +233,7 @@ void HALO_base::create_lists(
                                    (extent.j_max - extent.j_min) *
                                    (extent.k_max - extent.k_min) ;
 
-      auto reset_list = allocAndInitDataForSeqInit(pack_index_lists[l], pack_index_list_lengths[l], vid);
+      auto reset_list = allocAndInitDataForInit(pack_index_lists[l], pack_index_list_lengths[l], vid);
 
       Int_ptr pack_list = pack_index_lists[l];
 
@@ -265,7 +265,7 @@ void HALO_base::create_lists(
                                      (extent.j_max - extent.j_min) *
                                      (extent.k_max - extent.k_min) ;
 
-      auto reset_list = allocAndInitDataForSeqInit(unpack_index_lists[l], unpack_index_list_lengths[l], vid);
+      auto reset_list = allocAndInitDataForInit(unpack_index_lists[l], unpack_index_list_lengths[l], vid);
 
       Int_ptr unpack_list = unpack_index_lists[l];
 

--- a/src/common/CudaDataUtils.hpp
+++ b/src/common/CudaDataUtils.hpp
@@ -179,6 +179,7 @@ inline void copyCudaData(void* dst_ptr, const void* src_ptr, Size_type len)
 {
   cudaErrchk( cudaMemcpy( dst_ptr, src_ptr, len,
               cudaMemcpyDefault ) );
+  cudaErrchk( cudaDeviceSynchronize( ) );
 }
 
 /*!

--- a/src/common/HipDataUtils.hpp
+++ b/src/common/HipDataUtils.hpp
@@ -166,6 +166,7 @@ inline void copyHipData(void* dst_ptr, const void* src_ptr, Size_type len)
 {
   hipErrchk( hipMemcpy( dst_ptr, src_ptr, len,
              hipMemcpyDefault ) );
+  hipErrchk( hipDeviceSynchronize( ) );
 }
 
 /*!

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -419,6 +419,33 @@ public:
   }
 
   template <typename T>
+  rajaperf::AutoDataMover<T> allocDataForSeqInit(T*& ptr, Size_type len, VariantID vid)
+  {
+    DataSpace ds = getDataSpace(vid);
+    DataSpace hds = rajaperf::hostCopyDataSpace(ds);
+    rajaperf::allocData(hds, ptr, len, getDataAlignment());
+    return {ds, hds, ptr, len, getDataAlignment()};
+  }
+
+  template <typename T>
+  rajaperf::AutoDataMover<T> allocAndInitDataForSeqInit(T*& ptr, Size_type len, VariantID vid)
+  {
+    DataSpace ds = getDataSpace(vid);
+    DataSpace hds = rajaperf::hostCopyDataSpace(ds);
+    rajaperf::allocAndInitData(hds, ptr, len, getDataAlignment());
+    return {ds, hds, ptr, len, getDataAlignment()};
+  }
+
+  template <typename T>
+  rajaperf::AutoDataMover<T> allocAndInitDataConstForSeqInit(T*& ptr, Size_type len, T val, VariantID vid)
+  {
+    DataSpace ds = getDataSpace(vid);
+    DataSpace hds = rajaperf::hostCopyDataSpace(ds);
+    rajaperf::allocAndInitDataConst(hds, ptr, len, getDataAlignment(), val);
+    return {ds, hds, ptr, len, getDataAlignment()};
+  }
+
+  template <typename T>
   rajaperf::AutoDataMover<T> scopedMoveData(T*& ptr, Size_type len, VariantID vid)
   {
     DataSpace ds = getDataSpace(vid);

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -419,7 +419,7 @@ public:
   }
 
   template <typename T>
-  rajaperf::AutoDataMover<T> allocDataForSeqInit(T*& ptr, Size_type len, VariantID vid)
+  rajaperf::AutoDataMover<T> allocDataForInit(T*& ptr, Size_type len, VariantID vid)
   {
     DataSpace ds = getDataSpace(vid);
     DataSpace hds = rajaperf::hostCopyDataSpace(ds);
@@ -428,7 +428,7 @@ public:
   }
 
   template <typename T>
-  rajaperf::AutoDataMover<T> allocAndInitDataForSeqInit(T*& ptr, Size_type len, VariantID vid)
+  rajaperf::AutoDataMover<T> allocAndInitDataForInit(T*& ptr, Size_type len, VariantID vid)
   {
     DataSpace ds = getDataSpace(vid);
     DataSpace hds = rajaperf::hostCopyDataSpace(ds);
@@ -437,7 +437,7 @@ public:
   }
 
   template <typename T>
-  rajaperf::AutoDataMover<T> allocAndInitDataConstForSeqInit(T*& ptr, Size_type len, T val, VariantID vid)
+  rajaperf::AutoDataMover<T> allocAndInitDataConstForInit(T*& ptr, Size_type len, T val, VariantID vid)
   {
     DataSpace ds = getDataSpace(vid);
     DataSpace hds = rajaperf::hostCopyDataSpace(ds);

--- a/src/lcals/FIRST_MIN.cpp
+++ b/src/lcals/FIRST_MIN.cpp
@@ -75,10 +75,8 @@ FIRST_MIN::~FIRST_MIN()
 
 void FIRST_MIN::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  allocAndInitDataConst(m_x, m_N, 0.0, vid);
-
   {
-    auto reset_x = scopedMoveData(m_x, m_N, vid);
+    auto reset_x = allocAndInitDataConstForSeqInit(m_x, m_N, 0.0, vid);
 
     m_x[ m_N / 2 ] = -1.0e+10;
     m_xmin_init = m_x[0];

--- a/src/lcals/FIRST_MIN.cpp
+++ b/src/lcals/FIRST_MIN.cpp
@@ -75,12 +75,10 @@ FIRST_MIN::~FIRST_MIN()
 
 void FIRST_MIN::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  {
-    auto reset_x = allocAndInitDataConstForSeqInit(m_x, m_N, 0.0, vid);
+  auto reset_x = allocAndInitDataConstForInit(m_x, m_N, 0.0, vid);
 
-    m_x[ m_N / 2 ] = -1.0e+10;
-    m_xmin_init = m_x[0];
-  }
+  m_x[ m_N / 2 ] = -1.0e+10;
+  m_xmin_init = m_x[0];
 
   m_initloc = 0;
   m_minloc = -1;

--- a/src/lcals/INT_PREDICT.cpp
+++ b/src/lcals/INT_PREDICT.cpp
@@ -85,10 +85,20 @@ void INT_PREDICT::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 void INT_PREDICT::updateChecksum(VariantID vid, size_t tune_idx)
 {
   {
-    auto reset_px = scopedMoveData(m_px, m_array_length, vid);
+    Real_ptr px_host = m_px;
+    DataSpace ds = getDataSpace(vid);
+    DataSpace hds = rajaperf::hostCopyDataSpace(ds);
+    if (ds != hds) {
+      rajaperf::allocData(hds, px_host, m_array_length, getDataAlignment());
+      rajaperf::copyData(hds, px_host, ds, m_px, m_array_length);
+    }
 
     for (Index_type i = 0; i < getActualProblemSize(); ++i) {
-      m_px[i] -= m_px_initval;
+      px_host[i] -= m_px_initval;
+    }
+
+    if (ds != hds) {
+      rajaperf::deallocData(hds, px_host);
     }
   }
 


### PR DESCRIPTION
# Improve copies

This does a number of things to improve how copies are handled.
Add synchronization to copyData to ensure those copies complete. This fixes a potential issue around host->device and device->device copies with cuda and hip.
Use the programming model memcpy implementation instead of copyData in some sections of the code. This fixes a potential issue where a sequential memcpy implementation was used for host to host copies with cuda and hip that could lead to a host-device race condition.
Make a combined scopedMoveData and allocData API called allocDataForInit, along with variants that initialize memory. This generally reduces the number of allocations and copies used by allocating directly into the memory space used during initialization. This simplifies usage in setup routines, but makes allocate and copy patterns elsewhere more explicit.

- This PR is a refactoring, bugfix
- It does the following:
  - Modifies/refactors scopedMoveData to combine it with allocation and init and give it a better name.
  - Fixes a potential host/device race condition issue
