### PR TITLE
Femsweep cuda fix

### DIFF
--- a/src/apps/FEMSWEEP-Cuda.cpp
+++ b/src/apps/FEMSWEEP-Cuda.cpp
@@ -7,7 +7,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
-#define FEMSWEEP_ENABLE_UNROLL
 #include "FEMSWEEP.hpp"
 
 #include "RAJA/RAJA.hpp"
@@ -23,152 +22,187 @@ namespace rajaperf
 namespace apps
 {
 
-template < size_t block_size >
-__launch_bounds__(block_size)
-__global__ void FEMSweep3D( const Real_ptr Bdat,
-                            const Real_ptr Adat,
-                            const Real_ptr Fdat,
-                            Real_ptr Xdat,
-                            const Real_ptr Sgdat,
-                            const Real_ptr M0dat,
-                            const Index_type ne,
-                            const Index_type ng,
-                            const Index_type sharedinteriorfaces,
-                            const Index_ptr nhpaa_r,
-                            const Index_ptr ohpaa_r,
-                            const Index_ptr phpaa_r,
-                            const Index_ptr order_r,
-                            const Index_ptr AngleElem2FaceType,
-                            const Index_ptr elem_to_faces,
-                            const Index_ptr F_g2l,
-                            const Index_ptr idx1,
-                            const Index_ptr idx2 )
-{
-  const Index_type a = blockIdx.y;
-  const Index_type g = blockIdx.x;
-  FEMSWEEP_KERNEL_SETUP;
-  Index_type nehp_pos = 0;
-  for (Index_type hp = 0; hp < nhp; ++hp)
-  {
-    const Index_type nehp = phpaa_r[ohp + hp];
-    for (Index_type k = threadIdx.x; k < nehp; k += block_size)
-    {
-      FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT;
-    }
-    __syncthreads();
-    nehp_pos += nehp;
-  }
+#define FEMSWEEP_DEFINE_CUDA_KERNEL(KERNEL_NAME, ELEMENT) \
+template < size_t block_size > \
+__launch_bounds__(block_size) \
+__global__ void KERNEL_NAME( const Real_ptr Bdat, \
+                             const Real_ptr Adat, \
+                             const Real_ptr Fdat, \
+                             Real_ptr Xdat, \
+                             const Real_ptr Sgdat, \
+                             const Real_ptr M0dat, \
+                             const Index_type ne, \
+                             const Index_type ng, \
+                             const Index_type sharedinteriorfaces, \
+                             const Index_ptr nhpaa_r, \
+                             const Index_ptr ohpaa_r, \
+                             const Index_ptr phpaa_r, \
+                             const Index_ptr order_r, \
+                             const Index_ptr AngleElem2FaceType, \
+                             const Index_ptr elem_to_faces, \
+                             const Index_ptr F_g2l, \
+                             const Index_ptr idx1, \
+                             const Index_ptr idx2 ) \
+{ \
+  const Index_type a = blockIdx.y; \
+  const Index_type g = blockIdx.x; \
+  FEMSWEEP_KERNEL_SETUP; \
+  Index_type nehp_pos = 0; \
+  for (Index_type hp = 0; hp < nhp; ++hp) \
+  { \
+    const Index_type nehp = phpaa_r[ohp + hp]; \
+    for (Index_type k = threadIdx.x; k < nehp; k += block_size) \
+    { \
+      ELEMENT; \
+    } \
+    __syncthreads(); \
+    nehp_pos += nehp; \
+  } \
 }
 
-template < size_t block_size >
-void FEMSWEEP::runCudaVariantImpl(VariantID vid)
-{
-  setBlockSize(block_size);
+FEMSWEEP_DEFINE_CUDA_KERNEL(FEMSweep3D, FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT)
+FEMSWEEP_DEFINE_CUDA_KERNEL(FEMSweep3DUnroll, FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT_UNROLL)
 
-  const Index_type run_reps = getRunReps();
+#undef FEMSWEEP_DEFINE_CUDA_KERNEL
 
-  auto res{getCudaResource()};
-
-  FEMSWEEP_DATA_SETUP;
-
-  switch ( vid ) {
-
-    case Base_CUDA : {
-
-      startTimer();
-      // Loop counter increment uses macro to quiet C++20 compiler warning
-      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
-
-         const dim3 grid_size(ng, na);
-         constexpr size_t shmem = 0;
-
-         RPlaunchCudaKernel( (FEMSweep3D<block_size>),
-                             grid_size, block_size,
-                             shmem, res.get_stream(),
-                             Bdat,
-                             Adat,
-                             Fdat,
-                             Xdat,
-                             Sgdat,
-                             M0dat,
-                             ne,
-                             ng,
-                             sharedinteriorfaces,
-                             nhpaa_r,
-                             ohpaa_r,
-                             phpaa_r,
-                             order_r,
-                             AngleElem2FaceType,
-                             elem_to_faces,
-                             F_g2l,
-                             idx1,
-                             idx2 );
-
-      }
-      stopTimer();
-
-      break;
-    }
-
-    case RAJA_CUDA : {
-
-      constexpr bool async = true;
-
-      using launch_policy =
-          RAJA::LaunchPolicy<RAJA::cuda_launch_t<async, block_size>>;
-
-      using outer_y =
-          RAJA::LoopPolicy<RAJA::cuda_block_y_direct_unchecked>;
-
-      using outer_x =
-          RAJA::LoopPolicy<RAJA::cuda_block_x_direct_unchecked>;
-
-      using inner_x =
-          RAJA::LoopPolicy<RAJA::cuda_thread_size_x_loop<block_size>>;
-
-      startTimer();
-      // Loop counter increment uses macro to quiet C++20 compiler warning
-      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
-
-         RAJA::launch<launch_policy>( res,
-             RAJA::LaunchParams(RAJA::Teams(ng, na),
-                                RAJA::Threads(block_size)),
-             [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
-           RAJA::loop<outer_y>(ctx, RAJA::RangeSegment(0, na),
-               [&](Index_type a) {
-             RAJA::loop<outer_x>(ctx, RAJA::RangeSegment(0, ng),
-                 [&](Index_type g) {
-               FEMSWEEP_KERNEL_SETUP;
-               Index_type nehp_pos = 0;
-               for (Index_type hp = 0; hp < nhp; ++hp)
-               {
-                 const Index_type nehp = phpaa_r[ohp + hp];
-                 RAJA::loop<inner_x>(ctx, RAJA::RangeSegment(0, nehp),
-                     [&](Index_type k) {
-                   FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT;
-                 });  // k loop
-                 ctx.teamSync();
-                 nehp_pos += nehp;
-               }
-             });  // g loop
-           });  // a loop
-         });  // RAJA Launch
-
-      }
-      stopTimer();
-
-      break;
-    }
-
-    default : {
-      getCout() << "\n FEMSWEEP : Unknown CUDA variant id = " << vid << std::endl;
-    }
-
-  }
-
+#define FEMSWEEP_DEFINE_CUDA_VARIANT_IMPL(METHOD_NAME, KERNEL_NAME, ELEMENT) \
+template < size_t block_size > \
+void FEMSWEEP::METHOD_NAME(VariantID vid) \
+{ \
+  setBlockSize(block_size); \
+\
+  const Index_type run_reps = getRunReps(); \
+\
+  auto res{getCudaResource()}; \
+\
+  FEMSWEEP_DATA_SETUP; \
+\
+  switch ( vid ) { \
+\
+    case Base_CUDA : { \
+\
+      startTimer(); \
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) { \
+\
+         const dim3 grid_size(ng, na); \
+         constexpr size_t shmem = 0; \
+\
+         RPlaunchCudaKernel( (KERNEL_NAME<block_size>), \
+                             grid_size, block_size, \
+                             shmem, res.get_stream(), \
+                             Bdat, \
+                             Adat, \
+                             Fdat, \
+                             Xdat, \
+                             Sgdat, \
+                             M0dat, \
+                             ne, \
+                             ng, \
+                             sharedinteriorfaces, \
+                             nhpaa_r, \
+                             ohpaa_r, \
+                             phpaa_r, \
+                             order_r, \
+                             AngleElem2FaceType, \
+                             elem_to_faces, \
+                             F_g2l, \
+                             idx1, \
+                             idx2 ); \
+\
+      } \
+      stopTimer(); \
+\
+      break; \
+    } \
+\
+    case RAJA_CUDA : { \
+\
+      constexpr bool async = true; \
+\
+      using launch_policy = \
+          RAJA::LaunchPolicy<RAJA::cuda_launch_t<async, block_size>>; \
+\
+      using outer_y = \
+          RAJA::LoopPolicy<RAJA::cuda_block_y_direct_unchecked>; \
+\
+      using outer_x = \
+          RAJA::LoopPolicy<RAJA::cuda_block_x_direct_unchecked>; \
+\
+      using inner_x = \
+          RAJA::LoopPolicy<RAJA::cuda_thread_size_x_loop<block_size>>; \
+\
+      startTimer(); \
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) { \
+\
+         RAJA::launch<launch_policy>( res, \
+             RAJA::LaunchParams(RAJA::Teams(ng, na), \
+                                RAJA::Threads(block_size)), \
+             [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) { \
+           RAJA::loop<outer_y>(ctx, RAJA::RangeSegment(0, na), \
+               [&](Index_type a) { \
+             RAJA::loop<outer_x>(ctx, RAJA::RangeSegment(0, ng), \
+                 [&](Index_type g) { \
+               FEMSWEEP_KERNEL_SETUP; \
+               Index_type nehp_pos = 0; \
+               for (Index_type hp = 0; hp < nhp; ++hp) \
+               { \
+                 const Index_type nehp = phpaa_r[ohp + hp]; \
+                 RAJA::loop<inner_x>(ctx, RAJA::RangeSegment(0, nehp), \
+                     [&](Index_type k) { \
+                   ELEMENT; \
+                 }); \
+                 ctx.teamSync(); \
+                 nehp_pos += nehp; \
+               } \
+             }); \
+           }); \
+         }); \
+\
+      } \
+      stopTimer(); \
+\
+      break; \
+    } \
+\
+    default : { \
+      getCout() << "\n FEMSWEEP : Unknown CUDA variant id = " << vid << std::endl; \
+    } \
+\
+  } \
+\
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(FEMSWEEP, Cuda, Base_CUDA, RAJA_CUDA)
+FEMSWEEP_DEFINE_CUDA_VARIANT_IMPL(runCudaVariantImpl,
+                                  FEMSweep3D,
+                                  FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT)
+FEMSWEEP_DEFINE_CUDA_VARIANT_IMPL(runCudaVariantImplUnroll,
+                                  FEMSweep3DUnroll,
+                                  FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT_UNROLL)
+
+#undef FEMSWEEP_DEFINE_CUDA_VARIANT_IMPL
+
+void FEMSWEEP::defineCudaVariantTunings()
+{
+  for (VariantID vid : {Base_CUDA, RAJA_CUDA}) {
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+        if (block_size == 0u) {
+          addVariantTuning<&FEMSWEEP::runCudaVariantImpl<block_size>>(
+              vid, "block_auto");
+        } else {
+          addVariantTuning<&FEMSWEEP::runCudaVariantImpl<block_size>>(
+              vid, "block_" + std::to_string(block_size));
+        }
+
+        if (block_size == default_gpu_block_size) {
+          addVariantTuning<&FEMSWEEP::runCudaVariantImplUnroll<block_size>>(
+              vid, FEMSWEEP_UNROLL_64_TUNING_NAME);
+        }
+      }
+    });
+  }
+}
 
 } // end namespace apps
 } // end namespace rajaperf

--- a/src/apps/FEMSWEEP-Cuda.cpp
+++ b/src/apps/FEMSWEEP-Cuda.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
 
+#define FEMSWEEP_ENABLE_UNROLL
 #include "FEMSWEEP.hpp"
 
 #include "RAJA/RAJA.hpp"
@@ -23,7 +24,7 @@ namespace apps
 {
 
 template < size_t block_size >
-__launch_bounds__(block_size)
+__launch_bounds__(block_size,1)
 __global__ void FEMSweep3D( const Real_ptr Bdat,
                             const Real_ptr Adat,
                             const Real_ptr Fdat,

--- a/src/apps/FEMSWEEP-Cuda.cpp
+++ b/src/apps/FEMSWEEP-Cuda.cpp
@@ -24,7 +24,7 @@ namespace apps
 {
 
 template < size_t block_size >
-__launch_bounds__(block_size,1)
+__launch_bounds__(block_size)
 __global__ void FEMSweep3D( const Real_ptr Bdat,
                             const Real_ptr Adat,
                             const Real_ptr Fdat,

--- a/src/apps/FEMSWEEP.hpp
+++ b/src/apps/FEMSWEEP.hpp
@@ -96,6 +96,13 @@ constexpr long ND = 8;   // number of corners per element
 constexpr long NLF = 6;  // number of faces per element
 constexpr long FDS = 4;  // number of DOFs per face
 
+#define FEMSWEEP_UNROLL _Pragma("unroll")
+#define FEMSWEEP_UNROLL_ND _Pragma("unroll 8")
+#define FEMSWEEP_UNROLL_NLF _Pragma("unroll 6")
+#define FEMSWEEP_UNROLL_FDS _Pragma("unroll 4")
+
+
+
 #define FEMSWEEP_DATA_SETUP \
   Real_ptr Bdat = m_Bdat; \
   Real_ptr Adat = m_Adat; \
@@ -130,14 +137,17 @@ constexpr long FDS = 4;  // number of DOFs per face
   Real_type A[ND*ND]; \
   Real_type b[ND]; \
   const Index_type e = order_r[k + nehp_pos + a * ne]; \
+  FEMSWEEP_UNROLL_ND \
   for (Index_type j = 0; j < ND; ++j) \
   { \
     b[j] = Bdat[j + e * ND + a * ne * ND]; \
+    FEMSWEEP_UNROLL_ND \
     for (Index_type i = 0; i < ND; ++i) \
     { \
       A[i + j * ND] = Adat[i + j * ND + e * ND * ND + a * ne * ND * ND]; \
     } \
   } \
+  FEMSWEEP_UNROLL_NLF \
   for (Index_type face = 0; face < NLF; ++face) \
   { \
     const Index_type sf_gl = F_g2l[elem_to_faces[NLF * e + face]]; \
@@ -147,11 +157,13 @@ constexpr long FDS = 4;  // number of DOFs per face
     { \
       continue; \
     } \
+    FEMSWEEP_UNROLL_FDS \
     for (Index_type j = 0; j < FDS; ++j) \
     { \
       const Index_type ffj = f * FDS + j; \
       const Index_type djs = s == 0 ? idx1[ffj] : idx2[ffj]; \
       Real_type F = 0.0; \
+      FEMSWEEP_UNROLL_FDS \
       for (Index_type i = 0; i < FDS; i++) \
       { \
         const Index_type ffi = f * FDS + i; \
@@ -184,8 +196,10 @@ RAJA_HOST_DEVICE inline void SolveLinearSystemNxN(Real_ptr A,
 
   // tempA = A + s * M0
   // set L to 0, U to identity
+  FEMSWEEP_UNROLL
   for ( Index_type ii = 0; ii < N; ++ii )
   {
+    FEMSWEEP_UNROLL
     for ( Index_type jj = 0; jj < N; ++jj )
     {
       tempA[ii][jj] = A[ii * N + jj] + s * M[ii * N + jj];
@@ -202,11 +216,13 @@ RAJA_HOST_DEVICE inline void SolveLinearSystemNxN(Real_ptr A,
   }
 
   // set first column of L, and first row of U
+  FEMSWEEP_UNROLL
   for ( Index_type ii = 0; ii < N; ++ii )
   {
     L[ii][0] = tempA[ii][0];
   }
 
+  FEMSWEEP_UNROLL
   for ( Index_type ii = 1; ii < N; ++ii )
   {
     U[0][ii] = tempA[0][ii]/tempA[0][0];
@@ -215,12 +231,15 @@ RAJA_HOST_DEVICE inline void SolveLinearSystemNxN(Real_ptr A,
   // form L & U
   // L formed one column at a time
   // U formed one row at a time
+  FEMSWEEP_UNROLL
   for ( Index_type ii = 1; ii < N; ++ii )
   {
     // L column formation
+    FEMSWEEP_UNROLL
     for ( Index_type jj = ii; jj < N; ++jj )
     {
       Real_type sum = 0.0;
+      FEMSWEEP_UNROLL
       for ( Index_type kk = 0; kk < jj; ++kk )
       {
         sum += L[jj][kk] * U[kk][ii];
@@ -229,9 +248,11 @@ RAJA_HOST_DEVICE inline void SolveLinearSystemNxN(Real_ptr A,
     }
 
     // U row formation
+    FEMSWEEP_UNROLL
     for ( Index_type jj = ii+1; jj < N; ++jj )
     {
       Real_type sum = 0.0;
+      FEMSWEEP_UNROLL
       for ( Index_type kk = 0; kk < ii; ++kk )
       {
         sum += L[ii][kk] * U[kk][jj];
@@ -242,9 +263,11 @@ RAJA_HOST_DEVICE inline void SolveLinearSystemNxN(Real_ptr A,
 
   // forward substitution
   D[0] = b[0]/L[0][0];
+  FEMSWEEP_UNROLL
   for ( Index_type ii = 1; ii < N; ++ii )
   {
     Real_type sum = 0.0;
+    FEMSWEEP_UNROLL
     for ( Index_type jj = 0; jj < ii; ++jj )
     {
       sum += L[ii][jj] * D[jj];
@@ -254,9 +277,11 @@ RAJA_HOST_DEVICE inline void SolveLinearSystemNxN(Real_ptr A,
 
   // backward substitution
   x[N-1] = tempx[N-1] = D[N-1];
+  FEMSWEEP_UNROLL
   for ( Index_type ii = N - 1 - 1; ii > -1; --ii )
   {
     Real_type sum = 0.0;
+    FEMSWEEP_UNROLL
     for ( Index_type jj = ii+1; jj < N; ++jj )
     {
       sum += U[ii][jj] * tempx[jj];
@@ -302,7 +327,7 @@ private:
 #if defined(RAJA_ENABLE_HIP)
   static const size_t default_gpu_block_size = 64;
 #else
-  static const size_t default_gpu_block_size = 128;
+  static const size_t default_gpu_block_size = 64;
 #endif
   using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
                                                          integer::MultipleOf<32>>;

--- a/src/apps/FEMSWEEP.hpp
+++ b/src/apps/FEMSWEEP.hpp
@@ -96,10 +96,17 @@ constexpr long ND = 8;   // number of corners per element
 constexpr long NLF = 6;  // number of faces per element
 constexpr long FDS = 4;  // number of DOFs per face
 
+#if defined(FEMSWEEP_ENABLE_UNROLL)
 #define FEMSWEEP_UNROLL _Pragma("unroll")
 #define FEMSWEEP_UNROLL_ND _Pragma("unroll 8")
 #define FEMSWEEP_UNROLL_NLF _Pragma("unroll 6")
 #define FEMSWEEP_UNROLL_FDS _Pragma("unroll 4")
+#else
+#define FEMSWEEP_UNROLL
+#define FEMSWEEP_UNROLL_ND
+#define FEMSWEEP_UNROLL_NLF
+#define FEMSWEEP_UNROLL_FDS
+#endif
 
 
 

--- a/src/apps/FEMSWEEP.hpp
+++ b/src/apps/FEMSWEEP.hpp
@@ -98,14 +98,8 @@ constexpr long FDS = 4;  // number of DOFs per face
 
 #if defined(FEMSWEEP_ENABLE_UNROLL)
 #define FEMSWEEP_UNROLL _Pragma("unroll")
-#define FEMSWEEP_UNROLL_ND _Pragma("unroll 8")
-#define FEMSWEEP_UNROLL_NLF _Pragma("unroll 6")
-#define FEMSWEEP_UNROLL_FDS _Pragma("unroll 4")
 #else
 #define FEMSWEEP_UNROLL
-#define FEMSWEEP_UNROLL_ND
-#define FEMSWEEP_UNROLL_NLF
-#define FEMSWEEP_UNROLL_FDS
 #endif
 
 
@@ -144,17 +138,17 @@ constexpr long FDS = 4;  // number of DOFs per face
   Real_type A[ND*ND]; \
   Real_type b[ND]; \
   const Index_type e = order_r[k + nehp_pos + a * ne]; \
-  FEMSWEEP_UNROLL_ND \
+  FEMSWEEP_UNROLL \
   for (Index_type j = 0; j < ND; ++j) \
   { \
     b[j] = Bdat[j + e * ND + a * ne * ND]; \
-    FEMSWEEP_UNROLL_ND \
+    FEMSWEEP_UNROLL \
     for (Index_type i = 0; i < ND; ++i) \
     { \
       A[i + j * ND] = Adat[i + j * ND + e * ND * ND + a * ne * ND * ND]; \
     } \
   } \
-  FEMSWEEP_UNROLL_NLF \
+  FEMSWEEP_UNROLL \
   for (Index_type face = 0; face < NLF; ++face) \
   { \
     const Index_type sf_gl = F_g2l[elem_to_faces[NLF * e + face]]; \
@@ -164,13 +158,13 @@ constexpr long FDS = 4;  // number of DOFs per face
     { \
       continue; \
     } \
-    FEMSWEEP_UNROLL_FDS \
+    FEMSWEEP_UNROLL \
     for (Index_type j = 0; j < FDS; ++j) \
     { \
       const Index_type ffj = f * FDS + j; \
       const Index_type djs = s == 0 ? idx1[ffj] : idx2[ffj]; \
       Real_type F = 0.0; \
-      FEMSWEEP_UNROLL_FDS \
+      FEMSWEEP_UNROLL \
       for (Index_type i = 0; i < FDS; i++) \
       { \
         const Index_type ffi = f * FDS + i; \

--- a/src/apps/FEMSWEEP.hpp
+++ b/src/apps/FEMSWEEP.hpp
@@ -96,13 +96,7 @@ constexpr long ND = 8;   // number of corners per element
 constexpr long NLF = 6;  // number of faces per element
 constexpr long FDS = 4;  // number of DOFs per face
 
-#if defined(FEMSWEEP_ENABLE_UNROLL)
-#define FEMSWEEP_UNROLL _Pragma("unroll")
-#else
-#define FEMSWEEP_UNROLL
-#endif
-
-
+#define FEMSWEEP_UNROLL_64_TUNING_NAME "unroll_64"
 
 #define FEMSWEEP_DATA_SETUP \
   Real_ptr Bdat = m_Bdat; \
@@ -134,21 +128,21 @@ constexpr long FDS = 4;  // number of DOFs per face
   const Index_type ohp = ohpaa_r[a]; \
   Real_type Ffactor = fmax(sin(Adat[order_r[a*ne]*ND*ND + a*ne*ND*ND]) - 2.0, 0.0);
 
-#define FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT \
+#define FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT_IMPL(UNROLL, SOLVE) \
   Real_type A[ND*ND]; \
   Real_type b[ND]; \
   const Index_type e = order_r[k + nehp_pos + a * ne]; \
-  FEMSWEEP_UNROLL \
+  UNROLL \
   for (Index_type j = 0; j < ND; ++j) \
   { \
     b[j] = Bdat[j + e * ND + a * ne * ND]; \
-    FEMSWEEP_UNROLL \
+    UNROLL \
     for (Index_type i = 0; i < ND; ++i) \
     { \
       A[i + j * ND] = Adat[i + j * ND + e * ND * ND + a * ne * ND * ND]; \
     } \
   } \
-  FEMSWEEP_UNROLL \
+  UNROLL \
   for (Index_type face = 0; face < NLF; ++face) \
   { \
     const Index_type sf_gl = F_g2l[elem_to_faces[NLF * e + face]]; \
@@ -158,13 +152,13 @@ constexpr long FDS = 4;  // number of DOFs per face
     { \
       continue; \
     } \
-    FEMSWEEP_UNROLL \
+    UNROLL \
     for (Index_type j = 0; j < FDS; ++j) \
     { \
       const Index_type ffj = f * FDS + j; \
       const Index_type djs = s == 0 ? idx1[ffj] : idx2[ffj]; \
       Real_type F = 0.0; \
-      FEMSWEEP_UNROLL \
+      UNROLL \
       for (Index_type i = 0; i < FDS; i++) \
       { \
         const Index_type ffi = f * FDS + i; \
@@ -175,122 +169,123 @@ constexpr long FDS = 4;  // number of DOFs per face
     } \
   } \
   const Real_type s = Sgdat[e + g * ne]; \
-  SolveLinearSystemNxN<ND>(A, s, &M0dat[0 + 0 * ND + e * ND * ND], b, &Xdat[e * ND + g * ND * ne + a * ng * ND * ne]);
+  SOLVE<ND>(A, s, &M0dat[0 + 0 * ND + e * ND * ND], b, &Xdat[e * ND + g * ND * ne + a * ng * ND * ne]);
+
+#define FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT \
+  FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT_IMPL(, SolveLinearSystemNxN)
+
+#define FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT_UNROLL \
+  FEMSWEEP_KERNEL_HYPERPLANE_ELEMENT_IMPL(RAJA_UNROLL, SolveLinearSystemNxNUnroll)
 
 
 namespace rajaperf
 {
 
 // LU factorization with no pivoting
-template <long N>
-RAJA_HOST_DEVICE inline void SolveLinearSystemNxN(Real_ptr A, 
-                                                  const Real_type s,
-                                                  Real_const_ptr M, 
-                                                  Real_ptr b, 
-                                                  Real_ptr x)
-{
-  Real_type tempA[N][N];
-  Real_type L[N][N];
-  Real_type U[N][N];
-  Real_type D[N];
-  Real_type tempx[N];
-
-  // tempA = A + s * M0
-  // set L to 0, U to identity
-  FEMSWEEP_UNROLL
-  for ( Index_type ii = 0; ii < N; ++ii )
-  {
-    FEMSWEEP_UNROLL
-    for ( Index_type jj = 0; jj < N; ++jj )
-    {
-      tempA[ii][jj] = A[ii * N + jj] + s * M[ii * N + jj];
-      L[ii][jj] = 0.0;
-      if ( ii == jj )
-      {
-        U[ii][jj] = 1.0;
-      }
-      else
-      {
-        U[ii][jj] = 0.0;
-      }
-    }
-  }
-
-  // set first column of L, and first row of U
-  FEMSWEEP_UNROLL
-  for ( Index_type ii = 0; ii < N; ++ii )
-  {
-    L[ii][0] = tempA[ii][0];
-  }
-
-  FEMSWEEP_UNROLL
-  for ( Index_type ii = 1; ii < N; ++ii )
-  {
-    U[0][ii] = tempA[0][ii]/tempA[0][0];
-  }
-
-  // form L & U
-  // L formed one column at a time
-  // U formed one row at a time
-  FEMSWEEP_UNROLL
-  for ( Index_type ii = 1; ii < N; ++ii )
-  {
-    // L column formation
-    FEMSWEEP_UNROLL
-    for ( Index_type jj = ii; jj < N; ++jj )
-    {
-      Real_type sum = 0.0;
-      FEMSWEEP_UNROLL
-      for ( Index_type kk = 0; kk < jj; ++kk )
-      {
-        sum += L[jj][kk] * U[kk][ii];
-      }
-      L[jj][ii] = tempA[jj][ii] - sum;
-    }
-
-    // U row formation
-    FEMSWEEP_UNROLL
-    for ( Index_type jj = ii+1; jj < N; ++jj )
-    {
-      Real_type sum = 0.0;
-      FEMSWEEP_UNROLL
-      for ( Index_type kk = 0; kk < ii; ++kk )
-      {
-        sum += L[ii][kk] * U[kk][jj];
-      }
-      U[ii][jj] = (tempA[ii][jj] - sum)/L[ii][ii];
-    }
-  }
-
-  // forward substitution
-  D[0] = b[0]/L[0][0];
-  FEMSWEEP_UNROLL
-  for ( Index_type ii = 1; ii < N; ++ii )
-  {
-    Real_type sum = 0.0;
-    FEMSWEEP_UNROLL
-    for ( Index_type jj = 0; jj < ii; ++jj )
-    {
-      sum += L[ii][jj] * D[jj];
-    }
-    D[ii] = (b[ii] - sum)/L[ii][ii];
-  }
-
-  // backward substitution
-  x[N-1] = tempx[N-1] = D[N-1];
-  FEMSWEEP_UNROLL
-  for ( Index_type ii = N - 1 - 1; ii > -1; --ii )
-  {
-    Real_type sum = 0.0;
-    FEMSWEEP_UNROLL
-    for ( Index_type jj = ii+1; jj < N; ++jj )
-    {
-      sum += U[ii][jj] * tempx[jj];
-    }
-    x[ii] = tempx[ii] = D[ii] - sum;
-  }
-
+#define FEMSWEEP_DEFINE_SOLVE_LINEAR_SYSTEM_NXN(FUNCTION_NAME, UNROLL) \
+template <long N> \
+RAJA_HOST_DEVICE inline void FUNCTION_NAME(Real_ptr A, \
+                                           const Real_type s, \
+                                           Real_const_ptr M, \
+                                           Real_ptr b, \
+                                           Real_ptr x) \
+{ \
+  Real_type tempA[N][N]; \
+  Real_type L[N][N]; \
+  Real_type U[N][N]; \
+  Real_type D[N]; \
+  Real_type tempx[N]; \
+\
+  UNROLL \
+  for ( Index_type ii = 0; ii < N; ++ii ) \
+  { \
+    UNROLL \
+    for ( Index_type jj = 0; jj < N; ++jj ) \
+    { \
+      tempA[ii][jj] = A[ii * N + jj] + s * M[ii * N + jj]; \
+      L[ii][jj] = 0.0; \
+      if ( ii == jj ) \
+      { \
+        U[ii][jj] = 1.0; \
+      } \
+      else \
+      { \
+        U[ii][jj] = 0.0; \
+      } \
+    } \
+  } \
+\
+  UNROLL \
+  for ( Index_type ii = 0; ii < N; ++ii ) \
+  { \
+    L[ii][0] = tempA[ii][0]; \
+  } \
+\
+  UNROLL \
+  for ( Index_type ii = 1; ii < N; ++ii ) \
+  { \
+    U[0][ii] = tempA[0][ii]/tempA[0][0]; \
+  } \
+\
+  UNROLL \
+  for ( Index_type ii = 1; ii < N; ++ii ) \
+  { \
+    UNROLL \
+    for ( Index_type jj = ii; jj < N; ++jj ) \
+    { \
+      Real_type sum = 0.0; \
+      UNROLL \
+      for ( Index_type kk = 0; kk < jj; ++kk ) \
+      { \
+        sum += L[jj][kk] * U[kk][ii]; \
+      } \
+      L[jj][ii] = tempA[jj][ii] - sum; \
+    } \
+\
+    UNROLL \
+    for ( Index_type jj = ii+1; jj < N; ++jj ) \
+    { \
+      Real_type sum = 0.0; \
+      UNROLL \
+      for ( Index_type kk = 0; kk < ii; ++kk ) \
+      { \
+        sum += L[ii][kk] * U[kk][jj]; \
+      } \
+      U[ii][jj] = (tempA[ii][jj] - sum)/L[ii][ii]; \
+    } \
+  } \
+\
+  D[0] = b[0]/L[0][0]; \
+  UNROLL \
+  for ( Index_type ii = 1; ii < N; ++ii ) \
+  { \
+    Real_type sum = 0.0; \
+    UNROLL \
+    for ( Index_type jj = 0; jj < ii; ++jj ) \
+    { \
+      sum += L[ii][jj] * D[jj]; \
+    } \
+    D[ii] = (b[ii] - sum)/L[ii][ii]; \
+  } \
+\
+  x[N-1] = tempx[N-1] = D[N-1]; \
+  UNROLL \
+  for ( Index_type ii = N - 1 - 1; ii > -1; --ii ) \
+  { \
+    Real_type sum = 0.0; \
+    UNROLL \
+    for ( Index_type jj = ii+1; jj < N; ++jj ) \
+    { \
+      sum += U[ii][jj] * tempx[jj]; \
+    } \
+    x[ii] = tempx[ii] = D[ii] - sum; \
+  } \
 }
+
+FEMSWEEP_DEFINE_SOLVE_LINEAR_SYSTEM_NXN(SolveLinearSystemNxN, )
+FEMSWEEP_DEFINE_SOLVE_LINEAR_SYSTEM_NXN(SolveLinearSystemNxNUnroll, RAJA_UNROLL)
+
+#undef FEMSWEEP_DEFINE_SOLVE_LINEAR_SYSTEM_NXN
 
 
 class RunParams;
@@ -321,6 +316,8 @@ public:
 
   template < size_t block_size >
   void runCudaVariantImpl(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantImplUnroll(VariantID vid);
   template < size_t block_size >
   void runHipVariantImpl(VariantID vid);
 


### PR DESCRIPTION
# Summary

- This PR is a fix for the CUDA version of femsweep to bring its performance closer to the HIP version
- It does the following:
  - Adds loop unrolling to femsweep as requested by @pearce8 

# Details 
We found that the performance of the femsweep kernel was around 2-3x worse on NVIDIA(H100) vs AMD(MI300A). The NVIDIA version was spilling to local memory instead of using registers and forcing loops to unroll fixed the issue.

Note: This version also changes the block size for the NVIDIA version to be 64 to match the AMD version. 