### PR TITLE
Remove matrix from CI checks

### DIFF
--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -23,15 +23,15 @@ variables:
 # Project specific deps for dane
   PROJECT_DANE_DEPS: "^blt@develop "
 
-# Matrix
-# Arguments for top level allocation
-  MATRIX_SHARED_ALLOC: "--exclusive --time=45 --nodes=1"
-# Arguments for job level allocation
-  MATRIX_JOB_ALLOC: "--nodes=1"
-# Project specific variants for matrix
-  PROJECT_MATRIX_VARIANTS: "~shared +openmp +cuda cuda_arch=75"
-# Project specific deps for matrix
-  PROJECT_MATRIX_DEPS: "^blt@develop "
+## Matrix
+## Arguments for top level allocation
+#  MATRIX_SHARED_ALLOC: "--exclusive --time=45 --nodes=1"
+## Arguments for job level allocation
+#  MATRIX_JOB_ALLOC: "--nodes=1"
+## Project specific variants for matrix
+#  PROJECT_MATRIX_VARIANTS: "~shared +openmp +cuda cuda_arch=75"
+## Project specific deps for matrix
+#  PROJECT_MATRIX_DEPS: "^blt@develop "
 
 # Corona
 # Arguments for top level allocation

--- a/.gitlab/subscribed-pipelines.yml
+++ b/.gitlab/subscribed-pipelines.yml
@@ -42,14 +42,14 @@ generate-job-lists:
     LOCAL_JOBS_PATH: ".gitlab/jobs"
   script:
     - cat ${RADIUSS_JOBS_PATH}/dane.yml ${LOCAL_JOBS_PATH}/dane.yml > dane-jobs.yml
-    - cat ${RADIUSS_JOBS_PATH}/matrix.yml ${LOCAL_JOBS_PATH}/matrix.yml > matrix-jobs.yml
+#    - cat ${RADIUSS_JOBS_PATH}/matrix.yml ${LOCAL_JOBS_PATH}/matrix.yml > matrix-jobs.yml
     - cat ${RADIUSS_JOBS_PATH}/corona.yml ${LOCAL_JOBS_PATH}/corona.yml > corona-jobs.yml
     - cat ${RADIUSS_JOBS_PATH}/tioga.yml ${LOCAL_JOBS_PATH}/tioga.yml > tioga-jobs.yml
     - cat ${RADIUSS_JOBS_PATH}/tuolumne.yml ${LOCAL_JOBS_PATH}/tuolumne.yml > tuolumne-jobs.yml
   artifacts:
     paths:
       - dane-jobs.yml
-      - matrix-jobs.yml
+#      - matrix-jobs.yml
       - corona-jobs.yml
       - tioga-jobs.yml
       - tuolumne-jobs.yml
@@ -76,27 +76,27 @@ dane-build-and-test:
       when: never
     - when: on_success
 
-# MATRIX
-matrix-up-check:
-  variables:
-    CI_MACHINE: "matrix"
-  extends: [.machine-check]
-  rules:
-    # Runs except if we explicitly deactivate matrix by variable.
-    - if: '$ON_MATRIX == "OFF"'
-      when: never
-    - when: on_success
-
-matrix-build-and-test:
-  variables:
-    CI_MACHINE: "matrix"
-  needs: [matrix-up-check, generate-job-lists]
-  extends: [.build-and-test]
-  rules:
-    # Runs except if we explicitly deactivate matrix by variable.
-    - if: '$ON_MATRIX == "OFF"'
-      when: never
-    - when: on_success
+## MATRIX
+#matrix-up-check:
+#  variables:
+#    CI_MACHINE: "matrix"
+#  extends: [.machine-check]
+#  rules:
+#    # Runs except if we explicitly deactivate matrix by variable.
+#    - if: '$ON_MATRIX == "OFF"'
+#      when: never
+#    - when: on_success
+#
+#matrix-build-and-test:
+#  variables:
+#    CI_MACHINE: "matrix"
+#  needs: [matrix-up-check, generate-job-lists]
+#  extends: [.build-and-test]
+#  rules:
+#    # Runs except if we explicitly deactivate matrix by variable.
+#    - if: '$ON_MATRIX == "OFF"'
+#      when: never
+#    - when: on_success
 
 # CORONA
 corona-up-check:


### PR DESCRIPTION
# Summary

- This PR removes matrix from GitLab CI checks (due to timeout failures)
- We will be adding CUDA builds and tests on matrix via other mechanisms.