### PR TITLE
Feature(Kokkos-PolyBench): Add Jacobi 1D/2D and Heat 3D Kokkos implementations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_subdirectory(apps-kokkos)
 add_subdirectory(lcals)
 add_subdirectory(lcals-kokkos)
 add_subdirectory(polybench)
+add_subdirectory(polybench-kokkos)
 add_subdirectory(stream)
 add_subdirectory(stream-kokkos)
 add_subdirectory(algorithm)
@@ -31,6 +32,7 @@ set(RAJA_PERFSUITE_LIBS
     lcals
     lcals-kokkos
     polybench
+    polybench-kokkos
     stream
     stream-kokkos
     algorithm

--- a/src/basic-kokkos/NESTED_INIT-Kokkos.cpp
+++ b/src/basic-kokkos/NESTED_INIT-Kokkos.cpp
@@ -27,12 +27,6 @@ void NESTED_INIT::runKokkosVariant(VariantID vid) {
   // See the basic NESTED_INIT.hpp file for defnition of NESTED_INIT
 
   auto array_kokkos_view = getViewFromPointer(array, nk, nj, ni);
-  //
-  // Used in Kokkos variant (below).  Do not remove.
-  //
-  auto nestedinit_lam = [=](Index_type i, Index_type j, Index_type k) {
-    NESTED_INIT_BODY;
-  };
 
   switch (vid) {
 

--- a/src/lcals-kokkos/INT_PREDICT-Kokkos.cpp
+++ b/src/lcals-kokkos/INT_PREDICT-Kokkos.cpp
@@ -35,15 +35,6 @@ void INT_PREDICT::runKokkosVariant(VariantID vid) {
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      // Declare variables in INT_PREDICT.hpp
-      Real_type dm22 = m_dm22;
-      Real_type dm23 = m_dm23;
-      Real_type dm24 = m_dm24;
-      Real_type dm25 = m_dm25;
-      Real_type dm26 = m_dm26;
-      Real_type dm27 = m_dm27;
-      Real_type dm28 = m_dm28;
-
       Kokkos::parallel_for(
           "INT_PREDICT_Kokkos Kokkos_Lambda",
           Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(ibegin, iend),

--- a/src/polybench-kokkos/CMakeLists.txt
+++ b/src/polybench-kokkos/CMakeLists.txt
@@ -1,0 +1,17 @@
+###############################################################################
+# Copyright (c) Lawrence Livermore National Security, LLC and other
+# RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+# files for dates and other details. No copyright assignment is required
+# to contribute to RAJA Performance Suite.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+###############################################################################
+
+blt_add_library(
+  NAME polybench-kokkos
+  SOURCES
+          POLYBENCH_HEAT_3D-Kokkos.cpp
+          POLYBENCH_JACOBI_2D-Kokkos.cpp
+  INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../polybench
+  DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}
+  )

--- a/src/polybench-kokkos/CMakeLists.txt
+++ b/src/polybench-kokkos/CMakeLists.txt
@@ -11,6 +11,7 @@ blt_add_library(
   NAME polybench-kokkos
   SOURCES
           POLYBENCH_HEAT_3D-Kokkos.cpp
+          POLYBENCH_JACOBI_1D-Kokkos.cpp
           POLYBENCH_JACOBI_2D-Kokkos.cpp
   INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../polybench
   DEPENDS_ON common ${RAJA_PERFSUITE_DEPENDS}

--- a/src/polybench-kokkos/POLYBENCH_HEAT_3D-Kokkos.cpp
+++ b/src/polybench-kokkos/POLYBENCH_HEAT_3D-Kokkos.cpp
@@ -1,0 +1,91 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "POLYBENCH_HEAT_3D.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace polybench {
+
+void POLYBENCH_HEAT_3D::runKokkosVariant(VariantID vid) {
+  const Index_type run_reps = getRunReps();
+
+  POLYBENCH_HEAT_3D_DATA_SETUP;
+
+  // Views 3D : dimension order (i, j, k), i.e. (N, N, N)
+  auto A_view = getViewFromPointer(A, N, N, N);
+  auto B_view = getViewFromPointer(B, N, N, N);
+
+  switch (vid) {
+    case Kokkos_Lambda: {
+
+      Kokkos::fence();
+      startTimer();
+
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        Kokkos::parallel_for(
+            "POLYBENCH_HEAT_3D Kokkos_Lambda--BODY1",
+            Kokkos::MDRangePolicy<Kokkos::Rank<3>,
+                                  Kokkos::IndexType<Index_type>>(
+                {1, 1, 1}, {N - 1, N - 1, N - 1}),
+            KOKKOS_LAMBDA(Index_type i, Index_type j, Index_type k) {
+              B_view(i, j, k) =
+                  0.125 * (A_view(i + 1, j, k) - 2.0 * A_view(i, j, k) +
+                           A_view(i - 1, j, k)) +
+                  0.125 * (A_view(i, j + 1, k) - 2.0 * A_view(i, j, k) +
+                           A_view(i, j - 1, k)) +
+                  0.125 * (A_view(i, j, k + 1) - 2.0 * A_view(i, j, k) +
+                           A_view(i, j, k - 1)) +
+                  A_view(i, j, k);
+            });
+
+        Kokkos::parallel_for(
+            "POLYBENCH_HEAT_3D Kokkos_Lambda--BODY2",
+            Kokkos::MDRangePolicy<Kokkos::Rank<3>,
+                                  Kokkos::IndexType<Index_type>>(
+                {1, 1, 1}, {N - 1, N - 1, N - 1}),
+            KOKKOS_LAMBDA(Index_type i, Index_type j, Index_type k) {
+              A_view(i, j, k) =
+                  0.125 * (B_view(i + 1, j, k) - 2.0 * B_view(i, j, k) +
+                           B_view(i - 1, j, k)) +
+                  0.125 * (B_view(i, j + 1, k) - 2.0 * B_view(i, j, k) +
+                           B_view(i, j - 1, k)) +
+                  0.125 * (B_view(i, j, k + 1) - 2.0 * B_view(i, j, k) +
+                           B_view(i, j, k - 1)) +
+                  B_view(i, j, k);
+            });
+
+      }
+
+      Kokkos::fence();
+      stopTimer();
+
+      moveDataToHostFromKokkosView(A, A_view, N, N, N);
+      moveDataToHostFromKokkosView(B, B_view, N, N, N);
+
+      break;
+    }
+
+    default: {
+      std::cout << "\n  POLYBENCH_HEAT_3D : Unknown variant id = " << vid
+                << std::endl;
+    }
+  }
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(POLYBENCH_HEAT_3D, Kokkos,
+                                           Kokkos_Lambda)
+
+}  // end namespace polybench
+}  // end namespace rajaperf
+#endif  // RUN_KOKKOS

--- a/src/polybench-kokkos/POLYBENCH_HEAT_3D-Kokkos.cpp
+++ b/src/polybench-kokkos/POLYBENCH_HEAT_3D-Kokkos.cpp
@@ -8,8 +8,11 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_HEAT_3D.hpp"
+
 #if defined(RUN_KOKKOS)
+
 #include "common/KokkosViewUtils.hpp"
+
 #include <iostream>
 
 namespace rajaperf {
@@ -83,8 +86,7 @@ void POLYBENCH_HEAT_3D::runKokkosVariant(VariantID vid) {
   }
 }
 
-RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(POLYBENCH_HEAT_3D, Kokkos,
-                                           Kokkos_Lambda)
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(POLYBENCH_HEAT_3D, Kokkos, Kokkos_Lambda)
 
 }  // end namespace polybench
 }  // end namespace rajaperf

--- a/src/polybench-kokkos/POLYBENCH_JACOBI_1D-Kokkos.cpp
+++ b/src/polybench-kokkos/POLYBENCH_JACOBI_1D-Kokkos.cpp
@@ -1,0 +1,76 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "POLYBENCH_JACOBI_1D.hpp"
+
+#if defined(RUN_KOKKOS)
+
+#include "common/KokkosViewUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf {
+namespace polybench {
+
+void POLYBENCH_JACOBI_1D::runKokkosVariant(VariantID vid) {
+  const Index_type run_reps = getRunReps();
+
+  POLYBENCH_JACOBI_1D_DATA_SETUP;
+
+  auto A_view = getViewFromPointer(A, N);
+  auto B_view = getViewFromPointer(B, N);
+
+  switch (vid) {
+    case Kokkos_Lambda: {
+
+      Kokkos::fence();
+      startTimer();
+
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        Kokkos::parallel_for(
+            "JACOBI_1D_Kokkos Kokkos_Lambda--BODY1",
+            Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace,
+                                Kokkos::IndexType<Index_type>>(1, N - 1),
+            KOKKOS_LAMBDA(Index_type i) {
+              B_view(i) = 0.33333 * (A_view(i - 1) + A_view(i) + A_view(i + 1));
+            });
+
+        Kokkos::parallel_for(
+            "JACOBI_1D_Kokkos Kokkos_Lambda--BODY2",
+            Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace,
+                                Kokkos::IndexType<Index_type>>(1, N - 1),
+            KOKKOS_LAMBDA(Index_type i) {
+              A_view(i) = 0.33333 * (B_view(i - 1) + B_view(i) + B_view(i + 1));
+            });
+
+      }
+
+      Kokkos::fence();
+      stopTimer();
+
+      moveDataToHostFromKokkosView(A, A_view, N);
+      moveDataToHostFromKokkosView(B, B_view, N);
+
+      break;
+    }
+
+    default: {
+      std::cout << "\n  POLYBENCH_JACOBI_1D : Unknown variant id = " << vid
+                << std::endl;
+    }
+  }
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(POLYBENCH_JACOBI_1D, Kokkos, Kokkos_Lambda)
+
+}  // end namespace polybench
+}  // end namespace rajaperf
+#endif  // RUN_KOKKOS

--- a/src/polybench-kokkos/POLYBENCH_JACOBI_2D-Kokkos.cpp
+++ b/src/polybench-kokkos/POLYBENCH_JACOBI_2D-Kokkos.cpp
@@ -8,8 +8,11 @@
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
 #include "POLYBENCH_JACOBI_2D.hpp"
+
 #if defined(RUN_KOKKOS)
+
 #include "common/KokkosViewUtils.hpp"
+
 #include <iostream>
 
 namespace rajaperf {
@@ -72,8 +75,7 @@ void POLYBENCH_JACOBI_2D::runKokkosVariant(VariantID vid) {
   }
 }
 
-RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(POLYBENCH_JACOBI_2D, Kokkos,
-                                           Kokkos_Lambda)
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(POLYBENCH_JACOBI_2D, Kokkos, Kokkos_Lambda)
 
 }  // end namespace polybench
 }  // end namespace rajaperf

--- a/src/polybench-kokkos/POLYBENCH_JACOBI_2D-Kokkos.cpp
+++ b/src/polybench-kokkos/POLYBENCH_JACOBI_2D-Kokkos.cpp
@@ -1,0 +1,80 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "POLYBENCH_JACOBI_2D.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace polybench {
+
+void POLYBENCH_JACOBI_2D::runKokkosVariant(VariantID vid) {
+  const Index_type run_reps = getRunReps();
+
+  POLYBENCH_JACOBI_2D_DATA_SETUP;
+
+  auto A_view = getViewFromPointer(A, N, N);
+  auto B_view = getViewFromPointer(B, N, N);
+
+  switch (vid) {
+    case Kokkos_Lambda: {
+
+      Kokkos::fence();
+      startTimer();
+
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        Kokkos::parallel_for(
+            "JACOBI_2D_Kokkos Kokkos_Lambda--BODY1",
+            Kokkos::MDRangePolicy<Kokkos::Rank<2>,
+                                  Kokkos::IndexType<Index_type>>(
+                {1, 1}, {N - 1, N - 1}),
+            KOKKOS_LAMBDA(Index_type i, Index_type j) {
+              B_view(i, j) =
+                  0.2 * (A_view(i, j) + A_view(i, j - 1) + A_view(i, j + 1) +
+                         A_view(i + 1, j) + A_view(i - 1, j));
+            });
+
+        Kokkos::parallel_for(
+            "JACOBI_2D_Kokkos Kokkos_Lambda--BODY2",
+            Kokkos::MDRangePolicy<Kokkos::Rank<2>,
+                                  Kokkos::IndexType<Index_type>>(
+                {1, 1}, {N - 1, N - 1}),
+            KOKKOS_LAMBDA(Index_type i, Index_type j) {
+              A_view(i, j) =
+                  0.2 * (B_view(i, j) + B_view(i, j - 1) + B_view(i, j + 1) +
+                         B_view(i + 1, j) + B_view(i - 1, j));
+            });
+
+      }
+
+      Kokkos::fence();
+      stopTimer();
+
+      moveDataToHostFromKokkosView(A, A_view, N, N);
+      moveDataToHostFromKokkosView(B, B_view, N, N);
+
+      break;
+    }
+
+    default: {
+      std::cout << "\n  POLYBENCH_JACOBI_2D : Unknown variant id = " << vid
+                << std::endl;
+    }
+  }
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(POLYBENCH_JACOBI_2D, Kokkos,
+                                           Kokkos_Lambda)
+
+}  // end namespace polybench
+}  // end namespace rajaperf
+#endif  // RUN_KOKKOS

--- a/src/polybench/POLYBENCH_HEAT_3D.hpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.hpp
@@ -112,6 +112,7 @@ public:
   void defineSeqVariantTunings();
   void defineOpenMPVariantTunings();
   void defineOpenMPTargetVariantTunings();
+  void defineKokkosVariantTunings();
   void defineCudaVariantTunings();
   void defineHipVariantTunings();
   void defineSyclVariantTunings();
@@ -119,6 +120,7 @@ public:
   void runSeqVariant(VariantID vid);
   void runOpenMPVariant(VariantID vid);
   void runOpenMPTargetVariant(VariantID vid);
+  void runKokkosVariant(VariantID vid);
 
   template < size_t block_size >
   void runCudaVariantImpl(VariantID vid);

--- a/src/polybench/POLYBENCH_JACOBI_1D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D.hpp
@@ -60,6 +60,7 @@ public:
   void defineSeqVariantTunings();
   void defineOpenMPVariantTunings();
   void defineOpenMPTargetVariantTunings();
+  void defineKokkosVariantTunings();
   void defineCudaVariantTunings();
   void defineHipVariantTunings();
   void defineSyclVariantTunings();
@@ -67,6 +68,7 @@ public:
   void runSeqVariant(VariantID vid);
   void runOpenMPVariant(VariantID vid);
   void runOpenMPTargetVariant(VariantID vid);
+  void runKokkosVariant(VariantID vid);
 
   template < size_t block_size >
   void runCudaVariantImpl(VariantID vid);

--- a/src/polybench/POLYBENCH_JACOBI_2D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.hpp
@@ -79,6 +79,8 @@ public:
   void defineSeqVariantTunings();
   void defineOpenMPVariantTunings();
   void defineOpenMPTargetVariantTunings();
+  void defineKokkosVariantTunings();
+
   void defineCudaVariantTunings();
   void defineHipVariantTunings();
   void defineSyclVariantTunings();
@@ -86,6 +88,7 @@ public:
   void runSeqVariant(VariantID vid);
   void runOpenMPVariant(VariantID vid);
   void runOpenMPTargetVariant(VariantID vid);
+  void runKokkosVariant(VariantID vid);
 
   template < size_t block_size >
   void runCudaVariantImpl(VariantID vid);

--- a/src/polybench/POLYBENCH_JACOBI_2D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.hpp
@@ -80,7 +80,6 @@ public:
   void defineOpenMPVariantTunings();
   void defineOpenMPTargetVariantTunings();
   void defineKokkosVariantTunings();
-
   void defineCudaVariantTunings();
   void defineHipVariantTunings();
   void defineSyclVariantTunings();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set(RAJA_PERFSUITE_TEST_EXECUTABLE_DEPENDS
     lcals
     lcals-kokkos
     polybench
+    polybench-kokkos
     stream
     stream-kokkos
     algorithm


### PR DESCRIPTION
## Summary
Add a directory for kokkos-polybench with 3 benchmarks.

- This PR is a feature
- It adds the Kokkos version of the following PolyBench suites:
  - Jacobi_1D
  - Jacobi_2D
  - Heat_3D
