### PR TITLE
Honor align setting with comm buffers

### DIFF
--- a/src/comm/HALO_EXCHANGE.cpp
+++ b/src/comm/HALO_EXCHANGE.cpp
@@ -77,7 +77,7 @@ HALO_EXCHANGE::~HALO_EXCHANGE()
 
 void HALO_EXCHANGE::setUp(VariantID vid, size_t tune_idx)
 {
-  setUp_base(m_my_mpi_rank, m_mpi_dims.data(), vid, tune_idx);
+  setUp_base(m_my_mpi_rank, m_mpi_dims.data(), m_num_vars, vid, tune_idx);
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
@@ -87,34 +87,6 @@ void HALO_EXCHANGE::setUp(VariantID vid, size_t tune_idx)
 
     for (Index_type i = 0; i < m_var_size; i++) {
       var[i] = i + v;
-    }
-  }
-
-  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
-
-  m_pack_buffers.resize(s_num_neighbors, nullptr);
-  m_send_buffers.resize(s_num_neighbors, nullptr);
-  for (Index_type l = 0; l < s_num_neighbors; ++l) {
-    Index_type buffer_len = m_num_vars * m_pack_index_list_lengths[l];
-    if (separate_buffers) {
-      allocAndInitData(getDataSpace(vid), m_pack_buffers[l], buffer_len);
-      allocAndInitData(DataSpace::Host, m_send_buffers[l], buffer_len);
-    } else {
-      allocAndInitData(getMPIDataSpace(vid), m_pack_buffers[l], buffer_len);
-      m_send_buffers[l] = m_pack_buffers[l];
-    }
-  }
-
-  m_unpack_buffers.resize(s_num_neighbors, nullptr);
-  m_recv_buffers.resize(s_num_neighbors, nullptr);
-  for (Index_type l = 0; l < s_num_neighbors; ++l) {
-    Index_type buffer_len = m_num_vars * m_unpack_index_list_lengths[l];
-    if (separate_buffers) {
-      allocAndInitData(getDataSpace(vid), m_unpack_buffers[l], buffer_len);
-      allocAndInitData(DataSpace::Host, m_recv_buffers[l], buffer_len);
-    } else {
-      allocAndInitData(getMPIDataSpace(vid), m_unpack_buffers[l], buffer_len);
-      m_recv_buffers[l] = m_unpack_buffers[l];
     }
   }
 }
@@ -128,30 +100,6 @@ void HALO_EXCHANGE::updateChecksum(VariantID vid, size_t tune_idx)
 
 void HALO_EXCHANGE::tearDown(VariantID vid, size_t tune_idx)
 {
-  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
-
-  for (int l = 0; l < s_num_neighbors; ++l) {
-    if (separate_buffers) {
-      deallocData(DataSpace::Host, m_recv_buffers[l]);
-      deallocData(getDataSpace(vid), m_unpack_buffers[l]);
-    } else {
-      deallocData(getMPIDataSpace(vid), m_unpack_buffers[l]);
-    }
-  }
-  m_recv_buffers.clear();
-  m_unpack_buffers.clear();
-
-  for (int l = 0; l < s_num_neighbors; ++l) {
-    if (separate_buffers) {
-      deallocData(DataSpace::Host, m_send_buffers[l]);
-      deallocData(getDataSpace(vid), m_pack_buffers[l]);
-    } else {
-      deallocData(getMPIDataSpace(vid), m_pack_buffers[l]);
-    }
-  }
-  m_send_buffers.clear();
-  m_pack_buffers.clear();
-
   for (int v = 0; v < m_num_vars; ++v) {
     deallocData(m_vars[v], vid);
   }

--- a/src/comm/HALO_EXCHANGE.hpp
+++ b/src/comm/HALO_EXCHANGE.hpp
@@ -133,12 +133,6 @@ private:
   Index_type m_var_size;
 
   std::vector<Real_ptr> m_vars;
-
-  std::vector<Real_ptr> m_pack_buffers;
-  std::vector<Real_ptr> m_unpack_buffers;
-
-  std::vector<Real_ptr> m_send_buffers;
-  std::vector<Real_ptr> m_recv_buffers;
 };
 
 } // end namespace comm

--- a/src/comm/HALO_EXCHANGE_FUSED.cpp
+++ b/src/comm/HALO_EXCHANGE_FUSED.cpp
@@ -77,7 +77,7 @@ HALO_EXCHANGE_FUSED::~HALO_EXCHANGE_FUSED()
 
 void HALO_EXCHANGE_FUSED::setUp(VariantID vid, size_t tune_idx)
 {
-  setUp_base(m_my_mpi_rank, m_mpi_dims.data(), vid, tune_idx);
+  setUp_base(m_my_mpi_rank, m_mpi_dims.data(), m_num_vars, vid, tune_idx);
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
@@ -87,34 +87,6 @@ void HALO_EXCHANGE_FUSED::setUp(VariantID vid, size_t tune_idx)
 
     for (Index_type i = 0; i < m_var_size; i++) {
       var[i] = i + v;
-    }
-  }
-
-  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
-
-  m_pack_buffers.resize(s_num_neighbors, nullptr);
-  m_send_buffers.resize(s_num_neighbors, nullptr);
-  for (Index_type l = 0; l < s_num_neighbors; ++l) {
-    Index_type buffer_len = m_num_vars * m_pack_index_list_lengths[l];
-    if (separate_buffers) {
-      allocAndInitData(getDataSpace(vid), m_pack_buffers[l], buffer_len);
-      allocAndInitData(DataSpace::Host, m_send_buffers[l], buffer_len);
-    } else {
-      allocAndInitData(getMPIDataSpace(vid), m_pack_buffers[l], buffer_len);
-      m_send_buffers[l] = m_pack_buffers[l];
-    }
-  }
-
-  m_unpack_buffers.resize(s_num_neighbors, nullptr);
-  m_recv_buffers.resize(s_num_neighbors, nullptr);
-  for (Index_type l = 0; l < s_num_neighbors; ++l) {
-    Index_type buffer_len = m_num_vars * m_unpack_index_list_lengths[l];
-    if (separate_buffers) {
-      allocAndInitData(getDataSpace(vid), m_unpack_buffers[l], buffer_len);
-      allocAndInitData(DataSpace::Host, m_recv_buffers[l], buffer_len);
-    } else {
-      allocAndInitData(getMPIDataSpace(vid), m_unpack_buffers[l], buffer_len);
-      m_recv_buffers[l] = m_unpack_buffers[l];
     }
   }
 }
@@ -128,30 +100,6 @@ void HALO_EXCHANGE_FUSED::updateChecksum(VariantID vid, size_t tune_idx)
 
 void HALO_EXCHANGE_FUSED::tearDown(VariantID vid, size_t tune_idx)
 {
-  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
-
-  for (int l = 0; l < s_num_neighbors; ++l) {
-    if (separate_buffers) {
-      deallocData(DataSpace::Host, m_recv_buffers[l]);
-      deallocData(getDataSpace(vid), m_unpack_buffers[l]);
-    } else {
-      deallocData(getMPIDataSpace(vid), m_unpack_buffers[l]);
-    }
-  }
-  m_recv_buffers.clear();
-  m_unpack_buffers.clear();
-
-  for (int l = 0; l < s_num_neighbors; ++l) {
-    if (separate_buffers) {
-      deallocData(DataSpace::Host, m_send_buffers[l]);
-      deallocData(getDataSpace(vid), m_pack_buffers[l]);
-    } else {
-      deallocData(getMPIDataSpace(vid), m_pack_buffers[l]);
-    }
-  }
-  m_send_buffers.clear();
-  m_pack_buffers.clear();
-
   for (int v = 0; v < m_num_vars; ++v) {
     deallocData(m_vars[v], vid);
   }

--- a/src/comm/HALO_EXCHANGE_FUSED.hpp
+++ b/src/comm/HALO_EXCHANGE_FUSED.hpp
@@ -194,12 +194,6 @@ private:
   Index_type m_var_size;
 
   std::vector<Real_ptr> m_vars;
-
-  std::vector<Real_ptr> m_pack_buffers;
-  std::vector<Real_ptr> m_unpack_buffers;
-
-  std::vector<Real_ptr> m_send_buffers;
-  std::vector<Real_ptr> m_recv_buffers;
 };
 
 } // end namespace comm

--- a/src/comm/HALO_PACKING.cpp
+++ b/src/comm/HALO_PACKING.cpp
@@ -66,7 +66,7 @@ void HALO_PACKING::setUp(VariantID vid, size_t tune_idx)
 {
   int my_mpi_rank = 0;
   const int mpi_dims[3] = {1,1,1};
-  setUp_base(my_mpi_rank, mpi_dims, vid, tune_idx);
+  setUp_base(my_mpi_rank, mpi_dims, m_num_vars, vid, tune_idx);
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
@@ -76,34 +76,6 @@ void HALO_PACKING::setUp(VariantID vid, size_t tune_idx)
 
     for (Index_type i = 0; i < m_var_size; i++) {
       var[i] = i + v;
-    }
-  }
-
-  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
-
-  m_pack_buffers.resize(s_num_neighbors, nullptr);
-  m_send_buffers.resize(s_num_neighbors, nullptr);
-  for (Index_type l = 0; l < s_num_neighbors; ++l) {
-    Index_type buffer_len = m_num_vars * m_pack_index_list_lengths[l];
-    if (separate_buffers) {
-      allocAndInitData(getDataSpace(vid), m_pack_buffers[l], buffer_len);
-      allocAndInitData(DataSpace::Host, m_send_buffers[l], buffer_len);
-    } else {
-      allocAndInitData(getMPIDataSpace(vid), m_pack_buffers[l], buffer_len);
-      m_send_buffers[l] = m_pack_buffers[l];
-    }
-  }
-
-  m_unpack_buffers.resize(s_num_neighbors, nullptr);
-  m_recv_buffers.resize(s_num_neighbors, nullptr);
-  for (Index_type l = 0; l < s_num_neighbors; ++l) {
-    Index_type buffer_len = m_num_vars * m_unpack_index_list_lengths[l];
-    if (separate_buffers) {
-      allocAndInitData(getDataSpace(vid), m_unpack_buffers[l], buffer_len);
-      allocAndInitData(DataSpace::Host, m_recv_buffers[l], buffer_len);
-    } else {
-      allocAndInitData(getMPIDataSpace(vid), m_unpack_buffers[l], buffer_len);
-      m_recv_buffers[l] = m_unpack_buffers[l];
     }
   }
 }
@@ -128,30 +100,6 @@ void HALO_PACKING::updateChecksum(VariantID vid, size_t tune_idx)
 
 void HALO_PACKING::tearDown(VariantID vid, size_t tune_idx)
 {
-  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
-
-  for (int l = 0; l < s_num_neighbors; ++l) {
-    if (separate_buffers) {
-      deallocData(DataSpace::Host, m_recv_buffers[l]);
-      deallocData(getDataSpace(vid), m_unpack_buffers[l]);
-    } else {
-      deallocData(getMPIDataSpace(vid), m_unpack_buffers[l]);
-    }
-  }
-  m_recv_buffers.clear();
-  m_unpack_buffers.clear();
-
-  for (int l = 0; l < s_num_neighbors; ++l) {
-    if (separate_buffers) {
-      deallocData(DataSpace::Host, m_send_buffers[l]);
-      deallocData(getDataSpace(vid), m_pack_buffers[l]);
-    } else {
-      deallocData(getMPIDataSpace(vid), m_pack_buffers[l]);
-    }
-  }
-  m_send_buffers.clear();
-  m_pack_buffers.clear();
-
   for (int v = 0; v < m_num_vars; ++v) {
     deallocData(m_vars[v], vid);
   }

--- a/src/comm/HALO_PACKING.hpp
+++ b/src/comm/HALO_PACKING.hpp
@@ -104,12 +104,6 @@ private:
   Index_type m_var_size;
 
   std::vector<Real_ptr> m_vars;
-
-  std::vector<Real_ptr> m_pack_buffers;
-  std::vector<Real_ptr> m_unpack_buffers;
-
-  std::vector<Real_ptr> m_send_buffers;
-  std::vector<Real_ptr> m_recv_buffers;
 };
 
 } // end namespace comm

--- a/src/comm/HALO_PACKING_FUSED.cpp
+++ b/src/comm/HALO_PACKING_FUSED.cpp
@@ -66,7 +66,7 @@ void HALO_PACKING_FUSED::setUp(VariantID vid, size_t tune_idx)
 {
   int my_mpi_rank = 0;
   const int mpi_dims[3] = {1,1,1};
-  setUp_base(my_mpi_rank, mpi_dims, vid, tune_idx);
+  setUp_base(my_mpi_rank, mpi_dims, m_num_vars, vid, tune_idx);
 
   m_vars.resize(m_num_vars, nullptr);
   for (Index_type v = 0; v < m_num_vars; ++v) {
@@ -76,34 +76,6 @@ void HALO_PACKING_FUSED::setUp(VariantID vid, size_t tune_idx)
 
     for (Index_type i = 0; i < m_var_size; i++) {
       var[i] = i + v;
-    }
-  }
-
-  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
-
-  m_pack_buffers.resize(s_num_neighbors, nullptr);
-  m_send_buffers.resize(s_num_neighbors, nullptr);
-  for (Index_type l = 0; l < s_num_neighbors; ++l) {
-    Index_type buffer_len = m_num_vars * m_pack_index_list_lengths[l];
-    if (separate_buffers) {
-      allocAndInitData(getDataSpace(vid), m_pack_buffers[l], buffer_len);
-      allocAndInitData(DataSpace::Host, m_send_buffers[l], buffer_len);
-    } else {
-      allocAndInitData(getMPIDataSpace(vid), m_pack_buffers[l], buffer_len);
-      m_send_buffers[l] = m_pack_buffers[l];
-    }
-  }
-
-  m_unpack_buffers.resize(s_num_neighbors, nullptr);
-  m_recv_buffers.resize(s_num_neighbors, nullptr);
-  for (Index_type l = 0; l < s_num_neighbors; ++l) {
-    Index_type buffer_len = m_num_vars * m_unpack_index_list_lengths[l];
-    if (separate_buffers) {
-      allocAndInitData(getDataSpace(vid), m_unpack_buffers[l], buffer_len);
-      allocAndInitData(DataSpace::Host, m_recv_buffers[l], buffer_len);
-    } else {
-      allocAndInitData(getMPIDataSpace(vid), m_unpack_buffers[l], buffer_len);
-      m_recv_buffers[l] = m_unpack_buffers[l];
     }
   }
 }
@@ -128,30 +100,6 @@ void HALO_PACKING_FUSED::updateChecksum(VariantID vid, size_t tune_idx)
 
 void HALO_PACKING_FUSED::tearDown(VariantID vid, size_t tune_idx)
 {
-  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
-
-  for (int l = 0; l < s_num_neighbors; ++l) {
-    if (separate_buffers) {
-      deallocData(DataSpace::Host, m_recv_buffers[l]);
-      deallocData(getDataSpace(vid), m_unpack_buffers[l]);
-    } else {
-      deallocData(getMPIDataSpace(vid), m_unpack_buffers[l]);
-    }
-  }
-  m_recv_buffers.clear();
-  m_unpack_buffers.clear();
-
-  for (int l = 0; l < s_num_neighbors; ++l) {
-    if (separate_buffers) {
-      deallocData(DataSpace::Host, m_send_buffers[l]);
-      deallocData(getDataSpace(vid), m_pack_buffers[l]);
-    } else {
-      deallocData(getMPIDataSpace(vid), m_pack_buffers[l]);
-    }
-  }
-  m_send_buffers.clear();
-  m_pack_buffers.clear();
-
   for (int v = 0; v < m_num_vars; ++v) {
     deallocData(m_vars[v], vid);
   }

--- a/src/comm/HALO_PACKING_FUSED.hpp
+++ b/src/comm/HALO_PACKING_FUSED.hpp
@@ -168,12 +168,6 @@ private:
   Index_type m_var_size;
 
   std::vector<Real_ptr> m_vars;
-
-  std::vector<Real_ptr> m_pack_buffers;
-  std::vector<Real_ptr> m_unpack_buffers;
-
-  std::vector<Real_ptr> m_send_buffers;
-  std::vector<Real_ptr> m_recv_buffers;
 };
 
 } // end namespace comm

--- a/src/comm/HALO_SENDRECV.cpp
+++ b/src/comm/HALO_SENDRECV.cpp
@@ -60,29 +60,7 @@ HALO_SENDRECV::~HALO_SENDRECV()
 
 void HALO_SENDRECV::setUp(VariantID vid, size_t tune_idx)
 {
-  setUp_base(m_my_mpi_rank, m_mpi_dims.data(), vid, tune_idx);
-
-  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
-
-  m_send_buffers.resize(s_num_neighbors, nullptr);
-  for (Index_type l = 0; l < s_num_neighbors; ++l) {
-    Index_type buffer_len = m_num_vars * m_pack_index_list_lengths[l];
-    if (separate_buffers) {
-      allocAndInitData(DataSpace::Host, m_send_buffers[l], buffer_len);
-    } else {
-      allocAndInitData(getMPIDataSpace(vid), m_send_buffers[l], buffer_len);
-    }
-  }
-
-  m_recv_buffers.resize(s_num_neighbors, nullptr);
-  for (Index_type l = 0; l < s_num_neighbors; ++l) {
-    Index_type buffer_len = m_num_vars * m_unpack_index_list_lengths[l];
-    if (separate_buffers) {
-      allocAndInitData(DataSpace::Host, m_recv_buffers[l], buffer_len);
-    } else {
-      allocAndInitData(getMPIDataSpace(vid), m_recv_buffers[l], buffer_len);
-    }
-  }
+  setUp_base(m_my_mpi_rank, m_mpi_dims.data(), m_num_vars, vid, tune_idx);
 }
 
 void HALO_SENDRECV::updateChecksum(VariantID vid, size_t tune_idx)
@@ -101,26 +79,6 @@ void HALO_SENDRECV::updateChecksum(VariantID vid, size_t tune_idx)
 
 void HALO_SENDRECV::tearDown(VariantID vid, size_t tune_idx)
 {
-  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
-
-  for (int l = 0; l < s_num_neighbors; ++l) {
-    if (separate_buffers) {
-      deallocData(DataSpace::Host, m_recv_buffers[l]);
-    } else {
-      deallocData(getMPIDataSpace(vid), m_recv_buffers[l]);
-    }
-  }
-  m_recv_buffers.clear();
-
-  for (int l = 0; l < s_num_neighbors; ++l) {
-    if (separate_buffers) {
-      deallocData(DataSpace::Host, m_send_buffers[l]);
-    } else {
-      deallocData(getMPIDataSpace(vid), m_send_buffers[l]);
-    }
-  }
-  m_send_buffers.clear();
-
   tearDown_base(vid, tune_idx);
 }
 

--- a/src/comm/HALO_SENDRECV.hpp
+++ b/src/comm/HALO_SENDRECV.hpp
@@ -112,9 +112,6 @@ private:
 
   Index_type m_num_vars;
   Index_type m_var_size;
-
-  std::vector<Real_ptr> m_send_buffers;
-  std::vector<Real_ptr> m_recv_buffers;
 };
 
 } // end namespace comm

--- a/src/comm/HALO_base.cpp
+++ b/src/comm/HALO_base.cpp
@@ -50,7 +50,8 @@ HALO_base::~HALO_base()
 }
 
 void HALO_base::setUp_base(const int my_mpi_rank, const int* mpi_dims,
-                                   VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+                           const Index_type num_vars,
+                           VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
   m_mpi_ranks.resize(s_num_neighbors, -1);
   m_send_tags.resize(s_num_neighbors, -1);
@@ -64,10 +65,18 @@ void HALO_base::setUp_base(const int my_mpi_rank, const int* mpi_dims,
       m_recv_tags, m_unpack_index_lists, m_unpack_index_list_lengths,
       m_halo_width, m_grid_dims,
       s_num_neighbors, vid);
+  create_buffers(m_pack_index_list_lengths, m_pack_buffers, m_send_buffers,
+                 s_num_neighbors, num_vars, vid);
+  create_buffers(m_unpack_index_list_lengths, m_unpack_buffers, m_recv_buffers,
+                 s_num_neighbors, num_vars, vid);
 }
 
 void HALO_base::tearDown_base(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
+  destroy_buffers(m_unpack_buffers, m_recv_buffers,
+                  s_num_neighbors, vid);
+  destroy_buffers(m_pack_buffers, m_send_buffers,
+                  s_num_neighbors, vid);
   destroy_lists(m_pack_index_lists, m_unpack_index_lists, s_num_neighbors, vid);
   m_unpack_index_list_lengths.clear();
   m_unpack_index_lists.clear();
@@ -303,6 +312,66 @@ void HALO_base::destroy_lists(
   for (Index_type l = 0; l < num_neighbors; ++l) {
     deallocData(unpack_index_lists[l], vid);
   }
+}
+
+
+void HALO_base::create_buffers(std::vector<Index_type> const& index_list_lengths,
+                               std::vector<Real_ptr>& our_buffers,
+                               std::vector<Real_ptr>& mpi_buffers,
+                               const Index_type num_neighbors,
+                               const Index_type num_vars,
+                               VariantID vid)
+{
+  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
+
+  Size_type combined_buffer_size = 0;
+  for (Index_type l = 0; l < num_neighbors; ++l) {
+    Index_type buffer_len = num_vars * index_list_lengths[l];
+    Size_type buffer_size = getSizePaddedToDataAlignment(buffer_len*sizeof(Real_type));
+    combined_buffer_size += buffer_size;
+  }
+
+  our_buffers.resize(num_neighbors, nullptr);
+  mpi_buffers.resize(num_neighbors, nullptr);
+
+  if (num_neighbors > 0) {
+    if (separate_buffers) {
+      rajaperf::allocAndInitData(getDataSpace(vid),
+          our_buffers[0], combined_buffer_size, getDataAlignment());
+      rajaperf::allocAndInitData(DataSpace::Host,
+          mpi_buffers[0], combined_buffer_size, getDataAlignment());
+    } else {
+      rajaperf::allocAndInitData(getMPIDataSpace(vid),
+          our_buffers[0], combined_buffer_size, getDataAlignment());
+      mpi_buffers[0] = our_buffers[0];
+    }
+
+    for (Index_type l = 1; l < num_neighbors; ++l) {
+      Index_type last_buffer_len = num_vars * index_list_lengths[l-1];
+      Size_type last_buffer_size = getSizePaddedToDataAlignment(last_buffer_len*sizeof(Real_type));
+      our_buffers[l] = offsetPointer(our_buffers[l-1], last_buffer_size);
+      mpi_buffers[l] = offsetPointer(mpi_buffers[l-1], last_buffer_size);
+    }
+  }
+}
+
+void HALO_base::destroy_buffers(std::vector<Real_ptr>& our_buffers,
+                                std::vector<Real_ptr>& mpi_buffers,
+                                const Index_type num_neighbors,
+                                VariantID vid)
+{
+  const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);
+
+  if (!mpi_buffers.empty()) {
+    if (separate_buffers) {
+      deallocData(DataSpace::Host, mpi_buffers[0]);
+      deallocData(getDataSpace(vid), our_buffers[0]);
+    } else {
+      deallocData(getMPIDataSpace(vid), our_buffers[0]);
+    }
+  }
+  mpi_buffers.clear();
+  our_buffers.clear();
 }
 
 } // end namespace comm

--- a/src/comm/HALO_base.hpp
+++ b/src/comm/HALO_base.hpp
@@ -85,7 +85,8 @@ public:
   ~HALO_base();
 
   void setUp_base(const int my_mpi_rank, const int* mpi_dims,
-             VariantID vid, size_t tune_idx);
+                  const Index_type num_vars,
+                  VariantID vid, size_t tune_idx);
   void tearDown_base(VariantID vid, size_t tune_idx);
 
   struct Packer {
@@ -139,10 +140,14 @@ protected:
   std::vector<int> m_send_tags;
   std::vector<Int_ptr> m_pack_index_lists;
   std::vector<Index_type > m_pack_index_list_lengths;
+  std::vector<Real_ptr> m_pack_buffers;
+  std::vector<Real_ptr> m_send_buffers;
 
   std::vector<int> m_recv_tags;
   std::vector<Int_ptr> m_unpack_index_lists;
   std::vector<Index_type > m_unpack_index_list_lengths;
+  std::vector<Real_ptr> m_unpack_buffers;
+  std::vector<Real_ptr> m_recv_buffers;
 
   Extent make_boundary_extent(
     const message_type msg_type,
@@ -166,6 +171,20 @@ protected:
   void destroy_lists(
       std::vector<Int_ptr>& pack_index_lists,
       std::vector<Int_ptr>& unpack_index_lists,
+      const Index_type num_neighbors,
+      VariantID vid);
+
+  void create_buffers(
+      std::vector<Index_type> const& index_list_lengths,
+      std::vector<Real_ptr>& our_buffers,
+      std::vector<Real_ptr>& mpi_buffers,
+      const Index_type num_neighbors,
+      const Index_type num_vars,
+      VariantID vid);
+
+  void destroy_buffers(
+      std::vector<Real_ptr>& our_buffers,
+      std::vector<Real_ptr>& mpi_buffers,
       const Index_type num_neighbors,
       VariantID vid);
 };

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -679,6 +679,13 @@ KernelBase* Executor::makeKernel()
 
 void Executor::runKernel(KernelBase* kernel, bool print_kernel_name)
 {
+#if defined(RAJA_PERFSUITE_ENABLE_MPI)
+  int num_ranks = -1;
+  if ( run_params.showProgress() ) {
+    MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
+  }
+#endif
+
   if ( run_params.showProgress() || print_kernel_name) {
     getCout()  << endl << "Run kernel -- " << kernel->getName() << endl;
   }
@@ -707,13 +714,32 @@ void Executor::runKernel(KernelBase* kernel, bool print_kernel_name)
       { 
         // Check if valid tuning
         if ( run_params.showProgress() ) {
-          getCout() << "\t\tRunning " << tuning_name << " tuning";
+          const auto default_width = getCout().width();
+          size_t tuning_width = std::max(size_t(12), tuning_name.size());
+          getCout() << "\t\tRunning " << setw(tuning_width) << tuning_name
+                    << setw(default_width) << " tuning" << flush;
         }
 
         kernel->execute(vid, tune_idx); // Execute kernel
 
         if ( run_params.showProgress() ) {
-          getCout() << " -- " << kernel->getLastTime() << " sec." << endl;
+          getCout() << " -- " << kernel->getLastTime() << " sec.";
+
+          size_t prec = 20;
+          const auto default_precision = getCout().precision();
+          Checksum_type checksum = kernel->getChecksum(vid, tune_idx);
+#if defined(RAJA_PERFSUITE_ENABLE_MPI)
+          {
+            Checksum_type checksum_sum = 0;
+            Allreduce(&checksum, &checksum_sum, 1, MPI_SUM, MPI_COMM_WORLD);
+            checksum = checksum_sum / num_ranks;
+          }
+          getCout() << " checksum_avg ";
+#else
+          getCout() << " checksum ";
+#endif
+          getCout() << setprecision(prec) << checksum
+                    << setprecision(default_precision) << endl;
         }
 
       } else {

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -238,6 +238,15 @@ Size_type KernelBase::getDataAlignment() const
   return run_params.getDataAlignment();
 }
 
+Size_type KernelBase::getSizePaddedToDataAlignment(Size_type size) const
+{
+  Size_type misalignment = size % run_params.getDataAlignment();
+  if (misalignment) {
+    size += run_params.getDataAlignment() - misalignment;
+  }
+  return size;
+}
+
 DataSpace KernelBase::getDataSpace(VariantID vid) const
 {
   switch ( vid ) {

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -308,6 +308,13 @@ public:
   }
 
   Size_type getDataAlignment() const;
+  Size_type getSizePaddedToDataAlignment(Size_type size) const;
+
+  template <typename T>
+  T offsetPointer(T ptr, Size_type size) const
+  {
+    return (T)(((char*)ptr) + size);
+  }
 
   DataSpace getDataSpace(VariantID vid) const;
   DataSpace getReductionDataSpace(VariantID vid) const;


### PR DESCRIPTION
# Summary

Strictly honor the requested alignment when getting comm buffers by getting one large allocation and doling it out with the given alignment.

- This PR is a refactoring
- It does the following:
  - Modifies/refactors comm buffer allocation code
