### PR TITLE
Jacobi 2D Seq, OMP, and OMPTarget launch twice

### DIFF
--- a/src/polybench/POLYBENCH_JACOBI_2D-OMP.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-OMP.cpp
@@ -108,11 +108,6 @@ void POLYBENCH_JACOBI_2D::runOpenMPVariant(VariantID vid)
             RAJA::statement::For<1, RAJA::seq_exec,
               RAJA::statement::Lambda<0>
             >
-          >,
-          RAJA::statement::For<0, RAJA::omp_parallel_for_exec,
-            RAJA::statement::For<1, RAJA::seq_exec,
-              RAJA::statement::Lambda<1>
-            >
           >
         >;
 
@@ -124,8 +119,13 @@ void POLYBENCH_JACOBI_2D::runOpenMPVariant(VariantID vid)
           RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
                            RAJA::RangeSegment{1, N-1}),
           res,
+          poly_jacobi2d_lam1
+        );
 
-          poly_jacobi2d_lam1,
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1}),
+          res,
           poly_jacobi2d_lam2
         );
 

--- a/src/polybench/POLYBENCH_JACOBI_2D-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-OMPTarget.cpp
@@ -64,10 +64,6 @@ void POLYBENCH_JACOBI_2D::runOpenMPTargetVariant(VariantID vid)
         RAJA::statement::Collapse<RAJA::omp_target_parallel_collapse_exec,
                                   RAJA::ArgList<0, 1>,
           RAJA::statement::Lambda<0>
-        >,
-        RAJA::statement::Collapse<RAJA::omp_target_parallel_collapse_exec,
-                                  RAJA::ArgList<0, 1>,
-          RAJA::statement::Lambda<1>
         >
       >;
 
@@ -81,7 +77,13 @@ void POLYBENCH_JACOBI_2D::runOpenMPTargetVariant(VariantID vid)
         res,
         [=] (Index_type i, Index_type j) {
           POLYBENCH_JACOBI_2D_BODY1_RAJA;
-        },
+        }
+      );
+
+      RAJA::kernel_resource<EXEC_POL>(
+        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                         RAJA::RangeSegment{1, N-1}),
+        res,
         [=] (Index_type i, Index_type j) {
           POLYBENCH_JACOBI_2D_BODY2_RAJA;
         }
@@ -102,4 +104,3 @@ RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(POLYBENCH_JACOBI_2D, OpenMPTarget, Ba
 } // end namespace rajaperf
 
 #endif  // RAJA_ENABLE_TARGET_OPENMP
-

--- a/src/polybench/POLYBENCH_JACOBI_2D-Seq.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Seq.cpp
@@ -103,11 +103,6 @@ void POLYBENCH_JACOBI_2D::runSeqVariant(VariantID vid)
             RAJA::statement::For<1, RAJA::seq_exec,
               RAJA::statement::Lambda<0>
             >
-          >,
-          RAJA::statement::For<0, RAJA::seq_exec,
-            RAJA::statement::For<1, RAJA::seq_exec,
-              RAJA::statement::Lambda<1>
-            >
           >
         >;
 
@@ -119,8 +114,13 @@ void POLYBENCH_JACOBI_2D::runSeqVariant(VariantID vid)
           RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
                            RAJA::RangeSegment{1, N-1}),
           res,
+          poly_jacobi2d_lam1
+        );
 
-          poly_jacobi2d_lam1,
+        RAJA::kernel_resource<EXEC_POL>(
+          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
+                           RAJA::RangeSegment{1, N-1}),
+          res,
           poly_jacobi2d_lam2
         );
 


### PR DESCRIPTION


# Summary

- This PR is a bugfix
- It does the following (modify list as needed):
  - Fixes `src/polybench/POLYBENCH_JACOBI_2D-OMP.cpp`, `src/polybench/POLYBENCH_JACOBI_2D-Seq.cpp`, and `src/polybench/POLYBENCH_JACOBI_2D-OMPTarget.cpp` lambda/raja variants to launch twice instead of once, to match other variants and programming models.
