### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ RAJA Performance Suite
 [![Documentation Status](https://readthedocs.org/projects/rajaperf/badge/?version=develop)](https://raja.readthedocs.io/en/develop/?badge=develop)
 
 The RAJA Performance Suite is a companion project to the [RAJA] C++ performance
-portability abstraction library. The Performance Suite designed to eplore
+portability abstraction library. The Performance Suite designed to explore
 performance of loop-based computational kernels found in HPC applications.
 Specifically, it is used to assess and monitor runtime performance of kernels 
 implemented using [RAJA] compare those to variants implemented using common 


### PR DESCRIPTION
# Summary

Fix typo in first paragraph of readme.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes a typo
