### PR TITLE
Use RAJA views in all LTIMES variants

### DIFF
--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -108,7 +108,7 @@ void LTIMES::runCudaVariantImpl(VariantID vid, size_t tune_idx)
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
       auto ltimes_lambda = [=] __device__ (IZ z, IG g, IM m) {
-        for (Index_type d(0); d < num_d; ++d ) {
+        for (ID d(0); d < num_d; ++d ) {
           LTIMES_BODY;
         }
       };

--- a/src/apps/LTIMES-Cuda.cpp
+++ b/src/apps/LTIMES-Cuda.cpp
@@ -21,6 +21,8 @@ namespace rajaperf
 namespace apps
 {
 
+using namespace ltimes_idx;
+
 //
 // Define thread block shape for CUDA execution
 //
@@ -36,23 +38,22 @@ namespace apps
   static_assert(m_block_sz*g_block_sz*z_block_sz == block_size, "Invalid block_size");
 
 #define LTIMES_NBLOCKS_CUDA \
-  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz)), \
-               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz)), \
-               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz)));
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(*num_m, m_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(*num_g, g_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(*num_z, z_block_sz)));
 
 
 template < size_t m_block_size, size_t g_block_size, size_t z_block_size >
 __launch_bounds__(m_block_size*g_block_size*z_block_size)
-__global__ void ltimes(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
-                       Index_type num_d,
-                       Index_type num_m, Index_type num_g, Index_type num_z)
+__global__ void ltimes(PHI_VIEW phi, ELL_VIEW ell, PSI_VIEW psi,
+                       ID num_d, IM num_m, IG num_g, IZ num_z)
 {
-   Index_type m = blockIdx.x * m_block_size + threadIdx.x;
-   Index_type g = blockIdx.y * g_block_size + threadIdx.y;
-   Index_type z = blockIdx.z * z_block_size + threadIdx.z;
+   IM m(blockIdx.x * m_block_size + threadIdx.x);
+   IG g(blockIdx.y * g_block_size + threadIdx.y);
+   IZ z(blockIdx.z * z_block_size + threadIdx.z);
 
    if (m < num_m && g < num_g && z < num_z) {
-     for (Index_type d = 0; d < num_d; ++d ) {
+     for (ID d(0); d < num_d; ++d ) {
        LTIMES_BODY;
      }
    }
@@ -60,12 +61,12 @@ __global__ void ltimes(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
 
 template < size_t m_block_size, size_t g_block_size, size_t z_block_size, typename Lambda >
 __launch_bounds__(m_block_size*g_block_size*z_block_size)
-__global__ void ltimes_lam(Index_type num_m, Index_type num_g, Index_type num_z,
+__global__ void ltimes_lam(IM num_m, IG num_g, IZ num_z,
                            Lambda body)
 {
-   Index_type m = blockIdx.x * m_block_size + threadIdx.x;
-   Index_type g = blockIdx.y * g_block_size + threadIdx.y;
-   Index_type z = blockIdx.z * z_block_size + threadIdx.z;
+   IM m(blockIdx.x * m_block_size + threadIdx.x);
+   IG g(blockIdx.y * g_block_size + threadIdx.y);
+   IZ z(blockIdx.z * z_block_size + threadIdx.z);
 
    if (m < num_m && g < num_g && z < num_z) {
      body(z, g, m);
@@ -95,7 +96,7 @@ void LTIMES::runCudaVariantImpl(VariantID vid, size_t tune_idx)
         (ltimes<LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        phidat, elldat, psidat,
+        phi, ell, psi,
         num_d, num_m, num_g, num_z );
 
     }
@@ -106,9 +107,8 @@ void LTIMES::runCudaVariantImpl(VariantID vid, size_t tune_idx)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      auto ltimes_lambda = [=] __device__ (Index_type z, Index_type g, 
-                                           Index_type m) {
-        for (Index_type d = 0; d < num_d; ++d ) {
+      auto ltimes_lambda = [=] __device__ (IZ z, IG g, IM m) {
+        for (Index_type d(0); d < num_d; ++d ) {
           LTIMES_BODY;
         }
       };
@@ -129,8 +129,6 @@ void LTIMES::runCudaVariantImpl(VariantID vid, size_t tune_idx)
     stopTimer();
 
   } else if ( vid == RAJA_CUDA ) {
-
-    LTIMES_VIEWS_RANGES_RAJA;
 
     if (tune_idx == 0) {
 
@@ -153,13 +151,13 @@ void LTIMES::runCudaVariantImpl(VariantID vid, size_t tune_idx)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         RAJA::kernel_resource<EXEC_POL>(
-          RAJA::make_tuple(IDRange(0, num_d),
-                           IZRange(0, num_z),
-                           IGRange(0, num_g),
-                           IMRange(0, num_m)),
+          RAJA::make_tuple(IDRange(0, *num_d),
+                           IZRange(0, *num_z),
+                           IGRange(0, *num_g),
+                           IMRange(0, *num_m)),
           res,
           [=] __device__ (ID d, IZ z, IG g, IM m) {
-            LTIMES_BODY_RAJA;
+            LTIMES_BODY;
           }
         );
 
@@ -180,11 +178,11 @@ void LTIMES::runCudaVariantImpl(VariantID vid, size_t tune_idx)
 
       using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
 
-      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz);
+      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(*num_z, z_block_sz);
 
-      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz);
+      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(*num_g, g_block_sz);
 
-      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz);
+      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(*num_m, m_block_sz);
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -194,15 +192,15 @@ void LTIMES::runCudaVariantImpl(VariantID vid, size_t tune_idx)
                                RAJA::Threads(m_block_sz, g_block_sz, z_block_sz)),
             [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
 
-              RAJA::loop<z_policy>(ctx, IZRange(0, num_z),
+              RAJA::loop<z_policy>(ctx, IZRange(0, *num_z),
                 [&](IZ z) {
-                  RAJA::loop<g_policy>(ctx, IGRange(0, num_g),
+                  RAJA::loop<g_policy>(ctx, IGRange(0, *num_g),
                     [&](IG g) {
-                      RAJA::loop<m_policy>(ctx, IMRange(0, num_m),
+                      RAJA::loop<m_policy>(ctx, IMRange(0, *num_m),
                         [&](IM m) {
-                          RAJA::loop<d_policy>(ctx, IDRange(0, num_d),
+                          RAJA::loop<d_policy>(ctx, IDRange(0, *num_d),
                             [&](ID d) {
-                              LTIMES_BODY_RAJA
+                              LTIMES_BODY
                             }
                           ); // RAJA::loop<d_policy>
                         }

--- a/src/apps/LTIMES-Hip.cpp
+++ b/src/apps/LTIMES-Hip.cpp
@@ -21,6 +21,8 @@ namespace rajaperf
 namespace apps
 {
 
+using namespace ltimes_idx;
+
 //
 // Define thread block shape for Hip execution
 //
@@ -35,23 +37,22 @@ namespace apps
   dim3 nthreads_per_block(LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP);
 
 #define LTIMES_NBLOCKS_HIP \
-  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz)), \
-               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz)), \
-               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz)));
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(*num_m, m_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(*num_g, g_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(*num_z, z_block_sz)));
 
 
 template < size_t m_block_size, size_t g_block_size, size_t z_block_size >
 __launch_bounds__(m_block_size*g_block_size*z_block_size)
-__global__ void ltimes(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
-                       Index_type num_d,
-                       Index_type num_m, Index_type num_g, Index_type num_z)
+__global__ void ltimes(PHI_VIEW phi, ELL_VIEW ell, PSI_VIEW psi,
+                       ID num_d, IM num_m, IG num_g, IZ num_z)
 {
-   Index_type m = blockIdx.x * m_block_size + threadIdx.x;
-   Index_type g = blockIdx.y * g_block_size + threadIdx.y;
-   Index_type z = blockIdx.z * z_block_size + threadIdx.z;
+   IM m(blockIdx.x * m_block_size + threadIdx.x);
+   IG g(blockIdx.y * g_block_size + threadIdx.y);
+   IZ z(blockIdx.z * z_block_size + threadIdx.z);
 
    if (m < num_m && g < num_g && z < num_z) {
-     for (Index_type d = 0; d < num_d; ++d ) {
+     for (ID d(0); d < num_d; ++d ) {
        LTIMES_BODY;
      }
    }
@@ -59,12 +60,12 @@ __global__ void ltimes(Real_ptr phidat, Real_ptr elldat, Real_ptr psidat,
 
 template < size_t m_block_size, size_t g_block_size, size_t z_block_size, typename Lambda >
 __launch_bounds__(m_block_size*g_block_size*z_block_size)
-__global__ void ltimes_lam(Index_type num_m, Index_type num_g, Index_type num_z,
+__global__ void ltimes_lam(IM num_m, IG num_g, IZ num_z,
                            Lambda body)
 {
-   Index_type m = blockIdx.x * m_block_size + threadIdx.x;
-   Index_type g = blockIdx.y * g_block_size + threadIdx.y;
-   Index_type z = blockIdx.z * z_block_size + threadIdx.z;
+   IM m(blockIdx.x * m_block_size + threadIdx.x);
+   IG g(blockIdx.y * g_block_size + threadIdx.y);
+   IZ z(blockIdx.z * z_block_size + threadIdx.z);
 
    if (m < num_m && g < num_g && z < num_z) {
      body(z, g, m);
@@ -94,7 +95,7 @@ void LTIMES::runHipVariantImpl(VariantID vid, size_t tune_idx)
         (ltimes<LTIMES_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        phidat, elldat, psidat,
+        phi, ell, psi,
         num_d, num_m, num_g, num_z );
 
     }
@@ -105,9 +106,8 @@ void LTIMES::runHipVariantImpl(VariantID vid, size_t tune_idx)
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      auto ltimes_lambda = [=] __device__ (Index_type z, Index_type g, 
-                                           Index_type m) {
-       for (Index_type d = 0; d < num_d; ++d ) {
+      auto ltimes_lambda = [=] __device__ (IZ z, IG g, IM m) {
+       for (ID d(0); d < num_d; ++d ) {
          LTIMES_BODY;
        }
       };
@@ -128,8 +128,6 @@ void LTIMES::runHipVariantImpl(VariantID vid, size_t tune_idx)
     stopTimer();
 
   } else if ( vid == RAJA_HIP ) {
-
-    LTIMES_VIEWS_RANGES_RAJA;
 
     if (tune_idx == 0) {
 
@@ -152,13 +150,13 @@ void LTIMES::runHipVariantImpl(VariantID vid, size_t tune_idx)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         RAJA::kernel_resource<EXEC_POL>(
-          RAJA::make_tuple(IDRange(0, num_d),
-                           IZRange(0, num_z),
-                           IGRange(0, num_g),
-                           IMRange(0, num_m)),
+          RAJA::make_tuple(IDRange(0, *num_d),
+                           IZRange(0, *num_z),
+                           IGRange(0, *num_g),
+                           IMRange(0, *num_m)),
           res,
           [=] __device__ (ID d, IZ z, IG g, IM m) {
-            LTIMES_BODY_RAJA;
+            LTIMES_BODY;
           }
         );
 
@@ -179,11 +177,11 @@ void LTIMES::runHipVariantImpl(VariantID vid, size_t tune_idx)
 
       using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
 
-      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(num_z, z_block_sz);
+      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(*num_z, z_block_sz);
 
-      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(num_g, g_block_sz);
+      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(*num_g, g_block_sz);
 
-      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(num_m, m_block_sz);
+      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(*num_m, m_block_sz);
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -193,15 +191,15 @@ void LTIMES::runHipVariantImpl(VariantID vid, size_t tune_idx)
                                RAJA::Threads(m_block_sz, g_block_sz, z_block_sz)),
             [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
 
-              RAJA::loop<z_policy>(ctx, IZRange(0, num_z),
+              RAJA::loop<z_policy>(ctx, IZRange(0, *num_z),
                 [&](IZ z) {
-                  RAJA::loop<g_policy>(ctx, IGRange(0, num_g),
+                  RAJA::loop<g_policy>(ctx, IGRange(0, *num_g),
                     [&](IG g) {
-                      RAJA::loop<m_policy>(ctx, IMRange(0, num_m),
+                      RAJA::loop<m_policy>(ctx, IMRange(0, *num_m),
                         [&](IM m) {
-                          RAJA::loop<d_policy>(ctx, IDRange(0, num_d),
+                          RAJA::loop<d_policy>(ctx, IDRange(0, *num_d),
                             [&](ID d) {
-                              LTIMES_BODY_RAJA
+                              LTIMES_BODY
                             }
                           ); // RAJA::loop<d_policy>
                         }

--- a/src/apps/LTIMES-OMP.cpp
+++ b/src/apps/LTIMES-OMP.cpp
@@ -17,6 +17,7 @@ namespace rajaperf
 namespace apps
 {
 
+using namespace ltimes_idx;
 
 void LTIMES::runOpenMPVariant(VariantID vid, size_t tune_idx)
 {
@@ -34,10 +35,11 @@ void LTIMES::runOpenMPVariant(VariantID vid, size_t tune_idx)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         #pragma omp parallel for
-        for (Index_type z = 0; z < num_z; ++z ) {
-          for (Index_type g = 0; g < num_g; ++g ) {
-            for (Index_type m = 0; m < num_m; ++m ) {
-              for (Index_type d = 0; d < num_d; ++d ) {
+        for (RAJA::Index_type iz = 0; iz < *num_z; ++iz ) {
+          IZ z(iz);
+          for (IG g(0); g < num_g; ++g ) {
+            for (IM m(0); m < num_m; ++m ) {
+              for (ID d(0); d < num_d; ++d ) {
                 LTIMES_BODY;
               }
             }
@@ -52,8 +54,7 @@ void LTIMES::runOpenMPVariant(VariantID vid, size_t tune_idx)
 
     case Lambda_OpenMP : {
 
-      auto ltimes_base_lam = [=](Index_type d, Index_type z,
-                                 Index_type g, Index_type m) {
+      auto ltimes_base_lam = [=](ID d, IZ z, IG g, IM m) {
                                LTIMES_BODY;
                              };
 
@@ -61,10 +62,11 @@ void LTIMES::runOpenMPVariant(VariantID vid, size_t tune_idx)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         #pragma omp parallel for
-        for (Index_type z = 0; z < num_z; ++z ) {
-          for (Index_type g = 0; g < num_g; ++g ) {
-            for (Index_type m = 0; m < num_m; ++m ) {
-              for (Index_type d = 0; d < num_d; ++d ) {
+        for (RAJA::Index_type iz = 0; iz < *num_z; ++iz ) {
+          IZ z(iz);
+          for (IG g(0); g < num_g; ++g ) {
+            for (IM m(0); m < num_m; ++m ) {
+              for (ID d(0); d < num_d; ++d ) {
                 ltimes_base_lam(d, z, g, m);
               }
             }
@@ -81,12 +83,10 @@ void LTIMES::runOpenMPVariant(VariantID vid, size_t tune_idx)
 
       auto res{getHostResource()};
 
-      LTIMES_VIEWS_RANGES_RAJA;
-
       if (tune_idx == 0) {
 
         auto ltimes_lam = [=](ID d, IZ z, IG g, IM m) {
-                            LTIMES_BODY_RAJA;
+                            LTIMES_BODY;
                           };
 
         using EXEC_POL =
@@ -105,10 +105,10 @@ void LTIMES::runOpenMPVariant(VariantID vid, size_t tune_idx)
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-          RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, num_d),
-                                                            IZRange(0, num_z),
-                                                            IGRange(0, num_g),
-                                                            IMRange(0, num_m)),
+          RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, *num_d),
+                                                            IZRange(0, *num_z),
+                                                            IGRange(0, *num_g),
+                                                            IMRange(0, *num_m)),
                                            res,
                                            ltimes_lam
                                          );
@@ -135,15 +135,15 @@ void LTIMES::runOpenMPVariant(VariantID vid, size_t tune_idx)
               RAJA::LaunchParams(),
               [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
 
-                RAJA::loop<z_policy>(ctx, IZRange(0, num_z),
+                RAJA::loop<z_policy>(ctx, IZRange(0, *num_z),
                   [&](IZ z) {
-                    RAJA::loop<g_policy>(ctx, IGRange(0, num_g),
+                    RAJA::loop<g_policy>(ctx, IGRange(0, *num_g),
                       [&](IG g) {
-                        RAJA::loop<m_policy>(ctx, IMRange(0, num_m),
+                        RAJA::loop<m_policy>(ctx, IMRange(0, *num_m),
                           [&](IM m) {
-                            RAJA::loop<d_policy>(ctx, IDRange(0, num_d),
+                            RAJA::loop<d_policy>(ctx, IDRange(0, *num_d),
                               [&](ID d) {
-                                LTIMES_BODY_RAJA
+                                LTIMES_BODY
                               }
                             ); // RAJA::loop<d_policy>
                           }

--- a/src/apps/LTIMES-OMPTarget.cpp
+++ b/src/apps/LTIMES-OMPTarget.cpp
@@ -34,7 +34,7 @@ void LTIMES::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      #pragma omp target device( did )
+      #pragma omp target firstprivate(psi, ell, phi, num_z, num_g, num_m, num_d) device( did )
       #pragma omp teams distribute parallel for schedule(static, 1) collapse(3)
       for (RAJA::Index_type iz = 0; iz < *num_z; ++iz ) {
         for (RAJA::Index_type ig = 0; ig < *num_g; ++ig ) {

--- a/src/apps/LTIMES-OMPTarget.cpp
+++ b/src/apps/LTIMES-OMPTarget.cpp
@@ -21,6 +21,7 @@ namespace rajaperf
 namespace apps
 {
 
+using namespace ltimes_idx;
 
 void LTIMES::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
@@ -35,10 +36,13 @@ void LTIMES::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
 
       #pragma omp target is_device_ptr(phidat, elldat, psidat) device( did )
       #pragma omp teams distribute parallel for schedule(static, 1) collapse(3)
-      for (Index_type z = 0; z < num_z; ++z ) {
-        for (Index_type g = 0; g < num_g; ++g ) {
-          for (Index_type m = 0; m < num_m; ++m ) {
-            for (Index_type d = 0; d < num_d; ++d ) {
+      for (RAJA::Index_type iz = 0; iz < *num_z; ++iz ) {
+        for (RAJA::Index_type ig = 0; ig < *num_g; ++ig ) {
+          for (RAJA::Index_type im = 0; im < *num_m; ++im ) {
+            IZ z(iz);
+            IG g(ig);
+            IM m(im);
+            for (ID d(0); d < num_d; ++d ) {
               LTIMES_BODY;
             }
           }
@@ -51,8 +55,6 @@ void LTIMES::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
   } else if ( vid == RAJA_OpenMPTarget ) {
 
     auto res{getOmpTargetResource()};
-
-    LTIMES_VIEWS_RANGES_RAJA;
 
     using EXEC_POL =
       RAJA::KernelPolicy<
@@ -67,13 +69,13 @@ void LTIMES::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, num_d),
-                                                        IZRange(0, num_z),
-                                                        IGRange(0, num_g),
-                                                        IMRange(0, num_m)),
+      RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, *num_d),
+                                                        IZRange(0, *num_z),
+                                                        IGRange(0, *num_g),
+                                                        IMRange(0, *num_m)),
         res,
         [=] (ID d, IZ z, IG g, IM m) {
-        LTIMES_BODY_RAJA;
+        LTIMES_BODY;
       });
 
     }

--- a/src/apps/LTIMES-OMPTarget.cpp
+++ b/src/apps/LTIMES-OMPTarget.cpp
@@ -34,7 +34,7 @@ void LTIMES::runOpenMPTargetVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tu
     startTimer();
     for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-      #pragma omp target is_device_ptr(phidat, elldat, psidat) device( did )
+      #pragma omp target device( did )
       #pragma omp teams distribute parallel for schedule(static, 1) collapse(3)
       for (RAJA::Index_type iz = 0; iz < *num_z; ++iz ) {
         for (RAJA::Index_type ig = 0; ig < *num_g; ++ig ) {

--- a/src/apps/LTIMES-Seq.cpp
+++ b/src/apps/LTIMES-Seq.cpp
@@ -17,6 +17,7 @@ namespace rajaperf
 namespace apps
 {
 
+using namespace ltimes_idx;
 
 void LTIMES::runSeqVariant(VariantID vid, size_t tune_idx)
 {
@@ -31,10 +32,10 @@ void LTIMES::runSeqVariant(VariantID vid, size_t tune_idx)
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        for (Index_type z = 0; z < num_z; ++z ) {
-          for (Index_type g = 0; g < num_g; ++g ) {
-            for (Index_type m = 0; m < num_m; ++m ) {
-              for (Index_type d = 0; d < num_d; ++d ) {
+        for (IZ z(0); z < num_z; ++z ) {
+          for (IG g(0); g < num_g; ++g ) {
+            for (IM m(0); m < num_m; ++m ) {
+              for (ID d(0); d < num_d; ++d ) {
                 LTIMES_BODY;
               }
             }
@@ -50,18 +51,17 @@ void LTIMES::runSeqVariant(VariantID vid, size_t tune_idx)
 #if defined(RUN_RAJA_SEQ)
     case Lambda_Seq : {
 
-      auto ltimes_base_lam = [=](Index_type d, Index_type z,
-                                 Index_type g, Index_type m) {
+      auto ltimes_base_lam = [=](ID d, IZ z, IG g, IM m) {
                                LTIMES_BODY;
                              };
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-        for (Index_type z = 0; z < num_z; ++z ) {
-          for (Index_type g = 0; g < num_g; ++g ) {
-            for (Index_type m = 0; m < num_m; ++m ) {
-              for (Index_type d = 0; d < num_d; ++d ) {
+        for (IZ z(0); z < num_z; ++z ) {
+          for (IG g(0); g < num_g; ++g ) {
+            for (IM m(0); m < num_m; ++m ) {
+              for (ID d(0); d < num_d; ++d ) {
                 ltimes_base_lam(d, z, g, m);
               }
             }
@@ -78,14 +78,11 @@ void LTIMES::runSeqVariant(VariantID vid, size_t tune_idx)
 
       auto res{getHostResource()};
 
-      LTIMES_VIEWS_RANGES_RAJA;
-
       if (tune_idx == 0) {
 
         auto ltimes_lam = [=](ID d, IZ z, IG g, IM m) {
-                            LTIMES_BODY_RAJA;
+                            LTIMES_BODY;
                           };
-
 
         using EXEC_POL =
           RAJA::KernelPolicy<
@@ -103,10 +100,10 @@ void LTIMES::runSeqVariant(VariantID vid, size_t tune_idx)
         startTimer();
         for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
-          RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, num_d),
-                                                            IZRange(0, num_z),
-                                                            IGRange(0, num_g),
-                                                            IMRange(0, num_m)),
+          RAJA::kernel_resource<EXEC_POL>( RAJA::make_tuple(IDRange(0, *num_d),
+                                                            IZRange(0, *num_z),
+                                                            IGRange(0, *num_g),
+                                                            IMRange(0, *num_m)),
                                            res,
                                            ltimes_lam
                                          );
@@ -133,15 +130,15 @@ void LTIMES::runSeqVariant(VariantID vid, size_t tune_idx)
               RAJA::LaunchParams(),
               [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
 
-                RAJA::loop<z_policy>(ctx, IZRange(0, num_z),
+                RAJA::loop<z_policy>(ctx, IZRange(0, *num_z),
                   [&](IZ z) {
-                    RAJA::loop<g_policy>(ctx, IGRange(0, num_g),
+                    RAJA::loop<g_policy>(ctx, IGRange(0, *num_g),
                       [&](IG g) {
-                        RAJA::loop<m_policy>(ctx, IMRange(0, num_m),
+                        RAJA::loop<m_policy>(ctx, IMRange(0, *num_m),
                           [&](IM m) {
-                            RAJA::loop<d_policy>(ctx, IDRange(0, num_d),
+                            RAJA::loop<d_policy>(ctx, IDRange(0, *num_d),
                               [&](ID d) {
-                                LTIMES_BODY_RAJA
+                                LTIMES_BODY
                               }
                             ); // RAJA::loop<d_policy>
                           }

--- a/src/apps/LTIMES-Sycl.cpp
+++ b/src/apps/LTIMES-Sycl.cpp
@@ -21,6 +21,8 @@ namespace rajaperf
 namespace apps
 {
 
+using namespace ltimes_idx;
+
 //
 // Define work-group shape for SYCL execution
 //
@@ -40,9 +42,9 @@ void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
 
   if ( vid == Base_SYCL ) {
 
-    sycl::range<3> global_dim(z_wg_sz * RAJA_DIVIDE_CEILING_INT(num_z, z_wg_sz),
-                              g_wg_sz * RAJA_DIVIDE_CEILING_INT(num_g, g_wg_sz),
-                              m_wg_sz * RAJA_DIVIDE_CEILING_INT(num_m, m_wg_sz));
+    sycl::range<3> global_dim(z_wg_sz * RAJA_DIVIDE_CEILING_INT(*num_z, z_wg_sz),
+                              g_wg_sz * RAJA_DIVIDE_CEILING_INT(*num_g, g_wg_sz),
+                              m_wg_sz * RAJA_DIVIDE_CEILING_INT(*num_m, m_wg_sz));
     sycl::range<3> wkgroup_dim(z_wg_sz, g_wg_sz, m_wg_sz);
 
     startTimer();
@@ -52,12 +54,12 @@ void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
         h.parallel_for(sycl::nd_range<3> ( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 
-          Index_type m = item.get_global_id(2);
-          Index_type g = item.get_global_id(1);
-          Index_type z = item.get_global_id(0);
+          IM m(item.get_global_id(2));
+          IG g(item.get_global_id(1));
+          IZ z(item.get_global_id(0));
 
           if (m < num_m && g < num_g && z < num_z) {
-            for (Index_type d = 0; d < num_d; ++d) {
+            for (ID d(0); d < num_d; ++d) {
               LTIMES_BODY;
             }
           }
@@ -69,8 +71,6 @@ void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
     stopTimer();
 
   } else if ( vid == RAJA_SYCL ) {
-
-    LTIMES_VIEWS_RANGES_RAJA;
 
     if (tune_idx == 0) {
 
@@ -93,13 +93,13 @@ void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
 
         RAJA::kernel_resource<EXEC_POL>( 
-          RAJA::make_tuple(IDRange(0, num_d),
-                           IZRange(0, num_z),
-                           IGRange(0, num_g),
-                           IMRange(0, num_m)),
+          RAJA::make_tuple(IDRange(0, *num_d),
+                           IZRange(0, *num_z),
+                           IGRange(0, *num_g),
+                           IMRange(0, *num_m)),
           res,
           [=] (ID d, IZ z, IG g, IM m) {
-          LTIMES_BODY_RAJA;
+          LTIMES_BODY;
         });
 
       }
@@ -119,11 +119,11 @@ void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
 
       using d_policy = RAJA::LoopPolicy<RAJA::seq_exec>;
 
-      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(num_z, z_wg_sz);
+      const size_t z_grid_sz = RAJA_DIVIDE_CEILING_INT(*num_z, z_wg_sz);
 
-      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(num_g, g_wg_sz);
+      const size_t g_grid_sz = RAJA_DIVIDE_CEILING_INT(*num_g, g_wg_sz);
 
-      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(num_m, m_wg_sz);
+      const size_t m_grid_sz = RAJA_DIVIDE_CEILING_INT(*num_m, m_wg_sz);
 
       startTimer();
       for (RepIndex_type irep = 0; irep < run_reps; ++irep) {
@@ -133,15 +133,15 @@ void LTIMES::runSyclVariantImpl(VariantID vid, size_t tune_idx)
                                RAJA::Threads(m_wg_sz, g_wg_sz, z_wg_sz)),
             [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
 
-              RAJA::loop<z_policy>(ctx, IZRange(0, num_z),
+              RAJA::loop<z_policy>(ctx, IZRange(0, *num_z),
                 [&](IZ z) {
-                  RAJA::loop<g_policy>(ctx, IGRange(0, num_g),
+                  RAJA::loop<g_policy>(ctx, IGRange(0, *num_g),
                     [&](IG g) {
-                      RAJA::loop<m_policy>(ctx, IMRange(0, num_m),
+                      RAJA::loop<m_policy>(ctx, IMRange(0, *num_m),
                         [&](IM m) {
-                          RAJA::loop<d_policy>(ctx, IDRange(0, num_d),
+                          RAJA::loop<d_policy>(ctx, IDRange(0, *num_d),
                             [&](ID d) {
-                              LTIMES_BODY_RAJA
+                              LTIMES_BODY
                             }
                           ); // RAJA::loop<d_policy>
                         }

--- a/src/apps/LTIMES.hpp
+++ b/src/apps/LTIMES.hpp
@@ -31,50 +31,23 @@
 #define RAJAPerf_Apps_LTIMES_HPP
 
 #define LTIMES_DATA_SETUP \
-  Real_ptr phidat = m_phidat; \
-  Real_ptr elldat = m_elldat; \
-  Real_ptr psidat = m_psidat; \
+  ID num_d(m_num_d); \
+  IZ num_z(m_num_z); \
+  IG num_g(m_num_g); \
+  IM num_m(m_num_m); \
 \
-  Index_type num_d = m_num_d; \
-  Index_type num_z = m_num_z; \
-  Index_type num_g = m_num_g; \
-  Index_type num_m = m_num_m;
+  PSI_VIEW psi(m_psidat, \
+               RAJA::make_permuted_layout( {{*num_z, *num_g, *num_d}}, \
+                     RAJA::as_array<RAJA::Perm<0, 1, 2> >::get() ) ); \
+  ELL_VIEW ell(m_elldat, \
+               RAJA::make_permuted_layout( {{*num_m, *num_d}}, \
+                     RAJA::as_array<RAJA::Perm<0, 1> >::get() ) ); \
+  PHI_VIEW phi(m_phidat, \
+               RAJA::make_permuted_layout( {{*num_z, *num_g, *num_m}}, \
+                     RAJA::as_array<RAJA::Perm<0, 1, 2> >::get() ) );
 
 #define LTIMES_BODY \
-  phidat[m+ (g * num_m) + (z * num_m * num_g)] += \
-    elldat[d+ (m * num_d)] * psidat[d+ (g * num_d) + (z * num_d * num_g)];
-
-#define LTIMES_BODY_RAJA \
   phi(z, g, m) +=  ell(m, d) * psi(z, g, d);
-
-
-#define LTIMES_VIEWS_RANGES_RAJA \
-  using namespace ltimes_idx; \
-\
-  using PSI_VIEW = RAJA::TypedView<Real_type, \
-                                   RAJA::Layout<3, Index_type, 2>, \
-                                   IZ, IG, ID>; \
-  using ELL_VIEW = RAJA::TypedView<Real_type, \
-                                   RAJA::Layout<2, Index_type, 1>, \
-                                   IM, ID>; \
-  using PHI_VIEW = RAJA::TypedView<Real_type, \
-                                   RAJA::Layout<3, Index_type, 2>, \
-                                   IZ, IG, IM>; \
-\
-  PSI_VIEW psi(psidat, \
-               RAJA::make_permuted_layout( {{num_z, num_g, num_d}}, \
-                     RAJA::as_array<RAJA::Perm<0, 1, 2> >::get() ) ); \
-  ELL_VIEW ell(elldat, \
-               RAJA::make_permuted_layout( {{num_m, num_d}}, \
-                     RAJA::as_array<RAJA::Perm<0, 1> >::get() ) ); \
-  PHI_VIEW phi(phidat, \
-               RAJA::make_permuted_layout( {{num_z, num_g, num_m}}, \
-                     RAJA::as_array<RAJA::Perm<0, 1, 2> >::get() ) ); \
-\
-      using IDRange = RAJA::TypedRangeSegment<ID>; \
-      using IZRange = RAJA::TypedRangeSegment<IZ>; \
-      using IGRange = RAJA::TypedRangeSegment<IG>; \
-      using IMRange = RAJA::TypedRangeSegment<IM>;
 
 
 #include "common/KernelBase.hpp"
@@ -97,6 +70,21 @@ namespace ltimes_idx {
   RAJA_INDEX_VALUE(IZ, "IZ");
   RAJA_INDEX_VALUE(IG, "IG");
   RAJA_INDEX_VALUE(IM, "IM");
+
+  using PSI_VIEW = RAJA::TypedView<Real_type,
+                                   RAJA::Layout<3, Index_type, 2>,
+                                   IZ, IG, ID>;
+  using ELL_VIEW = RAJA::TypedView<Real_type,
+                                   RAJA::Layout<2, Index_type, 1>,
+                                   IM, ID>;
+  using PHI_VIEW = RAJA::TypedView<Real_type,
+                                   RAJA::Layout<3, Index_type, 2>,
+                                   IZ, IG, IM>;
+
+  using IDRange = RAJA::TypedRangeSegment<ID>;
+  using IZRange = RAJA::TypedRangeSegment<IZ>;
+  using IGRange = RAJA::TypedRangeSegment<IG>;
+  using IMRange = RAJA::TypedRangeSegment<IM>;
 }
 
 class LTIMES : public KernelBase


### PR DESCRIPTION
# Summary

The difference between LTIMES and LTIMES_NOVIEW is supposed to be whether a view is used or not. However only the RAJA variants of LTIMES used a view. Use RAJA views in all LTIMES variants so the only difference is the backend.
