### PR TITLE
Use hip wavesize from RAJA

### DIFF
--- a/src/algorithm/ATOMIC-Hip.cpp
+++ b/src/algorithm/ATOMIC-Hip.cpp
@@ -24,7 +24,7 @@ namespace rajaperf
 namespace algorithm
 {
 
-const size_t warp_size = 64;
+const size_t warp_size = RAJA_HIP_WAVESIZE;
 
 template < size_t block_size, size_t replication >
 __launch_bounds__(block_size)

--- a/src/algorithm/HISTOGRAM-Hip.cpp
+++ b/src/algorithm/HISTOGRAM-Hip.cpp
@@ -29,7 +29,7 @@ namespace rajaperf
 namespace algorithm
 {
 
-constexpr Index_type warp_size = 64;
+constexpr Index_type warp_size = RAJA_HIP_WAVESIZE;
 
 template < Index_type block_size >
 __launch_bounds__(block_size)

--- a/src/basic/MULTI_REDUCE-Hip.cpp
+++ b/src/basic/MULTI_REDUCE-Hip.cpp
@@ -21,7 +21,7 @@ namespace rajaperf
 namespace basic
 {
 
-constexpr Index_type warp_size = 64;
+constexpr Index_type warp_size = RAJA_HIP_WAVESIZE;
 
 template < Index_type block_size >
 __launch_bounds__(block_size)

--- a/src/common/HipGridScan.hpp
+++ b/src/common/HipGridScan.hpp
@@ -15,6 +15,8 @@
 
 #include <iostream>
 
+#include "RAJA/config.hpp"
+
 namespace rajaperf
 {
 namespace detail
@@ -25,7 +27,7 @@ namespace hip
 //
 // Define magic numbers for HIP execution
 //
-const size_t warp_size = 64;
+const size_t warp_size = RAJA_HIP_WAVESIZE;
 const size_t max_static_shmem = 65536;
 
 


### PR DESCRIPTION
# Summary

Get the hip wave size from RAJA as there is a config option there.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes (issue number(s))
