### PR TITLE
Fix misuse of GIT_SUBMODULE_DEPTH

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -98,7 +98,6 @@ generate-job-lists:
   stage: prerequisites
   tags: [shell, oslic]
   variables:
-    GIT_SUBMODULE_DEPTH: 2
     GIT_SUBMODULE_STRATEGY: recursive
     GIT_SUBMODULE_PATHS: tpl/RAJA
     RADIUSS_JOBS_PATH: "tpl/RAJA/scripts/radiuss-spack-configs/gitlab/radiuss-jobs"


### PR DESCRIPTION
GIT_SUBMODULE_DEPTH is not intended to set the depth of the recursive submodule fetch, but the depth of the clone for each submodule. As such, a value too small can lead to issues.

I noticed this while investigating an issue involving failures in submodules fetch, but this change is not related. It is rather cleaning a misleading configuration.