### PR TITLE
Fix icpx scripts and change -sp time printing

### DIFF
--- a/scripts/lc-builds/toss4_icpx.sh
+++ b/scripts/lc-builds/toss4_icpx.sh
@@ -40,8 +40,8 @@ source /usr/tce/packages/intel/intel-${COMP_VER}/setvars.sh
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_CXX_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/compiler/${COMP_VER}/linux/bin/icpx \
-  -DCMAKE_C_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/compiler/${COMP_VER}/linux/bin/icx \
+  -DCMAKE_CXX_COMPILER=icpx \
+  -DCMAKE_C_COMPILER=icx \
   -DBLT_CXX_STD=c++17 \
   -C ${RAJA_HOSTCONFIG} \
   -DRAJA_ENABLE_FORCEINLINE_RECURSIVE=Off \

--- a/scripts/lc-builds/toss4_mvapich2_icpx.sh
+++ b/scripts/lc-builds/toss4_mvapich2_icpx.sh
@@ -48,8 +48,8 @@ cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DMPI_C_COMPILER="/usr/tce/packages/mvapich2/mvapich2-${MPI_VER}-intel-${COMP_VER}/bin/mpicc" \
   -DMPI_CXX_COMPILER="/usr/tce/packages/mvapich2/mvapich2-${MPI_VER}-intel-${COMP_VER}/bin/mpicxx" \
-  -DCMAKE_CXX_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/compiler/${COMP_VER}/linux/bin/icpx \
-  -DCMAKE_C_COMPILER=/usr/tce/packages/intel/intel-${COMP_VER}/compiler/${COMP_VER}/linux/bin/icx \
+  -DCMAKE_CXX_COMPILER=icpx \
+  -DCMAKE_C_COMPILER=icx \
   -DBLT_CXX_STD=c++17 \
   -C ${RAJA_HOSTCONFIG} \
   -DENABLE_MPI=ON \

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -723,7 +723,7 @@ void Executor::runKernel(KernelBase* kernel, bool print_kernel_name)
         kernel->execute(vid, tune_idx); // Execute kernel
 
         if ( run_params.showProgress() ) {
-          getCout() << " -- " << kernel->getLastTime() << " sec.";
+          getCout() << " -- " << kernel->getLastTime() / kernel->getRunReps() << " sec. x " << kernel->getRunReps() << " rep.";
 
           size_t prec = 20;
           const auto default_precision = getCout().precision();


### PR DESCRIPTION
# Summary
Fix icpx scripts. 
Change how -sp prints time by printing the average time per rep and the number of reps. This is helpful when trying to quickly compare two similar kernels, that have different numbers of repetitions.

- This PR is a bugfix, feature
- It does the following:
  - Fixes toss4_icpx scripts
  - Adds more easily comparable -sp times at the request of me
