### PR TITLE
Add launch tunings of LTIMES

### DIFF
--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -74,7 +74,7 @@ __global__ void ltimes_lam(Index_type num_m, Index_type num_g, Index_type num_z,
 
 
 template < size_t block_size >
-void LTIMES::runCudaVariantImpl(VariantID vid)
+void LTIMES::runCudaVariantImpl(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
 
@@ -132,20 +132,22 @@ void LTIMES::runCudaVariantImpl(VariantID vid)
 
     LTIMES_VIEWS_RANGES_RAJA;
 
-    using EXEC_POL =
-      RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
-          RAJA::statement::For<1, RAJA::cuda_global_size_z_direct<z_block_sz>,     //z
-            RAJA::statement::For<2, RAJA::cuda_global_size_y_direct<g_block_sz>,   //g
-              RAJA::statement::For<3, RAJA::cuda_global_size_x_direct<m_block_sz>, //m
-                RAJA::statement::For<0, RAJA::seq_exec,           //d
-                  RAJA::statement::Lambda<0>
+    if (tune_idx == 0) {
+
+      using EXEC_POL =
+        RAJA::KernelPolicy<
+          RAJA::statement::CudaKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
+            RAJA::statement::For<1, RAJA::cuda_global_size_z_direct<z_block_sz>,     //z
+              RAJA::statement::For<2, RAJA::cuda_global_size_y_direct<g_block_sz>,   //g
+                RAJA::statement::For<3, RAJA::cuda_global_size_x_direct<m_block_sz>, //m
+                  RAJA::statement::For<0, RAJA::seq_exec,           //d
+                    RAJA::statement::Lambda<0>
+                  >
                 >
               >
             >
           >
-        >
-      >;
+        >;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -164,12 +166,127 @@ void LTIMES::runCudaVariantImpl(VariantID vid)
       }
       stopTimer();
 
+    } else if (tune_idx == 1) {
+
+      constexpr bool async = true;
+
+      using launch_policy = RAJA::LaunchPolicy<RAJA::cuda_launch_t<async, m_block_sz*g_block_sz*z_block_sz>>;
+
+      using z_policy = RAJA::LoopPolicy<RAJA::cuda_global_size_z_loop<z_block_sz>>;
+
+      using g_policy = RAJA::LoopPolicy<RAJA::cuda_global_size_y_loop<g_block_sz>>;
+
+      using m_policy = RAJA::LoopPolicy<RAJA::cuda_global_size_x_loop<m_block_sz>>;
+
+      using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz);
+
+      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz);
+
+      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz);
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::launch<launch_policy>( res,
+            RAJA::LaunchParams(RAJA::Teams(m_grid_sz, g_grid_sz, z_grid_sz),
+                               RAJA::Threads(m_block_sz, g_block_sz, z_block_sz)),
+            [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+              RAJA::loop<z_policy>(ctx, IZRange(0, num_z),
+                [&](IZ z) {
+                  RAJA::loop<g_policy>(ctx, IGRange(0, num_g),
+                    [&](IG g) {
+                      RAJA::loop<m_policy>(ctx, IMRange(0, num_m),
+                        [&](IM m) {
+                          RAJA::loop<d_policy>(ctx, IDRange(0, num_d),
+                            [&](ID d) {
+                              LTIMES_BODY_RAJA
+                            }
+                          ); // RAJA::loop<d_policy>
+                        }
+                      ); // RAJA::loop<m_policy>
+                    }
+                  ); // RAJA::loop<g_policy>
+                }
+              ); // RAJA::loop<z_policy>
+
+            } // outer lambda (ctx)
+        );    // RAJA::launch
+
+      } // loop over kernel reps
+      stopTimer();
+    }
+
   } else {
      getCout() << "\n LTIMES : Unknown Cuda variant id = " << vid << std::endl;
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(LTIMES, Cuda)
+void LTIMES::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (vid == RAJA_CUDA) {
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runCudaVariantImpl<block_size>(vid, tune_idx);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runCudaVariantImpl<block_size>(vid, tune_idx);
+
+        }
+
+        t += 1;
+
+      } else {
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runCudaVariantImpl<block_size>(vid, tune_idx);
+
+        }
+
+        t += 1;
+      }
+
+    }
+
+  });
+}
+
+void LTIMES::setCudaTuningDefinitions(VariantID vid)
+{
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (vid == RAJA_CUDA) {
+        addVariantTuningName(vid, "kernel_"+std::to_string(block_size));
+        addVariantTuningName(vid, "launch_"+std::to_string(block_size));
+      } else {
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+      }
+
+    }
+
+  });
+
+}
 
 } // end namespace apps
 } // end namespace rajaperf

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -237,7 +237,7 @@ void LTIMES::runCudaVariant(VariantID vid, size_t tune_idx)
 
         if (tune_idx == t) {
           setBlockSize(block_size);
-          runCudaVariantImpl<block_size>(vid, tune_idx);
+          runCudaVariantImpl<block_size>(vid, 0);
 
         }
 
@@ -245,7 +245,7 @@ void LTIMES::runCudaVariant(VariantID vid, size_t tune_idx)
 
         if (tune_idx == t) {
           setBlockSize(block_size);
-          runCudaVariantImpl<block_size>(vid, tune_idx);
+          runCudaVariantImpl<block_size>(vid, 1);
 
         }
 
@@ -255,7 +255,7 @@ void LTIMES::runCudaVariant(VariantID vid, size_t tune_idx)
 
         if (tune_idx == t) {
           setBlockSize(block_size);
-          runCudaVariantImpl<block_size>(vid, tune_idx);
+          runCudaVariantImpl<block_size>(vid, 0);
 
         }
 

--- a/src/apps/LTIMES-Hip.cpp
+++ b/src/apps/LTIMES-Hip.cpp
@@ -73,7 +73,7 @@ __global__ void ltimes_lam(Index_type num_m, Index_type num_g, Index_type num_z,
 
 
 template < size_t block_size >
-void LTIMES::runHipVariantImpl(VariantID vid)
+void LTIMES::runHipVariantImpl(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
 
@@ -131,44 +131,161 @@ void LTIMES::runHipVariantImpl(VariantID vid)
 
     LTIMES_VIEWS_RANGES_RAJA;
 
-    using EXEC_POL =
-      RAJA::KernelPolicy<
-        RAJA::statement::HipKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
-          RAJA::statement::For<1, RAJA::hip_global_size_z_direct<z_block_sz>,     //z
-            RAJA::statement::For<2, RAJA::hip_global_size_y_direct<g_block_sz>,   //g
-              RAJA::statement::For<3, RAJA::hip_global_size_x_direct<m_block_sz>, //m
-                RAJA::statement::For<0, RAJA::seq_exec,          //d
-                  RAJA::statement::Lambda<0>
+    if (tune_idx == 0) {
+
+      using EXEC_POL =
+        RAJA::KernelPolicy<
+          RAJA::statement::HipKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
+            RAJA::statement::For<1, RAJA::hip_global_size_z_direct<z_block_sz>,     //z
+              RAJA::statement::For<2, RAJA::hip_global_size_y_direct<g_block_sz>,   //g
+                RAJA::statement::For<3, RAJA::hip_global_size_x_direct<m_block_sz>, //m
+                  RAJA::statement::For<0, RAJA::seq_exec,          //d
+                    RAJA::statement::Lambda<0>
+                  >
                 >
               >
             >
           >
-        >
-      >;
+        >;
 
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(IDRange(0, num_d),
-                         IZRange(0, num_z),
-                         IGRange(0, num_g),
-                         IMRange(0, num_m)),
-        res,
-        [=] __device__ (ID d, IZ z, IG g, IM m) {
-          LTIMES_BODY_RAJA;
-        }
-      );
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(IDRange(0, num_d),
+                           IZRange(0, num_z),
+                           IGRange(0, num_g),
+                           IMRange(0, num_m)),
+          res,
+          [=] __device__ (ID d, IZ z, IG g, IM m) {
+            LTIMES_BODY_RAJA;
+          }
+        );
 
+      }
+      stopTimer();
+
+    } else if (tune_idx == 1) {
+
+      constexpr bool async = true;
+
+      using launch_policy = RAJA::LaunchPolicy<RAJA::hip_launch_t<async, m_block_sz*g_block_sz*z_block_sz>>;
+
+      using z_policy = RAJA::LoopPolicy<RAJA::hip_global_size_z_loop<z_block_sz>>;
+
+      using g_policy = RAJA::LoopPolicy<RAJA::hip_global_size_y_loop<g_block_sz>>;
+
+      using m_policy = RAJA::LoopPolicy<RAJA::hip_global_size_x_loop<m_block_sz>>;
+
+      using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz);
+
+      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz);
+
+      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz);
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::launch<launch_policy>( res,
+            RAJA::LaunchParams(RAJA::Teams(m_grid_sz, g_grid_sz, z_grid_sz),
+                               RAJA::Threads(m_block_sz, g_block_sz, z_block_sz)),
+            [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+              RAJA::loop<z_policy>(ctx, IZRange(0, num_z),
+                [&](IZ z) {
+                  RAJA::loop<g_policy>(ctx, IGRange(0, num_g),
+                    [&](IG g) {
+                      RAJA::loop<m_policy>(ctx, IMRange(0, num_m),
+                        [&](IM m) {
+                          RAJA::loop<d_policy>(ctx, IDRange(0, num_d),
+                            [&](ID d) {
+                              LTIMES_BODY_RAJA
+                            }
+                          ); // RAJA::loop<d_policy>
+                        }
+                      ); // RAJA::loop<m_policy>
+                    }
+                  ); // RAJA::loop<g_policy>
+                }
+              ); // RAJA::loop<z_policy>
+
+            } // outer lambda (ctx)
+        );    // RAJA::launch
+
+      } // loop over kernel reps
+      stopTimer();
     }
-    stopTimer();
 
   } else {
      getCout() << "\n LTIMES : Unknown Hip variant id = " << vid << std::endl;
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(LTIMES, Hip)
+void LTIMES::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (vid == RAJA_HIP) {
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runHipVariantImpl<block_size>(vid, tune_idx);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runHipVariantImpl<block_size>(vid, tune_idx);
+
+        }
+
+        t += 1;
+
+      } else {
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runHipVariantImpl<block_size>(vid, tune_idx);
+
+        }
+
+        t += 1;
+      }
+
+    }
+
+  });
+}
+
+void LTIMES::setHipTuningDefinitions(VariantID vid)
+{
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (vid == RAJA_HIP) {
+        addVariantTuningName(vid, "kernel_"+std::to_string(block_size));
+        addVariantTuningName(vid, "launch_"+std::to_string(block_size));
+      } else {
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+      }
+
+    }
+
+  });
+
+}
 
 } // end namespace apps
 } // end namespace rajaperf

--- a/src/apps/LTIMES-Hip.cpp
+++ b/src/apps/LTIMES-Hip.cpp
@@ -236,7 +236,7 @@ void LTIMES::runHipVariant(VariantID vid, size_t tune_idx)
 
         if (tune_idx == t) {
           setBlockSize(block_size);
-          runHipVariantImpl<block_size>(vid, tune_idx);
+          runHipVariantImpl<block_size>(vid, 0);
 
         }
 
@@ -244,7 +244,7 @@ void LTIMES::runHipVariant(VariantID vid, size_t tune_idx)
 
         if (tune_idx == t) {
           setBlockSize(block_size);
-          runHipVariantImpl<block_size>(vid, tune_idx);
+          runHipVariantImpl<block_size>(vid, 1);
 
         }
 
@@ -254,7 +254,7 @@ void LTIMES::runHipVariant(VariantID vid, size_t tune_idx)
 
         if (tune_idx == t) {
           setBlockSize(block_size);
-          runHipVariantImpl<block_size>(vid, tune_idx);
+          runHipVariantImpl<block_size>(vid, 0);
 
         }
 

--- a/src/apps/LTIMES-OMP.cpp
+++ b/src/apps/LTIMES-OMP.cpp
@@ -18,7 +18,7 @@ namespace apps
 {
 
 
-void LTIMES::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void LTIMES::runOpenMPVariant(VariantID vid, size_t tune_idx)
 {
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
 
@@ -83,36 +83,83 @@ void LTIMES::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
 
       LTIMES_VIEWS_RANGES_RAJA;
 
-      auto ltimes_lam = [=](ID d, IZ z, IG g, IM m) {
-                          LTIMES_BODY_RAJA;
-                        };
+      if (tune_idx == 0) {
 
-      using EXEC_POL =
-        RAJA::KernelPolicy<
-          RAJA::statement::For<1, RAJA::omp_parallel_for_exec, // z
-            RAJA::statement::For<2, RAJA::seq_exec,            // g
-              RAJA::statement::For<3, RAJA::seq_exec,          // m
-                RAJA::statement::For<0, RAJA::seq_exec,        // d
-                  RAJA::statement::Lambda<0>
+        auto ltimes_lam = [=](ID d, IZ z, IG g, IM m) {
+                            LTIMES_BODY_RAJA;
+                          };
+
+        using EXEC_POL =
+          RAJA::KernelPolicy<
+            RAJA::statement::For<1, RAJA::omp_parallel_for_exec, // z
+              RAJA::statement::For<2, RAJA::seq_exec,            // g
+                RAJA::statement::For<3, RAJA::seq_exec,          // m
+                  RAJA::statement::For<0, RAJA::seq_exec,        // d
+                    RAJA::statement::Lambda<0>
+                  >
                 >
               >
             >
-          >
-        >;
+          >;
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, num_d),
-                                                          IZRange(0, num_z),
-                                                          IGRange(0, num_g),
-                                                          IMRange(0, num_m)),
-                                         res,
-                                         ltimes_lam
-                                       );
+          RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, num_d),
+                                                            IZRange(0, num_z),
+                                                            IGRange(0, num_g),
+                                                            IMRange(0, num_m)),
+                                           res,
+                                           ltimes_lam
+                                         );
+
+        }
+        stopTimer();
+
+      } else if (tune_idx == 1) {
+
+        using launch_policy = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
+
+        using z_policy = RAJA::LoopPolicy<RAJA::omp_for_exec>;
+
+        using g_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        using m_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          RAJA::launch<launch_policy>( res,
+              RAJA::LaunchParams(),
+              [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+                RAJA::loop<z_policy>(ctx, IZRange(0, num_z),
+                  [&](IZ z) {
+                    RAJA::loop<g_policy>(ctx, IGRange(0, num_g),
+                      [&](IG g) {
+                        RAJA::loop<m_policy>(ctx, IMRange(0, num_m),
+                          [&](IM m) {
+                            RAJA::loop<d_policy>(ctx, IDRange(0, num_d),
+                              [&](ID d) {
+                                LTIMES_BODY_RAJA
+                              }
+                            ); // RAJA::loop<d_policy>
+                          }
+                        ); // RAJA::loop<m_policy>
+                      }
+                    ); // RAJA::loop<g_policy>
+                  }
+                ); // RAJA::loop<z_policy>
+
+              } // outer lambda (ctx)
+          );    // RAJA::launch
+
+        } // loop over kernel reps
+        stopTimer();
 
       }
-      stopTimer();
 
       break;
     }
@@ -126,6 +173,18 @@ void LTIMES::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx
 #else
   RAJA_UNUSED_VAR(vid);
 #endif
+}
+
+void LTIMES::setOpenMPTuningDefinitions(VariantID vid)
+{
+
+  if (vid == RAJA_OpenMP) {
+    addVariantTuningName(vid, "kernel");
+    addVariantTuningName(vid, "launch");
+  } else {
+    addVariantTuningName(vid, "default");
+  }
+
 }
 
 } // end namespace apps

--- a/src/apps/LTIMES-OMPTarget.cpp
+++ b/src/apps/LTIMES-OMPTarget.cpp
@@ -84,6 +84,17 @@ void LTIMES::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
   }
 }
 
+void LTIMES::setOpenMPTargetTuningDefinitions(VariantID vid)
+{
+
+  if (vid == RAJA_OpenMPTarget) {
+    addVariantTuningName(vid, "kernel");
+  } else {
+    addVariantTuningName(vid, "default");
+  }
+
+}
+
 } // end namespace apps
 } // end namespace rajaperf
 

--- a/src/apps/LTIMES-Seq.cpp
+++ b/src/apps/LTIMES-Seq.cpp
@@ -18,7 +18,7 @@ namespace apps
 {
 
 
-void LTIMES::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void LTIMES::runSeqVariant(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
 
@@ -80,37 +80,84 @@ void LTIMES::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 
       LTIMES_VIEWS_RANGES_RAJA;
 
-      auto ltimes_lam = [=](ID d, IZ z, IG g, IM m) {
-                          LTIMES_BODY_RAJA;
-                        };
+      if (tune_idx == 0) {
+
+        auto ltimes_lam = [=](ID d, IZ z, IG g, IM m) {
+                            LTIMES_BODY_RAJA;
+                          };
 
 
-      using EXEC_POL =
-        RAJA::KernelPolicy<
-          RAJA::statement::For<1, RAJA::seq_exec,       // z
-            RAJA::statement::For<2, RAJA::seq_exec,     // g
-              RAJA::statement::For<3, RAJA::seq_exec,   // m
-                RAJA::statement::For<0, RAJA::seq_exec, // d
-                  RAJA::statement::Lambda<0>
+        using EXEC_POL =
+          RAJA::KernelPolicy<
+            RAJA::statement::For<1, RAJA::seq_exec,       // z
+              RAJA::statement::For<2, RAJA::seq_exec,     // g
+                RAJA::statement::For<3, RAJA::seq_exec,   // m
+                  RAJA::statement::For<0, RAJA::seq_exec, // d
+                    RAJA::statement::Lambda<0>
+                  >
                 >
               >
             >
-          >
-        >;
+          >;
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, num_d),
-                                                          IZRange(0, num_z),
-                                                          IGRange(0, num_g),
-                                                          IMRange(0, num_m)),
-                                         res,
-                                         ltimes_lam
-                                       );
+          RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, num_d),
+                                                            IZRange(0, num_z),
+                                                            IGRange(0, num_g),
+                                                            IMRange(0, num_m)),
+                                           res,
+                                           ltimes_lam
+                                         );
+
+        }
+        stopTimer();
+
+      } else if (tune_idx == 1) {
+
+        using launch_policy = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
+
+        using z_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        using g_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        using m_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          RAJA::launch<launch_policy>( res,
+              RAJA::LaunchParams(),
+              [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+                RAJA::loop<z_policy>(ctx, IZRange(0, num_z),
+                  [&](IZ z) {
+                    RAJA::loop<g_policy>(ctx, IGRange(0, num_g),
+                      [&](IG g) {
+                        RAJA::loop<m_policy>(ctx, IMRange(0, num_m),
+                          [&](IM m) {
+                            RAJA::loop<d_policy>(ctx, IDRange(0, num_d),
+                              [&](ID d) {
+                                LTIMES_BODY_RAJA
+                              }
+                            ); // RAJA::loop<d_policy>
+                          }
+                        ); // RAJA::loop<m_policy>
+                      }
+                    ); // RAJA::loop<g_policy>
+                  }
+                ); // RAJA::loop<z_policy>
+
+              } // outer lambda (ctx)
+          );    // RAJA::launch
+
+        } // loop over kernel reps
+        stopTimer();
 
       }
-      stopTimer();
 
       break;
     }
@@ -120,6 +167,18 @@ void LTIMES::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
       getCout() << "\n LTIMES : Unknown variant id = " << vid << std::endl;
     }
 
+  }
+
+}
+
+void LTIMES::setSeqTuningDefinitions(VariantID vid)
+{
+
+  if (vid == RAJA_Seq) {
+    addVariantTuningName(vid, "kernel");
+    addVariantTuningName(vid, "launch");
+  } else {
+    addVariantTuningName(vid, "default");
   }
 
 }

--- a/src/apps/LTIMES-Sycl.cpp
+++ b/src/apps/LTIMES-Sycl.cpp
@@ -72,20 +72,22 @@ void LTIMES::runSyclVariantImpl(VariantID vid)
 
     LTIMES_VIEWS_RANGES_RAJA;
 
-    using EXEC_POL =
-      RAJA::KernelPolicy<
-        RAJA::statement::SyclKernelAsync<
-          RAJA::statement::For<1, RAJA::sycl_global_2<z_wg_sz>,      //z 
-            RAJA::statement::For<2, RAJA::sycl_global_1<g_wg_sz>,    //g
-              RAJA::statement::For<3, RAJA::sycl_global_0<m_wg_sz>,  //m
-                RAJA::statement::For<0, RAJA::seq_exec,              //d
-                  RAJA::statement::Lambda<0>
+    if (tune_idx == 0) {
+
+      using EXEC_POL =
+        RAJA::KernelPolicy<
+          RAJA::statement::SyclKernelAsync<
+            RAJA::statement::For<1, RAJA::sycl_global_2<z_wg_sz>,      //z
+              RAJA::statement::For<2, RAJA::sycl_global_1<g_wg_sz>,    //g
+                RAJA::statement::For<3, RAJA::sycl_global_0<m_wg_sz>,  //m
+                  RAJA::statement::For<0, RAJA::seq_exec,              //d
+                    RAJA::statement::Lambda<0>
+                  >
                 >
               >
             >
           >
-        >
-      >;
+        >;
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -103,12 +105,127 @@ void LTIMES::runSyclVariantImpl(VariantID vid)
       }
       stopTimer();
 
+    } else if (tune_idx == 1) {
+
+      constexpr bool async = true;
+
+      using launch_policy = RAJA::LaunchPolicy<RAJA::sycl_launch_t<async>>;
+
+      using z_policy = RAJA::LoopPolicy<RAJA::sycl_global_2<z_wg_sz>>;
+
+      using g_policy = RAJA::LoopPolicy<RAJA::sycl_global_1<g_wg_sz>>;
+
+      using m_policy = RAJA::LoopPolicy<RAJA::sycl_global_0<m_wg_sz>>;
+
+      using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(num_z, z_wg_sz);
+
+      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(num_g, g_wg_sz);
+
+      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(num_m, m_wg_sz);
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::launch<launch_policy>( res,
+            RAJA::LaunchParams(RAJA::Teams(m_grid_sz, g_grid_sz, z_grid_sz),
+                               RAJA::Threads(m_wg_sz, g_wg_sz, z_wg_sz)),
+            [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+              RAJA::loop<z_policy>(ctx, IZRange(0, num_z),
+                [&](IZ z) {
+                  RAJA::loop<g_policy>(ctx, IGRange(0, num_g),
+                    [&](IG g) {
+                      RAJA::loop<m_policy>(ctx, IMRange(0, num_m),
+                        [&](IM m) {
+                          RAJA::loop<d_policy>(ctx, IDRange(0, num_d),
+                            [&](ID d) {
+                              LTIMES_BODY_RAJA
+                            }
+                          ); // RAJA::loop<d_policy>
+                        }
+                      ); // RAJA::loop<m_policy>
+                    }
+                  ); // RAJA::loop<g_policy>
+                }
+              ); // RAJA::loop<z_policy>
+
+            } // outer lambda (ctx)
+        );    // RAJA::launch
+
+      } // loop over kernel reps
+      stopTimer();
+    }
+
   } else {
      std::cout << "\n LTIMES : Unknown Sycl variant id = " << vid << std::endl;
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(LTIMES, Sycl)
+void LTIMES::runSyclVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto work_group_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(work_group_size)) {
+
+      if (vid == RAJA_SYCL) {
+
+        if (tune_idx == t) {
+          setBlockSize(work_group_size);
+          runSyclVariantImpl<work_group_size>(vid, tune_idx);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+          setBlockSize(work_group_size);
+          runSyclVariantImpl<work_group_size>(vid, tune_idx);
+
+        }
+
+        t += 1;
+
+      } else {
+
+        if (tune_idx == t) {
+          setBlockSize(work_group_size);
+          runSyclVariantImpl<work_group_size>(vid, tune_idx);
+
+        }
+
+        t += 1;
+      }
+
+    }
+
+  });
+}
+
+void LTIMES::setSyclTuningDefinitions(VariantID vid)
+{
+
+  seq_for(gpu_block_sizes_type{}, [&](auto work_group_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(work_group_size)) {
+
+      if (vid == RAJA_SYCL) {
+        addVariantTuningName(vid, "kernel_"+std::to_string(work_group_size));
+        addVariantTuningName(vid, "launch_"+std::to_string(work_group_size));
+      } else {
+        addVariantTuningName(vid, "block_"+std::to_string(work_group_size));
+      }
+
+    }
+
+  });
+
+}
 
 } // end namespace apps
 } // end namespace rajaperf

--- a/src/apps/LTIMES-Sycl.cpp
+++ b/src/apps/LTIMES-Sycl.cpp
@@ -129,8 +129,8 @@ void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         RAJA::launch<launch_policy>( res,
-            RAJA::LaunchParams(RAJA::Teams(z_grid_sz, g_grid_sz, m_grid_sz),
-                               RAJA::Threads(z_wg_sz, g_wg_sz, m_wg_sz)),
+            RAJA::LaunchParams(RAJA::Teams(m_grid_sz, g_grid_sz, z_grid_sz),
+                               RAJA::Threads(m_wg_sz, g_wg_sz, z_wg_sz)),
             [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
 
               RAJA::loop<z_policy>(ctx, IZRange(0, num_z),

--- a/src/apps/LTIMES-Sycl.cpp
+++ b/src/apps/LTIMES-Sycl.cpp
@@ -77,9 +77,9 @@ void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
       using EXEC_POL =
         RAJA::KernelPolicy<
           RAJA::statement::SyclKernelAsync<
-            RAJA::statement::For<1, RAJA::sycl_global_2<z_wg_sz>,      //z
+            RAJA::statement::For<1, RAJA::sycl_global_0<z_wg_sz>,      //z
               RAJA::statement::For<2, RAJA::sycl_global_1<g_wg_sz>,    //g
-                RAJA::statement::For<3, RAJA::sycl_global_0<m_wg_sz>,  //m
+                RAJA::statement::For<3, RAJA::sycl_global_2<m_wg_sz>,  //m
                   RAJA::statement::For<0, RAJA::seq_exec,              //d
                     RAJA::statement::Lambda<0>
                   >
@@ -111,11 +111,11 @@ void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
 
       using launch_policy = RAJA::LaunchPolicy<RAJA::sycl_launch_t<async>>;
 
-      using z_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_2>;
+      using z_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_0>;
 
       using g_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_1>;
 
-      using m_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_0>;
+      using m_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_2>;
 
       using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
 
@@ -129,8 +129,8 @@ void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         RAJA::launch<launch_policy>( res,
-            RAJA::LaunchParams(RAJA::Teams(m_grid_sz, g_grid_sz, z_grid_sz),
-                               RAJA::Threads(m_wg_sz, g_wg_sz, z_wg_sz)),
+            RAJA::LaunchParams(RAJA::Teams(z_grid_sz, g_grid_sz, m_grid_sz),
+                               RAJA::Threads(z_wg_sz, g_wg_sz, m_wg_sz)),
             [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
 
               RAJA::loop<z_policy>(ctx, IZRange(0, num_z),

--- a/src/apps/LTIMES-Sycl.cpp
+++ b/src/apps/LTIMES-Sycl.cpp
@@ -29,7 +29,7 @@ namespace apps
 #define z_wg_sz (integer::lesser_of_squarest_factor_pair(work_group_size/m_wg_sz))
 
 template <size_t work_group_size >
-void LTIMES::runSyclVariantImpl(VariantID vid)
+void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
 
@@ -176,7 +176,7 @@ void LTIMES::runSyclVariant(VariantID vid, size_t tune_idx)
 
         if (tune_idx == t) {
           setBlockSize(work_group_size);
-          runSyclVariantImpl<work_group_size>(vid, tune_idx);
+          runSyclVariantImpl<work_group_size>(vid, 0);
 
         }
 
@@ -184,7 +184,7 @@ void LTIMES::runSyclVariant(VariantID vid, size_t tune_idx)
 
         if (tune_idx == t) {
           setBlockSize(work_group_size);
-          runSyclVariantImpl<work_group_size>(vid, tune_idx);
+          runSyclVariantImpl<work_group_size>(vid, 1);
 
         }
 
@@ -194,7 +194,7 @@ void LTIMES::runSyclVariant(VariantID vid, size_t tune_idx)
 
         if (tune_idx == t) {
           setBlockSize(work_group_size);
-          runSyclVariantImpl<work_group_size>(vid, tune_idx);
+          runSyclVariantImpl<work_group_size>(vid, 0);
 
         }
 

--- a/src/apps/LTIMES-Sycl.cpp
+++ b/src/apps/LTIMES-Sycl.cpp
@@ -111,11 +111,11 @@ void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
 
       using launch_policy = RAJA::LaunchPolicy<RAJA::sycl_launch_t<async>>;
 
-      using z_policy = RAJA::LoopPolicy<RAJA::sycl_global_2<z_wg_sz>>;
+      using z_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_2>;
 
-      using g_policy = RAJA::LoopPolicy<RAJA::sycl_global_1<g_wg_sz>>;
+      using g_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_1>;
 
-      using m_policy = RAJA::LoopPolicy<RAJA::sycl_global_0<m_wg_sz>>;
+      using m_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_0>;
 
       using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
 

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -56,6 +56,7 @@ LTIMES::LTIMES(const RunParams& params)
   setComplexity(Complexity::N);
 
   setUsesFeature(Kernel);
+  setUsesFeature(Launch);
   setUsesFeature(View);
 
   setVariantDefined( Base_Seq );

--- a/src/apps/LTIMES.hpp
+++ b/src/apps/LTIMES.hpp
@@ -118,16 +118,19 @@ public:
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
   void runSyclVariant(VariantID vid, size_t tune_idx);
 
+  void setSeqTuningDefinitions(VariantID vid);
+  void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid); 
 
   template < size_t block_size >
-  void runCudaVariantImpl(VariantID vid);
+  void runCudaVariantImpl(VariantID vid, size_t tune_idx);
   template < size_t block_size >
-  void runHipVariantImpl(VariantID vid);
+  void runHipVariantImpl(VariantID vid, size_t tune_idx);
   template < size_t work_group_size >
-  void runSyclVariantImpl(VariantID vid);
+  void runSyclVariantImpl(VariantID vid, size_t tune_idx);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/apps/LTIMES_NOVIEW-Cuda.cpp
+++ b/src/apps/LTIMES_NOVIEW-Cuda.cpp
@@ -73,7 +73,7 @@ __global__ void ltimes_noview_lam(Index_type num_m, Index_type num_g, Index_type
 
 
 template < size_t block_size >
-void LTIMES_NOVIEW::runCudaVariantImpl(VariantID vid)
+void LTIMES_NOVIEW::runCudaVariantImpl(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
 
@@ -129,45 +129,162 @@ void LTIMES_NOVIEW::runCudaVariantImpl(VariantID vid)
 
   } else if ( vid == RAJA_CUDA ) {
 
-    using EXEC_POL =
-      RAJA::KernelPolicy<
-        RAJA::statement::CudaKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
-          RAJA::statement::For<1, RAJA::cuda_global_size_z_direct<z_block_sz>,     //z
-            RAJA::statement::For<2, RAJA::cuda_global_size_y_direct<g_block_sz>,   //g
-              RAJA::statement::For<3, RAJA::cuda_global_size_x_direct<m_block_sz>, //m
-                RAJA::statement::For<0, RAJA::seq_exec,           //d
-                  RAJA::statement::Lambda<0>
+    if (tune_idx == 0) {
+
+      using EXEC_POL =
+        RAJA::KernelPolicy<
+          RAJA::statement::CudaKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
+            RAJA::statement::For<1, RAJA::cuda_global_size_z_direct<z_block_sz>,     //z
+              RAJA::statement::For<2, RAJA::cuda_global_size_y_direct<g_block_sz>,   //g
+                RAJA::statement::For<3, RAJA::cuda_global_size_x_direct<m_block_sz>, //m
+                  RAJA::statement::For<0, RAJA::seq_exec,           //d
+                    RAJA::statement::Lambda<0>
+                  >
                 >
               >
             >
           >
-        >
-      >;
+        >;
 
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
-                         RAJA::RangeSegment(0, num_z),
-                         RAJA::RangeSegment(0, num_g),
-                         RAJA::RangeSegment(0, num_m)),
-        res,
-        [=] __device__ (Index_type d, Index_type z,
-                        Index_type g, Index_type m) {
-          LTIMES_NOVIEW_BODY;
-        }
-      );
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
+                           RAJA::RangeSegment(0, num_z),
+                           RAJA::RangeSegment(0, num_g),
+                           RAJA::RangeSegment(0, num_m)),
+          res,
+          [=] __device__ (Index_type d, Index_type z,
+                          Index_type g, Index_type m) {
+            LTIMES_NOVIEW_BODY;
+          }
+        );
 
+      }
+      stopTimer();
+
+    } else if (tune_idx == 1) {
+
+      constexpr bool async = true;
+
+      using launch_policy = RAJA::LaunchPolicy<RAJA::cuda_launch_t<async, m_block_sz*g_block_sz*z_block_sz>>;
+
+      using z_policy = RAJA::LoopPolicy<RAJA::cuda_global_size_z_loop<z_block_sz>>;
+
+      using g_policy = RAJA::LoopPolicy<RAJA::cuda_global_size_y_loop<g_block_sz>>;
+
+      using m_policy = RAJA::LoopPolicy<RAJA::cuda_global_size_x_loop<m_block_sz>>;
+
+      using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz);
+
+      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz);
+
+      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz);
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::launch<launch_policy>( res,
+            RAJA::LaunchParams(RAJA::Teams(m_grid_sz, g_grid_sz, z_grid_sz),
+                               RAJA::Threads(m_block_sz, g_block_sz, z_block_sz)),
+            [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+              RAJA::loop<z_policy>(ctx, RAJA::RangeSegment(0, num_z),
+                [&](Index_type z) {
+                  RAJA::loop<g_policy>(ctx, RAJA::RangeSegment(0, num_g),
+                    [&](Index_type g) {
+                      RAJA::loop<m_policy>(ctx, RAJA::RangeSegment(0, num_m),
+                        [&](Index_type m) {
+                          RAJA::loop<d_policy>(ctx, RAJA::RangeSegment(0, num_d),
+                            [&](Index_type d) {
+                              LTIMES_NOVIEW_BODY
+                            }
+                          ); // RAJA::loop<d_policy>
+                        }
+                      ); // RAJA::loop<m_policy>
+                    }
+                  ); // RAJA::loop<g_policy>
+                }
+              ); // RAJA::loop<z_policy>
+
+            } // outer lambda (ctx)
+        );    // RAJA::launch
+
+      } // loop over kernel reps
+      stopTimer();
     }
-    stopTimer();
 
   } else {
      getCout() << "\n LTIMES_NOVIEW : Unknown Cuda variant id = " << vid << std::endl;
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(LTIMES_NOVIEW, Cuda)
+void LTIMES_NOVIEW::runCudaVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (vid == RAJA_CUDA) {
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runCudaVariantImpl<block_size>(vid, 0);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runCudaVariantImpl<block_size>(vid, 1);
+
+        }
+
+        t += 1;
+
+      } else {
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runCudaVariantImpl<block_size>(vid, 0);
+
+        }
+
+        t += 1;
+      }
+
+    }
+
+  });
+}
+
+void LTIMES_NOVIEW::setCudaTuningDefinitions(VariantID vid)
+{
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (vid == RAJA_CUDA) {
+        addVariantTuningName(vid, "kernel_"+std::to_string(block_size));
+        addVariantTuningName(vid, "launch_"+std::to_string(block_size));
+      } else {
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+      }
+
+    }
+
+  });
+
+}
 
 } // end namespace apps
 } // end namespace rajaperf

--- a/src/apps/LTIMES_NOVIEW-Hip.cpp
+++ b/src/apps/LTIMES_NOVIEW-Hip.cpp
@@ -73,7 +73,7 @@ __global__ void ltimes_noview_lam(Index_type num_m, Index_type num_g, Index_type
 
 
 template < size_t block_size >
-void LTIMES_NOVIEW::runHipVariantImpl(VariantID vid)
+void LTIMES_NOVIEW::runHipVariantImpl(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
 
@@ -129,45 +129,162 @@ void LTIMES_NOVIEW::runHipVariantImpl(VariantID vid)
 
   } else if ( vid == RAJA_HIP ) {
 
-    using EXEC_POL =
-      RAJA::KernelPolicy<
-        RAJA::statement::HipKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
-          RAJA::statement::For<1, RAJA::hip_global_size_z_direct<z_block_sz>,     //z
-            RAJA::statement::For<2, RAJA::hip_global_size_y_direct<g_block_sz>,   //g
-              RAJA::statement::For<3, RAJA::hip_global_size_x_direct<m_block_sz>, //m
-                RAJA::statement::For<0, RAJA::seq_exec,          //d
-                  RAJA::statement::Lambda<0>
+    if (tune_idx == 0) {
+
+      using EXEC_POL =
+        RAJA::KernelPolicy<
+          RAJA::statement::HipKernelFixedAsync<m_block_sz*g_block_sz*z_block_sz,
+            RAJA::statement::For<1, RAJA::hip_global_size_z_direct<z_block_sz>,     //z
+              RAJA::statement::For<2, RAJA::hip_global_size_y_direct<g_block_sz>,   //g
+                RAJA::statement::For<3, RAJA::hip_global_size_x_direct<m_block_sz>, //m
+                  RAJA::statement::For<0, RAJA::seq_exec,          //d
+                    RAJA::statement::Lambda<0>
+                  >
                 >
               >
             >
           >
-        >
-      >;
+        >;
 
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
-                         RAJA::RangeSegment(0, num_z),
-                         RAJA::RangeSegment(0, num_g),
-                         RAJA::RangeSegment(0, num_m)),
-        res,
-        [=] __device__ (Index_type d, Index_type z,
-                        Index_type g, Index_type m) {
-          LTIMES_NOVIEW_BODY;
-        }
-      );
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
+                           RAJA::RangeSegment(0, num_z),
+                           RAJA::RangeSegment(0, num_g),
+                           RAJA::RangeSegment(0, num_m)),
+          res,
+          [=] __device__ (Index_type d, Index_type z,
+                          Index_type g, Index_type m) {
+            LTIMES_NOVIEW_BODY;
+          }
+        );
 
+      }
+      stopTimer();
+
+    } else if (tune_idx == 1) {
+
+      constexpr bool async = true;
+
+      using launch_policy = RAJA::LaunchPolicy<RAJA::hip_launch_t<async, m_block_sz*g_block_sz*z_block_sz>>;
+
+      using z_policy = RAJA::LoopPolicy<RAJA::hip_global_size_z_loop<z_block_sz>>;
+
+      using g_policy = RAJA::LoopPolicy<RAJA::hip_global_size_y_loop<g_block_sz>>;
+
+      using m_policy = RAJA::LoopPolicy<RAJA::hip_global_size_x_loop<m_block_sz>>;
+
+      using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz);
+
+      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz);
+
+      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz);
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::launch<launch_policy>( res,
+            RAJA::LaunchParams(RAJA::Teams(m_grid_sz, g_grid_sz, z_grid_sz),
+                               RAJA::Threads(m_block_sz, g_block_sz, z_block_sz)),
+            [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+              RAJA::loop<z_policy>(ctx, RAJA::RangeSegment(0, num_z),
+                [&](Index_type z) {
+                  RAJA::loop<g_policy>(ctx, RAJA::RangeSegment(0, num_g),
+                    [&](Index_type g) {
+                      RAJA::loop<m_policy>(ctx, RAJA::RangeSegment(0, num_m),
+                        [&](Index_type m) {
+                          RAJA::loop<d_policy>(ctx, RAJA::RangeSegment(0, num_d),
+                            [&](Index_type d) {
+                              LTIMES_NOVIEW_BODY
+                            }
+                          ); // RAJA::loop<d_policy>
+                        }
+                      ); // RAJA::loop<m_policy>
+                    }
+                  ); // RAJA::loop<g_policy>
+                }
+              ); // RAJA::loop<z_policy>
+
+            } // outer lambda (ctx)
+        );    // RAJA::launch
+
+      } // loop over kernel reps
+      stopTimer();
     }
-    stopTimer();
 
   } else {
      getCout() << "\n LTIMES_NOVIEW : Unknown Hip variant id = " << vid << std::endl;
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(LTIMES_NOVIEW, Hip)
+void LTIMES_NOVIEW::runHipVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (vid == RAJA_HIP) {
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runHipVariantImpl<block_size>(vid, 0);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runHipVariantImpl<block_size>(vid, 1);
+
+        }
+
+        t += 1;
+
+      } else {
+
+        if (tune_idx == t) {
+          setBlockSize(block_size);
+          runHipVariantImpl<block_size>(vid, 0);
+
+        }
+
+        t += 1;
+      }
+
+    }
+
+  });
+}
+
+void LTIMES_NOVIEW::setHipTuningDefinitions(VariantID vid)
+{
+
+  seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(block_size)) {
+
+      if (vid == RAJA_HIP) {
+        addVariantTuningName(vid, "kernel_"+std::to_string(block_size));
+        addVariantTuningName(vid, "launch_"+std::to_string(block_size));
+      } else {
+        addVariantTuningName(vid, "block_"+std::to_string(block_size));
+      }
+
+    }
+
+  });
+
+}
 
 } // end namespace apps
 } // end namespace rajaperf

--- a/src/apps/LTIMES_NOVIEW-OMP.cpp
+++ b/src/apps/LTIMES_NOVIEW-OMP.cpp
@@ -18,18 +18,13 @@ namespace apps
 {
 
 
-void LTIMES_NOVIEW::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void LTIMES_NOVIEW::runOpenMPVariant(VariantID vid, size_t tune_idx)
 {
 #if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
 
   const Index_type run_reps = getRunReps();
 
   LTIMES_NOVIEW_DATA_SETUP;
-
-  auto ltimesnoview_lam = [=](Index_type d, Index_type z,
-                              Index_type g, Index_type m) {
-                                LTIMES_NOVIEW_BODY;
-                          };
 
   switch ( vid ) {
 
@@ -57,6 +52,11 @@ void LTIMES_NOVIEW::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
 
     case Lambda_OpenMP : {
 
+      auto ltimesnoview_lam = [=](Index_type d, Index_type z,
+                                  Index_type g, Index_type m) {
+                                LTIMES_NOVIEW_BODY;
+                              };
+
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
@@ -81,32 +81,84 @@ void LTIMES_NOVIEW::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
 
       auto res{getHostResource()};
 
-      using EXEC_POL =
-        RAJA::KernelPolicy<
-          RAJA::statement::For<1, RAJA::omp_parallel_for_exec, // z
-            RAJA::statement::For<2, RAJA::seq_exec,            // g
-              RAJA::statement::For<3, RAJA::seq_exec,          // m
-                RAJA::statement::For<0, RAJA::seq_exec,        // d
-                  RAJA::statement::Lambda<0>
+      if (tune_idx == 0) {
+
+        auto ltimesnoview_lam = [=](Index_type d, Index_type z,
+                                    Index_type g, Index_type m) {
+                                  LTIMES_NOVIEW_BODY;
+                                };
+
+        using EXEC_POL =
+          RAJA::KernelPolicy<
+            RAJA::statement::For<1, RAJA::omp_parallel_for_exec, // z
+              RAJA::statement::For<2, RAJA::seq_exec,            // g
+                RAJA::statement::For<3, RAJA::seq_exec,          // m
+                  RAJA::statement::For<0, RAJA::seq_exec,        // d
+                    RAJA::statement::Lambda<0>
+                  >
                 >
               >
             >
-          >
-        >;
+          >;
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
-                                                          RAJA::RangeSegment(0, num_z),
-                                                          RAJA::RangeSegment(0, num_g),
-                                                          RAJA::RangeSegment(0, num_m)),
-                                         res,
-                                         ltimesnoview_lam
-                                       );
+          RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
+                                                            RAJA::RangeSegment(0, num_z),
+                                                            RAJA::RangeSegment(0, num_g),
+                                                            RAJA::RangeSegment(0, num_m)),
+                                           res,
+                                           ltimesnoview_lam
+                                         );
+
+        }
+        stopTimer();
+
+      } else if (tune_idx == 1) {
+
+        using launch_policy = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
+
+        using z_policy = RAJA::LoopPolicy<RAJA::omp_for_exec>;
+
+        using g_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        using m_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          RAJA::launch<launch_policy>( res,
+              RAJA::LaunchParams(),
+              [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+                RAJA::loop<z_policy>(ctx, RAJA::RangeSegment(0, num_z),
+                  [&](Index_type z) {
+                    RAJA::loop<g_policy>(ctx, RAJA::RangeSegment(0, num_g),
+                      [&](Index_type g) {
+                        RAJA::loop<m_policy>(ctx, RAJA::RangeSegment(0, num_m),
+                          [&](Index_type m) {
+                            RAJA::loop<d_policy>(ctx, RAJA::RangeSegment(0, num_d),
+                              [&](Index_type d) {
+                                LTIMES_NOVIEW_BODY
+                              }
+                            ); // RAJA::loop<d_policy>
+                          }
+                        ); // RAJA::loop<m_policy>
+                      }
+                    ); // RAJA::loop<g_policy>
+                  }
+                ); // RAJA::loop<z_policy>
+
+              } // outer lambda (ctx)
+          );    // RAJA::launch
+
+        } // loop over kernel reps
+        stopTimer();
 
       }
-      stopTimer();
 
       break;
     }
@@ -120,6 +172,18 @@ void LTIMES_NOVIEW::runOpenMPVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
 #else
   RAJA_UNUSED_VAR(vid);
 #endif
+}
+
+void LTIMES_NOVIEW::setOpenMPTuningDefinitions(VariantID vid)
+{
+
+  if (vid == RAJA_OpenMP) {
+    addVariantTuningName(vid, "kernel");
+    addVariantTuningName(vid, "launch");
+  } else {
+    addVariantTuningName(vid, "default");
+  }
+
 }
 
 } // end namespace apps

--- a/src/apps/LTIMES_NOVIEW-OMPTarget.cpp
+++ b/src/apps/LTIMES_NOVIEW-OMPTarget.cpp
@@ -83,6 +83,17 @@ void LTIMES_NOVIEW::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED
   }
 }
 
+void LTIMES_NOVIEW::setOpenMPTargetTuningDefinitions(VariantID vid)
+{
+
+  if (vid == RAJA_OpenMPTarget) {
+    addVariantTuningName(vid, "kernel");
+  } else {
+    addVariantTuningName(vid, "default");
+  }
+
+}
+
 } // end namespace apps
 } // end namespace rajaperf
 

--- a/src/apps/LTIMES_NOVIEW-Seq.cpp
+++ b/src/apps/LTIMES_NOVIEW-Seq.cpp
@@ -18,18 +18,11 @@ namespace apps
 {
 
 
-void LTIMES_NOVIEW::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+void LTIMES_NOVIEW::runSeqVariant(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
 
   LTIMES_NOVIEW_DATA_SETUP;
-
-#if defined(RUN_RAJA_SEQ)
-  auto ltimesnoview_lam = [=](Index_type d, Index_type z,
-                              Index_type g, Index_type m) {
-                                LTIMES_NOVIEW_BODY;
-                          };
-#endif
 
   switch ( vid ) {
 
@@ -57,6 +50,11 @@ void LTIMES_NOVIEW::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
 #if defined(RUN_RAJA_SEQ)
     case Lambda_Seq : {
 
+      auto ltimesnoview_lam = [=](Index_type d, Index_type z,
+                                  Index_type g, Index_type m) {
+                                LTIMES_NOVIEW_BODY;
+                              };
+
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
@@ -80,32 +78,84 @@ void LTIMES_NOVIEW::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
 
       auto res{getHostResource()};
 
-      using EXEC_POL =
-        RAJA::KernelPolicy<
-          RAJA::statement::For<1, RAJA::seq_exec,       // z
-            RAJA::statement::For<2, RAJA::seq_exec,     // g
-              RAJA::statement::For<3, RAJA::seq_exec,   // m
-                RAJA::statement::For<0, RAJA::seq_exec, // d
-                  RAJA::statement::Lambda<0>
+      if (tune_idx == 0) {
+
+        auto ltimesnoview_lam = [=](Index_type d, Index_type z,
+                                    Index_type g, Index_type m) {
+                                  LTIMES_NOVIEW_BODY;
+                                };
+
+        using EXEC_POL =
+          RAJA::KernelPolicy<
+            RAJA::statement::For<1, RAJA::seq_exec,       // z
+              RAJA::statement::For<2, RAJA::seq_exec,     // g
+                RAJA::statement::For<3, RAJA::seq_exec,   // m
+                  RAJA::statement::For<0, RAJA::seq_exec, // d
+                    RAJA::statement::Lambda<0>
+                  >
                 >
               >
             >
-          >
-        >;
+          >;
 
-      startTimer();
-      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
-                                                          RAJA::RangeSegment(0, num_z),
-                                                          RAJA::RangeSegment(0, num_g),
-                                                          RAJA::RangeSegment(0, num_m)),
-                                         res,
-                                         ltimesnoview_lam
-                                       );
+          RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
+                                                            RAJA::RangeSegment(0, num_z),
+                                                            RAJA::RangeSegment(0, num_g),
+                                                            RAJA::RangeSegment(0, num_m)),
+                                           res,
+                                           ltimesnoview_lam
+                                         );
+
+        }
+        stopTimer();
+
+      } else if (tune_idx == 1) {
+
+        using launch_policy = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
+
+        using z_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        using g_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        using m_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+        startTimer();
+        for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+          RAJA::launch<launch_policy>( res,
+              RAJA::LaunchParams(),
+              [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+                RAJA::loop<z_policy>(ctx, RAJA::RangeSegment(0, num_z),
+                  [&](Index_type z) {
+                    RAJA::loop<g_policy>(ctx, RAJA::RangeSegment(0, num_g),
+                      [&](Index_type g) {
+                        RAJA::loop<m_policy>(ctx, RAJA::RangeSegment(0, num_m),
+                          [&](Index_type m) {
+                            RAJA::loop<d_policy>(ctx, RAJA::RangeSegment(0, num_d),
+                              [&](Index_type d) {
+                                LTIMES_NOVIEW_BODY
+                              }
+                            ); // RAJA::loop<d_policy>
+                          }
+                        ); // RAJA::loop<m_policy>
+                      }
+                    ); // RAJA::loop<g_policy>
+                  }
+                ); // RAJA::loop<z_policy>
+
+              } // outer lambda (ctx)
+          );    // RAJA::launch
+
+        } // loop over kernel reps
+        stopTimer();
 
       }
-      stopTimer();
 
       break;
     }
@@ -115,6 +165,18 @@ void LTIMES_NOVIEW::runSeqVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune
       getCout() << "\n LTIMES_NOVIEW : Unknown variant id = " << vid << std::endl;
     }
 
+  }
+
+}
+
+void LTIMES_NOVIEW::setSeqTuningDefinitions(VariantID vid)
+{
+
+  if (vid == RAJA_Seq) {
+    addVariantTuningName(vid, "kernel");
+    addVariantTuningName(vid, "launch");
+  } else {
+    addVariantTuningName(vid, "default");
   }
 
 }

--- a/src/apps/LTIMES_NOVIEW-Sycl.cpp
+++ b/src/apps/LTIMES_NOVIEW-Sycl.cpp
@@ -75,9 +75,9 @@ void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid, size_t tune_idx)
       using EXEC_POL =
         RAJA::KernelPolicy<
           RAJA::statement::SyclKernelAsync<
-            RAJA::statement::For<1, RAJA::sycl_global_2<z_wg_sz>,      //z
+            RAJA::statement::For<1, RAJA::sycl_global_0<z_wg_sz>,      //z
               RAJA::statement::For<2, RAJA::sycl_global_1<g_wg_sz>,    //g
-                RAJA::statement::For<3, RAJA::sycl_global_0<m_wg_sz>,  //m
+                RAJA::statement::For<3, RAJA::sycl_global_2<m_wg_sz>,  //m
                   RAJA::statement::For<0, RAJA::seq_exec,              //d
                     RAJA::statement::Lambda<0>
                   >
@@ -109,11 +109,11 @@ void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid, size_t tune_idx)
 
       using launch_policy = RAJA::LaunchPolicy<RAJA::sycl_launch_t<async>>;
 
-      using z_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_2>;
+      using z_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_0>;
 
       using g_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_1>;
 
-      using m_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_0>;
+      using m_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_2>;
 
       using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
 
@@ -127,8 +127,8 @@ void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid, size_t tune_idx)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         RAJA::launch<launch_policy>( res,
-            RAJA::LaunchParams(RAJA::Teams(m_grid_sz, g_grid_sz, z_grid_sz),
-                               RAJA::Threads(m_wg_sz, g_wg_sz, z_wg_sz)),
+            RAJA::LaunchParams(RAJA::Teams(z_grid_sz, g_grid_sz, m_grid_sz),
+                               RAJA::Threads(z_wg_sz, g_wg_sz, m_wg_sz)),
             [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
 
               RAJA::loop<z_policy>(ctx, RAJA::RangeSegment(0, num_z),

--- a/src/apps/LTIMES_NOVIEW-Sycl.cpp
+++ b/src/apps/LTIMES_NOVIEW-Sycl.cpp
@@ -109,11 +109,11 @@ void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid, size_t tune_idx)
 
       using launch_policy = RAJA::LaunchPolicy<RAJA::sycl_launch_t<async>>;
 
-      using z_policy = RAJA::LoopPolicy<RAJA::sycl_global_2<z_wg_sz>>;
+      using z_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_2>;
 
-      using g_policy = RAJA::LoopPolicy<RAJA::sycl_global_1<g_wg_sz>>;
+      using g_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_1>;
 
-      using m_policy = RAJA::LoopPolicy<RAJA::sycl_global_0<m_wg_sz>>;
+      using m_policy = RAJA::LoopPolicy<RAJA::sycl_global_item_0>;
 
       using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
 

--- a/src/apps/LTIMES_NOVIEW-Sycl.cpp
+++ b/src/apps/LTIMES_NOVIEW-Sycl.cpp
@@ -29,7 +29,7 @@ namespace apps
 #define z_wg_sz (integer::lesser_of_squarest_factor_pair(work_group_size/m_wg_sz))
 
 template <size_t work_group_size >
-void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid)
+void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid, size_t tune_idx)
 {
   const Index_type run_reps = getRunReps();
 
@@ -70,43 +70,160 @@ void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid)
 
   } else if ( vid == RAJA_SYCL ) {
 
-    using EXEC_POL =
-      RAJA::KernelPolicy<
-        RAJA::statement::SyclKernelAsync<
-          RAJA::statement::For<1, RAJA::sycl_global_2<z_wg_sz>,      //z
-            RAJA::statement::For<2, RAJA::sycl_global_1<g_wg_sz>,    //g
-              RAJA::statement::For<3, RAJA::sycl_global_0<m_wg_sz>,  //m
-                RAJA::statement::For<0, RAJA::seq_exec,              //d
-                  RAJA::statement::Lambda<0>
+    if (tune_idx == 0) {
+
+      using EXEC_POL =
+        RAJA::KernelPolicy<
+          RAJA::statement::SyclKernelAsync<
+            RAJA::statement::For<1, RAJA::sycl_global_2<z_wg_sz>,      //z
+              RAJA::statement::For<2, RAJA::sycl_global_1<g_wg_sz>,    //g
+                RAJA::statement::For<3, RAJA::sycl_global_0<m_wg_sz>,  //m
+                  RAJA::statement::For<0, RAJA::seq_exec,              //d
+                    RAJA::statement::Lambda<0>
+                  >
                 >
               >
             >
           >
-        >
-      >;
+        >;
 
-    startTimer();
-    for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>( 
-        RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
-                         RAJA::RangeSegment(0, num_z),
-                         RAJA::RangeSegment(0, num_g),
-                         RAJA::RangeSegment(0, num_m)),
-        res,
-        [=] (Index_type d, Index_type z, Index_type g, Index_type m) {
-        LTIMES_NOVIEW_BODY;
-      });
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment(0, num_d),
+                           RAJA::RangeSegment(0, num_z),
+                           RAJA::RangeSegment(0, num_g),
+                           RAJA::RangeSegment(0, num_m)),
+          res,
+          [=] (Index_type d, Index_type z, Index_type g, Index_type m) {
+          LTIMES_NOVIEW_BODY;
+        });
 
+      }
+      stopTimer();
+
+    } else if (tune_idx == 1) {
+
+      constexpr bool async = true;
+
+      using launch_policy = RAJA::LaunchPolicy<RAJA::sycl_launch_t<async>>;
+
+      using z_policy = RAJA::LoopPolicy<RAJA::sycl_global_2<z_wg_sz>>;
+
+      using g_policy = RAJA::LoopPolicy<RAJA::sycl_global_1<g_wg_sz>>;
+
+      using m_policy = RAJA::LoopPolicy<RAJA::sycl_global_0<m_wg_sz>>;
+
+      using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(num_z, z_wg_sz);
+
+      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(num_g, g_wg_sz);
+
+      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(num_m, m_wg_sz);
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
+
+        RAJA::launch<launch_policy>( res,
+            RAJA::LaunchParams(RAJA::Teams(m_grid_sz, g_grid_sz, z_grid_sz),
+                               RAJA::Threads(m_wg_sz, g_wg_sz, z_wg_sz)),
+            [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+              RAJA::loop<z_policy>(ctx, RAJA::RangeSegment(0, num_z),
+                [&](Index_type z) {
+                  RAJA::loop<g_policy>(ctx, RAJA::RangeSegment(0, num_g),
+                    [&](Index_type g) {
+                      RAJA::loop<m_policy>(ctx, RAJA::RangeSegment(0, num_m),
+                        [&](Index_type m) {
+                          RAJA::loop<d_policy>(ctx, RAJA::RangeSegment(0, num_d),
+                            [&](Index_type d) {
+                              LTIMES_NOVIEW_BODY
+                            }
+                          ); // RAJA::loop<d_policy>
+                        }
+                      ); // RAJA::loop<m_policy>
+                    }
+                  ); // RAJA::loop<g_policy>
+                }
+              ); // RAJA::loop<z_policy>
+
+            } // outer lambda (ctx)
+        );    // RAJA::launch
+
+      } // loop over kernel reps
+      stopTimer();
     }
-    stopTimer();
 
   } else {
      std::cout << "\n LTIMES_NOVIEW : Unknown Sycl variant id = " << vid << std::endl;
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(LTIMES_NOVIEW, Sycl)
+void LTIMES_NOVIEW::runSyclVariant(VariantID vid, size_t tune_idx)
+{
+  size_t t = 0;
+
+  seq_for(gpu_block_sizes_type{}, [&](auto work_group_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(work_group_size)) {
+
+      if (vid == RAJA_SYCL) {
+
+        if (tune_idx == t) {
+          setBlockSize(work_group_size);
+          runSyclVariantImpl<work_group_size>(vid, 0);
+
+        }
+
+        t += 1;
+
+        if (tune_idx == t) {
+          setBlockSize(work_group_size);
+          runSyclVariantImpl<work_group_size>(vid, 1);
+
+        }
+
+        t += 1;
+
+      } else {
+
+        if (tune_idx == t) {
+          setBlockSize(work_group_size);
+          runSyclVariantImpl<work_group_size>(vid, 0);
+
+        }
+
+        t += 1;
+      }
+
+    }
+
+  });
+}
+
+void LTIMES_NOVIEW::setSyclTuningDefinitions(VariantID vid)
+{
+
+  seq_for(gpu_block_sizes_type{}, [&](auto work_group_size) {
+
+    if (run_params.numValidGPUBlockSize() == 0u ||
+        run_params.validGPUBlockSize(work_group_size)) {
+
+      if (vid == RAJA_SYCL) {
+        addVariantTuningName(vid, "kernel_"+std::to_string(work_group_size));
+        addVariantTuningName(vid, "launch_"+std::to_string(work_group_size));
+      } else {
+        addVariantTuningName(vid, "block_"+std::to_string(work_group_size));
+      }
+
+    }
+
+  });
+
+}
 
 } // end namespace apps
 } // end namespace rajaperf

--- a/src/apps/LTIMES_NOVIEW-Sycl.cpp
+++ b/src/apps/LTIMES_NOVIEW-Sycl.cpp
@@ -127,8 +127,8 @@ void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid, size_t tune_idx)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         RAJA::launch<launch_policy>( res,
-            RAJA::LaunchParams(RAJA::Teams(z_grid_sz, g_grid_sz, m_grid_sz),
-                               RAJA::Threads(z_wg_sz, g_wg_sz, m_wg_sz)),
+            RAJA::LaunchParams(RAJA::Teams(m_grid_sz, g_grid_sz, z_grid_sz),
+                               RAJA::Threads(m_wg_sz, g_wg_sz, z_wg_sz)),
             [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
 
               RAJA::loop<z_policy>(ctx, RAJA::RangeSegment(0, num_z),

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -56,6 +56,7 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   setComplexity(Complexity::N);
 
   setUsesFeature(Kernel);
+  setUsesFeature(Launch);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );

--- a/src/apps/LTIMES_NOVIEW.hpp
+++ b/src/apps/LTIMES_NOVIEW.hpp
@@ -11,7 +11,7 @@
 ///
 /// for (Index_type z = 0; z < num_z; ++z ) {
 ///   for (Index_type g = 0; g < num_g; ++g ) {
-///     for (Index_type m = 0; z < num_m; ++m ) {
+///     for (Index_type m = 0; m < num_m; ++m ) {
 ///       for (Index_type d = 0; d < num_d; ++d ) {
 ///
 ///         phi[m+ (g * num_m) + (z * num_m * num_g)] +=
@@ -68,16 +68,19 @@ public:
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
   void runSyclVariant(VariantID vid, size_t tune_idx);
 
+  void setSeqTuningDefinitions(VariantID vid);
+  void setOpenMPTuningDefinitions(VariantID vid);
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
+  void setOpenMPTargetTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);
 
   template < size_t block_size >
-  void runCudaVariantImpl(VariantID vid);
+  void runCudaVariantImpl(VariantID vid, size_t tune_idx);
   template < size_t block_size >
-  void runHipVariantImpl(VariantID vid);
+  void runHipVariantImpl(VariantID vid, size_t tune_idx);
   template < size_t work_group_size >
-  void runSyclVariantImpl(VariantID vid);
+  void runSyclVariantImpl(VariantID vid, size_t tune_idx);
 
 private:
   static const size_t default_gpu_block_size = 256;


### PR DESCRIPTION
# Summary

Add tunings to LTIMES kernels for launch in addition to kernel.

This is intended to be used with performance studies to understand differences between the kernel and launch APIs.

Todo:
- [x] Add LTIMES_NOVIEW

- This PR is a feature
- It does the following (modify list as needed):
  - Adds launch tuning at the request of myself
