### PR TITLE
CAMP sycl API changed from using sycl::queue ptr to reference; change…

### DIFF
--- a/src/algorithm/REDUCE_SUM-Sycl.cpp
+++ b/src/algorithm/REDUCE_SUM-Sycl.cpp
@@ -50,7 +50,7 @@ void REDUCE_SUM::runSyclVariantImpl(VariantID vid)
 
       initSyclDeviceData(sum, &m_sum_init, 1, qu); 
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
 
         auto sumReduction = sycl::reduction(sum, sycl::plus<Real_type>());
 

--- a/src/apps/CONVECTION3DPA-Sycl.cpp
+++ b/src/apps/CONVECTION3DPA-Sycl.cpp
@@ -44,7 +44,7 @@ void CONVECTION3DPA::runSyclVariantImpl(VariantID vid) {
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&](::sycl::handler& h) {
+      qu.submit([&](::sycl::handler& h) {
 
         constexpr Index_type max_D1D = conv::D1D;
         constexpr Index_type max_Q1D = conv::Q1D;

--- a/src/apps/DEL_DOT_VEC_2D-Sycl.cpp
+++ b/src/apps/DEL_DOT_VEC_2D-Sycl.cpp
@@ -46,7 +46,7 @@ void DEL_DOT_VEC_2D::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/apps/DIFFUSION3DPA-Sycl.cpp
+++ b/src/apps/DIFFUSION3DPA-Sycl.cpp
@@ -45,7 +45,7 @@ void DIFFUSION3DPA::runSyclVariantImpl(VariantID vid) {
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&](::sycl::handler& h) {
+      qu.submit([&](::sycl::handler& h) {
 
         constexpr Index_type MQ1 = diff::Q1D;
         constexpr Index_type MD1 = diff::D1D;

--- a/src/apps/EDGE3D-Sycl.cpp
+++ b/src/apps/EDGE3D-Sycl.cpp
@@ -47,7 +47,7 @@ void EDGE3D::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 

--- a/src/apps/ENERGY-Sycl.cpp
+++ b/src/apps/ENERGY-Sycl.cpp
@@ -47,7 +47,7 @@ void ENERGY::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size); 
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -59,7 +59,7 @@ void ENERGY::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
             
@@ -71,7 +71,7 @@ void ENERGY::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -82,7 +82,7 @@ void ENERGY::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -94,7 +94,7 @@ void ENERGY::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -106,7 +106,7 @@ void ENERGY::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/apps/FIR-Sycl.cpp
+++ b/src/apps/FIR-Sycl.cpp
@@ -59,7 +59,7 @@ void FIR::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/apps/LTIMES-Sycl.cpp
+++ b/src/apps/LTIMES-Sycl.cpp
@@ -54,7 +54,7 @@ void LTIMES::runSyclVariantImpl(VariantID vid)
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3> ( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 

--- a/src/apps/LTIMES_NOVIEW-Sycl.cpp
+++ b/src/apps/LTIMES_NOVIEW-Sycl.cpp
@@ -52,7 +52,7 @@ void LTIMES_NOVIEW::runSyclVariantImpl(VariantID vid)
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3> ( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 

--- a/src/apps/MASS3DEA-Sycl.cpp
+++ b/src/apps/MASS3DEA-Sycl.cpp
@@ -43,7 +43,7 @@ void MASS3DEA::runSyclVariantImpl(VariantID vid) {
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
       constexpr size_t shmem = 0;
-      qu->submit([&](::sycl::handler& h) {
+      qu.submit([&](::sycl::handler& h) {
 
       ::sycl::local_accessor<Real_type, 2> s_B(::sycl::range<2>(mea::Q1D,mea::D1D),h);
       ::sycl::local_accessor<Real_type, 3> s_D(::sycl::range<3>(mea::Q1D,mea::Q1D,mea::Q1D),h);

--- a/src/apps/MASS3DPA-Sycl.cpp
+++ b/src/apps/MASS3DPA-Sycl.cpp
@@ -45,7 +45,7 @@ void MASS3DPA::runSyclVariantImpl(VariantID vid) {
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&](::sycl::handler& h) {
+      qu.submit([&](::sycl::handler& h) {
 
         constexpr Index_type MQ1 = mpa::Q1D;
         constexpr Index_type MD1 = mpa::D1D;

--- a/src/apps/MASS3DPA_ATOMIC-Sycl.cpp
+++ b/src/apps/MASS3DPA_ATOMIC-Sycl.cpp
@@ -45,7 +45,7 @@ void MASS3DPA_ATOMIC::runSyclVariantImpl(VariantID vid) {
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&](::sycl::handler& h) {
+      qu.submit([&](::sycl::handler& h) {
 
         constexpr Index_type MQ1 = mpa_at::Q1D;
         constexpr Index_type MD1 = mpa_at::D1D;

--- a/src/apps/MASSVEC3DPA-Sycl.cpp
+++ b/src/apps/MASSVEC3DPA-Sycl.cpp
@@ -47,7 +47,7 @@ void MASSVEC3DPA::runSyclVariantImpl(VariantID vid)
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&](::sycl::handler& h) {
+      qu.submit([&](::sycl::handler& h) {
 
         constexpr Index_type MQ1 = mvpa::Q1D;
         constexpr Index_type MD1 = mvpa::D1D;

--- a/src/apps/MATVEC_3D_STENCIL-Sycl.cpp
+++ b/src/apps/MATVEC_3D_STENCIL-Sycl.cpp
@@ -46,7 +46,7 @@ void MATVEC_3D_STENCIL::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/apps/PRESSURE-Sycl.cpp
+++ b/src/apps/PRESSURE-Sycl.cpp
@@ -46,7 +46,7 @@ void PRESSURE::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -58,7 +58,7 @@ void PRESSURE::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/apps/VOL3D-Sycl.cpp
+++ b/src/apps/VOL3D-Sycl.cpp
@@ -46,7 +46,7 @@ void VOL3D::runSyclVariantImpl(VariantID vid)
  
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend-ibegin, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/apps/ZONAL_ACCUMULATION_3D-Sycl.cpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D-Sycl.cpp
@@ -47,7 +47,7 @@ void ZONAL_ACCUMULATION_3D::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
    
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 

--- a/src/basic/ARRAY_OF_PTRS-Sycl.cpp
+++ b/src/basic/ARRAY_OF_PTRS-Sycl.cpp
@@ -45,7 +45,7 @@ void ARRAY_OF_PTRS::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 

--- a/src/basic/COPY8-Sycl.cpp
+++ b/src/basic/COPY8-Sycl.cpp
@@ -45,7 +45,7 @@ void COPY8::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 

--- a/src/basic/DAXPY-Sycl.cpp
+++ b/src/basic/DAXPY-Sycl.cpp
@@ -44,7 +44,7 @@ void DAXPY::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 

--- a/src/basic/EMPTY-Sycl.cpp
+++ b/src/basic/EMPTY-Sycl.cpp
@@ -44,7 +44,7 @@ void EMPTY::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 

--- a/src/basic/IF_QUAD-Sycl.cpp
+++ b/src/basic/IF_QUAD-Sycl.cpp
@@ -44,7 +44,7 @@ void IF_QUAD::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 

--- a/src/basic/INIT3-Sycl.cpp
+++ b/src/basic/INIT3-Sycl.cpp
@@ -44,7 +44,7 @@ void INIT3::runSyclVariantImpl(VariantID vid)
  
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                                          [=] (sycl::nd_item<1> item ) {
 

--- a/src/basic/INIT_VIEW1D-Sycl.cpp
+++ b/src/basic/INIT_VIEW1D-Sycl.cpp
@@ -44,7 +44,7 @@ void INIT_VIEW1D::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                                         [=] (sycl::nd_item<1> item ) {
 

--- a/src/basic/INIT_VIEW1D_OFFSET-Sycl.cpp
+++ b/src/basic/INIT_VIEW1D_OFFSET-Sycl.cpp
@@ -44,7 +44,7 @@ void INIT_VIEW1D_OFFSET::runSyclVariantImpl(VariantID vid)
  
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend-ibegin, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                                          [=] (sycl::nd_item<1> item ) {
 

--- a/src/basic/MAT_MAT_SHARED-Sycl.cpp
+++ b/src/basic/MAT_MAT_SHARED-Sycl.cpp
@@ -50,7 +50,7 @@ void MAT_MAT_SHARED::runSyclVariantImpl(VariantID vid)
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&](::sycl::handler& h) {
+      qu.submit([&](::sycl::handler& h) {
 
        ::sycl::local_accessor<double, 2> As(::sycl::range<2>(tile_size, tile_size), h);
        ::sycl::local_accessor<double, 2> Bs(::sycl::range<2>(tile_size, tile_size), h);

--- a/src/basic/MULADDSUB-Sycl.cpp
+++ b/src/basic/MULADDSUB-Sycl.cpp
@@ -44,7 +44,7 @@ void MULADDSUB::runSyclVariantImpl(VariantID vid)
  
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                                          [=] (sycl::nd_item<1> item ) {
 

--- a/src/basic/NESTED_INIT-Sycl.cpp
+++ b/src/basic/NESTED_INIT-Sycl.cpp
@@ -52,7 +52,7 @@ void NESTED_INIT::runSyclVariantImpl(VariantID vid)
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&] (::sycl::handler& h) {
+      qu.submit([&] (::sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3> ( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) { 
 

--- a/src/basic/PI_REDUCE-Sycl.cpp
+++ b/src/basic/PI_REDUCE-Sycl.cpp
@@ -54,7 +54,7 @@ void PI_REDUCE::runSyclVariantImpl(VariantID vid)
 
       initSyclDeviceData(pi, &m_pi_init, 1, qu);
 
-      qu->submit([&] (sycl::handler& hdl) {
+      qu.submit([&] (sycl::handler& hdl) {
 
         auto sum_reduction = sycl::reduction(pi, sycl::plus<>());
 

--- a/src/basic/REDUCE3_INT-Sycl.cpp
+++ b/src/basic/REDUCE3_INT-Sycl.cpp
@@ -56,7 +56,7 @@ void REDUCE3_INT::runSyclVariantImpl(VariantID vid)
       initSyclDeviceData(hmin, &m_vmin_init, 1, qu);
       initSyclDeviceData(hmax, &m_vmax_init, 1, qu);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
 
         auto sum_reduction = sycl::reduction(hsum, sycl::plus<>());
         auto min_reduction = sycl::reduction(hmin, sycl::minimum<>());

--- a/src/basic/TRAP_INT-Sycl.cpp
+++ b/src/basic/TRAP_INT-Sycl.cpp
@@ -52,7 +52,7 @@ void TRAP_INT::runSyclVariantImpl(VariantID vid)
 
       initSyclDeviceData(sumx, &m_sumx_init, 1, qu);
   
-      qu->submit([&] (sycl::handler& hdl) {
+      qu.submit([&] (sycl::handler& hdl) {
 
         auto sum_reduction = sycl::reduction(sumx, sycl::plus<>());
 

--- a/src/common/KernelBase.hpp
+++ b/src/common/KernelBase.hpp
@@ -410,7 +410,7 @@ public:
 #if defined(RAJA_ENABLE_SYCL)
     if ( running_variant == Base_SYCL ||
          running_variant == RAJA_SYCL ) {
-      getSyclResource().get_queue()->wait();
+      getSyclResource().get_queue().wait();
     }
 #endif
 

--- a/src/common/SyclDataUtils.hpp
+++ b/src/common/SyclDataUtils.hpp
@@ -34,9 +34,9 @@ namespace rajaperf
  * and of propoer size for copy operation to succeed.
  */
 template <typename T>
-void initSyclDeviceData(T& dptr, const T hptr, int len, sycl::queue* qu)
+void initSyclDeviceData(T& dptr, const T hptr, int len, sycl::queue& qu)
 {
-  auto e = qu->memcpy( dptr, hptr,
+  auto e = qu.memcpy( dptr, hptr,
                        len * sizeof(typename std::remove_pointer<T>::type));
   e.wait();
 
@@ -48,9 +48,9 @@ void initSyclDeviceData(T& dptr, const T hptr, int len, sycl::queue* qu)
  * data to device array.
  */
 template <typename T>
-void allocAndInitSyclDeviceData(T& dptr, const T hptr, int len, sycl::queue *qu)
+void allocAndInitSyclDeviceData(T& dptr, const T hptr, int len, sycl::queue& qu)
 {
-  dptr = sycl::malloc_device<typename std::remove_pointer<T>::type>(len, *qu);
+  dptr = sycl::malloc_device<typename std::remove_pointer<T>::type>(len, qu);
 
   initSyclDeviceData(dptr, hptr, len, qu);
 }
@@ -62,9 +62,9 @@ void allocAndInitSyclDeviceData(T& dptr, const T hptr, int len, sycl::queue *qu)
  * and of propoer size for copy operation to succeed.
  */
 template <typename T>
-void getSyclDeviceData(T& hptr, const T dptr, int len, sycl::queue *qu)
+void getSyclDeviceData(T& hptr, const T dptr, int len, sycl::queue& qu)
 {
-  auto e = qu->memcpy( hptr, dptr,
+  auto e = qu.memcpy( hptr, dptr,
                       len * sizeof(typename std::remove_pointer<T>::type));
   e.wait();
 }
@@ -73,9 +73,9 @@ void getSyclDeviceData(T& hptr, const T dptr, int len, sycl::queue *qu)
  * \brief Free device data array.
  */
 template <typename T>
-void deallocSyclDeviceData(T& dptr, sycl::queue *qu)
+void deallocSyclDeviceData(T& dptr, sycl::queue& qu)
 {
-  sycl::free(dptr, *qu);
+  sycl::free(dptr, qu);
   dptr = 0;
 }
 
@@ -84,39 +84,39 @@ namespace detail
 /*
  * Copy memory len bytes from src to dst.
  */
-inline void copySyclData(void* dst_ptr, const void* src_ptr, Size_type len, sycl::queue *qu)
+inline void copySyclData(void* dst_ptr, const void* src_ptr, Size_type len, sycl::queue& qu)
 {
-  auto e = qu->memcpy( dst_ptr, src_ptr, len);
+  auto e = qu.memcpy( dst_ptr, src_ptr, len);
   e.wait();
 }
 
 /*!
  * \brief Allocate SYCL device data array (dptr).
  */
-inline void* allocSyclDeviceData(Size_type len, sycl::queue *qu)
+inline void* allocSyclDeviceData(Size_type len, sycl::queue& qu)
 {
   void* dptr = nullptr;
-  dptr = sycl::malloc_device(len, *qu);
+  dptr = sycl::malloc_device(len, qu);
   return dptr;
 }
 
 /*!
  * \brief Allocate SYCL managed data array (dptr).
  */
-inline void* allocSyclManagedData(Size_type len, sycl::queue *qu)
+inline void* allocSyclManagedData(Size_type len, sycl::queue& qu)
 {
   void* mptr = nullptr;
-  mptr = sycl::malloc_shared(len, *qu);
+  mptr = sycl::malloc_shared(len, qu);
   return mptr;
 }
 
 /*!
  * \brief Allocate SYCL pinned data array (pptr).
  */
-inline void* allocSyclPinnedData(Size_type len, sycl::queue *qu)
+inline void* allocSyclPinnedData(Size_type len, sycl::queue& qu)
 {
   void* pptr = nullptr;
-  pptr = sycl::malloc_host(len, *qu);
+  pptr = sycl::malloc_host(len, qu);
   return pptr;
 }
 
@@ -124,27 +124,27 @@ inline void* allocSyclPinnedData(Size_type len, sycl::queue *qu)
 /*!
  * \brief Free device data array.
  */
-inline void deallocSyclDeviceData(void* dptr, sycl::queue *qu)
+inline void deallocSyclDeviceData(void* dptr, sycl::queue& qu)
 {
-  sycl::free(dptr, *qu);
+  sycl::free(dptr, qu);
   dptr = 0;
 }
 
 /*!
  * \brief Free managed data array.
  */
-inline void deallocSyclManagedData(void* dptr, sycl::queue *qu)
+inline void deallocSyclManagedData(void* dptr, sycl::queue& qu)
 {
-  sycl::free(dptr, *qu);
+  sycl::free(dptr, qu);
   dptr = 0;
 }
 
 /*!
  * \brief Free managed data array.
  */
-inline void deallocSyclPinnedData(void* dptr, sycl::queue *qu)
+inline void deallocSyclPinnedData(void* dptr, sycl::queue& qu)
 {
-  sycl::free(dptr, *qu);
+  sycl::free(dptr, qu);
   dptr = 0;
 }
 

--- a/src/lcals/DIFF_PREDICT-Sycl.cpp
+++ b/src/lcals/DIFF_PREDICT-Sycl.cpp
@@ -44,7 +44,7 @@ void DIFF_PREDICT::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h)
+      qu.submit([&] (sycl::handler& h)
       {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item ) {

--- a/src/lcals/EOS-Sycl.cpp
+++ b/src/lcals/EOS-Sycl.cpp
@@ -44,7 +44,7 @@ void EOS::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) { 
+      qu.submit([&] (sycl::handler& h) { 
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 

--- a/src/lcals/FIRST_DIFF-Sycl.cpp
+++ b/src/lcals/FIRST_DIFF-Sycl.cpp
@@ -44,7 +44,7 @@ void FIRST_DIFF::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/lcals/FIRST_MIN-Sycl.cpp
+++ b/src/lcals/FIRST_MIN-Sycl.cpp
@@ -50,7 +50,7 @@ void FIRST_MIN::runSyclVariantImpl(VariantID vid)
 
     using result_type = reduce_pair<Real_type, Index_type>;
 
-    auto result = sycl::malloc_shared< result_type >(1, *qu); 
+    auto result = sycl::malloc_shared< result_type >(1, qu); 
  
     startTimer();
     // Loop counter increment uses macro to quiet C++20 compiler warning
@@ -62,7 +62,7 @@ void FIRST_MIN::runSyclVariantImpl(VariantID vid)
       *result = result_init;
       auto reduction_obj = sycl::reduction( result, result_init, sycl::minimum<result_type>() ); 
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
 
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        reduction_obj,
@@ -77,14 +77,14 @@ void FIRST_MIN::runSyclVariantImpl(VariantID vid)
 
       });
 
-      qu->wait();
+      qu.wait();
 
       m_minloc = static_cast<Index_type>(result->idx);
 
     }
     stopTimer();
 
-    sycl::free(result, *qu);
+    sycl::free(result, qu);
 
   } else if ( vid == RAJA_SYCL ) {
 

--- a/src/lcals/FIRST_SUM-Sycl.cpp
+++ b/src/lcals/FIRST_SUM-Sycl.cpp
@@ -45,7 +45,7 @@ void FIRST_SUM::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 

--- a/src/lcals/GEN_LIN_RECUR-Sycl.cpp
+++ b/src/lcals/GEN_LIN_RECUR-Sycl.cpp
@@ -42,7 +42,7 @@ void GEN_LIN_RECUR::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size1 = work_group_size * RAJA_DIVIDE_CEILING_INT(N, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size1, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -56,7 +56,7 @@ void GEN_LIN_RECUR::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size2 = work_group_size * RAJA_DIVIDE_CEILING_INT(N+1, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size2, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/lcals/HYDRO_1D-Sycl.cpp
+++ b/src/lcals/HYDRO_1D-Sycl.cpp
@@ -44,7 +44,7 @@ void HYDRO_1D::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 

--- a/src/lcals/HYDRO_2D-Sycl.cpp
+++ b/src/lcals/HYDRO_2D-Sycl.cpp
@@ -55,7 +55,7 @@ void HYDRO_2D::runSyclVariantImpl(VariantID vid) {
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&] (sycl::handler& h) { 
+      qu.submit([&] (sycl::handler& h) { 
 
         h.parallel_for(sycl::nd_range<3>( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
@@ -70,7 +70,7 @@ void HYDRO_2D::runSyclVariantImpl(VariantID vid) {
         });
       });
 
-      qu->submit([&] (sycl::handler& h) { 
+      qu.submit([&] (sycl::handler& h) { 
         h.parallel_for(sycl::nd_range<3>( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 
@@ -84,7 +84,7 @@ void HYDRO_2D::runSyclVariantImpl(VariantID vid) {
         });
       });
 
-      qu->submit([&] (sycl::handler& h) { 
+      qu.submit([&] (sycl::handler& h) { 
         h.parallel_for(sycl::nd_range<3>( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 

--- a/src/lcals/INT_PREDICT-Sycl.cpp
+++ b/src/lcals/INT_PREDICT-Sycl.cpp
@@ -44,7 +44,7 @@ void INT_PREDICT::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/lcals/PLANCKIAN-Sycl.cpp
+++ b/src/lcals/PLANCKIAN-Sycl.cpp
@@ -47,7 +47,7 @@ void PLANCKIAN::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/lcals/TRIDIAG_ELIM-Sycl.cpp
+++ b/src/lcals/TRIDIAG_ELIM-Sycl.cpp
@@ -44,7 +44,7 @@ void TRIDIAG_ELIM::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/polybench/POLYBENCH_2MM-Sycl.cpp
+++ b/src/polybench/POLYBENCH_2MM-Sycl.cpp
@@ -58,7 +58,7 @@ void POLYBENCH_2MM::runSyclVariantImpl(VariantID vid)
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim1, wkgroup_dim), 
                        [=] (sycl::nd_item<3> item) {
 
@@ -76,7 +76,7 @@ void POLYBENCH_2MM::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim2, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 

--- a/src/polybench/POLYBENCH_3MM-Sycl.cpp
+++ b/src/polybench/POLYBENCH_3MM-Sycl.cpp
@@ -61,7 +61,7 @@ void POLYBENCH_3MM::runSyclVariantImpl(VariantID vid)
 
       sycl::range<3> wkgroup_dim(1, out_wg_sz, in_wg_sz);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim1, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 
@@ -79,7 +79,7 @@ void POLYBENCH_3MM::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim2, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 
@@ -97,7 +97,7 @@ void POLYBENCH_3MM::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim3, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 

--- a/src/polybench/POLYBENCH_ADI-Sycl.cpp
+++ b/src/polybench/POLYBENCH_ADI-Sycl.cpp
@@ -42,7 +42,7 @@ void POLYBENCH_ADI::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(n-2, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -62,7 +62,7 @@ void POLYBENCH_ADI::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/polybench/POLYBENCH_ATAX-Sycl.cpp
+++ b/src/polybench/POLYBENCH_ATAX-Sycl.cpp
@@ -42,7 +42,7 @@ void POLYBENCH_ATAX::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(N, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -59,7 +59,7 @@ void POLYBENCH_ATAX::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) { 
+      qu.submit([&] (sycl::handler& h) { 
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) { 
 

--- a/src/polybench/POLYBENCH_FDTD_2D-Sycl.cpp
+++ b/src/polybench/POLYBENCH_FDTD_2D-Sycl.cpp
@@ -49,7 +49,7 @@ void POLYBENCH_FDTD_2D::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size1 = work_group_size * RAJA_DIVIDE_CEILING_INT(ny, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size1, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -67,7 +67,7 @@ void POLYBENCH_FDTD_2D::runSyclVariantImpl(VariantID vid)
 
       sycl::range<3> wkgroup_dim234(1, i_wg_sz, j_wg_sz);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim234, wkgroup_dim234),
                        [=] (sycl::nd_item<3> item) {
 
@@ -81,7 +81,7 @@ void POLYBENCH_FDTD_2D::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim234, wkgroup_dim234),
                        [=] (sycl::nd_item<3> item) {
 
@@ -95,7 +95,7 @@ void POLYBENCH_FDTD_2D::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim234, wkgroup_dim234),
                        [=] (sycl::nd_item<3> item) {
 

--- a/src/polybench/POLYBENCH_FLOYD_WARSHALL-Sycl.cpp
+++ b/src/polybench/POLYBENCH_FLOYD_WARSHALL-Sycl.cpp
@@ -53,7 +53,7 @@ void POLYBENCH_FLOYD_WARSHALL::runSyclVariantImpl(VariantID vid)
 
       for (Index_type k = 0; k < N; ++k) {
 
-        qu->submit([&] (sycl::handler& h) {
+        qu.submit([&] (sycl::handler& h) {
           h.parallel_for(sycl::nd_range<3>( global_dim, wkgroup_dim),
                          [=] (sycl::nd_item<3> item) {
 

--- a/src/polybench/POLYBENCH_GEMM-Sycl.cpp
+++ b/src/polybench/POLYBENCH_GEMM-Sycl.cpp
@@ -53,7 +53,7 @@ void POLYBENCH_GEMM::runSyclVariantImpl(VariantID vid)
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 

--- a/src/polybench/POLYBENCH_GEMVER-Sycl.cpp
+++ b/src/polybench/POLYBENCH_GEMVER-Sycl.cpp
@@ -54,7 +54,7 @@ void POLYBENCH_GEMVER::runSyclVariantImpl(VariantID vid)
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim1, wkgroup_dim1),
                        [=] (sycl::nd_item<3> item) {
 
@@ -68,7 +68,7 @@ void POLYBENCH_GEMVER::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size234, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 
@@ -84,7 +84,7 @@ void POLYBENCH_GEMVER::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size234, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 
@@ -96,7 +96,7 @@ void POLYBENCH_GEMVER::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size234, work_group_size),
                        [=] (sycl::nd_item<1> item ) {
 

--- a/src/polybench/POLYBENCH_GESUMMV-Sycl.cpp
+++ b/src/polybench/POLYBENCH_GESUMMV-Sycl.cpp
@@ -43,7 +43,7 @@ void POLYBENCH_GESUMMV::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(N, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/polybench/POLYBENCH_HEAT_3D-Sycl.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Sycl.cpp
@@ -54,7 +54,7 @@ void POLYBENCH_HEAT_3D::runSyclVariantImpl(VariantID vid)
 
       sycl::range<3> wkgroup_dim(i_wg_sz, j_wg_sz, k_wg_sz);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 
@@ -69,7 +69,7 @@ void POLYBENCH_HEAT_3D::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 

--- a/src/polybench/POLYBENCH_JACOBI_1D-Sycl.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_1D-Sycl.cpp
@@ -42,7 +42,7 @@ void POLYBENCH_JACOBI_1D::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(N, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -54,7 +54,7 @@ void POLYBENCH_JACOBI_1D::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/polybench/POLYBENCH_JACOBI_2D-Sycl.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Sycl.cpp
@@ -53,7 +53,7 @@ void POLYBENCH_JACOBI_2D::runSyclVariantImpl(VariantID vid)
 
       sycl::range<3> wkgroup_dim(1, i_wg_sz, j_wg_sz);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 
@@ -67,7 +67,7 @@ void POLYBENCH_JACOBI_2D::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<3>( global_dim, wkgroup_dim),
                        [=] (sycl::nd_item<3> item) {
 

--- a/src/polybench/POLYBENCH_MVT-Sycl.cpp
+++ b/src/polybench/POLYBENCH_MVT-Sycl.cpp
@@ -43,7 +43,7 @@ void POLYBENCH_MVT::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(N, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 
@@ -60,7 +60,7 @@ void POLYBENCH_MVT::runSyclVariantImpl(VariantID vid)
         });
       });
 
-      qu->submit([&] (sycl::handler& h) { 
+      qu.submit([&] (sycl::handler& h) { 
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) { 
 

--- a/src/stream/ADD-Sycl.cpp
+++ b/src/stream/ADD-Sycl.cpp
@@ -44,7 +44,7 @@ void ADD::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/stream/COPY-Sycl.cpp
+++ b/src/stream/COPY-Sycl.cpp
@@ -44,7 +44,7 @@ void COPY::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                                    [=] (sycl::nd_item<1> item) {
 

--- a/src/stream/DOT-Sycl.cpp
+++ b/src/stream/DOT-Sycl.cpp
@@ -50,7 +50,7 @@ void DOT::runSyclVariantImpl(VariantID vid)
 
       initSyclDeviceData(dot, &m_dot_init, 1, qu); 
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
 
         auto sumReduction = sycl::reduction(dot, sycl::plus<Real_type>());
 

--- a/src/stream/MUL-Sycl.cpp
+++ b/src/stream/MUL-Sycl.cpp
@@ -44,7 +44,7 @@ void MUL::runSyclVariantImpl(VariantID vid)
 
       const size_t global_size = work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 

--- a/src/stream/TRIAD-Sycl.cpp
+++ b/src/stream/TRIAD-Sycl.cpp
@@ -44,7 +44,7 @@ void TRIAD::runSyclVariantImpl(VariantID vid)
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      qu->submit([&] (sycl::handler& h) {
+      qu.submit([&] (sycl::handler& h) {
         h.parallel_for(sycl::nd_range<1> (global_size, work_group_size),
                        [=] (sycl::nd_item<1> item) {
 


### PR DESCRIPTION
Changes sycl queue pointer to sycl queue reference.  CAMP changed so this follows CAMP and more closely matches the Sycl API (e.g. sycl allocation and free calls take reference).

