### PR TITLE
Task/smith84/rsc 2026 6 0 lc ci errors

### DIFF
--- a/.gitlab/custom-variables.yml
+++ b/.gitlab/custom-variables.yml
@@ -57,7 +57,7 @@ variables:
 
   # Tuolumne (flux) allocation settings
   TUOLUMNE_SHARED_ALLOC: "OFF"
-  TUOLUMNE_JOB_ALLOC: "--queue=pci --nodes=1 --time-limit=15m"
+  TUOLUMNE_JOB_ALLOC: "--queue=pci --nodes=1 --time-limit=20m"
   # Arguments for performance job allocation (dedicated allocation with no overlapping).
   TUOLUMNE_PERF_ALLOC: "--queue=pci --exclusive --time-limit=15m --nodes=1"
   # Project specific variants for tuolumne

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -39,7 +39,6 @@ rocmcc_6_4_3_hip:
 
 rocmcc_6_4_3_hip_openmp:
   variables:
-    MODULE_LIST: "rocm/6.4.3"
     SPEC: "~shared +rocm +openmp amdgpu_target=gfx90a %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
     HSA_ENABLE_SDMA: "1"
     HSA_ENABLE_SDMA_COPY_SIZE_OVERRIDE: "0"
@@ -48,8 +47,7 @@ rocmcc_6_4_3_hip_openmp:
 
 rocmcc_6_4_3_hip_openmp_mpi:
   variables:
-    MODULE_LIST: "rocm/6.4.3"
-    SPEC: "~shared +rocm +openmp +mpi amdgpu_target=gfx90a %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
+    SPEC: "~shared +rocm +openmp +mpi amdgpu_target=gfx90a %llvm-amdgpu@=6.4.3 ^hip@6.4.3 ^cray-mpich%llvm-amdgpu@=6.4.3 ^blt%llvm-amdgpu@=6.4.3"
     HSA_ENABLE_SDMA: "1"
     HSA_ENABLE_SDMA_COPY_SIZE_OVERRIDE: "0"
     GPU_FORCE_BLIT_COPY_SIZE: "0"

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -48,6 +48,7 @@ rocmcc_6_4_3_hip_openmp:
 
 rocmcc_6_4_3_hip_openmp_mpi:
   variables:
+    MODULE_LIST: "rocm/6.4.3"
     SPEC: "~shared +rocm +openmp +mpi amdgpu_target=gfx90a %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
     HSA_ENABLE_SDMA: "1"
     HSA_ENABLE_SDMA_COPY_SIZE_OVERRIDE: "0"

--- a/.gitlab/jobs/tioga.yml
+++ b/.gitlab/jobs/tioga.yml
@@ -39,6 +39,7 @@ rocmcc_6_4_3_hip:
 
 rocmcc_6_4_3_hip_openmp:
   variables:
+    MODULE_LIST: "rocm/6.4.3"
     SPEC: "~shared +rocm +openmp amdgpu_target=gfx90a %llvm-amdgpu@=6.4.3 ^hip@6.4.3"
     HSA_ENABLE_SDMA: "1"
     HSA_ENABLE_SDMA_COPY_SIZE_OVERRIDE: "0"


### PR DESCRIPTION
Add cray-mpich specification to prevent ROCm 7 dependency on Tioga.
Increase job time limit to help with timeout issues on Tuolumne.