### PR TITLE
Squash unused arg warning

### DIFF
--- a/src/comm/HALO_base.cpp
+++ b/src/comm/HALO_base.cpp
@@ -357,7 +357,7 @@ void HALO_base::create_buffers(std::vector<Index_type> const& index_list_lengths
 
 void HALO_base::destroy_buffers(std::vector<Real_ptr>& our_buffers,
                                 std::vector<Real_ptr>& mpi_buffers,
-                                const Index_type num_neighbors,
+                                const Index_type RAJA_UNUSED_ARG(num_neighbors),
                                 VariantID vid)
 {
   const bool separate_buffers = (getMPIDataSpace(vid) == DataSpace::Copy);


### PR DESCRIPTION
# Summary

- This PR does what the title says

@MrBurmark I used the RAJA macro rather than remove the argument because the change is smaller and I thought you may want to use it in the future. Please let me know if I should remove the arg in question from the code.
