### PR TITLE
DRAFT: Bump cmake version on LC system to 2.24 or greater

### DIFF
--- a/scripts/lc-builds/corona_sycl.sh
+++ b/scripts/lc-builds/corona_sycl.sh
@@ -40,7 +40,7 @@ DATE=$(printf '%(%Y-%m-%d)T\n' -1)
 export PATH=${SYCL_PATH}/bin:$PATH
 export LD_LIBRARY_PATH=${SYCL_PATH}/lib:${SYCL_PATH}/lib64:$LD_LIBRARY_PATH
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 cmake \
   -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \

--- a/scripts/lc-builds/toss4_clang-mpi_caliper.sh
+++ b/scripts/lc-builds/toss4_clang-mpi_caliper.sh
@@ -38,7 +38,7 @@ echo
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/lc-builds/toss4_clang.sh
+++ b/scripts/lc-builds/toss4_clang.sh
@@ -31,7 +31,7 @@ echo
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/lc-builds/toss4_clang_caliper.sh
+++ b/scripts/lc-builds/toss4_clang_caliper.sh
@@ -38,7 +38,7 @@ echo
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/lc-builds/toss4_cray-mpich_amdclang.sh
+++ b/scripts/lc-builds/toss4_cray-mpich_amdclang.sh
@@ -78,7 +78,7 @@ rm -rf build_${BUILD_SUFFIX} >/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 # unload rocm to avoid configuration problems where the loaded rocm and COMP_VER
 # are inconsistent causing the rocprim from the module to be used unexpectedly

--- a/scripts/lc-builds/toss4_cray-mpich_amdclang_asan.sh
+++ b/scripts/lc-builds/toss4_cray-mpich_amdclang_asan.sh
@@ -78,7 +78,7 @@ rm -rf build_${BUILD_SUFFIX} >/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 # unload rocm to avoid configuration problems where the loaded rocm and COMP_VER
 # are inconsistent causing the rocprim from the module to be used unexpectedly

--- a/scripts/lc-builds/toss4_cray-mpich_amdclang_caliper.sh
+++ b/scripts/lc-builds/toss4_cray-mpich_amdclang_caliper.sh
@@ -82,7 +82,7 @@ rm -rf build_${BUILD_SUFFIX} >/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 # unload rocm to avoid configuration problems where the loaded rocm and COMP_VER
 # are inconsistent causing the rocprim from the module to be used unexpectedly

--- a/scripts/lc-builds/toss4_gcc-mpi_caliper.sh
+++ b/scripts/lc-builds/toss4_gcc-mpi_caliper.sh
@@ -38,7 +38,7 @@ echo
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/lc-builds/toss4_gcc.sh
+++ b/scripts/lc-builds/toss4_gcc.sh
@@ -31,7 +31,7 @@ echo
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/lc-builds/toss4_gcc_caliper.sh
+++ b/scripts/lc-builds/toss4_gcc_caliper.sh
@@ -38,7 +38,7 @@ echo
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/lc-builds/toss4_icpc-classic.sh
+++ b/scripts/lc-builds/toss4_icpc-classic.sh
@@ -31,7 +31,7 @@ echo
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 ##
 # CMake option -DRAJA_ENABLE_FORCEINLINE_RECURSIVE=Off used to speed up compile

--- a/scripts/lc-builds/toss4_icpc.sh
+++ b/scripts/lc-builds/toss4_icpc.sh
@@ -31,7 +31,7 @@ echo
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 ##
 # CMake option -DRAJA_ENABLE_FORCEINLINE_RECURSIVE=Off used to speed up compile

--- a/scripts/lc-builds/toss4_icpx.sh
+++ b/scripts/lc-builds/toss4_icpx.sh
@@ -31,7 +31,7 @@ echo
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 ##
 # CMake option -DRAJA_ENABLE_FORCEINLINE_RECURSIVE=Off used to speed up compile

--- a/scripts/lc-builds/toss4_mvapich2_gcc.sh
+++ b/scripts/lc-builds/toss4_mvapich2_gcc.sh
@@ -37,7 +37,7 @@ echo
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 cmake \
   -DCMAKE_BUILD_TYPE=Release \

--- a/scripts/lc-builds/toss4_mvapich2_icpx.sh
+++ b/scripts/lc-builds/toss4_mvapich2_icpx.sh
@@ -37,7 +37,7 @@ echo
 rm -rf build_${BUILD_SUFFIX} 2>/dev/null
 mkdir build_${BUILD_SUFFIX} && cd build_${BUILD_SUFFIX}
 
-module load cmake/3.23.1
+module load cmake/3.25.2
 
 ##
 # CMake option -DRAJA_ENABLE_FORCEINLINE_RECURSIVE=Off used to speed up compile


### PR DESCRIPTION
# Bump cmake version loaded in LC scripts to 3.24 or greater

Minimum cmake required has been bumped to 3.24; update scripts to load this new minimum.