### PR TITLE
Add Atomic Feature to DAXPY_ATOMIC

### DIFF
--- a/src/basic/DAXPY_ATOMIC.cpp
+++ b/src/basic/DAXPY_ATOMIC.cpp
@@ -36,6 +36,7 @@ DAXPY_ATOMIC::DAXPY_ATOMIC(const RunParams& params)
   setComplexity(Complexity::N);
 
   setUsesFeature(Forall);
+  setUsesFeature(Atomic);
 
   setVariantDefined( Base_Seq );
   setVariantDefined( Lambda_Seq );


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following (modify list as needed):
  - `src/basic/DAXPY_ATOMIC.cpp` missing atomic feature