### PR TITLE
Update ROCM version for LC Corona system

### DIFF
--- a/.gitlab/jobs/corona.yml
+++ b/.gitlab/jobs/corona.yml
@@ -32,6 +32,6 @@ clang_22_0_0_sycl_gcc_10_3_1_rocmcc_6_4_2:
   variables:
     SPEC: " ~shared +sycl ~openmp cxxflags==\"-w -fsycl -fsycl-unnamed-lambda -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906\" %sycl-clang-22-gcc-10"
     MODULE_LIST: "rocm/6.4.2"
-    SYCL_PATH: "/usr/workspace/raja-dev/clang_sycl_16b7bcb09915_hip_gcc10.3.1_rocm6.4.2"
+    SYCL_PATH: "/usr/workspace/raja-dev/clang_sycl_16b7bcb09915_hip_gcc10.3.1_rocm6.4.3"
     LD_LIBRARY_PATH: "${SYCL_PATH}/lib:${SYCL_PATH}/lib64:${LD_LIBRARY_PATH}"
   extends: .job_on_corona

--- a/scripts/lc-builds/corona_sycl.sh
+++ b/scripts/lc-builds/corona_sycl.sh
@@ -15,7 +15,7 @@ if [[ $# -lt 1 ]]; then
   echo "   1) SYCL compiler installation path"
   echo
   echo "For example: "
-  echo "    corona_sycl.sh /usr/workspace/raja-dev/clang_sycl_730cd3a5275f_hip_gcc10.3.1_rocm6.0.2"
+  echo "    corona_sycl.sh /usr/workspace/raja-dev/clang_sycl_16b7bcb09915_hip_gcc10.3.1_rocm6.4.3"
   exit
 fi
 


### PR DESCRIPTION
# Updates the ROCM version used in the Sycl CI tests and docs to ROCM 6.4.3 on the Corona system
