### PR TITLE
Fix flop counts in MASS3DEA and DIFFUSION3DPA

### DIFF
--- a/src/apps/DIFFUSION3DPA.cpp
+++ b/src/apps/DIFFUSION3DPA.cpp
@@ -64,12 +64,12 @@ void DIFFUSION3DPA::setSize(Index_type target_size, Index_type target_reps)
   setBytesModifyWrittenPerRep( 1*sizeof(Real_type) * diff::D1D*diff::D1D*diff::D1D*m_NE ); // y
   setBytesAtomicModifyWrittenPerRep( 0 );
 
-  setFLOPsPerRep(m_NE * (4 * diff::D1D * diff::D1D * diff::D1D + //DIFFUSION3DPA_3
-                         6 * diff::D1D * diff::Q1D * diff::Q1D + //DIFFUSION3DPA_4
+  setFLOPsPerRep(m_NE * (4 * diff::D1D * diff::D1D * diff::D1D * diff::Q1D + //DIFFUSION3DPA_3
+                         6 * diff::D1D * diff::D1D * diff::Q1D * diff::Q1D + //DIFFUSION3DPA_4
                          (6 * diff::D1D  + 15) * diff::Q1D * diff::Q1D * diff::Q1D + //DIFFUSION3DPA_5
                          (6 * diff::Q1D) * diff::D1D * diff::Q1D * diff::Q1D + //DIFFUSION3DPA_7
                          (6 * diff::Q1D) * diff::D1D * diff::D1D * diff::Q1D + //DIFFUSION3DPA_8
-                         (6 * diff::Q1D + 1)*diff::D1D*diff::D1D*diff::D1D)); //DIFFUSION3DPA_9
+                         (6 * diff::Q1D + 3)*diff::D1D*diff::D1D*diff::D1D)); //DIFFUSION3DPA_9
 }
 
 DIFFUSION3DPA::~DIFFUSION3DPA()

--- a/src/apps/DIFFUSION3DPA.cpp
+++ b/src/apps/DIFFUSION3DPA.cpp
@@ -69,7 +69,7 @@ void DIFFUSION3DPA::setSize(Index_type target_size, Index_type target_reps)
                          (6 * diff::D1D  + 15) * diff::Q1D * diff::Q1D * diff::Q1D + //DIFFUSION3DPA_5
                          (6 * diff::Q1D) * diff::D1D * diff::Q1D * diff::Q1D + //DIFFUSION3DPA_7
                          (6 * diff::Q1D) * diff::D1D * diff::D1D * diff::Q1D + //DIFFUSION3DPA_8
-                         (6 * diff::Q1D + 3)*diff::D1D*diff::D1D*diff::D1D)); //DIFFUSION3DPA_9
+                         (6 * diff::Q1D + 3) * diff::D1D * diff::D1D * diff::D1D)); //DIFFUSION3DPA_9
 }
 
 DIFFUSION3DPA::~DIFFUSION3DPA()

--- a/src/apps/MASS3DEA.cpp
+++ b/src/apps/MASS3DEA.cpp
@@ -47,7 +47,7 @@ MASS3DEA::MASS3DEA(const RunParams& params)
 void MASS3DEA::setSize(Index_type target_size, Index_type target_reps)
 {
   const Index_type ea_mat_entries = mea::D1D*mea::D1D*mea::D1D*mea::D1D*mea::D1D*mea::D1D;
-  const Index_type qpt_entries = mea::Q1D*mea::Q1D*mea::Q1D;
+  const Index_type qpt_entries = mea::Q1D * mea::Q1D * mea::Q1D;
   const Index_type flops_per_qpt = 7;
 
   m_NE = std::max((target_size + (ea_mat_entries)/2) / (ea_mat_entries), Index_type(1));

--- a/src/apps/MASS3DEA.cpp
+++ b/src/apps/MASS3DEA.cpp
@@ -47,6 +47,8 @@ MASS3DEA::MASS3DEA(const RunParams& params)
 void MASS3DEA::setSize(Index_type target_size, Index_type target_reps)
 {
   const Index_type ea_mat_entries = mea::D1D*mea::D1D*mea::D1D*mea::D1D*mea::D1D*mea::D1D;
+  const Index_type qpt_entries = mea::Q1D*mea::Q1D*mea::Q1D;
+  const Index_type flops_per_qpt = 7;
 
   m_NE = std::max((target_size + (ea_mat_entries)/2) / (ea_mat_entries), Index_type(1));
 
@@ -65,7 +67,7 @@ void MASS3DEA::setSize(Index_type target_size, Index_type target_reps)
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
 
-  setFLOPsPerRep(m_NE * 7 * ea_mat_entries);
+  setFLOPsPerRep(m_NE * flops_per_qpt * qpt_entries * ea_mat_entries);
 }
 
 MASS3DEA::~MASS3DEA()

--- a/src/apps/MASS3DEA.cpp
+++ b/src/apps/MASS3DEA.cpp
@@ -46,7 +46,7 @@ MASS3DEA::MASS3DEA(const RunParams& params)
 
 void MASS3DEA::setSize(Index_type target_size, Index_type target_reps)
 {
-  const Index_type ea_mat_entries = mea::D1D*mea::D1D*mea::D1D*mea::D1D*mea::D1D*mea::D1D;
+  const Index_type ea_mat_entries = mea::D1D * mea::D1D * mea::D1D * mea::D1D * mea::D1D * mea::D1D;
   const Index_type qpt_entries = mea::Q1D * mea::Q1D * mea::Q1D;
   const Index_type flops_per_qpt = 7;
 


### PR DESCRIPTION
# Summary

Fix flop counts in MASS3DEA and DIFFUSION3DPA.

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes flop counts
