### PR TITLE
Fix hang in hip custom scan with warp size 32

### DIFF
--- a/scripts/ubuntu-builds/ubuntu_amdclang.sh
+++ b/scripts/ubuntu-builds/ubuntu_amdclang.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+###############################################################################
+# Copyright (c) 2017-25, Lawrence Livermore National Security, LLC
+# and RAJA project contributors. See the RAJAPerf/LICENSE file for details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+if [[ $# -lt 2 ]]; then
+  echo
+  echo "You must pass 2 or more arguments to the script (in this order): "
+  echo "   1) compiler version number"
+  echo "   2) HIP compute architecture"
+  echo "   3...) optional arguments to cmake"
+  echo
+  echo "For example: "
+  echo "    toss4_amdclang.sh 6.4.1 gfx1201"
+  exit
+fi
+
+COMP_VER=$1
+COMP_ARCH=$2
+shift 2
+
+HOSTCONFIG="clang_X"
+
+BUILD_SUFFIX=lc_toss4-amdclang-${COMP_VER}-${COMP_ARCH}
+RAJA_HOSTCONFIG=../tpl/RAJA/host-configs/ubuntu-builds/${HOSTCONFIG}.cmake
+
+echo
+echo "Creating build directory ${BUILD_SUFFIX} and generating configuration in it"
+echo "Configuration extra arguments:"
+echo "   $@"
+echo
+echo "To get cmake to work you may have to configure with"
+echo "   -DHIP_PLATFORM=amd"
+echo
+echo "To use fp64 HW atomics you must configure with these options when using gfx90a and hip >= 5.2"
+echo "   -DCMAKE_CXX_FLAGS=\"-munsafe-fp-atomics\""
+echo
+
+rm -rf build_${BUILD_SUFFIX} >/dev/null
+mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
+
+
+# unload rocm to avoid configuration problems where the loaded rocm and COMP_VER
+# are inconsistent causing the rocprim from the module to be used unexpectedly
+# module unload rocm
+
+ROCM_PATH="/opt/rocm-${COMP_VER}"
+
+cmake \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DROCM_ROOT_DIR="${ROCM_PATH}" \
+  -DHIP_ROOT_DIR="${ROCM_PATH}/hip" \
+  -DHIP_PATH=${ROCM_PATH}/llvm/bin \
+  -DCMAKE_C_COMPILER=${ROCM_PATH}/llvm/bin/amdclang \
+  -DCMAKE_CXX_COMPILER=${ROCM_PATH}/llvm/bin/amdclang++ \
+  -DCMAKE_HIP_ARCHITECTURES="${COMP_ARCH}" \
+  -DGPU_TARGETS="${COMP_ARCH}" \
+  -DAMDGPU_TARGETS="${COMP_ARCH}" \
+  -DBLT_CXX_STD=c++14 \
+  -C ${RAJA_HOSTCONFIG} \
+  -DENABLE_HIP=ON \
+  -DENABLE_OPENMP=ON \
+  -DENABLE_CUDA=OFF \
+  -DCMAKE_INSTALL_PREFIX=../install_${BUILD_SUFFIX} \
+  "$@" \
+  ..
+
+echo
+echo "***********************************************************************"
+echo
+echo "cd into directory build_${BUILD_SUFFIX} and run make to build RAJAPerf"
+echo
+echo "***********************************************************************"

--- a/src/algorithm/SCAN-Cuda.cpp
+++ b/src/algorithm/SCAN-Cuda.cpp
@@ -34,11 +34,11 @@ using cuda_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
 __global__ void scan_custom(Real_ptr x,
-                     Real_ptr y,
-                     Real_ptr block_counts,
-                     Real_ptr grid_counts,
-                     unsigned* block_readys,
-                     Index_type iend)
+                            Real_ptr y,
+                            Real_ptr block_counts,
+                            Real_ptr grid_counts,
+                            unsigned* block_readys,
+                            Index_type iend)
 {
   // blocks do start running in order in cuda, so a block with a higher
   // index can wait on a block with a lower index without deadlocking

--- a/src/algorithm/SCAN-Cuda.cpp
+++ b/src/algorithm/SCAN-Cuda.cpp
@@ -33,7 +33,7 @@ using cuda_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
 
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
-__global__ void scan(Real_ptr x,
+__global__ void scan_custom(Real_ptr x,
                      Real_ptr y,
                      Real_ptr block_counts,
                      Real_ptr grid_counts,
@@ -141,7 +141,7 @@ void SCAN::runCudaVariantLibrary(VariantID vid)
 }
 
 template < size_t block_size, size_t items_per_thread >
-void SCAN::runCudaVariantImpl(VariantID vid)
+void SCAN::runCudaVariantCustom(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -168,7 +168,7 @@ void SCAN::runCudaVariantImpl(VariantID vid)
 
       cudaErrchk( cudaMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size,
                                   res.get_stream()) );
-      RPlaunchCudaKernel( (scan<block_size, items_per_thread>),
+      RPlaunchCudaKernel( (scan_custom<block_size, items_per_thread>),
                           grid_size, block_size,
                           shmem_size, res.get_stream(),
                           x+ibegin, y+ibegin,
@@ -203,7 +203,7 @@ void SCAN::runCudaVariant(VariantID vid, size_t tune_idx)
 
     t += 1;
 
-    if ( vid == Base_CUDA ) {
+    if ( vid == Base_CUDA && run_params.getEnableCustomScan() ) {
 
       seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 
@@ -216,7 +216,7 @@ void SCAN::runCudaVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              runCudaVariantImpl<decltype(block_size)::value,
+              runCudaVariantCustom<decltype(block_size)::value,
                                  detail::cuda::grid_scan_default_items_per_thread<
                                     Real_type, block_size, RAJA_PERFSUITE_TUNING_CUDA_ARCH>::value
                                  >(vid);
@@ -234,7 +234,7 @@ void SCAN::runCudaVariant(VariantID vid, size_t tune_idx)
 
               if (tune_idx == t) {
 
-                runCudaVariantImpl<decltype(block_size)::value, items_per_thread>(vid);
+                runCudaVariantCustom<decltype(block_size)::value, items_per_thread>(vid);
 
               }
 
@@ -263,7 +263,7 @@ void SCAN::setCudaTuningDefinitions(VariantID vid)
 
     addVariantTuningName(vid, "cub");
 
-    if ( vid == Base_CUDA ) {
+    if ( vid == Base_CUDA && run_params.getEnableCustomScan() ) {
 
       seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 

--- a/src/algorithm/SCAN-Hip.cpp
+++ b/src/algorithm/SCAN-Hip.cpp
@@ -38,7 +38,7 @@ using hip_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
 
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
-__global__ void scan(Real_ptr x,
+__global__ void scan_custom(Real_ptr x,
                      Real_ptr y,
                      Real_ptr block_counts,
                      Real_ptr grid_counts,
@@ -168,7 +168,7 @@ void SCAN::runHipVariantLibrary(VariantID vid)
 }
 
 template < size_t block_size, size_t items_per_thread >
-void SCAN::runHipVariantImpl(VariantID vid)
+void SCAN::runHipVariantCustom(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -196,7 +196,7 @@ void SCAN::runHipVariantImpl(VariantID vid)
       hipErrchk( hipMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size,
                                 res.get_stream()) );
 
-      RPlaunchHipKernel( (scan<block_size, items_per_thread>),
+      RPlaunchHipKernel( (scan_custom<block_size, items_per_thread>),
                          grid_size, block_size,
                          shmem_size, res.get_stream(),
                          x+ibegin, y+ibegin,
@@ -230,7 +230,7 @@ void SCAN::runHipVariant(VariantID vid, size_t tune_idx)
 
     t += 1;
 
-    if ( vid == Base_HIP ) {
+    if ( vid == Base_HIP && run_params.getEnableCustomScan() ) {
 
       seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 
@@ -243,7 +243,7 @@ void SCAN::runHipVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              runHipVariantImpl<decltype(block_size)::value,
+              runHipVariantCustom<decltype(block_size)::value,
                                  detail::hip::grid_scan_default_items_per_thread<
                                     Real_type, block_size, RAJA_PERFSUITE_TUNING_HIP_ARCH>::value
                                  >(vid);
@@ -261,7 +261,7 @@ void SCAN::runHipVariant(VariantID vid, size_t tune_idx)
 
               if (tune_idx == t) {
 
-                runHipVariantImpl<block_size, items_per_thread>(vid);
+                runHipVariantCustom<block_size, items_per_thread>(vid);
 
               }
 
@@ -289,7 +289,7 @@ void SCAN::setHipTuningDefinitions(VariantID vid)
 
     addVariantTuningName(vid, "rocprim");
 
-    if ( vid == Base_HIP ) {
+    if ( vid == Base_HIP && run_params.getEnableCustomScan() ) {
 
       seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 

--- a/src/algorithm/SCAN-Hip.cpp
+++ b/src/algorithm/SCAN-Hip.cpp
@@ -39,11 +39,11 @@ using hip_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
 __global__ void scan_custom(Real_ptr x,
-                     Real_ptr y,
-                     Real_ptr block_counts,
-                     Real_ptr grid_counts,
-                     unsigned* block_readys,
-                     Index_type iend)
+                            Real_ptr y,
+                            Real_ptr block_counts,
+                            Real_ptr grid_counts,
+                            unsigned* block_readys,
+                            Index_type iend)
 {
   // It looks like blocks do not start running in order in hip, so a block
   // with a higher index can't wait on a block with a lower index without

--- a/src/algorithm/SCAN.hpp
+++ b/src/algorithm/SCAN.hpp
@@ -70,9 +70,9 @@ public:
   void runHipVariantLibrary(VariantID vid);
 
   template < size_t block_size, size_t items_per_thread >
-  void runCudaVariantImpl(VariantID vid);
+  void runCudaVariantCustom(VariantID vid);
   template < size_t block_size, size_t items_per_thread >
-  void runHipVariantImpl(VariantID vid);
+  void runHipVariantCustom(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/basic/INDEXLIST-Cuda.cpp
+++ b/src/basic/INDEXLIST-Cuda.cpp
@@ -31,12 +31,12 @@ using cuda_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
 __global__ void indexlist_custom(Real_ptr x,
-                          Int_ptr list,
-                          Index_type* block_counts,
-                          Index_type* grid_counts,
-                          unsigned* block_readys,
-                          Index_type* len,
-                          Index_type iend)
+                                 Int_ptr list,
+                                 Index_type* block_counts,
+                                 Index_type* grid_counts,
+                                 unsigned* block_readys,
+                                 Index_type* len,
+                                 Index_type iend)
 {
   // blocks do start running in order in cuda, so a block with a higher
   // index can wait on a block with a lower index without deadlocking

--- a/src/basic/INDEXLIST-Cuda.cpp
+++ b/src/basic/INDEXLIST-Cuda.cpp
@@ -30,7 +30,7 @@ using cuda_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
 
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
-__global__ void indexlist(Real_ptr x,
+__global__ void indexlist_custom(Real_ptr x,
                           Int_ptr list,
                           Index_type* block_counts,
                           Index_type* grid_counts,
@@ -78,7 +78,7 @@ __global__ void indexlist(Real_ptr x,
 
 
 template < size_t block_size, size_t items_per_thread >
-void INDEXLIST::runCudaVariantImpl(VariantID vid)
+void INDEXLIST::runCudaVariantCustom(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -107,7 +107,7 @@ void INDEXLIST::runCudaVariantImpl(VariantID vid)
 
       cudaErrchk( cudaMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size, 
                                   res.get_stream()) );
-      RPlaunchCudaKernel( (indexlist<block_size, items_per_thread>),
+      RPlaunchCudaKernel( (indexlist_custom<block_size, items_per_thread>),
                           grid_size, block_size,
                           shmem_size, res.get_stream(),
                           x+ibegin, list+ibegin,
@@ -135,7 +135,7 @@ void INDEXLIST::runCudaVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
 
-  if ( vid == Base_CUDA ) {
+  if ( vid == Base_CUDA && run_params.getEnableCustomScan() ) {
 
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 
@@ -148,7 +148,7 @@ void INDEXLIST::runCudaVariant(VariantID vid, size_t tune_idx)
 
           if (tune_idx == t) {
 
-            runCudaVariantImpl<decltype(block_size)::value,
+            runCudaVariantCustom<decltype(block_size)::value,
                                detail::cuda::grid_scan_default_items_per_thread<
                                   Real_type, block_size, RAJA_PERFSUITE_TUNING_CUDA_ARCH>::value
                                >(vid);
@@ -166,7 +166,7 @@ void INDEXLIST::runCudaVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              runCudaVariantImpl<decltype(block_size)::value, items_per_thread>(vid);
+              runCudaVariantCustom<decltype(block_size)::value, items_per_thread>(vid);
 
             }
 
@@ -189,7 +189,7 @@ void INDEXLIST::runCudaVariant(VariantID vid, size_t tune_idx)
 
 void INDEXLIST::setCudaTuningDefinitions(VariantID vid)
 {
-  if ( vid == Base_CUDA ) {
+  if ( vid == Base_CUDA && run_params.getEnableCustomScan() ) {
 
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 

--- a/src/basic/INDEXLIST-Hip.cpp
+++ b/src/basic/INDEXLIST-Hip.cpp
@@ -30,7 +30,7 @@ using hip_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
 
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
-__global__ void indexlist(Real_ptr x,
+__global__ void indexlist_custom(Real_ptr x,
                           Int_ptr list,
                           Index_type* block_counts,
                           Index_type* grid_counts,
@@ -77,7 +77,7 @@ __global__ void indexlist(Real_ptr x,
 }
 
 template < size_t block_size, size_t items_per_thread >
-void INDEXLIST::runHipVariantImpl(VariantID vid)
+void INDEXLIST::runHipVariantCustom(VariantID vid)
 {
   const Index_type run_reps = getRunReps();
   const Index_type ibegin = 0;
@@ -107,7 +107,7 @@ void INDEXLIST::runHipVariantImpl(VariantID vid)
       hipErrchk( hipMemsetAsync(block_readys, 0, sizeof(unsigned)*grid_size,
                                 res.get_stream()) );
 
-      RPlaunchHipKernel( (indexlist<block_size, items_per_thread>),
+      RPlaunchHipKernel( (indexlist_custom<block_size, items_per_thread>),
                          grid_size, block_size,
                          shmem_size, res.get_stream(),
                          x+ibegin, list+ibegin,
@@ -135,7 +135,7 @@ void INDEXLIST::runHipVariant(VariantID vid, size_t tune_idx)
 {
   size_t t = 0;
 
-  if ( vid == Base_HIP ) {
+  if ( vid == Base_HIP && run_params.getEnableCustomScan() ) {
 
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 
@@ -148,7 +148,7 @@ void INDEXLIST::runHipVariant(VariantID vid, size_t tune_idx)
 
           if (tune_idx == t) {
 
-            runHipVariantImpl<decltype(block_size)::value,
+            runHipVariantCustom<decltype(block_size)::value,
                                detail::hip::grid_scan_default_items_per_thread<
                                   Real_type, block_size, RAJA_PERFSUITE_TUNING_HIP_ARCH>::value
                                >(vid);
@@ -166,7 +166,7 @@ void INDEXLIST::runHipVariant(VariantID vid, size_t tune_idx)
 
             if (tune_idx == t) {
 
-              runHipVariantImpl<block_size, items_per_thread>(vid);
+              runHipVariantCustom<block_size, items_per_thread>(vid);
 
             }
 
@@ -189,7 +189,7 @@ void INDEXLIST::runHipVariant(VariantID vid, size_t tune_idx)
 
 void INDEXLIST::setHipTuningDefinitions(VariantID vid)
 {
-  if ( vid == Base_HIP ) {
+  if ( vid == Base_HIP && run_params.getEnableCustomScan() ) {
 
     seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
 

--- a/src/basic/INDEXLIST-Hip.cpp
+++ b/src/basic/INDEXLIST-Hip.cpp
@@ -31,12 +31,12 @@ using hip_items_per_thread_type = integer::make_gpu_items_per_thread_list_type<
 template < size_t block_size, size_t items_per_thread >
 __launch_bounds__(block_size)
 __global__ void indexlist_custom(Real_ptr x,
-                          Int_ptr list,
-                          Index_type* block_counts,
-                          Index_type* grid_counts,
-                          unsigned* block_readys,
-                          Index_type* len,
-                          Index_type iend)
+                                 Int_ptr list,
+                                 Index_type* block_counts,
+                                 Index_type* grid_counts,
+                                 unsigned* block_readys,
+                                 Index_type* len,
+                                 Index_type iend)
 {
   // It looks like blocks do not start running in order in hip, so a block
   // with a higher index can't wait on a block with a lower index without

--- a/src/basic/INDEXLIST.cpp
+++ b/src/basic/INDEXLIST.cpp
@@ -50,9 +50,13 @@ INDEXLIST::INDEXLIST(const RunParams& params)
   setVariantDefined( Base_OpenMPTarget );
 #endif
 
-  setVariantDefined( Base_CUDA );
+  if (run_params.getEnableCustomScan()) {
 
-  setVariantDefined( Base_HIP );
+    setVariantDefined( Base_CUDA );
+
+    setVariantDefined( Base_HIP );
+
+  }
 }
 
 INDEXLIST::~INDEXLIST()

--- a/src/basic/INDEXLIST.hpp
+++ b/src/basic/INDEXLIST.hpp
@@ -65,9 +65,9 @@ public:
   void setHipTuningDefinitions(VariantID vid);
   
   template < size_t block_size, size_t items_per_thread >
-  void runCudaVariantImpl(VariantID vid);
+  void runCudaVariantCustom(VariantID vid);
   template < size_t block_size, size_t items_per_thread >
-  void runHipVariantImpl(VariantID vid);
+  void runHipVariantCustom(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/comm/HALO_EXCHANGE.hpp
+++ b/src/comm/HALO_EXCHANGE.hpp
@@ -70,8 +70,6 @@
   std::vector<MPI_Request> pack_mpi_requests(num_neighbors); \
   std::vector<MPI_Request> unpack_mpi_requests(num_neighbors); \
   \
-  const DataSpace dataSpace = getDataSpace(vid); \
-  \
   const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy); \
   \
   std::vector<Real_ptr> pack_buffers = m_pack_buffers; \

--- a/src/comm/HALO_EXCHANGE_FUSED.hpp
+++ b/src/comm/HALO_EXCHANGE_FUSED.hpp
@@ -73,8 +73,6 @@
   std::vector<MPI_Request> pack_mpi_requests(num_neighbors); \
   std::vector<MPI_Request> unpack_mpi_requests(num_neighbors); \
   \
-  const DataSpace dataSpace = getDataSpace(vid); \
-  \
   const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy); \
   \
   std::vector<Real_ptr> pack_buffers = m_pack_buffers; \

--- a/src/comm/HALO_PACKING.hpp
+++ b/src/comm/HALO_PACKING.hpp
@@ -49,8 +49,6 @@
   Index_type num_vars = m_num_vars; \
   std::vector<Real_ptr> vars = m_vars; \
   \
-  const DataSpace dataSpace = getDataSpace(vid); \
-  \
   const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy); \
   \
   std::vector<Real_ptr> pack_buffers = m_pack_buffers; \

--- a/src/comm/HALO_PACKING_FUSED.hpp
+++ b/src/comm/HALO_PACKING_FUSED.hpp
@@ -49,8 +49,6 @@
   Index_type num_vars = m_num_vars; \
   std::vector<Real_ptr> vars = m_vars; \
   \
-  const DataSpace dataSpace = getDataSpace(vid); \
-  \
   const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy); \
   \
   std::vector<Real_ptr> pack_buffers = m_pack_buffers; \

--- a/src/common/CudaGridScan.hpp
+++ b/src/common/CudaGridScan.hpp
@@ -35,12 +35,12 @@ struct GridScan
 {
   using BlockScan = cub::BlockScan<DataType, block_size>; //, cub::BLOCK_SCAN_WARP_SCANS>;
   using BlockExchange = cub::BlockExchange<DataType, block_size, items_per_thread>;
-  using WarpReduce = cub::WarpReduce<DataType, warp_size>;
+  using WarpReduce32 = cub::WarpReduce<DataType, 32>;
 
   union SharedStorage {
     typename BlockScan::TempStorage block_scan_storage;
     typename BlockExchange::TempStorage block_exchange_storage;
-    typename WarpReduce::TempStorage warp_reduce_storage;
+    typename WarpReduce32::TempStorage warp_reduce_storage32;
     volatile DataType prev_grid_count;
   };
 
@@ -96,7 +96,7 @@ struct GridScan
 
       DataType prev_grid_count = get_previous_grid_count(
             block_id, last_block, last_thread,
-            s_temp_storage.warp_reduce_storage, s_temp_storage.prev_grid_count,
+            s_temp_storage.warp_reduce_storage32, s_temp_storage.prev_grid_count,
             inclusive, block_counts, grid_counts, block_readys);
 
       for (size_t ti = 0; ti < items_per_thread; ++ti) {
@@ -110,7 +110,7 @@ struct GridScan
   static DataType get_previous_grid_count(const int block_id,
                                           const bool last_block,
                                           const bool last_thread,
-                                          typename WarpReduce::storage_type& s_warp_reduce_storage,
+                                          typename WarpReduce32::storage_type& s_warp_reduce_storage,
                                           volatile DataType& s_prev_grid_count,
                                           DataType (&inclusive)[items_per_thread],
                                           DataType* block_counts,
@@ -119,7 +119,7 @@ struct GridScan
   {
     const size_t warp_size = 32;
 
-    using ballot_type = typename ballot_type_helper<warp_size>::type;
+    using ballot_type = unsigned;
     static_assert(warp_size == sizeof(ballot_type)*CHAR_BIT, "");
 
     // get prev_grid_count using last warp in block

--- a/src/common/CudaGridScan.hpp
+++ b/src/common/CudaGridScan.hpp
@@ -110,7 +110,7 @@ struct GridScan
   static DataType get_previous_grid_count(const int block_id,
                                           const bool last_block,
                                           const bool last_thread,
-                                          typename WarpReduce32::storage_type& s_warp_reduce_storage,
+                                          typename WarpReduce32::TempStorage& s_warp_reduce_storage,
                                           volatile DataType& s_prev_grid_count,
                                           DataType (&inclusive)[items_per_thread],
                                           DataType* block_counts,

--- a/src/common/CudaGridScan.hpp
+++ b/src/common/CudaGridScan.hpp
@@ -198,7 +198,7 @@ struct GridScan
       }
 
 
-      prev_grid_count = WarpReduce(s_warp_reduce_storage).Sum(prev_grid_count);
+      prev_grid_count = WarpReduce32(s_warp_reduce_storage).Sum(prev_grid_count);
       prev_grid_count = __shfl_sync(0xffffffffu, prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
 
       if (last_thread) {

--- a/src/common/CudaGridScan.hpp
+++ b/src/common/CudaGridScan.hpp
@@ -13,6 +13,8 @@
 #include <cub/warp/warp_reduce.cuh>
 #include <cub/warp/warp_scan.cuh>
 
+#include <climits>
+
 namespace rajaperf
 {
 namespace detail
@@ -23,7 +25,6 @@ namespace cuda
 //
 // Define magic numbers for CUDA execution
 //
-const size_t warp_size = 32;
 const size_t max_static_shmem = 49154;
 
 
@@ -57,10 +58,6 @@ struct GridScan
     const bool first_block = (block_id == 0);
     const bool last_block = (block_id == gridDim.x-1);
     const bool last_thread = (threadIdx.x == block_size-1);
-    const bool last_warp = (threadIdx.x >= block_size - warp_size);
-    const int warp_index = (threadIdx.x % warp_size);
-    const unsigned warp_index_mask = (1u << warp_index);
-    const unsigned warp_index_mask_right = warp_index_mask | (warp_index_mask - 1u);
 
     __shared__ SharedStorage s_temp_storage;
 
@@ -97,99 +94,127 @@ struct GridScan
         atomicExch(&block_readys[block_id], 1u); // write block_counts is ready
       }
 
-      // get prev_grid_count using last warp in block
-      if (last_warp) {
-
-        DataType prev_grid_count = 0;
-
-        // accumulate previous block counts into registers of warp
-
-        int prev_block_base_id = block_id - warp_size;
-
-        unsigned prev_block_ready = 0u;
-        unsigned prev_blocks_ready_ballot = 0u;
-        unsigned prev_grids_ready_ballot = 0u;
-
-        // accumulate full warp worths of block counts
-        // stop if run out of full warps of a grid count is ready
-        while (prev_block_base_id >= 0) {
-
-          const int prev_block_id = prev_block_base_id + warp_index;
-
-          // ensure previous block_counts are ready
-          do {
-            prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
-
-            prev_blocks_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready >= 1u);
-
-          } while (prev_blocks_ready_ballot != 0xffffffffu);
-
-          prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
-
-          if (prev_grids_ready_ballot != 0u) {
-            break;
-          }
-
-          __threadfence(); // ensure block_counts or grid_counts ready (acquire)
-
-          // accumulate block_counts for prev_block_id
-          prev_grid_count += block_counts[prev_block_id];
-
-          prev_block_ready = 0u;
-
-          prev_block_base_id -= warp_size;
-        }
-
-        const int prev_block_id = prev_block_base_id + warp_index;
-
-        // ensure previous block_counts are ready
-        // this checks that block counts is ready for all blocks above
-        // the highest grid count that is ready
-        while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
-
-          if (prev_block_id >= 0) {
-            prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
-          }
-
-          prev_blocks_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready >= 1u);
-          prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
-        }
-        __threadfence(); // ensure block_counts or grid_counts ready (acquire)
-
-        // read one grid_count from a block with id grid_count_ready_id
-        // and read the block_counts from blocks with higher ids.
-        if (warp_index_mask > prev_grids_ready_ballot) {
-          // accumulate block_counts for prev_block_id
-          prev_grid_count += block_counts[prev_block_id];
-        } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
-          // accumulate grid_count for grid_count_ready_id
-          prev_grid_count += grid_counts[prev_block_id];
-        }
-
-
-        prev_grid_count = WarpReduce(s_temp_storage.warp_reduce_storage).Sum(prev_grid_count);
-        prev_grid_count = __shfl_sync(0xffffffffu, prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
-
-        if (last_thread) {
-
-          if (!last_block) {
-            grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
-            __threadfence();                        // ensure grid_counts ready (release)
-            atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
-          }
-
-          s_temp_storage.prev_grid_count = prev_grid_count;
-        }
-      }
-
-      __syncthreads();
-      DataType prev_grid_count = s_temp_storage.prev_grid_count;
+      DataType prev_grid_count = get_previous_grid_count(
+            block_id, last_block, last_thread,
+            s_temp_storage.warp_reduce_storage, s_temp_storage.prev_grid_count,
+            inclusive, block_counts, grid_counts, block_readys);
 
       for (size_t ti = 0; ti < items_per_thread; ++ti) {
         exclusive[ti] = prev_grid_count + exclusive[ti];
         inclusive[ti] = prev_grid_count + inclusive[ti];
       }
     }
+  }
+
+  __device__
+  static DataType get_previous_grid_count(const int block_id,
+                                          const bool last_block,
+                                          const bool last_thread,
+                                          typename WarpReduce::storage_type& s_warp_reduce_storage,
+                                          volatile DataType& s_prev_grid_count,
+                                          DataType (&inclusive)[items_per_thread],
+                                          DataType* block_counts,
+                                          DataType* grid_counts,
+                                          unsigned* block_readys)
+  {
+    const size_t warp_size = 32;
+
+    using ballot_type = typename ballot_type_helper<warp_size>::type;
+    static_assert(warp_size == sizeof(ballot_type)*CHAR_BIT, "");
+
+    // get prev_grid_count using last warp in block
+    const bool last_warp = (threadIdx.x >= block_size - warp_size);
+    if (last_warp) {
+
+      const int warp_index = (threadIdx.x % warp_size);
+      const ballot_type warp_index_mask = (ballot_type(1) << warp_index);
+      const ballot_type warp_index_mask_right = warp_index_mask | (warp_index_mask - ballot_type(1));
+
+      DataType prev_grid_count = 0;
+
+      // accumulate previous block counts into registers of warp
+
+      int prev_block_base_id = block_id - warp_size;
+
+      unsigned prev_block_ready = 0u;
+
+      ballot_type prev_blocks_ready_ballot = ballot_type(0);
+      ballot_type prev_grids_ready_ballot = ballot_type(0);
+
+      // accumulate full warp worths of block counts
+      // stop if run out of full warps of a grid count is ready
+      while (prev_block_base_id >= 0) {
+
+        const int prev_block_id = prev_block_base_id + warp_index;
+
+        // ensure previous block_counts are ready
+        do {
+          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+
+          prev_blocks_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready >= 1u);
+
+        } while (prev_blocks_ready_ballot != ~ballot_type(0));
+
+        prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
+
+        if (prev_grids_ready_ballot != ballot_type(0)) {
+          break;
+        }
+
+        __threadfence(); // ensure block_counts or grid_counts ready (acquire)
+
+        // accumulate block_counts for prev_block_id
+        prev_grid_count += block_counts[prev_block_id];
+
+        prev_block_ready = 0u;
+
+        prev_block_base_id -= warp_size;
+      }
+
+      const int prev_block_id = prev_block_base_id + warp_index;
+
+      // ensure previous block_counts are ready
+      // this checks that block counts is ready for all blocks above
+      // the highest grid count that is ready
+      while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
+
+        if (prev_block_id >= 0) {
+          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+        }
+
+        prev_blocks_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready >= 1u);
+        prev_grids_ready_ballot = __ballot_sync(0xffffffffu, prev_block_ready == 2u);
+      }
+      __threadfence(); // ensure block_counts or grid_counts ready (acquire)
+
+      // read one grid_count from a block with id grid_count_ready_id
+      // and read the block_counts from blocks with higher ids.
+      if (warp_index_mask > prev_grids_ready_ballot) {
+        // accumulate block_counts for prev_block_id
+        prev_grid_count += block_counts[prev_block_id];
+      } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
+        // accumulate grid_count for grid_count_ready_id
+        prev_grid_count += grid_counts[prev_block_id];
+      }
+
+
+      prev_grid_count = WarpReduce(s_warp_reduce_storage).Sum(prev_grid_count);
+      prev_grid_count = __shfl_sync(0xffffffffu, prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
+
+      if (last_thread) {
+
+        if (!last_block) {
+          grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
+          __threadfence();                        // ensure grid_counts ready (release)
+          atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
+        }
+
+        s_prev_grid_count = prev_grid_count;
+      }
+    }
+
+    __syncthreads();
+    return s_prev_grid_count;
   }
 
 };

--- a/src/common/HipGridScan.hpp
+++ b/src/common/HipGridScan.hpp
@@ -13,9 +13,8 @@
 #include <rocprim/warp/warp_reduce.hpp>
 #include <rocprim/warp/warp_scan.hpp>
 
-#include <iostream>
-
-#include "RAJA/config.hpp"
+#include <cassert>
+#include <climits>
 
 namespace rajaperf
 {
@@ -27,8 +26,14 @@ namespace hip
 //
 // Define magic numbers for HIP execution
 //
-const size_t warp_size = RAJA_HIP_WAVESIZE;
 const size_t max_static_shmem = 65536;
+
+template < size_t warp_size >
+struct ballot_type_helper;
+template < >
+struct ballot_type_helper<32> { using type = unsigned; };
+template < >
+struct ballot_type_helper<64> { using type = unsigned long long; };
 
 
 // perform a grid scan on val and returns the result at each thread
@@ -38,12 +43,14 @@ struct GridScan
 {
   using BlockScan = rocprim::block_scan<DataType, block_size>; //, rocprim::block_scan_algorithm::reduce_then_scan>;
   using BlockExchange = rocprim::block_exchange<DataType, block_size, items_per_thread>;
-  using WarpReduce = rocprim::warp_reduce<DataType, warp_size>;
+  using WarpReduce32 = rocprim::warp_reduce<DataType, 32>;
+  using WarpReduce64 = rocprim::warp_reduce<DataType, 64>;
 
   union SharedStorage {
     typename BlockScan::storage_type block_scan_storage;
     typename BlockExchange::storage_type block_exchange_storage;
-    typename WarpReduce::storage_type warp_reduce_storage;
+    typename WarpReduce32::storage_type warp_reduce_storage32;
+    typename WarpReduce64::storage_type warp_reduce_storage64;
     volatile DataType prev_grid_count;
   };
 
@@ -61,10 +68,6 @@ struct GridScan
     const bool first_block = (block_id == 0);
     const bool last_block = (block_id == static_cast<int>(gridDim.x-1));
     const bool last_thread = (threadIdx.x == block_size-1);
-    const bool last_warp = (threadIdx.x >= block_size - warp_size);
-    const int warp_index = (threadIdx.x % warp_size);
-    const unsigned long long warp_index_mask = (1ull << warp_index);
-    const unsigned long long warp_index_mask_right = warp_index_mask | (warp_index_mask - 1ull);
 
     __shared__ SharedStorage s_temp_storage;
 
@@ -101,99 +104,135 @@ struct GridScan
         atomicExch(&block_readys[block_id], 1u); // write block_counts is ready
       }
 
-      // get prev_grid_count using last warp in block
-      if (last_warp) {
-
-        DataType prev_grid_count = 0;
-
-        // accumulate previous block counts into registers of warp
-
-        int prev_block_base_id = block_id - warp_size;
-
-        unsigned prev_block_ready = 0u;
-        unsigned long long prev_blocks_ready_ballot = 0ull;
-        unsigned long long prev_grids_ready_ballot = 0ull;
-
-        // accumulate full warp worths of block counts
-        // stop if run out of full warps of a grid count is ready
-        while (prev_block_base_id >= 0) {
-
-          const int prev_block_id = prev_block_base_id + warp_index;
-
-          // ensure previous block_counts are ready
-          do {
-            prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
-
-            prev_blocks_ready_ballot = __ballot(prev_block_ready >= 1u);
-
-          } while (prev_blocks_ready_ballot != 0xffffffffffffffffull);
-
-          prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
-
-          if (prev_grids_ready_ballot != 0ull) {
-            break;
-          }
-
-          __threadfence(); // ensure block_counts or grid_counts ready (acquire)
-
-          // accumulate block_counts for prev_block_id
-          prev_grid_count += block_counts[prev_block_id];
-
-          prev_block_ready = 0u;
-
-          prev_block_base_id -= warp_size;
-        }
-
-        const int prev_block_id = prev_block_base_id + warp_index;
-
-        // ensure previous block_counts are ready
-        // this checks that block counts is ready for all blocks above
-        // the highest grid count that is ready
-        while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
-
-          if (prev_block_id >= 0) {
-            prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
-          }
-
-          prev_blocks_ready_ballot = __ballot(prev_block_ready >= 1u);
-          prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
-        }
-        __threadfence(); // ensure block_counts or grid_counts ready (acquire)
-
-        // read one grid_count from a block with id grid_count_ready_id
-        // and read the block_counts from blocks with higher ids.
-        if (warp_index_mask > prev_grids_ready_ballot) {
-          // accumulate block_counts for prev_block_id
-          prev_grid_count += block_counts[prev_block_id];
-        } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
-          // accumulate grid_count for grid_count_ready_id
-          prev_grid_count += grid_counts[prev_block_id];
-        }
-
-
-        WarpReduce().reduce(prev_grid_count, prev_grid_count, s_temp_storage.warp_reduce_storage);
-        prev_grid_count = __shfl(prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
-
-        if (last_thread) {
-
-          if (!last_block) {
-            grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
-            __threadfence();                        // ensure grid_counts ready (release)
-            atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
-          }
-
-          s_temp_storage.prev_grid_count = prev_grid_count;
-        }
+      DataType prev_grid_count{};
+      if (warpSize == 64) {
+        prev_grid_count = get_previous_grid_count<64, WarpReduce64>(
+            block_id, last_block, last_thread,
+            s_temp_storage.warp_reduce_storage64, s_temp_storage.prev_grid_count,
+            inclusive, block_counts, grid_counts, block_readys);
+      } else if (warpSize == 32) {
+        prev_grid_count = get_previous_grid_count<32, WarpReduce32>(
+            block_id, last_block, last_thread,
+            s_temp_storage.warp_reduce_storage32, s_temp_storage.prev_grid_count,
+            inclusive, block_counts, grid_counts, block_readys);
+      } else {
+        assert(warpSize == 32 || warpSize == 64);
       }
-
-      __syncthreads();
-      DataType prev_grid_count = s_temp_storage.prev_grid_count;
 
       for (size_t ti = 0; ti < items_per_thread; ++ti) {
         exclusive[ti] = prev_grid_count + exclusive[ti];
         inclusive[ti] = prev_grid_count + inclusive[ti];
       }
     }
+  }
+
+  template < size_t warp_size, typename WarpReduce >
+  __device__
+  static DataType get_previous_grid_count(const int block_id,
+                                          const bool last_block,
+                                          const bool last_thread,
+                                          typename WarpReduce::storage_type& s_warp_reduce_storage,
+                                          volatile DataType& s_prev_grid_count,
+                                          DataType (&inclusive)[items_per_thread],
+                                          DataType* block_counts,
+                                          DataType* grid_counts,
+                                          unsigned* block_readys)
+  {
+    using ballot_type = typename ballot_type_helper<warp_size>::type;
+    static_assert(warp_size == sizeof(ballot_type)*CHAR_BIT, "");
+
+    // get prev_grid_count using last warp in block
+    const bool last_warp = (threadIdx.x >= block_size - warp_size);
+    if (last_warp) {
+
+      const int warp_index = (threadIdx.x % warp_size);
+      const ballot_type warp_index_mask = (ballot_type(1) << warp_index);
+      const ballot_type warp_index_mask_right = warp_index_mask | (warp_index_mask - ballot_type(1));
+
+      DataType prev_grid_count = 0;
+
+      // accumulate previous block counts into registers of warp
+
+      int prev_block_base_id = block_id - warp_size;
+
+      unsigned prev_block_ready = 0u;
+
+      ballot_type prev_blocks_ready_ballot = ballot_type(0);
+      ballot_type prev_grids_ready_ballot = ballot_type(0);
+
+      // accumulate full warp worths of block counts
+      // stop if run out of full warps of a grid count is ready
+      while (prev_block_base_id >= 0) {
+
+        const int prev_block_id = prev_block_base_id + warp_index;
+
+        // ensure previous block_counts are ready
+        do {
+          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+
+          prev_blocks_ready_ballot = __ballot(prev_block_ready >= 1u);
+
+        } while (prev_blocks_ready_ballot != ~ballot_type(0));
+
+        prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
+
+        if (prev_grids_ready_ballot != ballot_type(0)) {
+          break;
+        }
+
+        __threadfence(); // ensure block_counts or grid_counts ready (acquire)
+
+        // accumulate block_counts for prev_block_id
+        prev_grid_count += block_counts[prev_block_id];
+
+        prev_block_ready = 0u;
+
+        prev_block_base_id -= warp_size;
+      }
+
+      const int prev_block_id = prev_block_base_id + warp_index;
+
+      // ensure previous block_counts are ready
+      // this checks that block counts is ready for all blocks above
+      // the highest grid count that is ready
+      while (~prev_blocks_ready_ballot >= prev_grids_ready_ballot) {
+
+        if (prev_block_id >= 0) {
+          prev_block_ready = atomicCAS(&block_readys[prev_block_id], 11u, 11u);
+        }
+
+        prev_blocks_ready_ballot = __ballot(prev_block_ready >= 1u);
+        prev_grids_ready_ballot = __ballot(prev_block_ready == 2u);
+      }
+      __threadfence(); // ensure block_counts or grid_counts ready (acquire)
+
+      // read one grid_count from a block with id grid_count_ready_id
+      // and read the block_counts from blocks with higher ids.
+      if (warp_index_mask > prev_grids_ready_ballot) {
+        // accumulate block_counts for prev_block_id
+        prev_grid_count += block_counts[prev_block_id];
+      } else if (prev_grids_ready_ballot == (prev_grids_ready_ballot & warp_index_mask_right)) {
+        // accumulate grid_count for grid_count_ready_id
+        prev_grid_count += grid_counts[prev_block_id];
+      }
+
+      WarpReduce().reduce(prev_grid_count, prev_grid_count, s_warp_reduce_storage);
+      prev_grid_count = __shfl(prev_grid_count, 0, warp_size); // broadcast output to all threads in warp
+
+      if (last_thread) {
+
+        if (!last_block) {
+          grid_counts[block_id] = prev_grid_count + inclusive[items_per_thread-1];   // write inclusive scan result for grid through block
+          __threadfence();                        // ensure grid_counts ready (release)
+          atomicExch(&block_readys[block_id], 2u); // write grid_counts is ready
+        }
+
+        s_prev_grid_count = prev_grid_count;
+      }
+    }
+
+    __syncthreads();
+    return s_prev_grid_count;
   }
 
 };

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -46,7 +46,7 @@ RunParams::RunParams(int argc, char** argv)
    array_of_ptrs_array_size(ARRAY_OF_PTRS_MAX_ARRAY_SIZE),
    halo_width(1),
    halo_num_vars(3),
-   enable_custom_scan(false),
+   enable_custom_scan(true),
    gpu_stream(1),
    gpu_block_sizes(),
    atomic_replications(),
@@ -1407,9 +1407,9 @@ void RunParams::printHelpMessage(std::ostream& str) const
       << "\t\t --exclude-features Forall (exclude all kernels that use RAJA forall)\n"
       << "\t\t -ef Forall Reduction (exclude all kernels that use RAJA forall or RAJA reductions)\n\n";
 
-  str << "\t --enable_custom_scan [default is to not enable tunings with RAJAPerf custom scan]\n"
+  str << "\t --enable_custom_scan [default is to enable tunings with RAJAPerf custom scan]\n"
       << "\t      (when this option is given, enable custom scan tunings HIP and CUDA kernel variants)\n\n";
-  str << "\t --disable_custom_scan [default is to not enable tunings with RAJAPerf custom scan]\n"
+  str << "\t --disable_custom_scan [default is to enable tunings with RAJAPerf custom scan]\n"
       << "\t      (when this option is given, disable custom scan tunings HIP and CUDA kernel variants)\n\n";
 
   str << "\t Options for selecting run size....\n"

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -46,6 +46,7 @@ RunParams::RunParams(int argc, char** argv)
    array_of_ptrs_array_size(ARRAY_OF_PTRS_MAX_ARRAY_SIZE),
    halo_width(1),
    halo_num_vars(3),
+   enable_custom_scan(false),
    gpu_stream(1),
    gpu_block_sizes(),
    atomic_replications(),
@@ -142,6 +143,8 @@ void RunParams::print(std::ostream& str) const
 
   str << "\n halo_width = " << halo_width;
   str << "\n halo_num_vars = " << halo_num_vars;
+
+  str << "\n custom_scan = " << (enable_custom_scan ? "enabled" : "disabled");
 
   str << "\n gpu stream = " << ((gpu_stream == 0) ? "0" : "RAJA default");
   str << "\n gpu_block_sizes = ";
@@ -676,6 +679,14 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
                   << std::endl;
         input_state = BadInput;
       }
+
+    } else if ( opt == std::string("--enable_custom_scan") ) {
+
+      enable_custom_scan = true;
+
+    } else if ( opt == std::string("--disable_custom_scan") ) {
+
+      enable_custom_scan = false;
 
     } else if ( opt == std::string("--gpu_stream_0") ) {
 
@@ -1395,6 +1406,11 @@ void RunParams::printHelpMessage(std::ostream& str) const
   str << "\t\t Examples...\n"
       << "\t\t --exclude-features Forall (exclude all kernels that use RAJA forall)\n"
       << "\t\t -ef Forall Reduction (exclude all kernels that use RAJA forall or RAJA reductions)\n\n";
+
+  str << "\t --enable_custom_scan [default is to not enable tunings with RAJAPerf custom scan]\n"
+      << "\t      (when this option is given, enable custom scan tunings HIP and CUDA kernel variants)\n\n";
+  str << "\t --disable_custom_scan [default is to not enable tunings with RAJAPerf custom scan]\n"
+      << "\t      (when this option is given, disable custom scan tunings HIP and CUDA kernel variants)\n\n";
 
   str << "\t Options for selecting run size....\n"
       << "\t ==================================\n\n";;

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -320,7 +320,7 @@ private:
   Index_type halo_width; /*!< halo width used in halo kernels (input option) */
   Index_type halo_num_vars; /*!< num vars used in halo kernels (input option) */
 
-  bool enable_custom_scan;
+  bool enable_custom_scan; /*!< enable tunings using custom scan implementations (input option) */
 
   int gpu_stream; /*!< 0 -> use stream 0; anything else -> use raja default stream */
   std::vector<size_t> gpu_block_sizes; /*!< Block sizes for gpu tunings to run (input option) */

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -170,6 +170,8 @@ public:
   Index_type getHaloWidth() const { return halo_width; }
   Index_type getHaloNumVars() const { return halo_num_vars; }
 
+  bool getEnableCustomScan() const { return enable_custom_scan; }
+
   int getGPUStream() const { return gpu_stream; }
   size_t numValidGPUBlockSize() const { return gpu_block_sizes.size(); }
   bool validGPUBlockSize(size_t block_size) const
@@ -317,6 +319,8 @@ private:
 
   Index_type halo_width; /*!< halo width used in halo kernels (input option) */
   Index_type halo_num_vars; /*!< num vars used in halo kernels (input option) */
+
+  bool enable_custom_scan;
 
   int gpu_stream; /*!< 0 -> use stream 0; anything else -> use raja default stream */
   std::vector<size_t> gpu_block_sizes; /*!< Block sizes for gpu tunings to run (input option) */


### PR DESCRIPTION
# Summary

Fix hang in hip custom scan implementation with warp size 32, on consumer cards.
Add a command line option to enable custom scan tunings, default to on.

- This PR is a (refactoring, bugfix, feature, something else)
- It does the following (modify list as needed):
  - Fixes #518 
