### PR TITLE
Resolving Compilation Issues Rlated to Kokkos

### DIFF
--- a/src/algorithm/ATOMIC.hpp
+++ b/src/algorithm/ATOMIC.hpp
@@ -77,7 +77,6 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
-  void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setSeqTuningDefinitions(VariantID vid);
   void setOpenMPTuningDefinitions(VariantID vid);

--- a/src/algorithm/HISTOGRAM.hpp
+++ b/src/algorithm/HISTOGRAM.hpp
@@ -101,7 +101,6 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
-  void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);

--- a/src/basic-kokkos/ARRAY_OF_PTRS-Kokkos.cpp
+++ b/src/basic-kokkos/ARRAY_OF_PTRS-Kokkos.cpp
@@ -22,7 +22,7 @@ void ARRAY_OF_PTRS::runKokkosVariant(VariantID vid, size_t RAJAPERF_UNUSED_ARG(t
   ARRAY_OF_PTRS_DATA_SETUP;
 
   using view_type = std::decay_t<decltype(getViewFromPointer(x[0], iend))>;
-  auto x_view[ARRAY_OF_PTRS_MAX_ARRAY_SIZE];
+  view_type x_view[ARRAY_OF_PTRS_MAX_ARRAY_SIZE];
   for (Index_type a = 0; a < array_size; ++a) {
     x_view[a] = getViewFromPointer(x[a], iend) ;
   }

--- a/src/basic/COPY8.hpp
+++ b/src/basic/COPY8.hpp
@@ -81,8 +81,6 @@ public:
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
   void runSyclVariant(VariantID vid, size_t tune_idx);
 
-  void runKokkosVariant(VariantID vid, size_t tune_idx);
-
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);
   void setSyclTuningDefinitions(VariantID vid);

--- a/src/basic/MULTI_REDUCE.hpp
+++ b/src/basic/MULTI_REDUCE.hpp
@@ -96,7 +96,6 @@ public:
   void runCudaVariant(VariantID vid, size_t tune_idx);
   void runHipVariant(VariantID vid, size_t tune_idx);
   void runOpenMPTargetVariant(VariantID vid, size_t tune_idx);
-  void runKokkosVariant(VariantID vid, size_t tune_idx);
 
   void setCudaTuningDefinitions(VariantID vid);
   void setHipTuningDefinitions(VariantID vid);


### PR DESCRIPTION
While working with the Kokkos_Lambda variant in RAJAPerf, I encountered several compilation issues and have implemented the following resolutions:

1. **Kokkos Submodule Version Update:**
  - The RAJAPerf codebase utilizes Kokkos::min and Kokkos::max, which are only available in Kokkos version 3.7 and above (previously under Kokkos::Experimental). To address this, I updated the Kokkos submodule to version 3.7.02. Further details on this change can be found [here].

2. **Array Declaration Correction in `ARRAY_OF_PTRS-Kokkos.cpp`:**
  - In `src/basic-kokkos/ARRAY_OF_PTRS-Kokkos.cpp`, the original declaration `auto x_view[ARRAY_OF_PTRS_MAX_ARRAY_SIZE]` resulted in a compiler error, as arrays of auto are not permitted. This was resolved by updating the declaration to `view_type x_view[ARRAY_OF_PTRS_MAX_ARRAY_SIZE]`.

3. **Removal of Redundant `runKokkosVariant` Calls:**
  - I identified and removed unnecessary invocations of `runKokkosVariant` in the following header files:
    - `src/algorithm/ATOMIC.hpp`
    -  `src/algorithm/HISTOGRAM.hpp`
    -  `src/basic/COPY8.hpp`
    -   `src/basic/MULTI_REDUCE.hpp`
