### PR TITLE
Add ChecksumConsistency string attribute to group by for Caliper

### DIFF
--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -525,7 +525,7 @@ void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
           { "expr": "any(max#View)", "as": "FeatureView" },
           { "expr": "any(max#MPI)", "as": "FeatureMPI" },
         ],
-        "group by": ["Complexity"],
+        "group by": ["Complexity", "ChecksumConsistency"],
       },
       {
         "level"  : "cross",
@@ -554,7 +554,7 @@ void KernelBase::setCaliperMgrVariantTuning(VariantID vid,
           { "expr": "any(any#max#View)", "as": "FeatureView" },
           { "expr": "any(any#max#MPI)", "as": "FeatureMPI" },
         ],
-        "group by": ["Complexity"],
+        "group by": ["Complexity", "ChecksumConsistency"],
       }
     ]
   }


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following:
  - Fixes the caliper additions from #607

Example how to read this attribute into thicket:
```
tk = th.Thicket.from_caliperreader("Base_Seq-default.cali", string_attributes=["Complexity", "ChecksumConsistency"])
```
