### PR TITLE
Add Simple Check to Prevent `npasses>1` When Caliper Enabled

### DIFF
--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -404,6 +404,14 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
       i++;
       if ( i < argc ) {
         npasses = ::atoi( argv[i] );
+        #if defined(RAJA_PERFSUITE_USE_CALIPER)
+          if (npasses > 1) {
+            getCout() << "\nBad input:"
+                  << " --npasses cannot be >1 when profiling with Caliper"
+                  << std::endl;
+            input_state = BadInput;
+          }
+        #endif
       } else {
         getCout() << "\nBad input:"
                   << " must give --npasses a value for number of passes (int)"


### PR DESCRIPTION
# Summary

- This PR is a bugfix
- It does the following (modify list as needed):
  - Modifies `src/common/RunParams.cpp`
  - Fixes #563

This PR addresses a known issue (https://github.com/llnl/RAJAPerf/issues/563) when using `--npasses>1`, where seemingly "incorrect" values will be propagated into the caliper files. 

@MrBurmark  and I discussed something like multiplying reps by npasses. Another option is we could rename reps to be reps/pass. However, @MrBurmark  during this discussion, I forgot the issue of the other attributes being incorrectly set on the subsequent passes after the first pass. So the solution cannot be this simple.

To solve this:

1. We could add a guard so attributes are not set again. This would also require one of the solutions discussed above as well, as metrics would need to be divided by npasses and reps in post-processing.
1. flush Caliper files after each pass. So files would be named `variant-tuning-passnum.cali` like `Base_Seq-1.cali`. I think this would be a solution more befitting of Caliper's model than the first option.

This is just a temporary mechanism to prevent users from generating bad data by accident, until I implement a better solution, which I'm not sure will land before the `2025.12.0` release, so I am making this PR. This issue can also be really difficult for a user to catch, so it does need to be addressed in some form.

I tested some cases, which show what a user will see:
```
# If not building with caliper
### fine
raja-perf.exe --npasses 1 --dryrun
### fine
raja-perf.exe --npasses 2 --dryrun

# If building with Caliper
### fine
raja-perf.exe --npasses 1 --dryrun
### bad input
$ raja-perf.exe --npasses 2 --dryrun


Running with 1 MPI ranks...


Reading command line input...

Bad input: --npasses cannot be >1 when profiling with Caliper
Compiler: icpx-2025.2.0
...
```
