### PR TITLE
Move Kernel Sizing to Function

### DIFF
--- a/TODO/WIP-COUPLE.cpp
+++ b/TODO/WIP-COUPLE.cpp
@@ -28,8 +28,23 @@ COUPLE::COUPLE(const RunParams& params)
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(50);
 
-  Index_type rzmax = std::cbrt(getTargetProblemSize())+1;
-  m_domain = new ADomain(rzmax, /* ndims = */ 3);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void COUPLE::setSize(Index_type target_size, Index_type target_reps)
+{
+  Index_type rzmax = std::cbrt(target_size)+1;
+  m_domain.reset(new ADomain(rzmax, /* ndims = */ 3));
 
   m_imin = m_domain->imin;
   m_imax = m_domain->imax;
@@ -39,20 +54,16 @@ COUPLE::COUPLE(const RunParams& params)
   m_kmax = m_domain->kmax;
 
   setActualProblemSize( m_domain->n_real_zones );
+  setRunReps( target_reps );
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
   setBytesPerRep( (3*sizeof(Complex_type) + 5*sizeof(Complex_type)) * m_domain->n_real_zones );
   setFLOPsPerRep(0);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 COUPLE::~COUPLE()
 {
-  delete m_domain;
 }
 
 void COUPLE::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/TODO/WIP-COUPLE.hpp
+++ b/TODO/WIP-COUPLE.hpp
@@ -162,6 +162,7 @@ public:
 
   ~COUPLE();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);
@@ -197,7 +198,7 @@ private:
   Index_type m_kmin;
   Index_type m_kmax;
 
-  ADomain* m_domain;
+  std::unique_ptr<ADomain> m_domain;
 };
 
 } // end namespace apps

--- a/src/algorithm/ATOMIC.cpp
+++ b/src/algorithm/ATOMIC.cpp
@@ -25,15 +25,8 @@ ATOMIC::ATOMIC(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 0 );
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // atomic (assumes replication == problem size)
-  setFLOPsPerRep(getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent); // atomics
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -44,6 +37,20 @@ ATOMIC::ATOMIC(const RunParams& params)
   setUsesFeature(Atomic);
 
   addVariantTunings();
+}
+
+void ATOMIC::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // atomic (assumes replication == problem size)
+  setFLOPsPerRep(getActualProblemSize());
 }
 
 ATOMIC::~ATOMIC()

--- a/src/algorithm/ATOMIC.hpp
+++ b/src/algorithm/ATOMIC.hpp
@@ -66,6 +66,7 @@ public:
 
   ~ATOMIC();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/algorithm/HISTOGRAM.cpp
+++ b/src/algorithm/HISTOGRAM.cpp
@@ -28,18 +28,11 @@ HISTOGRAM::HISTOGRAM(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
   m_num_bins = params.getMultiReduceNumBins();
   m_bin_assignment_algorithm = params.getMultiReduceBinAssignmentAlgorithm();
 
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Index_type) * getActualProblemSize() ); // bins
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Data_type) * m_num_bins ); // counts
-  setFLOPsPerRep( (std::is_floating_point_v<Data_type> ? 1 : 0) * getActualProblemSize() );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Consistent); // integer arithmetic
   setChecksumTolerance(ChecksumTolerance::zero);
@@ -50,6 +43,20 @@ HISTOGRAM::HISTOGRAM(const RunParams& params)
   setUsesFeature(Atomic);
 
   addVariantTunings();
+}
+
+void HISTOGRAM::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Index_type) * getActualProblemSize() ); // bins
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Data_type) * m_num_bins ); // counts
+  setFLOPsPerRep( (std::is_floating_point_v<Data_type> ? 1 : 0) * getActualProblemSize() );
 }
 
 HISTOGRAM::~HISTOGRAM()

--- a/src/algorithm/HISTOGRAM.hpp
+++ b/src/algorithm/HISTOGRAM.hpp
@@ -88,6 +88,7 @@ public:
 
   ~HISTOGRAM();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/algorithm/MEMCPY.cpp
+++ b/src/algorithm/MEMCPY.cpp
@@ -25,15 +25,8 @@ MEMCPY::MEMCPY(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(100);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // y
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(0);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Consistent);
   setChecksumTolerance(ChecksumTolerance::zero);
@@ -43,6 +36,20 @@ MEMCPY::MEMCPY(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings( );
+}
+
+void MEMCPY::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // y
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(0);
 }
 
 MEMCPY::~MEMCPY()

--- a/src/algorithm/MEMCPY.hpp
+++ b/src/algorithm/MEMCPY.hpp
@@ -46,6 +46,7 @@ public:
 
   ~MEMCPY();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/algorithm/MEMSET.cpp
+++ b/src/algorithm/MEMSET.cpp
@@ -25,15 +25,8 @@ MEMSET::MEMSET(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(100);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 0 );
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(0);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Consistent);
   setChecksumTolerance(ChecksumTolerance::zero);
@@ -43,6 +36,20 @@ MEMSET::MEMSET(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings( );
+}
+
+void MEMSET::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(0);
 }
 
 MEMSET::~MEMSET()

--- a/src/algorithm/MEMSET.hpp
+++ b/src/algorithm/MEMSET.hpp
@@ -46,6 +46,7 @@ public:
 
   ~MEMSET();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/algorithm/REDUCE_SUM.cpp
+++ b/src/algorithm/REDUCE_SUM.cpp
@@ -25,15 +25,8 @@ REDUCE_SUM::REDUCE_SUM(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) * (1+getActualProblemSize()) ); // x
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent); // Reduction may use atomics
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -44,6 +37,20 @@ REDUCE_SUM::REDUCE_SUM(const RunParams& params)
   setUsesFeature(Reduction);
 
   addVariantTunings( );
+}
+
+void REDUCE_SUM::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Real_type) * (1+getActualProblemSize()) ); // x
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(getActualProblemSize());
 }
 
 REDUCE_SUM::~REDUCE_SUM()

--- a/src/algorithm/REDUCE_SUM.hpp
+++ b/src/algorithm/REDUCE_SUM.hpp
@@ -50,6 +50,7 @@ public:
 
   ~REDUCE_SUM();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/algorithm/SCAN.cpp
+++ b/src/algorithm/SCAN.cpp
@@ -24,15 +24,8 @@ SCAN::SCAN(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(100);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // y
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(1 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent); // could depend on scheduling, this may be overly conservative
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -42,6 +35,20 @@ SCAN::SCAN(const RunParams& params)
   setUsesFeature(Scan);
 
   addVariantTunings( );
+}
+
+void SCAN::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // y
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(1 * getActualProblemSize());
 }
 
 SCAN::~SCAN()

--- a/src/algorithm/SCAN.hpp
+++ b/src/algorithm/SCAN.hpp
@@ -53,6 +53,7 @@ public:
 
   ~SCAN();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/algorithm/SORT.cpp
+++ b/src/algorithm/SORT.cpp
@@ -25,16 +25,8 @@ SORT::SORT(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(20);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  // not useful in this case due to O(n*log(n)) algorithm
-  setBytesReadPerRep( 0 );
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(0);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Consistent); // sort is not stable but values are equal if equivalent
   setChecksumTolerance(ChecksumTolerance::zero);
@@ -44,6 +36,21 @@ SORT::SORT(const RunParams& params)
   setUsesFeature(Sort);
 
   addVariantTunings( );
+}
+
+void SORT::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  // not useful in this case due to O(n*log(n)) algorithm
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(0);
 }
 
 SORT::~SORT()

--- a/src/algorithm/SORT.hpp
+++ b/src/algorithm/SORT.hpp
@@ -43,6 +43,7 @@ public:
 
   ~SORT();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/algorithm/SORTPAIRS.cpp
+++ b/src/algorithm/SORTPAIRS.cpp
@@ -25,16 +25,8 @@ SORTPAIRS::SORTPAIRS(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(20);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  // not useful in this case due to O(n*log(n)) algorithm
-  setBytesReadPerRep( 0 );
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // x, i
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(0);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent); // sort is not stable and could depend on scheduling
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -44,6 +36,21 @@ SORTPAIRS::SORTPAIRS(const RunParams& params)
   setUsesFeature(Sort);
 
   addVariantTunings( );
+}
+
+void SORTPAIRS::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  // not useful in this case due to O(n*log(n)) algorithm
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // x, i
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(0);
 }
 
 SORTPAIRS::~SORTPAIRS()

--- a/src/algorithm/SORTPAIRS.hpp
+++ b/src/algorithm/SORTPAIRS.hpp
@@ -42,6 +42,7 @@ public:
 
   ~SORTPAIRS();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/CONVECTION3DPA.cpp
+++ b/src/apps/CONVECTION3DPA.cpp
@@ -28,10 +28,26 @@ CONVECTION3DPA::CONVECTION3DPA(const RunParams& params)
   setDefaultProblemSize(NE_default*conv::D1D*conv::D1D*conv::D1D);
   setDefaultReps(50);
 
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Launch);
+
+  addVariantTunings();
+}
+
+void CONVECTION3DPA::setSize(Index_type target_size, Index_type target_reps)
+{
   //Define problem size in terms of DOFS
-  m_NE = std::max((getTargetProblemSize() + (conv::D1D*conv::D1D*conv::D1D)/2) / (conv::D1D*conv::D1D*conv::D1D), Index_type(1));
+  m_NE = std::max((target_size + (conv::D1D*conv::D1D*conv::D1D)/2) / (conv::D1D*conv::D1D*conv::D1D), Index_type(1));
 
   setActualProblemSize( m_NE*conv::D1D*conv::D1D*conv::D1D );
+  setRunReps( target_reps );
 
   setItsPerRep( m_NE*conv::D1D*conv::D1D*conv::D1D );
   setKernelsPerRep(1);
@@ -52,15 +68,6 @@ CONVECTION3DPA::CONVECTION3DPA(const RunParams& params)
                          2 * conv::Q1D * conv::D1D * conv::Q1D * conv::D1D + // 7
                          (1 + 2*conv::Q1D) * conv::D1D * conv::D1D * conv::D1D // 8
                          ));
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Launch);
-
-  addVariantTunings();
 }
 
 CONVECTION3DPA::~CONVECTION3DPA()

--- a/src/apps/CONVECTION3DPA.hpp
+++ b/src/apps/CONVECTION3DPA.hpp
@@ -366,6 +366,7 @@ public:
 
   ~CONVECTION3DPA();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -29,21 +29,8 @@ DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
   setDefaultProblemSize(1000*1000);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::sqrt(getTargetProblemSize()) + 1 + std::sqrt(2)-1;
-  m_domain = new ADomain(rzmax, /* ndims = */ 2);
-
-  m_array_length = m_domain->nnalls;
-
-  setActualProblemSize(m_domain->n_real_zones);
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Index_type) * getItsPerRep() + // real_zones
-                      4*sizeof(Real_type) * m_domain->n_real_nodes ); // x, y, fx, fy (2d nodal stencil pattern: 4 touches per iterate)
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() ); // div
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(54 * m_domain->n_real_zones);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -55,9 +42,30 @@ DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
   addVariantTunings();
 }
 
+void DEL_DOT_VEC_2D::setSize(Index_type target_size, Index_type target_reps)
+{
+  Index_type rzmax = std::sqrt(target_size) + 1 + std::sqrt(2)-1;
+  m_domain.reset(new ADomain(rzmax, /* ndims = */ 2));
+
+  m_array_length = m_domain->nnalls;
+
+  setActualProblemSize(m_domain->n_real_zones);
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Index_type) * getItsPerRep() + // real_zones
+                      4*sizeof(Real_type) * m_domain->n_real_nodes ); // x, y, fx, fy (2d nodal stencil pattern: 4 touches per iterate)
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() ); // div
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(54 * m_domain->n_real_zones);
+
+
+}
+
 DEL_DOT_VEC_2D::~DEL_DOT_VEC_2D()
 {
-  delete m_domain;
 }
 
 void DEL_DOT_VEC_2D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/src/apps/DEL_DOT_VEC_2D.hpp
+++ b/src/apps/DEL_DOT_VEC_2D.hpp
@@ -110,6 +110,7 @@ public:
 
   ~DEL_DOT_VEC_2D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);
@@ -145,7 +146,7 @@ private:
   Real_type m_ptiny;
   Real_type m_half;
 
-  ADomain* m_domain;
+  std::unique_ptr<ADomain> m_domain;
   Index_type* m_real_zones;
   Index_type m_array_length;
 };

--- a/src/apps/DIFFUSION3DPA.cpp
+++ b/src/apps/DIFFUSION3DPA.cpp
@@ -28,9 +28,25 @@ DIFFUSION3DPA::DIFFUSION3DPA(const RunParams& params)
   setDefaultProblemSize(NE_default*diff::D1D*diff::D1D*diff::D1D);
   setDefaultReps(50);
 
-  m_NE = std::max((getTargetProblemSize() + (diff::D1D*diff::D1D*diff::D1D)/2) / (diff::D1D*diff::D1D*diff::D1D), Index_type(1));
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Launch);
+
+  addVariantTunings();
+}
+
+void DIFFUSION3DPA::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_NE = std::max((target_size + (diff::D1D*diff::D1D*diff::D1D)/2) / (diff::D1D*diff::D1D*diff::D1D), Index_type(1));
 
   setActualProblemSize( m_NE*diff::D1D*diff::D1D*diff::D1D );
+  setRunReps( target_reps );
 
   setItsPerRep( m_NE*diff::D1D*diff::D1D*diff::D1D );
   setKernelsPerRep(1);
@@ -48,15 +64,6 @@ DIFFUSION3DPA::DIFFUSION3DPA(const RunParams& params)
                          (6 * diff::Q1D) * diff::D1D * diff::Q1D * diff::Q1D + //DIFFUSION3DPA_7
                          (6 * diff::Q1D) * diff::D1D * diff::D1D * diff::Q1D + //DIFFUSION3DPA_8
                          (6 * diff::Q1D + 1)*diff::D1D*diff::D1D*diff::D1D)); //DIFFUSION3DPA_9
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Launch);
-
-  addVariantTunings();
 }
 
 DIFFUSION3DPA::~DIFFUSION3DPA()

--- a/src/apps/DIFFUSION3DPA.hpp
+++ b/src/apps/DIFFUSION3DPA.hpp
@@ -414,6 +414,7 @@ public:
 
   ~DIFFUSION3DPA();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/EDGE3D.cpp
+++ b/src/apps/EDGE3D.cpp
@@ -28,13 +28,30 @@ EDGE3D::EDGE3D(const RunParams& params)
 {
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(10);
-  Index_type rzmax = std::cbrt(getTargetProblemSize()) + 1 + std::cbrt(3)-1;
-  m_domain = new ADomain(rzmax, /* ndims = */ 3);
+
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void EDGE3D::setSize(Index_type target_size, Index_type target_reps)
+{
+  Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
+  m_domain.reset(new ADomain(rzmax, /* ndims = */ 3));
 
   m_array_length = m_domain->nnalls;
   size_t number_of_elements = m_domain->lpz+1 - m_domain->fpz;
 
   setActualProblemSize( m_domain->n_real_zones );
+  setRunReps( target_reps );
 
   setItsPerRep( number_of_elements );
   setKernelsPerRep(1);
@@ -59,20 +76,10 @@ EDGE3D::EDGE3D(const RunParams& params)
   constexpr size_t flops_per_element = flops_i_loop*NQ_1D + 9*flops_Jxx() + flops_compute_detj();
 
   setFLOPsPerRep(number_of_elements * flops_per_element);
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 EDGE3D::~EDGE3D()
 {
-  delete m_domain;
 }
 
 void EDGE3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/src/apps/EDGE3D.hpp
+++ b/src/apps/EDGE3D.hpp
@@ -409,6 +409,7 @@ public:
 
   ~EDGE3D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);
@@ -440,7 +441,7 @@ private:
   Real_ptr m_z;
   Real_ptr m_sum;
 
-  ADomain* m_domain;
+  std::unique_ptr<ADomain> m_domain;
   Index_type m_array_length;
 };
 

--- a/src/apps/ENERGY.cpp
+++ b/src/apps/ENERGY.cpp
@@ -25,7 +25,26 @@ ENERGY::ENERGY(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(130);
 
-  setActualProblemSize( getTargetProblemSize() );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void ENERGY::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+
+  setActualProblemSize( target_size );
 
   setItsPerRep( 6 * getActualProblemSize() );
   setKernelsPerRep(6);
@@ -60,15 +79,6 @@ ENERGY::ENERGY(const RunParams& params)
                   19 + // 1 sqrt
                   9    // 1 sqrt
                   ) * getActualProblemSize());
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 ENERGY::~ENERGY()

--- a/src/apps/ENERGY.hpp
+++ b/src/apps/ENERGY.hpp
@@ -195,6 +195,7 @@ public:
 
   ~ENERGY();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/FEMSWEEP.cpp
+++ b/src/apps/FEMSWEEP.cpp
@@ -36,6 +36,23 @@ FEMSWEEP::FEMSWEEP(const RunParams& params)
   setDefaultProblemSize(ND * m_ne * m_ng * m_na);
   setDefaultReps(1);
 
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  // The checksum is inaccurate starting at the 10's digit for: AMD CPU and older clang versions on NVIDIA GPUs.
+  setChecksumTolerance(ChecksumTolerance::loose);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Launch);
+  //setUsesFeature(View);
+
+  addVariantTunings();
+}
+
+void FEMSWEEP::setSize(Index_type RAJAPERF_UNUSED_ARG(target_size), Index_type target_reps)
+{
   m_Blen = ND * m_ne * m_na;
   m_Alen = ND * ND * m_ne * m_na;
   // 9450 is a property of the mesh. Will need to derive this when mesh generator is available.
@@ -45,6 +62,7 @@ FEMSWEEP::FEMSWEEP(const RunParams& params)
   m_Xlen = ND * m_ne * m_ng * m_na;
 
   setActualProblemSize( m_Xlen );
+  setRunReps( target_reps );
 
   setItsPerRep(1);
   setKernelsPerRep(1);
@@ -64,17 +82,6 @@ FEMSWEEP::FEMSWEEP(const RunParams& params)
                   ND * (ND-1) * 3 +               // backward substitution
                   NLF * FDS - m_nx * m_ny * 6) *  // coupling between sides of faces
                   m_ne * m_na * m_ng );           // for all elements, angles, and groups
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  // The checksum is inaccurate starting at the 10's digit for: AMD CPU and older clang versions on NVIDIA GPUs.
-  setChecksumTolerance(ChecksumTolerance::loose);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Launch);
-  //setUsesFeature(View);
-
-  addVariantTunings();
 }
 
 FEMSWEEP::~FEMSWEEP()

--- a/src/apps/FEMSWEEP.hpp
+++ b/src/apps/FEMSWEEP.hpp
@@ -281,6 +281,7 @@ public:
 
   ~FEMSWEEP();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/FIR.cpp
+++ b/src/apps/FIR.cpp
@@ -27,16 +27,8 @@ FIR::FIR(const RunParams& params)
 
   m_coefflen = FIR_COEFFLEN;
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( m_coefflen*sizeof(Real_type) + // coeff
-                      1*sizeof(Real_type) * (getActualProblemSize() + m_coefflen-1) ); // in
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // out
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep((2 * m_coefflen) * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -46,6 +38,21 @@ FIR::FIR(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void FIR::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( m_coefflen*sizeof(Real_type) + // coeff
+                      1*sizeof(Real_type) * (getActualProblemSize() + m_coefflen-1) ); // in
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // out
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep((2 * m_coefflen) * getActualProblemSize());
 }
 
 FIR::~FIR()

--- a/src/apps/FIR.hpp
+++ b/src/apps/FIR.hpp
@@ -70,6 +70,7 @@ public:
 
   ~FIR();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/INTSC_HEXHEX.cpp
+++ b/src/apps/INTSC_HEXHEX.cpp
@@ -39,18 +39,35 @@ INTSC_HEXHEX::INTSC_HEXHEX(const RunParams& params)
   setDefaultProblemSize(n_std_intsc_def);
 
   setDefaultReps  (1);
-  setKernelsPerRep(2);   // main intersection kernel and final fixup.
 
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void INTSC_HEXHEX::setSize(Index_type target_size, Index_type target_reps)
+{
   // Number of standard intersections, by convention a cube number.
   Size_type a3 =
-      (Size_type) ( std::cbrt((Real_type) getTargetProblemSize() + 0.5) );
+      (Size_type) ( std::cbrt((Real_type) target_size + 0.5) );
 
   if ( a3 < 1UL ) { a3 = 1UL ; }
 
   Size_type n_std_intsc = a3*a3*a3 ;
 
   setActualProblemSize( n_std_intsc ) ;
-  setItsPerRep        ( n_std_intsc );
+  setRunReps( target_reps );
+
+  setItsPerRep( n_std_intsc );
+  setKernelsPerRep(2);   // main intersection kernel and final fixup.
 
   // touched data size, not actual number of stores and loads
   // see VOL3D.cpp
@@ -73,15 +90,6 @@ INTSC_HEXHEX::INTSC_HEXHEX(const RunParams& params)
   constexpr Size_type flops_per_intsc = flops_per_tri * tri_per_std_intsc ;
 
   setFLOPsPerRep(n_std_intsc * flops_per_intsc);
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 INTSC_HEXHEX::~INTSC_HEXHEX()

--- a/src/apps/INTSC_HEXHEX.hpp
+++ b/src/apps/INTSC_HEXHEX.hpp
@@ -150,6 +150,7 @@ public:
 
   ~INTSC_HEXHEX();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/INTSC_HEXRECT.cpp
+++ b/src/apps/INTSC_HEXRECT.cpp
@@ -40,13 +40,29 @@ INTSC_HEXRECT::INTSC_HEXRECT(const RunParams& params)
   constexpr Size_type a3_def = 50 ;
   Size_type n_intsc_def = intsc_per_zone * a3_def * a3_def * a3_def ;
   setDefaultProblemSize(n_intsc_def);
+  setDefaultReps(1);
 
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void INTSC_HEXRECT::setSize(Index_type target_size, Index_type target_reps)
+{
   //  Command line --size specifies requested number of intersections.
   //  Requested number of intersections will be converted to an even cube
   //  number of intersections.
   //
   Size_type a3 =
-      (Size_type) ( std::cbrt((Real_type) getTargetProblemSize() + 0.5) );
+      (Size_type) ( std::cbrt((Real_type) target_size + 0.5) );
 
   // number of donor zones on a side of the cube
   Size_type side = a3 / 2 ;
@@ -56,9 +72,9 @@ INTSC_HEXRECT::INTSC_HEXRECT(const RunParams& params)
   m_ndzones = side * side * side ;   // number of "donor zones" on a side
   Size_type n_intsc = intsc_per_zone*m_ndzones ;   // number of intersections
   m_ntzones = n_intsc ;          // one "target zone" per intersection
-  setDefaultReps(1);
 
   setActualProblemSize( n_intsc );
+  setRunReps( target_reps );
 
   setItsPerRep( n_intsc );
   setKernelsPerRep(1);
@@ -81,15 +97,6 @@ INTSC_HEXRECT::INTSC_HEXRECT(const RunParams& params)
   constexpr Size_type flops_per_intsc = flops_per_tri * tri_per_hex ;
 
   setFLOPsPerRep(n_intsc * flops_per_intsc);
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 INTSC_HEXRECT::~INTSC_HEXRECT()

--- a/src/apps/INTSC_HEXRECT.hpp
+++ b/src/apps/INTSC_HEXRECT.hpp
@@ -108,6 +108,7 @@ public:
 
   ~INTSC_HEXRECT();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/LTIMES.cpp
+++ b/src/apps/LTIMES.cpp
@@ -32,23 +32,8 @@ LTIMES::LTIMES(const RunParams& params)
   setDefaultProblemSize(m_num_d * m_num_g * num_z_default);
   setDefaultReps(50);
 
-  m_num_z = std::max((getTargetProblemSize() + (m_num_d * m_num_g)/2) / (m_num_d * m_num_g), Index_type(1));
-
-  m_philen = m_num_m * m_num_g * m_num_z;
-  m_elllen = m_num_d * m_num_m;
-  m_psilen = m_num_d * m_num_g * m_num_z;
-
-  setActualProblemSize( m_psilen );
-
-  setItsPerRep( m_philen );
-  setKernelsPerRep(1);
-  // using total data size instead of writes and reads
-  setBytesReadPerRep( 1*sizeof(Real_type) * m_elllen + // ell
-                      1*sizeof(Real_type) * m_psilen ); // psi
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 1*sizeof(Real_type) * m_philen ); // phi
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(2 * m_num_z * m_num_g * m_num_m * m_num_d);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -60,6 +45,28 @@ LTIMES::LTIMES(const RunParams& params)
   setUsesFeature(View);
 
   addVariantTunings();
+}
+
+void LTIMES::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_num_z = std::max((target_size + (m_num_d * m_num_g)/2) / (m_num_d * m_num_g), Index_type(1));
+
+  m_philen = m_num_m * m_num_g * m_num_z;
+  m_elllen = m_num_d * m_num_m;
+  m_psilen = m_num_d * m_num_g * m_num_z;
+
+  setActualProblemSize( m_psilen );
+  setRunReps( target_reps );
+
+  setItsPerRep( m_philen );
+  setKernelsPerRep(1);
+  // using total data size instead of writes and reads
+  setBytesReadPerRep( 1*sizeof(Real_type) * m_elllen + // ell
+                      1*sizeof(Real_type) * m_psilen ); // psi
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 1*sizeof(Real_type) * m_philen ); // phi
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(2 * m_num_z * m_num_g * m_num_m * m_num_d);
 }
 
 LTIMES::~LTIMES()

--- a/src/apps/LTIMES.hpp
+++ b/src/apps/LTIMES.hpp
@@ -96,6 +96,7 @@ public:
 
   ~LTIMES();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/LTIMES_NOVIEW.cpp
+++ b/src/apps/LTIMES_NOVIEW.cpp
@@ -32,23 +32,8 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   setDefaultProblemSize(m_num_d * m_num_g * num_z_default);
   setDefaultReps(50);
 
-  m_num_z = std::max((getTargetProblemSize() + (m_num_d * m_num_g)/2) / (m_num_d * m_num_g), Index_type(1));
-
-  m_philen = m_num_m * m_num_g * m_num_z;
-  m_elllen = m_num_d * m_num_m;
-  m_psilen = m_num_d * m_num_g * m_num_z;
-
-  setActualProblemSize( m_psilen );
-
-  setItsPerRep( m_philen );
-  setKernelsPerRep(1);
-  // using total data size instead of writes and reads
-  setBytesReadPerRep( 1*sizeof(Real_type) * m_elllen + // ell
-                      1*sizeof(Real_type) * m_psilen ); // psi
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 1*sizeof(Real_type) * m_philen ); // phi
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(2 * m_num_z * m_num_g * m_num_m * m_num_d);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -59,6 +44,28 @@ LTIMES_NOVIEW::LTIMES_NOVIEW(const RunParams& params)
   setUsesFeature(Launch);
 
   addVariantTunings();
+}
+
+void LTIMES_NOVIEW::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_num_z = std::max((target_size + (m_num_d * m_num_g)/2) / (m_num_d * m_num_g), Index_type(1));
+
+  m_philen = m_num_m * m_num_g * m_num_z;
+  m_elllen = m_num_d * m_num_m;
+  m_psilen = m_num_d * m_num_g * m_num_z;
+
+  setActualProblemSize( m_psilen );
+  setRunReps( target_reps );
+
+  setItsPerRep( m_philen );
+  setKernelsPerRep(1);
+  // using total data size instead of writes and reads
+  setBytesReadPerRep( 1*sizeof(Real_type) * m_elllen + // ell
+                      1*sizeof(Real_type) * m_psilen ); // psi
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 1*sizeof(Real_type) * m_philen ); // phi
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(2 * m_num_z * m_num_g * m_num_m * m_num_d);
 }
 
 LTIMES_NOVIEW::~LTIMES_NOVIEW()

--- a/src/apps/LTIMES_NOVIEW.hpp
+++ b/src/apps/LTIMES_NOVIEW.hpp
@@ -60,6 +60,7 @@ public:
 
   ~LTIMES_NOVIEW();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/MASS3DEA.cpp
+++ b/src/apps/MASS3DEA.cpp
@@ -28,11 +28,27 @@ MASS3DEA::MASS3DEA(const RunParams& params)
   setDefaultProblemSize(NE_default*mea::D1D*mea::D1D*mea::D1D);
   setDefaultReps(1);
 
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Launch);
+
+  addVariantTunings();
+}
+
+void MASS3DEA::setSize(Index_type target_size, Index_type target_reps)
+{
   const Index_type ea_mat_entries = mea::D1D*mea::D1D*mea::D1D*mea::D1D*mea::D1D*mea::D1D;
 
-  m_NE = std::max((getTargetProblemSize() + (ea_mat_entries)/2) / (ea_mat_entries), Index_type(1));
+  m_NE = std::max((target_size + (ea_mat_entries)/2) / (ea_mat_entries), Index_type(1));
 
   setActualProblemSize( m_NE*ea_mat_entries );
+  setRunReps( target_reps );
 
   setItsPerRep( m_NE*mea::D1D*mea::D1D*mea::D1D );
   setKernelsPerRep(1);
@@ -44,15 +60,6 @@ MASS3DEA::MASS3DEA(const RunParams& params)
   setBytesAtomicModifyWrittenPerRep( 0 );
 
   setFLOPsPerRep(m_NE * 7 * ea_mat_entries);
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Launch);
-
-  addVariantTunings();
 }
 
 MASS3DEA::~MASS3DEA()

--- a/src/apps/MASS3DEA.hpp
+++ b/src/apps/MASS3DEA.hpp
@@ -149,6 +149,7 @@ public:
 
   ~MASS3DEA();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/MASS3DPA.cpp
+++ b/src/apps/MASS3DPA.cpp
@@ -28,9 +28,25 @@ MASS3DPA::MASS3DPA(const RunParams& params)
   setDefaultProblemSize(NE_default*mpa::D1D*mpa::D1D*mpa::D1D);
   setDefaultReps(50);
 
-  m_NE = std::max((getTargetProblemSize() + (mpa::D1D*mpa::D1D*mpa::D1D)/2) / (mpa::D1D*mpa::D1D*mpa::D1D), Index_type(1));
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Launch);
+
+  addVariantTunings();
+}
+
+void MASS3DPA::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_NE = std::max((target_size + (mpa::D1D*mpa::D1D*mpa::D1D)/2) / (mpa::D1D*mpa::D1D*mpa::D1D), Index_type(1));
 
   setActualProblemSize( m_NE*mpa::D1D*mpa::D1D*mpa::D1D );
+  setRunReps( target_reps );
 
   setItsPerRep( m_NE*mpa::D1D*mpa::D1D );
   setKernelsPerRep(1);
@@ -48,15 +64,6 @@ MASS3DPA::MASS3DPA(const RunParams& params)
                          2 * mpa::Q1D * mpa::Q1D * mpa::Q1D * mpa::D1D +
                          2 * mpa::Q1D * mpa::Q1D * mpa::D1D * mpa::D1D +
                          2 * mpa::Q1D * mpa::D1D * mpa::D1D * mpa::D1D + mpa::D1D * mpa::D1D * mpa::D1D));
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Launch);
-
-  addVariantTunings();
 }
 
 MASS3DPA::~MASS3DPA()

--- a/src/apps/MASS3DPA.hpp
+++ b/src/apps/MASS3DPA.hpp
@@ -355,6 +355,7 @@ public:
 
   ~MASS3DPA();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/MASS3DPA_ATOMIC.cpp
+++ b/src/apps/MASS3DPA_ATOMIC.cpp
@@ -19,8 +19,8 @@ namespace rajaperf {
 namespace apps {
 
 MASS3DPA_ATOMIC::MASS3DPA_ATOMIC(const RunParams &params)
-    : KernelBase(rajaperf::Apps_MASS3DPA_ATOMIC, params) {
-
+    : KernelBase(rajaperf::Apps_MASS3DPA_ATOMIC, params)
+{
   Index_type DOF_default = 1000000;
   setDefaultProblemSize(DOF_default);
   setDefaultReps(50);
@@ -28,8 +28,23 @@ MASS3DPA_ATOMIC::MASS3DPA_ATOMIC(const RunParams &params)
   // polynomial order
   m_P = mpa_at::D1D - 1;
 
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Launch);
+
+  addVariantTunings();
+}
+
+void MASS3DPA_ATOMIC::setSize(Index_type target_size, Index_type target_reps)
+{
   // approximate how many elements we need
-  m_NE = std::max(static_cast<Index_type>(getTargetProblemSize() / pow(m_P, 3)),
+  m_NE = std::max(static_cast<Index_type>(target_size / pow(m_P, 3)),
                   Index_type(1));
 
   // Construct the mesh
@@ -42,6 +57,7 @@ MASS3DPA_ATOMIC::MASS3DPA_ATOMIC(const RunParams &params)
   m_Tot_Dofs = (m_Nx * m_P + 1) * (m_Ny * m_P + 1) * (m_Nz * m_P + 1);
 
   setActualProblemSize(m_Tot_Dofs);
+  setRunReps( target_reps );
 
   setItsPerRep(m_NE * mpa_at::D1D * mpa_at::D1D);
   setKernelsPerRep(1);
@@ -69,15 +85,6 @@ MASS3DPA_ATOMIC::MASS3DPA_ATOMIC(const RunParams &params)
        2 * mpa_at::Q1D * mpa_at::Q1D * mpa_at::D1D * mpa_at::D1D +
        2 * mpa_at::Q1D * mpa_at::D1D * mpa_at::D1D * mpa_at::D1D +
        mpa_at::D1D * mpa_at::D1D * mpa_at::D1D));
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Launch);
-
-  addVariantTunings();
 }
 
 MASS3DPA_ATOMIC::~MASS3DPA_ATOMIC() {}

--- a/src/apps/MASS3DPA_ATOMIC.hpp
+++ b/src/apps/MASS3DPA_ATOMIC.hpp
@@ -325,6 +325,7 @@ public:
 
   ~MASS3DPA_ATOMIC();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/MASSVEC3DPA.cpp
+++ b/src/apps/MASSVEC3DPA.cpp
@@ -21,18 +21,32 @@ namespace apps {
 MASSVEC3DPA::MASSVEC3DPA(const RunParams &params)
     : KernelBase(rajaperf::Apps_MASSVEC3DPA, params)
 {
-
   const Index_type NE_initial = 5208;
-
   setDefaultProblemSize(NE_initial * mvpa::DIM * mvpa::D1D * mvpa::D1D * mvpa::D1D);
   setDefaultReps(50);
 
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Launch);
+
+  addVariantTunings();
+}
+
+void MASSVEC3DPA::setSize(Index_type target_size, Index_type target_reps)
+{
   m_NE =
-      std::max((getTargetProblemSize() + (mvpa::DIM * mvpa::Q1D * mvpa::Q1D * mvpa::Q1D) / 2) /
+      std::max((target_size + (mvpa::DIM * mvpa::Q1D * mvpa::Q1D * mvpa::Q1D) / 2) /
                    (mvpa::DIM * mvpa::Q1D * mvpa::Q1D * mvpa::Q1D),
                Index_type(1));
 
   setActualProblemSize(m_NE * mvpa::DIM * mvpa::Q1D * mvpa::Q1D * mvpa::Q1D);
+  setRunReps( target_reps );
 
   setItsPerRep(getActualProblemSize());
   setKernelsPerRep(1);
@@ -56,15 +70,6 @@ MASSVEC3DPA::MASSVEC3DPA(const RunParams &params)
                   2 * mvpa::Q1D * mvpa::D1D * mvpa::Q1D * mvpa::Q1D +
                   2 * mvpa::Q1D * mvpa::D1D * mvpa::D1D * mvpa::Q1D +
                   2 * mvpa::Q1D * mvpa::D1D * mvpa::D1D * mvpa::D1D));
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Launch);
-
-  addVariantTunings();
 }
 
 MASSVEC3DPA::~MASSVEC3DPA() {}

--- a/src/apps/MASSVEC3DPA.hpp
+++ b/src/apps/MASSVEC3DPA.hpp
@@ -254,6 +254,7 @@ public:
 
   ~MASSVEC3DPA();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/MATVEC_3D_STENCIL.cpp
+++ b/src/apps/MATVEC_3D_STENCIL.cpp
@@ -29,12 +29,28 @@ MATVEC_3D_STENCIL::MATVEC_3D_STENCIL(const RunParams& params)
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::cbrt(getTargetProblemSize()) + 1 + std::cbrt(3)-1;
-  m_domain = new ADomain(rzmax, /* ndims = */ 3);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void MATVEC_3D_STENCIL::setSize(Index_type target_size, Index_type target_reps)
+{
+  Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
+  m_domain.reset(new ADomain(rzmax, /* ndims = */ 3));
 
   m_zonal_array_length = m_domain->lpz+1;
 
   setActualProblemSize( m_domain->n_real_zones );
+  setRunReps( target_reps );
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
@@ -80,20 +96,10 @@ MATVEC_3D_STENCIL::MATVEC_3D_STENCIL(const RunParams& params)
   const size_t multiplies = 27;
   const size_t adds = 26;
   setFLOPsPerRep((multiplies + adds) * getItsPerRep());
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 MATVEC_3D_STENCIL::~MATVEC_3D_STENCIL()
 {
-  delete m_domain;
 }
 
 void MATVEC_3D_STENCIL::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/src/apps/MATVEC_3D_STENCIL.hpp
+++ b/src/apps/MATVEC_3D_STENCIL.hpp
@@ -129,6 +129,7 @@ public:
 
   ~MATVEC_3D_STENCIL();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);
@@ -190,7 +191,7 @@ private:
   Real_ptr m_x;
   Matrix m_matrix;
 
-  ADomain* m_domain;
+  std::unique_ptr<ADomain> m_domain;
   Index_type* m_real_zones;
   Index_type m_zonal_array_length;
 };

--- a/src/apps/NODAL_ACCUMULATION_3D.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D.cpp
@@ -29,23 +29,8 @@ NODAL_ACCUMULATION_3D::NODAL_ACCUMULATION_3D(const RunParams& params)
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::cbrt(getTargetProblemSize()) + 1 + std::cbrt(3)-1;
-  m_domain = new ADomain(rzmax, /* ndims = */ 3);
-
-  m_nodal_array_length = m_domain->nnalls;
-  m_zonal_array_length = m_domain->lpz+1;
-
-  setActualProblemSize( m_domain->n_real_zones );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  // touched data size, not actual number of stores and loads
-  setBytesReadPerRep( 1*sizeof(Index_type) * getItsPerRep() + // real_zones
-                      1*sizeof(Real_type) * getItsPerRep() ); // vol
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Real_type) * m_domain->n_real_nodes ); // x (3d nodal stencil pattern: 8 touches per iterate)
-  setFLOPsPerRep(9 * getItsPerRep());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -58,9 +43,30 @@ NODAL_ACCUMULATION_3D::NODAL_ACCUMULATION_3D(const RunParams& params)
   addVariantTunings();
 }
 
+void NODAL_ACCUMULATION_3D::setSize(Index_type target_size, Index_type target_reps)
+{
+  Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
+  m_domain.reset(new ADomain(rzmax, /* ndims = */ 3));
+
+  m_nodal_array_length = m_domain->nnalls;
+  m_zonal_array_length = m_domain->lpz+1;
+
+  setActualProblemSize( m_domain->n_real_zones );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  // touched data size, not actual number of stores and loads
+  setBytesReadPerRep( 1*sizeof(Index_type) * getItsPerRep() + // real_zones
+                      1*sizeof(Real_type) * getItsPerRep() ); // vol
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Real_type) * m_domain->n_real_nodes ); // x (3d nodal stencil pattern: 8 touches per iterate)
+  setFLOPsPerRep(9 * getItsPerRep());
+}
+
 NODAL_ACCUMULATION_3D::~NODAL_ACCUMULATION_3D()
 {
-  delete m_domain;
 }
 
 void NODAL_ACCUMULATION_3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/src/apps/NODAL_ACCUMULATION_3D.hpp
+++ b/src/apps/NODAL_ACCUMULATION_3D.hpp
@@ -77,6 +77,7 @@ public:
 
   ~NODAL_ACCUMULATION_3D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);
@@ -105,7 +106,7 @@ private:
   Real_ptr m_x;
   Real_ptr m_vol;
 
-  ADomain* m_domain;
+  std::unique_ptr<ADomain> m_domain;
   Index_type* m_real_zones;
   Index_type m_nodal_array_length;
   Index_type m_zonal_array_length;

--- a/src/apps/PRESSURE.cpp
+++ b/src/apps/PRESSURE.cpp
@@ -25,7 +25,23 @@ PRESSURE::PRESSURE(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(700);
 
-  setActualProblemSize( getTargetProblemSize() );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void PRESSURE::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
 
   setItsPerRep( 2 * getActualProblemSize() );
   setKernelsPerRep(2);
@@ -38,15 +54,6 @@ PRESSURE::PRESSURE(const RunParams& params)
   setFLOPsPerRep((2 +
                   1
                   ) * getActualProblemSize());
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 PRESSURE::~PRESSURE()

--- a/src/apps/PRESSURE.hpp
+++ b/src/apps/PRESSURE.hpp
@@ -63,6 +63,7 @@ public:
 
   ~PRESSURE();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -29,21 +29,8 @@ VOL3D::VOL3D(const RunParams& params)
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::cbrt(getTargetProblemSize()) + 1 + std::cbrt(3)-1;
-  m_domain = new ADomain(rzmax, /* ndims = */ 3);
-
-  m_array_length = m_domain->nnalls;
-
-  setActualProblemSize( m_domain->n_real_zones );
-
-  setItsPerRep( m_domain->lpz+1 - m_domain->fpz );
-  setKernelsPerRep(1);
-  // touched data size, not actual number of stores and loads
-  setBytesReadPerRep( 3*sizeof(Real_type) * (getItsPerRep() + 1+m_domain->jp+m_domain->kp) ); // x, y, z (3d nodal stencil pattern: 8 touches per iterate)
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() ); // vol
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(72 * (m_domain->lpz+1 - m_domain->fpz));
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -55,9 +42,28 @@ VOL3D::VOL3D(const RunParams& params)
   addVariantTunings();
 }
 
+void VOL3D::setSize(Index_type target_size, Index_type target_reps)
+{
+  Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
+  m_domain.reset(new ADomain(rzmax, /* ndims = */ 3));
+
+  m_array_length = m_domain->nnalls;
+
+  setActualProblemSize( m_domain->n_real_zones );
+  setRunReps( target_reps );
+
+  setItsPerRep( m_domain->lpz+1 - m_domain->fpz );
+  setKernelsPerRep(1);
+  // touched data size, not actual number of stores and loads
+  setBytesReadPerRep( 3*sizeof(Real_type) * (getItsPerRep() + 1+m_domain->jp+m_domain->kp) ); // x, y, z (3d nodal stencil pattern: 8 touches per iterate)
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() ); // vol
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(72 * (m_domain->lpz+1 - m_domain->fpz));
+}
+
 VOL3D::~VOL3D()
 {
-  delete m_domain;
 }
 
 void VOL3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/src/apps/VOL3D.hpp
+++ b/src/apps/VOL3D.hpp
@@ -156,6 +156,7 @@ public:
 
   ~VOL3D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);
@@ -189,7 +190,7 @@ private:
 
   Real_type m_vnormq;
 
-  ADomain* m_domain;
+  std::unique_ptr<ADomain> m_domain;
   Index_type m_array_length;
 };
 

--- a/src/apps/ZONAL_ACCUMULATION_3D.cpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D.cpp
@@ -29,23 +29,8 @@ ZONAL_ACCUMULATION_3D::ZONAL_ACCUMULATION_3D(const RunParams& params)
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
-  Index_type rzmax = std::cbrt(getTargetProblemSize()) + 1 + std::cbrt(3)-1;
-  m_domain = new ADomain(rzmax, /* ndims = */ 3);
-
-  m_nodal_array_length = m_domain->nnalls;
-  m_zonal_array_length = m_domain->lpz+1;
-
-  setActualProblemSize( m_domain->n_real_zones );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  // touched data size, not actual number of stores and loads
-  setBytesReadPerRep( 1*sizeof(Index_type) * getItsPerRep() + // real_zones
-                      1*sizeof(Real_type) * m_domain->n_real_nodes ); // x (3d nodal stencil pattern: 8 touches per iterate)
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() ); // vol
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(8 * getItsPerRep());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -57,9 +42,30 @@ ZONAL_ACCUMULATION_3D::ZONAL_ACCUMULATION_3D(const RunParams& params)
   addVariantTunings();
 }
 
+void ZONAL_ACCUMULATION_3D::setSize(Index_type target_size, Index_type target_reps)
+{
+  Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
+  m_domain.reset(new ADomain(rzmax, /* ndims = */ 3));
+
+  m_nodal_array_length = m_domain->nnalls;
+  m_zonal_array_length = m_domain->lpz+1;
+
+  setActualProblemSize( m_domain->n_real_zones );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  // touched data size, not actual number of stores and loads
+  setBytesReadPerRep( 1*sizeof(Index_type) * getItsPerRep() + // real_zones
+                      1*sizeof(Real_type) * m_domain->n_real_nodes ); // x (3d nodal stencil pattern: 8 touches per iterate)
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getItsPerRep() ); // vol
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(8 * getItsPerRep());
+}
+
 ZONAL_ACCUMULATION_3D::~ZONAL_ACCUMULATION_3D()
 {
-  delete m_domain;
 }
 
 void ZONAL_ACCUMULATION_3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/src/apps/ZONAL_ACCUMULATION_3D.hpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D.hpp
@@ -73,6 +73,7 @@ public:
 
   ~ZONAL_ACCUMULATION_3D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);
@@ -102,7 +103,7 @@ private:
   Real_ptr m_x;
   Real_ptr m_vol;
 
-  ADomain* m_domain;
+  std::unique_ptr<ADomain> m_domain;
   Index_type* m_real_zones;
   Index_type m_nodal_array_length;
   Index_type m_zonal_array_length;

--- a/src/basic/ARRAY_OF_PTRS.cpp
+++ b/src/basic/ARRAY_OF_PTRS.cpp
@@ -25,17 +25,10 @@ ARRAY_OF_PTRS::ARRAY_OF_PTRS(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
   m_array_size = params.getArrayOfPtrsArraySize();
 
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( m_array_size*sizeof(Real_type) * getActualProblemSize() ); // x
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // y
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(m_array_size * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -45,6 +38,20 @@ ARRAY_OF_PTRS::ARRAY_OF_PTRS(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void ARRAY_OF_PTRS::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( m_array_size*sizeof(Real_type) * getActualProblemSize() ); // x
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // y
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(m_array_size * getActualProblemSize());
 }
 
 ARRAY_OF_PTRS::~ARRAY_OF_PTRS()

--- a/src/basic/ARRAY_OF_PTRS.hpp
+++ b/src/basic/ARRAY_OF_PTRS.hpp
@@ -62,6 +62,7 @@ public:
 
   ~ARRAY_OF_PTRS();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/COPY8.cpp
+++ b/src/basic/COPY8.cpp
@@ -25,15 +25,8 @@ COPY8::COPY8(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 8*sizeof(Real_type) * getActualProblemSize() ); // x0, x1, x2, x3, x4, x5, x6, x7
-  setBytesWrittenPerRep( 8*sizeof(Real_type) * getActualProblemSize() ); // y0, y1, y2, y3, y4, y5, y6, y7
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(0);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Consistent);
   setChecksumTolerance(ChecksumTolerance::zero);
@@ -43,6 +36,20 @@ COPY8::COPY8(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void COPY8::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 8*sizeof(Real_type) * getActualProblemSize() ); // x0, x1, x2, x3, x4, x5, x6, x7
+  setBytesWrittenPerRep( 8*sizeof(Real_type) * getActualProblemSize() ); // y0, y1, y2, y3, y4, y5, y6, y7
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(0);
 }
 
 COPY8::~COPY8()

--- a/src/basic/COPY8.hpp
+++ b/src/basic/COPY8.hpp
@@ -71,6 +71,7 @@ public:
 
   ~COPY8();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/DAXPY.cpp
+++ b/src/basic/DAXPY.cpp
@@ -25,15 +25,8 @@ DAXPY::DAXPY(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(500);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // y
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(2 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -43,6 +36,20 @@ DAXPY::DAXPY(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void DAXPY::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // y
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(2 * getActualProblemSize());
 }
 
 DAXPY::~DAXPY()

--- a/src/basic/DAXPY.hpp
+++ b/src/basic/DAXPY.hpp
@@ -44,6 +44,7 @@ public:
 
   ~DAXPY();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/DAXPY_ATOMIC.cpp
+++ b/src/basic/DAXPY_ATOMIC.cpp
@@ -25,15 +25,8 @@ DAXPY_ATOMIC::DAXPY_ATOMIC(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(500);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // y
-  setFLOPsPerRep(2 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -44,6 +37,20 @@ DAXPY_ATOMIC::DAXPY_ATOMIC(const RunParams& params)
   setUsesFeature(Atomic);
 
   addVariantTunings();
+}
+
+void DAXPY_ATOMIC::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // y
+  setFLOPsPerRep(2 * getActualProblemSize());
 }
 
 DAXPY_ATOMIC::~DAXPY_ATOMIC()

--- a/src/basic/DAXPY_ATOMIC.hpp
+++ b/src/basic/DAXPY_ATOMIC.hpp
@@ -44,6 +44,7 @@ public:
 
   ~DAXPY_ATOMIC();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/EMPTY.cpp
+++ b/src/basic/EMPTY.cpp
@@ -25,15 +25,8 @@ EMPTY::EMPTY(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(1000);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep( 1 );
-  setBytesReadPerRep( 0 );
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep( 0 );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Consistent);
   setChecksumTolerance(ChecksumTolerance::zero);
@@ -43,6 +36,20 @@ EMPTY::EMPTY(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void EMPTY::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep( 1 );
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep( 0 );
 }
 
 EMPTY::~EMPTY()

--- a/src/basic/EMPTY.hpp
+++ b/src/basic/EMPTY.hpp
@@ -48,6 +48,7 @@ public:
 
   ~EMPTY();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/IF_QUAD.cpp
+++ b/src/basic/IF_QUAD.cpp
@@ -25,7 +25,23 @@ IF_QUAD::IF_QUAD(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(180);
 
-  setActualProblemSize( getTargetProblemSize() );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void IF_QUAD::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
 
   setItsPerRep( getActualProblemSize() );
   setKernelsPerRep(1);
@@ -36,15 +52,6 @@ IF_QUAD::IF_QUAD(const RunParams& params)
   // estimate conditional true half of the time, 1 sqrt
   setFLOPsPerRep(4 * getActualProblemSize() +
                  7 * getActualProblemSize() / 2);
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 IF_QUAD::~IF_QUAD()

--- a/src/basic/IF_QUAD.hpp
+++ b/src/basic/IF_QUAD.hpp
@@ -61,6 +61,7 @@ public:
 
   ~IF_QUAD();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/INDEXLIST.cpp
+++ b/src/basic/INDEXLIST.cpp
@@ -24,15 +24,8 @@ INDEXLIST::INDEXLIST(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(100);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
-  setBytesWrittenPerRep( 1*sizeof(Int_type) * getActualProblemSize() / 2 ); // list (about 50% output)
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(0);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Consistent);
   setChecksumTolerance(ChecksumTolerance::zero);
@@ -47,6 +40,20 @@ INDEXLIST::INDEXLIST(const RunParams& params)
     addVariantTunings();
 
   }
+}
+
+void INDEXLIST::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // x
+  setBytesWrittenPerRep( 1*sizeof(Int_type) * getActualProblemSize() / 2 ); // list (about 50% output)
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(0);
 }
 
 INDEXLIST::~INDEXLIST()

--- a/src/basic/INDEXLIST.hpp
+++ b/src/basic/INDEXLIST.hpp
@@ -52,6 +52,7 @@ public:
 
   ~INDEXLIST();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/INDEXLIST_3LOOP.cpp
+++ b/src/basic/INDEXLIST_3LOOP.cpp
@@ -24,7 +24,24 @@ INDEXLIST_3LOOP::INDEXLIST_3LOOP(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(100);
 
-  setActualProblemSize( getTargetProblemSize() );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::Consistent);
+  setChecksumTolerance(ChecksumTolerance::zero);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+  setUsesFeature(Scan);
+
+  addVariantTunings();
+}
+
+void INDEXLIST_3LOOP::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
 
   setItsPerRep( 3 * getActualProblemSize() + 1 );
   setKernelsPerRep(3);
@@ -39,16 +56,6 @@ INDEXLIST_3LOOP::INDEXLIST_3LOOP(const RunParams& params)
                                0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
-
-  setChecksumConsistency(ChecksumConsistency::Consistent);
-  setChecksumTolerance(ChecksumTolerance::zero);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-  setUsesFeature(Scan);
-
-  addVariantTunings();
 }
 
 INDEXLIST_3LOOP::~INDEXLIST_3LOOP()

--- a/src/basic/INDEXLIST_3LOOP.hpp
+++ b/src/basic/INDEXLIST_3LOOP.hpp
@@ -70,6 +70,7 @@ public:
 
   ~INDEXLIST_3LOOP();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/INIT3.cpp
+++ b/src/basic/INIT3.cpp
@@ -25,15 +25,8 @@ INIT3::INIT3(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(500);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // in1, in2
-  setBytesWrittenPerRep( 3*sizeof(Real_type) * getActualProblemSize()  ); // out3, out2, out1
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(1 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -43,6 +36,20 @@ INIT3::INIT3(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void INIT3::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // in1, in2
+  setBytesWrittenPerRep( 3*sizeof(Real_type) * getActualProblemSize()  ); // out3, out2, out1
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(1 * getActualProblemSize());
 }
 
 INIT3::~INIT3()

--- a/src/basic/INIT3.hpp
+++ b/src/basic/INIT3.hpp
@@ -47,6 +47,7 @@ public:
 
   ~INIT3();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/INIT_VIEW1D.cpp
+++ b/src/basic/INIT_VIEW1D.cpp
@@ -25,15 +25,8 @@ INIT_VIEW1D::INIT_VIEW1D(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(2500);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 0 );
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // a
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(1 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::tight);
@@ -44,6 +37,20 @@ INIT_VIEW1D::INIT_VIEW1D(const RunParams& params)
   setUsesFeature(View);
 
   addVariantTunings();
+}
+
+void INIT_VIEW1D::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // a
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(1 * getActualProblemSize());
 }
 
 INIT_VIEW1D::~INIT_VIEW1D()

--- a/src/basic/INIT_VIEW1D.hpp
+++ b/src/basic/INIT_VIEW1D.hpp
@@ -58,6 +58,7 @@ public:
 
   ~INIT_VIEW1D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/INIT_VIEW1D_OFFSET.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.cpp
@@ -25,15 +25,8 @@ INIT_VIEW1D_OFFSET::INIT_VIEW1D_OFFSET(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(2500);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 0 );
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // a
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(1 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::tight);
@@ -44,6 +37,20 @@ INIT_VIEW1D_OFFSET::INIT_VIEW1D_OFFSET(const RunParams& params)
   setUsesFeature(View);
 
   addVariantTunings();
+}
+
+void INIT_VIEW1D_OFFSET::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // a
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(1 * getActualProblemSize());
 }
 
 INIT_VIEW1D_OFFSET::~INIT_VIEW1D_OFFSET()

--- a/src/basic/INIT_VIEW1D_OFFSET.hpp
+++ b/src/basic/INIT_VIEW1D_OFFSET.hpp
@@ -57,6 +57,7 @@ public:
 
   ~INIT_VIEW1D_OFFSET();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/MAT_MAT_SHARED.cpp
+++ b/src/basic/MAT_MAT_SHARED.cpp
@@ -24,10 +24,26 @@ MAT_MAT_SHARED::MAT_MAT_SHARED(const RunParams &params)
   setDefaultProblemSize(m_N_default*m_N_default);
   setDefaultReps(5);
 
-  m_N = std::sqrt(getTargetProblemSize()) + std::sqrt(2)-1;
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N_to_the_three_halves);
+
+  setUsesFeature(Launch);
+
+  addVariantTunings();
+}
+
+void MAT_MAT_SHARED::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_N = std::sqrt(target_size) + std::sqrt(2)-1;
   const Index_type num_tiles = RAJA_DIVIDE_CEILING_INT(m_N, TL_SZ);
 
   setActualProblemSize(m_N * m_N);
+  setRunReps( target_reps );
 
   setItsPerRep( num_tiles*num_tiles * TL_SZ*TL_SZ );
   setKernelsPerRep(1);
@@ -38,15 +54,6 @@ MAT_MAT_SHARED::MAT_MAT_SHARED(const RunParams &params)
   setBytesAtomicModifyWrittenPerRep( 0 );
 
   setFLOPsPerRep(2 * TL_SZ * TL_SZ * TL_SZ * num_tiles * num_tiles * num_tiles);
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N_to_the_three_halves);
-
-  setUsesFeature(Launch);
-
-  addVariantTunings();
 }
 
 MAT_MAT_SHARED::~MAT_MAT_SHARED() {}

--- a/src/basic/MAT_MAT_SHARED.hpp
+++ b/src/basic/MAT_MAT_SHARED.hpp
@@ -131,6 +131,7 @@ public:
 
   ~MAT_MAT_SHARED();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/MULADDSUB.cpp
+++ b/src/basic/MULADDSUB.cpp
@@ -25,15 +25,8 @@ MULADDSUB::MULADDSUB(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(350);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // in1, in2
-  setBytesWrittenPerRep( 3*sizeof(Real_type) * getActualProblemSize()  ); // out1, out2, out3
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(3 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::tight);
@@ -43,6 +36,20 @@ MULADDSUB::MULADDSUB(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void MULADDSUB::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // in1, in2
+  setBytesWrittenPerRep( 3*sizeof(Real_type) * getActualProblemSize()  ); // out1, out2, out3
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(3 * getActualProblemSize());
 }
 
 MULADDSUB::~MULADDSUB()

--- a/src/basic/MULADDSUB.hpp
+++ b/src/basic/MULADDSUB.hpp
@@ -50,6 +50,7 @@ public:
 
   ~MULADDSUB();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/MULTI_REDUCE.cpp
+++ b/src/basic/MULTI_REDUCE.cpp
@@ -28,19 +28,11 @@ MULTI_REDUCE::MULTI_REDUCE(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
   m_num_bins = params.getMultiReduceNumBins();
   m_bin_assignment_algorithm = params.getMultiReduceBinAssignmentAlgorithm();
 
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Data_type) * getActualProblemSize() + // bins
-                      1*sizeof(Index_type) * getActualProblemSize() ); // data
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Data_type) * m_num_bins ); // values
-  setFLOPsPerRep(1 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -51,6 +43,21 @@ MULTI_REDUCE::MULTI_REDUCE(const RunParams& params)
   setUsesFeature(Atomic);
 
   addVariantTunings();
+}
+
+void MULTI_REDUCE::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Data_type) * getActualProblemSize() + // bins
+                      1*sizeof(Index_type) * getActualProblemSize() ); // data
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Data_type) * m_num_bins ); // values
+  setFLOPsPerRep(1 * getActualProblemSize());
 }
 
 MULTI_REDUCE::~MULTI_REDUCE()

--- a/src/basic/MULTI_REDUCE.hpp
+++ b/src/basic/MULTI_REDUCE.hpp
@@ -87,6 +87,7 @@ public:
 
   ~MULTI_REDUCE();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -30,21 +30,8 @@ NESTED_INIT::NESTED_INIT(const RunParams& params)
   setDefaultProblemSize(m_n_init * m_n_init * m_n_init);
   setDefaultReps(1000);
 
-  auto n_final = std::cbrt( getTargetProblemSize() ) + std::cbrt(3)-1;
-  m_ni = n_final;
-  m_nj = n_final;
-  m_nk = n_final;
-  m_array_length = m_ni * m_nj * m_nk;
-
-  setActualProblemSize( m_array_length );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 0 );
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // array
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(3 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::tight);
@@ -54,6 +41,26 @@ NESTED_INIT::NESTED_INIT(const RunParams& params)
   setUsesFeature(Kernel);
 
   addVariantTunings();
+}
+
+void NESTED_INIT::setSize(Index_type target_size, Index_type target_reps)
+{
+  auto n_final = std::cbrt( target_size ) + std::cbrt(3)-1;
+  m_ni = n_final;
+  m_nj = n_final;
+  m_nk = n_final;
+  m_array_length = m_ni * m_nj * m_nk;
+
+  setActualProblemSize( m_array_length );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // array
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(3 * getActualProblemSize());
 }
 
 NESTED_INIT::~NESTED_INIT()

--- a/src/basic/NESTED_INIT.hpp
+++ b/src/basic/NESTED_INIT.hpp
@@ -50,6 +50,7 @@ public:
 
   ~NESTED_INIT();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/PI_ATOMIC.cpp
+++ b/src/basic/PI_ATOMIC.cpp
@@ -25,15 +25,8 @@ PI_ATOMIC::PI_ATOMIC(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 0 );
-  setBytesWrittenPerRep( 0  );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Real_type) ); // pi
-  setFLOPsPerRep(6 * getActualProblemSize() + 1);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -44,6 +37,20 @@ PI_ATOMIC::PI_ATOMIC(const RunParams& params)
   setUsesFeature(Atomic);
 
   addVariantTunings();
+}
+
+void PI_ATOMIC::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 0  );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 1*sizeof(Real_type) ); // pi
+  setFLOPsPerRep(6 * getActualProblemSize() + 1);
 }
 
 PI_ATOMIC::~PI_ATOMIC()

--- a/src/basic/PI_ATOMIC.hpp
+++ b/src/basic/PI_ATOMIC.hpp
@@ -57,6 +57,7 @@ public:
 
   ~PI_ATOMIC();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/PI_REDUCE.cpp
+++ b/src/basic/PI_REDUCE.cpp
@@ -25,15 +25,8 @@ PI_REDUCE::PI_REDUCE(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 0 );
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(6 * getActualProblemSize() + 1);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -44,6 +37,20 @@ PI_REDUCE::PI_REDUCE(const RunParams& params)
   setUsesFeature(Reduction);
 
   addVariantTunings();
+}
+
+void PI_REDUCE::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(6 * getActualProblemSize() + 1);
 }
 
 PI_REDUCE::~PI_REDUCE()

--- a/src/basic/PI_REDUCE.hpp
+++ b/src/basic/PI_REDUCE.hpp
@@ -48,6 +48,7 @@ public:
 
   ~PI_REDUCE();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/REDUCE3_INT.cpp
+++ b/src/basic/REDUCE3_INT.cpp
@@ -30,15 +30,8 @@ REDUCE3_INT::REDUCE3_INT(const RunParams& params)
 // reduction performance issues
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Int_type) * getActualProblemSize() ); // vec
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(0);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -49,6 +42,20 @@ REDUCE3_INT::REDUCE3_INT(const RunParams& params)
   setUsesFeature(Reduction);
 
   addVariantTunings();
+}
+
+void REDUCE3_INT::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Int_type) * getActualProblemSize() ); // vec
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(0);
 }
 
 REDUCE3_INT::~REDUCE3_INT()

--- a/src/basic/REDUCE3_INT.hpp
+++ b/src/basic/REDUCE3_INT.hpp
@@ -62,6 +62,7 @@ public:
 
   ~REDUCE3_INT();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/REDUCE_STRUCT.cpp
+++ b/src/basic/REDUCE_STRUCT.cpp
@@ -30,15 +30,8 @@ REDUCE_STRUCT::REDUCE_STRUCT(const RunParams& params)
 // reduction performance issues
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // x, y
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(2 * getActualProblemSize() + 2);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -49,6 +42,20 @@ REDUCE_STRUCT::REDUCE_STRUCT(const RunParams& params)
   setUsesFeature(Reduction);
 
   addVariantTunings();
+}
+
+void REDUCE_STRUCT::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // x, y
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(2 * getActualProblemSize() + 2);
 }
 
 REDUCE_STRUCT::~REDUCE_STRUCT()

--- a/src/basic/REDUCE_STRUCT.hpp
+++ b/src/basic/REDUCE_STRUCT.hpp
@@ -78,6 +78,7 @@ public:
 
   ~REDUCE_STRUCT();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/basic/TRAP_INT.cpp
+++ b/src/basic/TRAP_INT.cpp
@@ -25,15 +25,8 @@ TRAP_INT::TRAP_INT(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 0 );
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(10 * getActualProblemSize()); // 1 sqrt
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -44,6 +37,20 @@ TRAP_INT::TRAP_INT(const RunParams& params)
   setUsesFeature(Reduction);
 
   addVariantTunings();
+}
+
+void TRAP_INT::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 0 );
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(10 * getActualProblemSize()); // 1 sqrt
 }
 
 TRAP_INT::~TRAP_INT()

--- a/src/basic/TRAP_INT.hpp
+++ b/src/basic/TRAP_INT.hpp
@@ -59,6 +59,7 @@ public:
 
   ~TRAP_INT();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/comm/HALO_EXCHANGE.cpp
+++ b/src/comm/HALO_EXCHANGE.cpp
@@ -21,13 +21,33 @@ namespace comm
 HALO_EXCHANGE::HALO_EXCHANGE(const RunParams& params)
   : HALO_base(rajaperf::Comm_HALO_EXCHANGE, params)
 {
+  setDefaultReps(200);
+
   m_mpi_size = params.getMPISize();
   m_my_mpi_rank = params.getMPIRank();
   m_mpi_dims = params.getMPI3DDivision();
-
-  setDefaultReps(200);
-
   m_num_vars = params.getHaloNumVars();
+
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::Consistent);
+  setChecksumTolerance(ChecksumTolerance::zero);
+
+  setComplexity(Complexity::N_to_the_two_thirds);
+
+  setUsesFeature(Forall);
+  setUsesFeature(MPI);
+
+  if (params.validMPI3DDivision()) {
+    addVariantTunings();
+  }
+}
+
+void HALO_EXCHANGE::setSize(Index_type target_size, Index_type target_reps)
+{
+  setSize_base(target_size, target_reps);
+
   m_var_size = m_grid_plus_halo_size ;
   const Size_type halo_size = m_var_size - getActualProblemSize();
 
@@ -48,18 +68,6 @@ HALO_EXCHANGE::HALO_EXCHANGE(const RunParams& params)
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
-
-  setChecksumConsistency(ChecksumConsistency::Consistent);
-  setChecksumTolerance(ChecksumTolerance::zero);
-
-  setComplexity(Complexity::N_to_the_two_thirds);
-
-  setUsesFeature(Forall);
-  setUsesFeature(MPI);
-
-  if (params.validMPI3DDivision()) {
-    addVariantTunings();
-}
 }
 
 HALO_EXCHANGE::~HALO_EXCHANGE()

--- a/src/comm/HALO_EXCHANGE.hpp
+++ b/src/comm/HALO_EXCHANGE.hpp
@@ -102,6 +102,7 @@ public:
 
   ~HALO_EXCHANGE();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/comm/HALO_EXCHANGE_FUSED.cpp
+++ b/src/comm/HALO_EXCHANGE_FUSED.cpp
@@ -21,13 +21,33 @@ namespace comm
 HALO_EXCHANGE_FUSED::HALO_EXCHANGE_FUSED(const RunParams& params)
   : HALO_base(rajaperf::Comm_HALO_EXCHANGE_FUSED, params)
 {
+  setDefaultReps(200);
+
   m_mpi_size = params.getMPISize();
   m_my_mpi_rank = params.getMPIRank();
   m_mpi_dims = params.getMPI3DDivision();
-
-  setDefaultReps(200);
-
   m_num_vars = params.getHaloNumVars();
+
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::Consistent);
+  setChecksumTolerance(ChecksumTolerance::zero);
+
+  setComplexity(Complexity::N_to_the_two_thirds);
+
+  setUsesFeature(Workgroup);
+  setUsesFeature(MPI);
+
+  if (params.validMPI3DDivision()) {
+    addVariantTunings();
+  }
+}
+
+void HALO_EXCHANGE_FUSED::setSize(Index_type target_size, Index_type target_reps)
+{
+  setSize_base(target_size, target_reps);
+
   m_var_size = m_grid_plus_halo_size ;
   const Size_type halo_size = m_var_size - getActualProblemSize();
 
@@ -48,18 +68,6 @@ HALO_EXCHANGE_FUSED::HALO_EXCHANGE_FUSED(const RunParams& params)
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
-
-  setChecksumConsistency(ChecksumConsistency::Consistent);
-  setChecksumTolerance(ChecksumTolerance::zero);
-
-  setComplexity(Complexity::N_to_the_two_thirds);
-
-  setUsesFeature(Workgroup);
-  setUsesFeature(MPI);
-
-  if (params.validMPI3DDivision()) {
-    addVariantTunings();
-}
 }
 
 HALO_EXCHANGE_FUSED::~HALO_EXCHANGE_FUSED()

--- a/src/comm/HALO_EXCHANGE_FUSED.hpp
+++ b/src/comm/HALO_EXCHANGE_FUSED.hpp
@@ -146,6 +146,7 @@ public:
 
   ~HALO_EXCHANGE_FUSED();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/comm/HALO_PACKING.cpp
+++ b/src/comm/HALO_PACKING.cpp
@@ -22,6 +22,24 @@ HALO_PACKING::HALO_PACKING(const RunParams& params)
   setDefaultReps(200);
 
   m_num_vars = params.getHaloNumVars();
+
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::Consistent);
+  setChecksumTolerance(ChecksumTolerance::zero);
+
+  setComplexity(Complexity::N_to_the_two_thirds);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void HALO_PACKING::setSize(Index_type target_size, Index_type target_reps)
+{
+  setSize_base(target_size, target_reps);
+
   m_var_size = m_grid_plus_halo_size ;
   const Size_type halo_size = m_var_size - getActualProblemSize();
 
@@ -38,15 +56,6 @@ HALO_PACKING::HALO_PACKING(const RunParams& params)
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
-
-  setChecksumConsistency(ChecksumConsistency::Consistent);
-  setChecksumTolerance(ChecksumTolerance::zero);
-
-  setComplexity(Complexity::N_to_the_two_thirds);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 HALO_PACKING::~HALO_PACKING()

--- a/src/comm/HALO_PACKING.hpp
+++ b/src/comm/HALO_PACKING.hpp
@@ -78,6 +78,7 @@ public:
 
   ~HALO_PACKING();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/comm/HALO_PACKING_FUSED.cpp
+++ b/src/comm/HALO_PACKING_FUSED.cpp
@@ -22,6 +22,24 @@ HALO_PACKING_FUSED::HALO_PACKING_FUSED(const RunParams& params)
   setDefaultReps(200);
 
   m_num_vars = params.getHaloNumVars();
+
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::Consistent);
+  setChecksumTolerance(ChecksumTolerance::zero);
+
+  setComplexity(Complexity::N_to_the_two_thirds);
+
+  setUsesFeature(Workgroup);
+
+  addVariantTunings();
+}
+
+void HALO_PACKING_FUSED::setSize(Index_type target_size, Index_type target_reps)
+{
+  setSize_base(target_size, target_reps);
+
   m_var_size = m_grid_plus_halo_size ;
   const Size_type halo_size = m_var_size - getActualProblemSize();
 
@@ -38,15 +56,6 @@ HALO_PACKING_FUSED::HALO_PACKING_FUSED(const RunParams& params)
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(0);
-
-  setChecksumConsistency(ChecksumConsistency::Consistent);
-  setChecksumTolerance(ChecksumTolerance::zero);
-
-  setComplexity(Complexity::N_to_the_two_thirds);
-
-  setUsesFeature(Workgroup);
-
-  addVariantTunings();
 }
 
 HALO_PACKING_FUSED::~HALO_PACKING_FUSED()

--- a/src/comm/HALO_PACKING_FUSED.hpp
+++ b/src/comm/HALO_PACKING_FUSED.hpp
@@ -128,6 +128,7 @@ public:
 
   ~HALO_PACKING_FUSED();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/comm/HALO_SENDRECV.cpp
+++ b/src/comm/HALO_SENDRECV.cpp
@@ -21,23 +21,15 @@ namespace comm
 HALO_SENDRECV::HALO_SENDRECV(const RunParams& params)
   : HALO_base(rajaperf::Comm_HALO_SENDRECV, params)
 {
+  setDefaultReps(200);
+
   m_mpi_size = params.getMPISize();
   m_my_mpi_rank = params.getMPIRank();
   m_mpi_dims = params.getMPI3DDivision();
-
-  setDefaultReps(200);
-
   m_num_vars = params.getHaloNumVars();
-  m_var_size = m_grid_plus_halo_size ;
-  const Size_type halo_size = m_var_size - getActualProblemSize();
 
-  setItsPerRep( 0 );
-  setKernelsPerRep( 0 );
-  setBytesReadPerRep( 1*sizeof(Real_type) * m_num_vars * halo_size ); // send_buffers (MPI)
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * m_num_vars * halo_size ); // recv_buffers (MPI)
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(0);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Consistent);
   setChecksumTolerance(ChecksumTolerance::zero);
@@ -49,7 +41,23 @@ HALO_SENDRECV::HALO_SENDRECV(const RunParams& params)
 
   if (params.validMPI3DDivision()) {
     addVariantTunings();
+  }
 }
+
+void HALO_SENDRECV::setSize(Index_type target_size, Index_type target_reps)
+{
+  setSize_base(target_size, target_reps);
+
+  m_var_size = m_grid_plus_halo_size ;
+  const Size_type halo_size = m_var_size - getActualProblemSize();
+
+  setItsPerRep( 0 );
+  setKernelsPerRep( 0 );
+  setBytesReadPerRep( 1*sizeof(Real_type) * m_num_vars * halo_size ); // send_buffers (MPI)
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * m_num_vars * halo_size ); // recv_buffers (MPI)
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(0);
 }
 
 HALO_SENDRECV::~HALO_SENDRECV()

--- a/src/comm/HALO_SENDRECV.hpp
+++ b/src/comm/HALO_SENDRECV.hpp
@@ -96,6 +96,7 @@ public:
 
   ~HALO_SENDRECV();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/comm/HALO_base.cpp
+++ b/src/comm/HALO_base.cpp
@@ -29,12 +29,16 @@ HALO_base::HALO_base(KernelID kid, const RunParams& params)
                          s_grid_dims_default[1] *
                          s_grid_dims_default[2] );
 
-  double cbrt_run_size = std::cbrt(getTargetProblemSize()) + std::cbrt(3)-1;
+  m_halo_width = params.getHaloWidth();
+}
+
+void HALO_base::setSize_base(Index_type target_size, Index_type target_reps)
+{
+  double cbrt_run_size = std::cbrt(target_size) + std::cbrt(3)-1;
 
   m_grid_dims[0] = cbrt_run_size;
   m_grid_dims[1] = cbrt_run_size;
   m_grid_dims[2] = cbrt_run_size;
-  m_halo_width = params.getHaloWidth();
 
   m_grid_plus_halo_dims[0] = m_grid_dims[0] + 2*m_halo_width;
   m_grid_plus_halo_dims[1] = m_grid_dims[1] + 2*m_halo_width;
@@ -44,6 +48,7 @@ HALO_base::HALO_base(KernelID kid, const RunParams& params)
                           m_grid_plus_halo_dims[2] ;
 
   setActualProblemSize( m_grid_dims[0] * m_grid_dims[1] * m_grid_dims[1] );
+  setRunReps( target_reps );
 }
 
 HALO_base::~HALO_base()

--- a/src/comm/HALO_base.hpp
+++ b/src/comm/HALO_base.hpp
@@ -87,6 +87,7 @@ public:
 
   ~HALO_base();
 
+  void setSize_base(Index_type target_size, Index_type target_reps);
   void setUp_base(const int my_mpi_rank, const int* mpi_dims,
                   const Index_type num_vars,
                   VariantID vid, size_t tune_idx);

--- a/src/common/KernelBase.cpp
+++ b/src/common/KernelBase.cpp
@@ -142,31 +142,6 @@ KernelBase::~KernelBase()
 }
 
 
-Index_type KernelBase::getTargetProblemSize() const
-{
-  Index_type target_size = static_cast<Index_type>(0);
-  if (run_params.getSizeMeaning() == RunParams::SizeMeaning::Factor) {
-    target_size =
-      static_cast<Index_type>(default_prob_size*run_params.getSizeFactor());
-  } else if (run_params.getSizeMeaning() == RunParams::SizeMeaning::Direct) {
-    target_size = static_cast<Index_type>(run_params.getSize());
-  }
-  return target_size;
-}
-
-Index_type KernelBase::getRunReps() const
-{
-  Index_type run_reps = static_cast<Index_type>(0);
-  if (s_warmup_run) {
-    run_reps = static_cast<Index_type>(1);
-  } else if (run_params.getInputState() == RunParams::CheckRun) {
-    run_reps = static_cast<Index_type>(run_params.getCheckRunReps());
-  } else {
-    run_reps = static_cast<Index_type>(default_reps*run_params.getRepFactor());
-  }
-  return run_reps;
-}
-
 void KernelBase::addVariantTuning(VariantID vid, std::string name,
                                   variant_tuning_method_pointer method)
 {

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -116,6 +116,7 @@ public:
   void setDefaultProblemSize(Index_type size) { default_prob_size = size; }
   void setActualProblemSize(Index_type size) { actual_prob_size = size; }
   void setDefaultReps(Index_type reps) { default_reps = reps; }
+  void setRunReps(Index_type reps) { actual_reps = reps; }
   void setItsPerRep(Index_type its) { its_per_rep = its; };
   void setKernelsPerRep(Index_type nkerns) { kernels_per_rep = nkerns; };
   void setBytesReadPerRep(Index_type bytes) { bytes_read_per_rep = bytes;}
@@ -202,6 +203,7 @@ public:
   Index_type getDefaultProblemSize() const { return default_prob_size; }
   Index_type getActualProblemSize() const { return actual_prob_size; }
   Index_type getDefaultReps() const { return default_reps; }
+  Index_type getRunReps() const { return s_warmup_run ? 1 : actual_reps; }
   Index_type getItsPerRep() const { return its_per_rep; };
   Index_type getKernelsPerRep() const { return kernels_per_rep; };
   Index_type getBytesPerRep() const { return bytes_read_per_rep + bytes_written_per_rep + 2*bytes_modify_written_per_rep + 2*bytes_atomic_modify_written_per_rep; } // count modify_write operations twice to get the memory traffic
@@ -216,8 +218,6 @@ public:
   Checksum_type getChecksumTolerance() const { return checksum_tolerance; }
   Complexity getComplexity() const { return complexity; };
 
-  Index_type getTargetProblemSize() const;
-  Index_type getRunReps() const;
 
   bool usesFeature(FeatureID fid) const { return uses_feature[fid]; };
 
@@ -621,6 +621,7 @@ public:
   // by concrete kernel subclass.
   //
 
+  virtual void setSize(Index_type target_size, Index_type target_reps) = 0;
   virtual void setUp(VariantID vid, size_t tune_idx) = 0;
   virtual void updateChecksum(VariantID vid, size_t tune_idx) = 0;
   virtual void tearDown(VariantID vid, size_t tune_idx) = 0;
@@ -714,6 +715,7 @@ private:
   Index_type default_reps;
 
   Index_type actual_prob_size;
+  Index_type actual_reps;
 
   bool uses_feature[NumFeatures];
 

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -186,6 +186,28 @@ public:
 
   double getSizeFactor() const { return size_factor; }
 
+  Index_type getTargetSize(Index_type default_prob_size) const
+  {
+    Index_type target_size = static_cast<Index_type>(0);
+    if (size_meaning == RunParams::SizeMeaning::Factor) {
+      target_size = static_cast<Index_type>(default_prob_size*size_factor);
+    } else if (size_meaning == RunParams::SizeMeaning::Direct) {
+      target_size = static_cast<Index_type>(size);
+    }
+    return target_size;
+  }
+
+  Index_type getReps(Index_type default_reps) const
+  {
+    Index_type run_reps = static_cast<Index_type>(0);
+    if (input_state == RunParams::CheckRun) {
+      run_reps = static_cast<Index_type>(checkrun_reps);
+    } else {
+      run_reps = static_cast<Index_type>(default_reps*rep_fact);
+    }
+    return run_reps;
+  }
+
   Size_type getDataAlignment() const { return data_alignment; }
 
   Index_type getMultiReduceNumBins() const { return multi_reduce_num_bins; }

--- a/src/lcals/DIFF_PREDICT.cpp
+++ b/src/lcals/DIFF_PREDICT.cpp
@@ -24,16 +24,8 @@ DIFF_PREDICT::DIFF_PREDICT(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(200);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // cx(4)
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // px(13)
-  setBytesModifyWrittenPerRep( 9*sizeof(Real_type) * getActualProblemSize() ); // px(4), px(5), px(6), px(7), px(8), px(9), px(10), px(11), px(12)
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(9 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -43,6 +35,21 @@ DIFF_PREDICT::DIFF_PREDICT(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void DIFF_PREDICT::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // cx(4)
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // px(13)
+  setBytesModifyWrittenPerRep( 9*sizeof(Real_type) * getActualProblemSize() ); // px(4), px(5), px(6), px(7), px(8), px(9), px(10), px(11), px(12)
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(9 * getActualProblemSize());
 }
 
 DIFF_PREDICT::~DIFF_PREDICT()

--- a/src/lcals/DIFF_PREDICT.hpp
+++ b/src/lcals/DIFF_PREDICT.hpp
@@ -85,6 +85,7 @@ public:
 
   ~DIFF_PREDICT();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/lcals/EOS.cpp
+++ b/src/lcals/EOS.cpp
@@ -25,7 +25,23 @@ EOS::EOS(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(500);
 
-  setActualProblemSize( getTargetProblemSize() );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void EOS::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
 
   m_array_length = getActualProblemSize() + 6;
 
@@ -38,15 +54,6 @@ EOS::EOS(const RunParams& params)
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(16 * getActualProblemSize());
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 EOS::~EOS()

--- a/src/lcals/EOS.hpp
+++ b/src/lcals/EOS.hpp
@@ -54,6 +54,7 @@ public:
 
   ~EOS();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/lcals/FIRST_DIFF.cpp
+++ b/src/lcals/FIRST_DIFF.cpp
@@ -25,7 +25,23 @@ FIRST_DIFF::FIRST_DIFF(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(2000);
 
-  setActualProblemSize( getTargetProblemSize() );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::tight);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void FIRST_DIFF::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
 
   m_N = getActualProblemSize()+1;
 
@@ -36,15 +52,6 @@ FIRST_DIFF::FIRST_DIFF(const RunParams& params)
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * getActualProblemSize());
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::tight);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 FIRST_DIFF::~FIRST_DIFF()

--- a/src/lcals/FIRST_DIFF.hpp
+++ b/src/lcals/FIRST_DIFF.hpp
@@ -44,6 +44,7 @@ public:
 
   ~FIRST_DIFF();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/lcals/FIRST_MIN.cpp
+++ b/src/lcals/FIRST_MIN.cpp
@@ -28,17 +28,8 @@ FIRST_MIN::FIRST_MIN(const RunParams& params)
 // reduction performance issues
   setDefaultReps(100);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  m_N = getActualProblemSize();
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type ) * m_N ); // x
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(0);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Consistent); // The loc returned is always the first of equivalent mins
   setChecksumTolerance(ChecksumTolerance::zero);
@@ -49,6 +40,22 @@ FIRST_MIN::FIRST_MIN(const RunParams& params)
   setUsesFeature(Reduction);
 
   addVariantTunings();
+}
+
+void FIRST_MIN::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  m_N = getActualProblemSize();
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Real_type ) * m_N ); // x
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(0);
 }
 
 FIRST_MIN::~FIRST_MIN()

--- a/src/lcals/FIRST_MIN.hpp
+++ b/src/lcals/FIRST_MIN.hpp
@@ -71,6 +71,7 @@ public:
 
   ~FIRST_MIN();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/lcals/FIRST_SUM.cpp
+++ b/src/lcals/FIRST_SUM.cpp
@@ -25,7 +25,23 @@ FIRST_SUM::FIRST_SUM(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(2000);
 
-  setActualProblemSize( std::max(getTargetProblemSize(), Index_type(2)) );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::tight);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void FIRST_SUM::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( std::max(target_size, Index_type(2)) );
+  setRunReps( target_reps );
 
   m_N = getActualProblemSize();
 
@@ -36,15 +52,6 @@ FIRST_SUM::FIRST_SUM(const RunParams& params)
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(1 * (m_N-1));
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::tight);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 FIRST_SUM::~FIRST_SUM()

--- a/src/lcals/FIRST_SUM.hpp
+++ b/src/lcals/FIRST_SUM.hpp
@@ -47,6 +47,7 @@ public:
 
   ~FIRST_SUM();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/lcals/GEN_LIN_RECUR.cpp
+++ b/src/lcals/GEN_LIN_RECUR.cpp
@@ -25,7 +25,23 @@ GEN_LIN_RECUR::GEN_LIN_RECUR(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(500);
 
-  setActualProblemSize( getTargetProblemSize() );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void GEN_LIN_RECUR::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
 
   m_N = getActualProblemSize();
 
@@ -40,15 +56,6 @@ GEN_LIN_RECUR::GEN_LIN_RECUR(const RunParams& params)
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep((3 +
                   3 ) * m_N);
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 GEN_LIN_RECUR::~GEN_LIN_RECUR()

--- a/src/lcals/GEN_LIN_RECUR.hpp
+++ b/src/lcals/GEN_LIN_RECUR.hpp
@@ -68,6 +68,7 @@ public:
 
   ~GEN_LIN_RECUR();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/lcals/HYDRO_1D.cpp
+++ b/src/lcals/HYDRO_1D.cpp
@@ -25,7 +25,23 @@ HYDRO_1D::HYDRO_1D(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(1000);
 
-  setActualProblemSize( getTargetProblemSize() );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void HYDRO_1D::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
 
   m_array_length = getActualProblemSize() + 12;
 
@@ -37,15 +53,6 @@ HYDRO_1D::HYDRO_1D(const RunParams& params)
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(5 * getActualProblemSize());
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 HYDRO_1D::~HYDRO_1D()

--- a/src/lcals/HYDRO_1D.hpp
+++ b/src/lcals/HYDRO_1D.hpp
@@ -49,6 +49,7 @@ public:
 
   ~HYDRO_1D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -34,10 +34,26 @@ HYDRO_2D::HYDRO_2D(const RunParams& params)
   setDefaultProblemSize(m_kn * m_jn);
   setDefaultReps(100);
 
-  m_jn = m_kn = std::sqrt(getTargetProblemSize()) + std::sqrt(2)-1;
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void HYDRO_2D::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_jn = m_kn = std::sqrt(target_size) + std::sqrt(2)-1;
   m_array_length = m_kn * m_jn;
 
   setActualProblemSize( m_array_length );
+  setRunReps( target_reps );
 
   setItsPerRep( 3 * (m_kn-2) * (m_jn-2) );
   setKernelsPerRep(3);
@@ -62,15 +78,6 @@ HYDRO_2D::HYDRO_2D(const RunParams& params)
   setFLOPsPerRep((14 +
                   26 +
                   4  ) * (m_jn-2)*(m_kn-2));
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 HYDRO_2D::~HYDRO_2D()

--- a/src/lcals/HYDRO_2D.hpp
+++ b/src/lcals/HYDRO_2D.hpp
@@ -143,6 +143,7 @@ public:
 
   ~HYDRO_2D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/lcals/INT_PREDICT.cpp
+++ b/src/lcals/INT_PREDICT.cpp
@@ -25,15 +25,8 @@ INT_PREDICT::INT_PREDICT(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(400);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 10*sizeof(Real_type ) * getActualProblemSize() ); // px(12), px(11), px(10), px(9), px(8), px(7), px(6), px(4), px(5), px(2)
-  setBytesWrittenPerRep( 1*sizeof(Real_type ) * getActualProblemSize() ); // px(0)
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(17 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -43,6 +36,20 @@ INT_PREDICT::INT_PREDICT(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void INT_PREDICT::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 10*sizeof(Real_type ) * getActualProblemSize() ); // px(12), px(11), px(10), px(9), px(8), px(7), px(6), px(4), px(5), px(2)
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * getActualProblemSize() ); // px(0)
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(17 * getActualProblemSize());
 }
 
 INT_PREDICT::~INT_PREDICT()

--- a/src/lcals/INT_PREDICT.hpp
+++ b/src/lcals/INT_PREDICT.hpp
@@ -64,6 +64,7 @@ public:
 
   ~INT_PREDICT();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/lcals/PLANCKIAN.cpp
+++ b/src/lcals/PLANCKIAN.cpp
@@ -25,15 +25,8 @@ PLANCKIAN::PLANCKIAN(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(50);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 3*sizeof(Real_type ) * getActualProblemSize() ); // u, v, x
-  setBytesWrittenPerRep( 2*sizeof(Real_type ) * getActualProblemSize() ); // y, w
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(4 * getActualProblemSize()); // 1 exp
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -43,6 +36,20 @@ PLANCKIAN::PLANCKIAN(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void PLANCKIAN::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 3*sizeof(Real_type ) * getActualProblemSize() ); // u, v, x
+  setBytesWrittenPerRep( 2*sizeof(Real_type ) * getActualProblemSize() ); // y, w
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(4 * getActualProblemSize()); // 1 exp
 }
 
 PLANCKIAN::~PLANCKIAN()

--- a/src/lcals/PLANCKIAN.hpp
+++ b/src/lcals/PLANCKIAN.hpp
@@ -49,6 +49,7 @@ public:
 
   ~PLANCKIAN();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/lcals/TRIDIAG_ELIM.cpp
+++ b/src/lcals/TRIDIAG_ELIM.cpp
@@ -25,7 +25,23 @@ TRIDIAG_ELIM::TRIDIAG_ELIM(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(1000);
 
-  setActualProblemSize( std::max(getTargetProblemSize(), Index_type(2)) );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void TRIDIAG_ELIM::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( std::max(target_size, Index_type(2)) );
+  setRunReps( target_reps );
 
   m_N = getActualProblemSize();
 
@@ -36,15 +52,6 @@ TRIDIAG_ELIM::TRIDIAG_ELIM(const RunParams& params)
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * (m_N-1));
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-
-  addVariantTunings();
 }
 
 TRIDIAG_ELIM::~TRIDIAG_ELIM()

--- a/src/lcals/TRIDIAG_ELIM.hpp
+++ b/src/lcals/TRIDIAG_ELIM.hpp
@@ -49,6 +49,7 @@ public:
 
   ~TRIDIAG_ELIM();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/polybench/POLYBENCH_2MM.cpp
+++ b/src/polybench/POLYBENCH_2MM.cpp
@@ -23,25 +23,40 @@ namespace polybench
 POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_2MM, params)
 {
-  Index_type ni_default = 1000;
-  Index_type nj_default = 1000;
-  Index_type nk_default = 1120;
-  Index_type nl_default = 1000;
+  m_ni_default = 1000;
+  m_nj_default = 1000;
+  m_nk_default = 1120;
+  m_nl_default = 1000;
 
-  setDefaultProblemSize( std::max( ni_default*nj_default,
-                                   ni_default*nl_default ) );
+  setDefaultProblemSize( std::max( m_ni_default*m_nj_default,
+                                   m_ni_default*m_nl_default ) );
   setDefaultReps(2);
 
-  m_ni = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N_to_the_three_halves);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void POLYBENCH_2MM::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_ni = std::sqrt( target_size ) + std::sqrt(2)-1;
   m_nj = m_ni;
-  m_nk = Index_type(double(nk_default)/ni_default*m_ni);
+  m_nk = Index_type(double(m_nk_default)/m_ni_default*m_ni);
   m_nl = m_ni;
 
   m_alpha = 1.5;
   m_beta = 1.2;
 
-
   setActualProblemSize( std::max( m_ni*m_nj, m_ni*m_nl ) );
+  setRunReps( target_reps );
 
   setItsPerRep( m_ni*m_nj + m_ni*m_nl );
   setKernelsPerRep(2);
@@ -57,15 +72,6 @@ POLYBENCH_2MM::POLYBENCH_2MM(const RunParams& params)
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(3 * m_ni*m_nj*m_nk +
                  2 * m_ni*m_nj*m_nl );
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N_to_the_three_halves);
-
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 POLYBENCH_2MM::~POLYBENCH_2MM()

--- a/src/polybench/POLYBENCH_2MM.hpp
+++ b/src/polybench/POLYBENCH_2MM.hpp
@@ -119,6 +119,7 @@ public:
 
   ~POLYBENCH_2MM();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);
@@ -146,10 +147,16 @@ private:
   using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
                                                          integer::MultipleOf<32>>;
 
+  Index_type m_ni_default;
+  Index_type m_nj_default;
+  Index_type m_nk_default;
+  Index_type m_nl_default;
+
   Index_type m_ni;
   Index_type m_nj;
   Index_type m_nk;
   Index_type m_nl;
+
   Real_type m_alpha;
   Real_type m_beta;
   Real_ptr m_tmp;

--- a/src/polybench/POLYBENCH_3MM.cpp
+++ b/src/polybench/POLYBENCH_3MM.cpp
@@ -24,27 +24,42 @@ namespace polybench
 POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_3MM, params)
 {
-  Index_type ni_default = 1000;
-  Index_type nj_default = 1000;
-  Index_type nk_default = 1010;
-  Index_type nl_default = 1000;
-  Index_type nm_default = 1200;
+  m_ni_default = 1000;
+  m_nj_default = 1000;
+  m_nk_default = 1010;
+  m_nl_default = 1000;
+  m_nm_default = 1200;
 
-  setDefaultProblemSize( std::max( std::max( ni_default*nj_default,
-                                             nj_default*nl_default ),
-                                  ni_default*nl_default ) );
-  setDefaultProblemSize( ni_default * nj_default );
+  setDefaultProblemSize( std::max( std::max( m_ni_default*m_nj_default,
+                                             m_nj_default*m_nl_default ),
+                                  m_ni_default*m_nl_default ) );
+  setDefaultProblemSize( m_ni_default * m_nj_default );
   setDefaultReps(2);
 
-  m_ni = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
-  m_nj = m_ni;
-  m_nk = Index_type(double(nk_default)/ni_default*m_ni);
-  m_nl = m_ni;
-  m_nm = Index_type(double(nm_default)/ni_default*m_ni);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N_to_the_three_halves);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void POLYBENCH_3MM::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_ni = std::sqrt( target_size ) + std::sqrt(2)-1;
+  m_nj = m_ni;
+  m_nk = Index_type(double(m_nk_default)/m_ni_default*m_ni);
+  m_nl = m_ni;
+  m_nm = Index_type(double(m_nm_default)/m_ni_default*m_ni);
 
   setActualProblemSize( std::max( std::max( m_ni*m_nj, m_nj*m_nl ),
                                   m_ni*m_nl ) );
+  setRunReps( target_reps );
 
   setItsPerRep( m_ni*m_nj + m_nj*m_nl + m_ni*m_nl );
   setKernelsPerRep(3);
@@ -66,15 +81,6 @@ POLYBENCH_3MM::POLYBENCH_3MM(const RunParams& params)
   setFLOPsPerRep(2 * m_ni*m_nj*m_nk +
                  2 * m_nj*m_nl*m_nm +
                  2 * m_ni*m_nj*m_nl );
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N_to_the_three_halves);
-
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 POLYBENCH_3MM::~POLYBENCH_3MM()

--- a/src/polybench/POLYBENCH_3MM.hpp
+++ b/src/polybench/POLYBENCH_3MM.hpp
@@ -145,6 +145,7 @@ public:
 
   ~POLYBENCH_3MM();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);
@@ -172,12 +173,18 @@ private:
   using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
                                                          integer::MultipleOf<32>>;
 
+  Index_type m_ni_default;
+  Index_type m_nj_default;
+  Index_type m_nk_default;
+  Index_type m_nl_default;
+  Index_type m_nm_default;
+
   Index_type m_ni;
   Index_type m_nj;
   Index_type m_nk;
   Index_type m_nl;
   Index_type m_nm;
-  Index_type m_run_reps;
+
   Real_ptr m_A;
   Real_ptr m_B;
   Real_ptr m_C;

--- a/src/polybench/POLYBENCH_ADI.cpp
+++ b/src/polybench/POLYBENCH_ADI.cpp
@@ -23,17 +23,30 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
   , m_tsteps(4)
 {
   Index_type n_default = 1002;
-
   setDefaultProblemSize( (n_default-2) * (n_default-2) );
   setDefaultReps(4 * m_tsteps);
 
-  m_n = std::sqrt( getTargetProblemSize() ) + 2 + std::sqrt(2)-1;
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
-  setItsPerRep( 2 * (m_n-2) + (m_n-2) );
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
 
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void POLYBENCH_ADI::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_n = std::sqrt( target_size ) + 2 + std::sqrt(2)-1;
 
   setActualProblemSize( (m_n-2) * (m_n-2) );
+  setRunReps( target_reps );
 
+  setItsPerRep( 2 * (m_n-2) + (m_n-2) );
   setKernelsPerRep( 2 );
   setBytesReadPerRep( 1*sizeof(Real_type ) * (m_n-2) * (m_n  ) + // u
 
@@ -49,15 +62,6 @@ POLYBENCH_ADI::POLYBENCH_ADI(const RunParams& params)
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep( (13 + 2) * (m_n-2)*(m_n-2) +
                   (13 + 2) * (m_n-2)*(m_n-2) );
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 POLYBENCH_ADI::~POLYBENCH_ADI()

--- a/src/polybench/POLYBENCH_ADI.hpp
+++ b/src/polybench/POLYBENCH_ADI.hpp
@@ -186,6 +186,7 @@ public:
 
   ~POLYBENCH_ADI();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/polybench/POLYBENCH_ATAX.cpp
+++ b/src/polybench/POLYBENCH_ATAX.cpp
@@ -23,14 +23,28 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
   : KernelBase(rajaperf::Polybench_ATAX, params)
 {
   Index_type N_default = 1000;
-
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(100);
 
-  m_N = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void POLYBENCH_ATAX::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_N = std::sqrt( target_size ) + std::sqrt(2)-1;
 
   setActualProblemSize( m_N * m_N );
+  setRunReps( target_reps );
 
   setItsPerRep( 2 * m_N + m_N );
   setKernelsPerRep(2);
@@ -48,15 +62,6 @@ POLYBENCH_ATAX::POLYBENCH_ATAX(const RunParams& params)
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * m_N*m_N +
                  2 * m_N*m_N );
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 POLYBENCH_ATAX::~POLYBENCH_ATAX()

--- a/src/polybench/POLYBENCH_ATAX.hpp
+++ b/src/polybench/POLYBENCH_ATAX.hpp
@@ -107,6 +107,7 @@ public:
 
   ~POLYBENCH_ATAX();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/polybench/POLYBENCH_FDTD_2D.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.cpp
@@ -33,11 +33,26 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
                                     nx_default * (ny_default-1) ) );
   setDefaultReps(8 * m_tsteps);
 
-  m_nx = std::sqrt( getTargetProblemSize() ) + 1 + std::sqrt(2)-1;
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void POLYBENCH_FDTD_2D::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_nx = std::sqrt( target_size ) + 1 + std::sqrt(2)-1;
   m_ny = m_nx;
 
-
   setActualProblemSize( std::max( (m_nx-1)*m_ny, m_nx*(m_ny-1) ) );
+  setRunReps( target_reps );
 
   setItsPerRep( m_ny +
                 (m_nx-1)*m_ny +
@@ -71,15 +86,6 @@ POLYBENCH_FDTD_2D::POLYBENCH_FDTD_2D(const RunParams& params)
                   3 * (m_nx-1)*m_ny +
                   3 * m_nx*(m_ny-1) +
                   5 * (m_nx-1)*(m_ny-1) );
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 POLYBENCH_FDTD_2D::~POLYBENCH_FDTD_2D()

--- a/src/polybench/POLYBENCH_FDTD_2D.hpp
+++ b/src/polybench/POLYBENCH_FDTD_2D.hpp
@@ -104,6 +104,7 @@ public:
 
   ~POLYBENCH_FDTD_2D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.cpp
@@ -23,22 +23,11 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
   : KernelBase(rajaperf::Polybench_FLOYD_WARSHALL, params)
 {
   Index_type N_default = 1000;
-
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(8);
 
-  m_N = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
-
-
-  setActualProblemSize( m_N * m_N );
-
-  setItsPerRep( m_N * m_N*m_N );
-  setKernelsPerRep(m_N);
-  setBytesReadPerRep( m_N * 1*sizeof(Real_type ) * m_N * m_N ); // pin
-  setBytesWrittenPerRep( m_N * 1*sizeof(Real_type ) * m_N * m_N ); // pout
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep( m_N*m_N*m_N * 3 / 2 ); // conditional is true about half of the time
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::tight);
@@ -48,6 +37,22 @@ POLYBENCH_FLOYD_WARSHALL::POLYBENCH_FLOYD_WARSHALL(const RunParams& params)
   setUsesFeature(Kernel);
 
   addVariantTunings();
+}
+
+void POLYBENCH_FLOYD_WARSHALL::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_N = std::sqrt( target_size ) + std::sqrt(2)-1;
+
+  setActualProblemSize( m_N * m_N );
+  setRunReps( target_reps );
+
+  setItsPerRep( m_N * m_N*m_N );
+  setKernelsPerRep(m_N);
+  setBytesReadPerRep( m_N * 1*sizeof(Real_type ) * m_N * m_N ); // pin
+  setBytesWrittenPerRep( m_N * 1*sizeof(Real_type ) * m_N * m_N ); // pout
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep( m_N*m_N*m_N * 3 / 2 ); // conditional is true about half of the time
 }
 
 POLYBENCH_FLOYD_WARSHALL::~POLYBENCH_FLOYD_WARSHALL()

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL.hpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL.hpp
@@ -68,6 +68,7 @@ public:
 
   ~POLYBENCH_FLOYD_WARSHALL();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/polybench/POLYBENCH_GEMM.cpp
+++ b/src/polybench/POLYBENCH_GEMM.cpp
@@ -22,22 +22,36 @@ namespace polybench
 POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GEMM, params)
 {
-  Index_type ni_default = 1000;
-  Index_type nj_default = 1000;
-  Index_type nk_default = 1200;
-
-  setDefaultProblemSize( ni_default * nj_default );
+  m_ni_default = 1000;
+  m_nj_default = 1000;
+  m_nk_default = 1200;
+  setDefaultProblemSize( m_ni_default * m_nj_default );
   setDefaultReps(4);
-
-  m_ni = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
-  m_nj = m_ni;
-  m_nk = Index_type(double(nk_default)/ni_default*m_ni);
 
   m_alpha = 0.62;
   m_beta = 1.002;
 
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N_to_the_three_halves);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void POLYBENCH_GEMM::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_ni = std::sqrt( target_size ) + std::sqrt(2)-1;
+  m_nj = m_ni;
+  m_nk = Index_type(double(m_nk_default)/m_ni_default*m_ni);
 
   setActualProblemSize( m_ni * m_nj );
+  setRunReps( target_reps );
 
   setItsPerRep( m_ni * m_nj );
   setKernelsPerRep(1);
@@ -48,15 +62,6 @@ POLYBENCH_GEMM::POLYBENCH_GEMM(const RunParams& params)
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep((1 +
                   3 * m_nk) * m_ni*m_nj);
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N_to_the_three_halves);
-
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 POLYBENCH_GEMM::~POLYBENCH_GEMM()

--- a/src/polybench/POLYBENCH_GEMM.hpp
+++ b/src/polybench/POLYBENCH_GEMM.hpp
@@ -96,6 +96,7 @@ public:
 
   ~POLYBENCH_GEMM();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);
@@ -122,6 +123,10 @@ private:
   static const size_t default_gpu_block_size = 256;
   using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
                                                          integer::MultipleOf<32>>;
+
+  Index_type m_ni_default;
+  Index_type m_nj_default;
+  Index_type m_nk_default;
 
   Index_type m_ni;
   Index_type m_nj;

--- a/src/polybench/POLYBENCH_GEMVER.cpp
+++ b/src/polybench/POLYBENCH_GEMVER.cpp
@@ -23,17 +23,32 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GEMVER, params)
 {
   Index_type n_default = 1000;
-
   setDefaultProblemSize( n_default * n_default );
   setDefaultReps(20);
-
-  m_n =  std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
 
   m_alpha = 1.5;
   m_beta = 1.2;
 
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Forall);
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void POLYBENCH_GEMVER::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_n =  std::sqrt( target_size ) + std::sqrt(2)-1;
 
   setActualProblemSize( m_n * m_n );
+  setRunReps( target_reps );
 
   setItsPerRep( m_n*m_n +
                 m_n +
@@ -68,16 +83,6 @@ POLYBENCH_GEMVER::POLYBENCH_GEMVER(const RunParams& params)
                  3 * m_n*m_n +
                  1 * m_n +
                  3 * m_n*m_n );
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Forall);
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 POLYBENCH_GEMVER::~POLYBENCH_GEMVER()

--- a/src/polybench/POLYBENCH_GEMVER.hpp
+++ b/src/polybench/POLYBENCH_GEMVER.hpp
@@ -147,6 +147,7 @@ public:
 
   ~POLYBENCH_GEMVER();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/polybench/POLYBENCH_GESUMMV.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV.cpp
@@ -23,17 +23,31 @@ POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
   : KernelBase(rajaperf::Polybench_GESUMMV, params)
 {
   Index_type N_default = 1000;
-
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(120);
-
-  m_N = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
 
   m_alpha = 0.62;
   m_beta = 1.002;
 
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void POLYBENCH_GESUMMV::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_N = std::sqrt( target_size ) + std::sqrt(2)-1;
 
   setActualProblemSize( m_N * m_N );
+  setRunReps( target_reps );
 
   setItsPerRep( m_N );
   setKernelsPerRep(1);
@@ -44,15 +58,6 @@ POLYBENCH_GESUMMV::POLYBENCH_GESUMMV(const RunParams& params)
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep((4 * m_N +
                   3 ) * m_N  );
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 POLYBENCH_GESUMMV::~POLYBENCH_GESUMMV()

--- a/src/polybench/POLYBENCH_GESUMMV.hpp
+++ b/src/polybench/POLYBENCH_GESUMMV.hpp
@@ -90,6 +90,7 @@ public:
 
   ~POLYBENCH_GESUMMV();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -24,14 +24,28 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_HEAT_3D, params)
 {
   Index_type N_default = 102;
-
   setDefaultProblemSize( (N_default-2)*(N_default-2)*(N_default-2) );
   setDefaultReps(400);
 
-  m_N = std::cbrt( getTargetProblemSize() ) + 2 + std::cbrt(3)-1;
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void POLYBENCH_HEAT_3D::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_N = std::cbrt( target_size ) + 2 + std::cbrt(3)-1;
 
   setActualProblemSize( (m_N-2) * (m_N-2) * (m_N-2) );
+  setRunReps( target_reps );
 
   setItsPerRep( 2 * getActualProblemSize() );
   setKernelsPerRep( 2 );
@@ -45,15 +59,6 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep( 15 * (m_N-2) * (m_N-2) * (m_N-2) +
                   15 * (m_N-2) * (m_N-2) * (m_N-2) );
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 POLYBENCH_HEAT_3D::~POLYBENCH_HEAT_3D()

--- a/src/polybench/POLYBENCH_HEAT_3D.hpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.hpp
@@ -108,6 +108,7 @@ public:
 
   ~POLYBENCH_HEAT_3D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/polybench/POLYBENCH_JACOBI_1D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.cpp
@@ -27,23 +27,8 @@ POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
   setDefaultProblemSize( N_default-2 );
   setDefaultReps(1600);
 
-  m_N = getTargetProblemSize() + 2;
-
-
-  setActualProblemSize( m_N-2 );
-
-  setItsPerRep( 2 * getActualProblemSize() );
-  setKernelsPerRep(2);
-  setBytesReadPerRep( 1*sizeof(Real_type ) * m_N + // A (3 point stencil)
-
-                      1*sizeof(Real_type ) * m_N ); // B (3 point stencil)
-  setBytesWrittenPerRep( 1*sizeof(Real_type ) * (m_N-2) + // B
-
-                         1*sizeof(Real_type ) * (m_N-2) ); // A
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep( 3 * (m_N-2) +
-                  3 * (m_N-2) );
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
 #if defined(RAJA_ENABLE_TARGET_OPENMP)
@@ -58,6 +43,27 @@ POLYBENCH_JACOBI_1D::POLYBENCH_JACOBI_1D(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void POLYBENCH_JACOBI_1D::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_N = target_size + 2;
+
+  setActualProblemSize( m_N-2 );
+  setRunReps( target_reps );
+
+  setItsPerRep( 2 * getActualProblemSize() );
+  setKernelsPerRep(2);
+  setBytesReadPerRep( 1*sizeof(Real_type ) * m_N + // A (3 point stencil)
+
+                      1*sizeof(Real_type ) * m_N ); // B (3 point stencil)
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * (m_N-2) + // B
+
+                         1*sizeof(Real_type ) * (m_N-2) ); // A
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep( 3 * (m_N-2) +
+                  3 * (m_N-2) );
 }
 
 POLYBENCH_JACOBI_1D::~POLYBENCH_JACOBI_1D()

--- a/src/polybench/POLYBENCH_JACOBI_1D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.hpp
@@ -56,6 +56,7 @@ public:
 
   ~POLYBENCH_JACOBI_1D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -27,10 +27,25 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
   setDefaultProblemSize( (N_default-2)*(N_default-2) );
   setDefaultReps(2000);
 
-  m_N = std::sqrt( getTargetProblemSize() ) + 2 + std::sqrt(2)-1;
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void POLYBENCH_JACOBI_2D::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_N = std::sqrt( target_size ) + 2 + std::sqrt(2)-1;
 
   setActualProblemSize( (m_N-2) * (m_N-2) );
+  setRunReps( target_reps );
 
   setItsPerRep( 2 * (m_N-2) * (m_N-2) );
   setKernelsPerRep(2);
@@ -44,15 +59,6 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep( 5 * (m_N-2)*(m_N-2) +
                   5 * (m_N-2)*(m_N-2) );
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 POLYBENCH_JACOBI_2D::~POLYBENCH_JACOBI_2D()

--- a/src/polybench/POLYBENCH_JACOBI_2D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.hpp
@@ -75,6 +75,7 @@ public:
 
   ~POLYBENCH_JACOBI_2D();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/polybench/POLYBENCH_MVT.cpp
+++ b/src/polybench/POLYBENCH_MVT.cpp
@@ -27,10 +27,25 @@ POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
   setDefaultProblemSize( N_default * N_default );
   setDefaultReps(100);
 
-  m_N = std::sqrt( getTargetProblemSize() ) + std::sqrt(2)-1;
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void POLYBENCH_MVT::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_N = std::sqrt( target_size ) + std::sqrt(2)-1;
 
   setActualProblemSize( m_N * m_N );
+  setRunReps( target_reps );
 
   setItsPerRep( 2 * m_N );
   setKernelsPerRep(2);
@@ -46,15 +61,6 @@ POLYBENCH_MVT::POLYBENCH_MVT(const RunParams& params)
   setBytesAtomicModifyWrittenPerRep( 0 );
   setFLOPsPerRep(2 * m_N*m_N +
                  2 * m_N*m_N );
-
-  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
-  setChecksumTolerance(ChecksumTolerance::normal);
-
-  setComplexity(Complexity::N);
-
-  setUsesFeature(Kernel);
-
-  addVariantTunings();
 }
 
 POLYBENCH_MVT::~POLYBENCH_MVT()

--- a/src/polybench/POLYBENCH_MVT.hpp
+++ b/src/polybench/POLYBENCH_MVT.hpp
@@ -111,6 +111,7 @@ public:
 
   ~POLYBENCH_MVT();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/stream/ADD.cpp
+++ b/src/stream/ADD.cpp
@@ -25,15 +25,8 @@ ADD::ADD(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(1000);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // a, b
-  setBytesWrittenPerRep( 1*sizeof(Real_type ) * getActualProblemSize() ); // c
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(1 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::tight);
@@ -43,6 +36,20 @@ ADD::ADD(const RunParams& params)
   setUsesFeature(Forall);
 
   addVariantTunings();
+}
+
+void ADD::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // a, b
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * getActualProblemSize() ); // c
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(1 * getActualProblemSize());
 }
 
 ADD::~ADD()

--- a/src/stream/ADD.hpp
+++ b/src/stream/ADD.hpp
@@ -44,6 +44,7 @@ public:
 
   ~ADD();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/stream/COPY.cpp
+++ b/src/stream/COPY.cpp
@@ -25,15 +25,8 @@ COPY::COPY(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(1800);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // a
-  setBytesWrittenPerRep( 1*sizeof(Real_type ) * getActualProblemSize() ); // c
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(0);
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Consistent);
   setChecksumTolerance(ChecksumTolerance::zero);
@@ -43,6 +36,20 @@ COPY::COPY(const RunParams& params)
   setUsesFeature( Forall );
 
   addVariantTunings();
+}
+
+void COPY::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // a
+  setBytesWrittenPerRep( 1*sizeof(Real_type ) * getActualProblemSize() ); // c
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(0);
 }
 
 COPY::~COPY()

--- a/src/stream/COPY.hpp
+++ b/src/stream/COPY.hpp
@@ -43,6 +43,7 @@ public:
 
   ~COPY();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/stream/DOT.cpp
+++ b/src/stream/DOT.cpp
@@ -25,15 +25,8 @@ DOT::DOT(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(2000);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // a, b
-  setBytesWrittenPerRep( 0 );
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(2 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::Inconsistent);
   setChecksumTolerance(ChecksumTolerance::normal);
@@ -44,6 +37,20 @@ DOT::DOT(const RunParams& params)
   setUsesFeature( Reduction );
 
   addVariantTunings();
+}
+
+void DOT::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // a, b
+  setBytesWrittenPerRep( 0 );
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(2 * getActualProblemSize());
 }
 
 DOT::~DOT()

--- a/src/stream/DOT.hpp
+++ b/src/stream/DOT.hpp
@@ -43,6 +43,7 @@ public:
 
   ~DOT();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/stream/MUL.cpp
+++ b/src/stream/MUL.cpp
@@ -25,15 +25,8 @@ MUL::MUL(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(1800);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // c
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // b
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(1 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::tight);
@@ -43,6 +36,20 @@ MUL::MUL(const RunParams& params)
   setUsesFeature( Forall );
 
   addVariantTunings();
+}
+
+void MUL::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // c
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // b
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(1 * getActualProblemSize());
 }
 
 MUL::~MUL()

--- a/src/stream/MUL.hpp
+++ b/src/stream/MUL.hpp
@@ -44,6 +44,7 @@ public:
 
   ~MUL();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);

--- a/src/stream/TRIAD.cpp
+++ b/src/stream/TRIAD.cpp
@@ -25,15 +25,8 @@ TRIAD::TRIAD(const RunParams& params)
   setDefaultProblemSize(1000000);
   setDefaultReps(1000);
 
-  setActualProblemSize( getTargetProblemSize() );
-
-  setItsPerRep( getActualProblemSize() );
-  setKernelsPerRep(1);
-  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // b, c
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // a
-  setBytesModifyWrittenPerRep( 0 );
-  setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep(2 * getActualProblemSize());
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
 
   setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
   setChecksumTolerance(ChecksumTolerance::tight);
@@ -43,6 +36,20 @@ TRIAD::TRIAD(const RunParams& params)
   setUsesFeature( Forall );
 
   addVariantTunings();
+}
+
+void TRIAD::setSize(Index_type target_size, Index_type target_reps)
+{
+  setActualProblemSize( target_size );
+  setRunReps( target_reps );
+
+  setItsPerRep( getActualProblemSize() );
+  setKernelsPerRep(1);
+  setBytesReadPerRep( 2*sizeof(Real_type) * getActualProblemSize() ); // b, c
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * getActualProblemSize() ); // a
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+  setFLOPsPerRep(2 * getActualProblemSize());
 }
 
 TRIAD::~TRIAD()

--- a/src/stream/TRIAD.hpp
+++ b/src/stream/TRIAD.hpp
@@ -45,6 +45,7 @@ public:
 
   ~TRIAD();
 
+  void setSize(Index_type target_size, Index_type target_reps);
   void setUp(VariantID vid, size_t tune_idx);
   void updateChecksum(VariantID vid, size_t tune_idx);
   void tearDown(VariantID vid, size_t tune_idx);


### PR DESCRIPTION
# Summary

Move the Kernel Sizing code from the constructor to a virtual function so it can potentially be done multiple times.

The intention is to use this to use this in a later PR to be able to do things like set problem size based on memory usage by calling this multiple times to try to find a problem size that gets close to the desired value.

It also moves the logic for calculating the target problem size and reps into the params instead of having it in KernelBase.

- This PR is a refactoring
- It does the following (modify list as needed):
  - Modifies/refactors kernels to do sizing in a function
