### PR TITLE
Fix flops estimate in EDGE3D

### DIFF
--- a/src/apps/EDGE3D.cpp
+++ b/src/apps/EDGE3D.cpp
@@ -77,7 +77,12 @@ void EDGE3D::setSize(Index_type target_size, Index_type target_reps)
   constexpr size_t flops_j_loop = flops_k_loop*NQ_1D + 3*flops_Jxx() + 6;
   constexpr size_t flops_i_loop = flops_j_loop*NQ_1D + 1;
 
-  constexpr size_t flops_per_element = flops_i_loop*NQ_1D + 9*flops_Jxx() + flops_compute_detj();
+  constexpr size_t flops_edge_MpSmatrix = 9*flops_Jxx()
+                                          + flops_compute_detj()
+                                          + flops_i_loop*NQ_1D;
+
+  constexpr size_t flops_per_element = flops_edge_MpSmatrix
+                                       + (EB*EB + EB); // sum
 
   setFLOPsPerRep(number_of_elements * flops_per_element);
 }

--- a/src/apps/mixed_fem_helper.hpp
+++ b/src/apps/mixed_fem_helper.hpp
@@ -269,7 +269,7 @@ constexpr void transform_basis(
 template<rajaperf::Int_type M, rajaperf::Int_type P>
 constexpr rajaperf::Int_type flops_inner_product(const bool is_symmetric)
 {
-  return is_symmetric ? 6*P*(M+1)/2 : 6*P*M;
+  return is_symmetric ? 7*P*(M+1)/2 : 7*P*M;
 }
 
 template<rajaperf::Int_type M, rajaperf::Int_type P>
@@ -312,7 +312,7 @@ constexpr void inner_product(
 
 constexpr rajaperf::Int_type flops_bad_zone_algorithm()
 {
-  return 5;
+  return 3;
 }
 
 RAJA_HOST_DEVICE
@@ -435,7 +435,7 @@ constexpr rajaperf::Real_type Jzz(
 
 constexpr rajaperf::Int_type flops_Jxx()
 {
-  return 8;
+  return 11;
 }
 
 RAJA_HOST_DEVICE


### PR DESCRIPTION
# Summary

Fix flops estimate in EDGE3D

- This PR is a bugfix
- It does the following:
  - Fixes EDGE3D flop count estimate
