### PR TITLE
Implementation of Basic_MAT_MAT, a non shared memory variant of Basic_MAT_MAT_SHARED

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,6 +131,8 @@ blt_add_executable(
   basic/INIT_VIEW1D_OFFSET.cpp
   basic/INIT_VIEW1D_OFFSET-Seq.cpp
   basic/INIT_VIEW1D_OFFSET-OMPTarget.cpp
+  basic/MAT_MAT.cpp
+  basic/MAT_MAT-Seq.cpp
   basic/MAT_MAT_SHARED.cpp
   basic/MAT_MAT_SHARED-Seq.cpp
   basic/MULADDSUB.cpp

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -83,6 +83,12 @@ blt_add_library(
           INIT_VIEW1D_OFFSET-OMP.cpp
           INIT_VIEW1D_OFFSET-OMPTarget.cpp
           INIT_VIEW1D_OFFSET-Sycl.cpp
+          MAT_MAT.cpp
+          MAT_MAT-Seq.cpp
+          MAT_MAT-Hip.cpp
+          MAT_MAT-Cuda.cpp
+          MAT_MAT-OMP.cpp
+          MAT_MAT-Sycl.cpp
           MAT_MAT_SHARED.cpp
           MAT_MAT_SHARED-Seq.cpp
           MAT_MAT_SHARED-Hip.cpp

--- a/src/basic/MAT_MAT-Cuda.cpp
+++ b/src/basic/MAT_MAT-Cuda.cpp
@@ -1,0 +1,209 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+template < Index_type tile_size >
+  __launch_bounds__(tile_size*tile_size)
+__global__ void mat_mat(Index_type N, Real_ptr C, Real_ptr A,
+                        Real_ptr B) {
+
+  Index_type tx = threadIdx.x;
+  Index_type ty = threadIdx.y;
+  Index_type bx = blockIdx.x;
+  Index_type by = blockIdx.y;
+
+  MAT_MAT_BODY_1(tile_size)
+
+  for (Index_type k = 0; k < (tile_size + N - 1) / tile_size; k++) {
+
+    MAT_MAT_BODY_2(tile_size)
+  }
+
+  MAT_MAT_BODY_3(tile_size)
+}
+
+template < size_t block_size >
+void MAT_MAT::runCudaVariantImpl(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  constexpr Index_type tile_size = integer::sqrt(block_size);
+  static_assert(tile_size*tile_size == block_size, "Invalid block_size");
+
+  const Index_type run_reps = getRunReps();
+  const Index_type N = m_N;
+
+  dim3 blockDim(tile_size, tile_size);
+  dim3 gridDim(RAJA_DIVIDE_CEILING_INT(N, blockDim.x),
+               RAJA_DIVIDE_CEILING_INT(N, blockDim.y));
+  constexpr size_t shmem = 0;
+
+  const Index_type Nx = gridDim.x;
+  const Index_type Ny = gridDim.y;
+
+  auto res{getCudaResource()};
+
+  MAT_MAT_DATA_SETUP;
+
+  if (vid == Base_CUDA) {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      RPlaunchCudaKernel( (mat_mat<tile_size>),
+                          gridDim, blockDim,
+                          shmem, res.get_stream(),
+                          N, C, A, B );
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+    }
+    stopTimer();
+
+  } else if (vid == Lambda_CUDA) {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      auto mat_mat_lambda = [=] __device__() {
+
+        auto outer_y = [&](Index_type by) {
+          auto outer_x = [&](Index_type bx) {
+
+            auto inner_y = [&](Index_type ty) {
+              auto inner_x = [&](Index_type tx) {
+
+                MAT_MAT_BODY_1(tile_size)
+
+                for (Index_type k = 0; k < (tile_size + N - 1) / tile_size; ++k) {
+                  MAT_MAT_BODY_2(tile_size)
+                }
+
+                MAT_MAT_BODY_3(tile_size)
+              };
+
+              {
+                Index_type tx = threadIdx.x;
+                if (tx < tile_size)
+                  inner_x(tx);
+              }
+            };
+
+            {
+              Index_type ty = threadIdx.y;
+              if (ty < tile_size)
+                inner_y(ty);
+            }
+          }; // outer_x
+
+          {
+            Index_type bx = blockIdx.x;
+            if(bx < Nx) outer_x(bx);
+          }
+        };
+
+        {
+          Index_type by = blockIdx.y;
+          if(by < Ny) outer_y(by);
+        }
+      };
+
+      RPlaunchCudaKernel( (lambda_cuda<tile_size*tile_size,
+                                       decltype(mat_mat_lambda)>),
+                          gridDim, blockDim,
+                          shmem, res.get_stream(),
+                          mat_mat_lambda );
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+    }
+    stopTimer();
+
+  } else if (vid == RAJA_CUDA) {
+
+    constexpr bool async = true;
+
+    using launch_policy = RAJA::LaunchPolicy<RAJA::cuda_launch_t<async, tile_size*tile_size>>;
+
+    using teams_x = RAJA::LoopPolicy<RAJA::cuda_block_x_direct>;
+
+    using teams_y = RAJA::LoopPolicy<RAJA::cuda_block_y_direct>;
+
+    using threads_x = RAJA::LoopPolicy<RAJA::cuda_thread_size_x_direct<tile_size>>;
+
+    using threads_y = RAJA::LoopPolicy<RAJA::cuda_thread_size_y_direct<tile_size>>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      RAJA::launch<launch_policy>( res,
+        RAJA::LaunchParams(RAJA::Teams(Nx, Ny),
+                         RAJA::Threads(tile_size, tile_size)),
+        [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+          RAJA::loop<teams_y>(ctx, RAJA::RangeSegment(0, Ny),
+            [&](Index_type by) {
+              RAJA::loop<teams_x>(ctx, RAJA::RangeSegment(0, Nx),
+                [&](Index_type bx) {
+
+                  RAJA::loop<threads_y>(ctx, RAJA::RangeSegment(0, tile_size),
+                    [&](Index_type ty) {
+                      RAJA::loop<threads_x>(ctx, RAJA::RangeSegment(0, tile_size),
+                        [&](Index_type tx) {
+
+                          MAT_MAT_BODY_1(tile_size)
+
+                          for (Index_type k = 0; k < (tile_size + N - 1) / tile_size; k++) {
+                            MAT_MAT_BODY_2(tile_size)
+                          }  // for (k)
+
+                          MAT_MAT_BODY_3(tile_size)
+                        }
+                      );  // RAJA::loop<threads_x>
+                    }
+                  );  // RAJA::loop<threads_y>
+
+                }  // lambda (bx)
+              );  // RAJA::loop<teams_x>
+            }  // lambda (by)
+          );  // RAJA::loop<teams_y>
+
+        }   // outer lambda (ctx)
+      );  // RAJA::launch
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+
+    }  // loop over kernel reps
+    stopTimer();
+
+  } else {
+    getCout() << "\n  MAT_MAT : Unknown Cuda variant id = " << vid
+              << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(MAT_MAT, Cuda, Base_CUDA, Lambda_CUDA, RAJA_CUDA)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // RAJA_ENABLE_CUDA

--- a/src/basic/MAT_MAT-Hip.cpp
+++ b/src/basic/MAT_MAT-Hip.cpp
@@ -1,0 +1,209 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+#include "common/HipDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+template < Index_type tile_size >
+  __launch_bounds__(tile_size*tile_size)
+__global__ void mat_mat(Index_type N, Real_ptr C, Real_ptr A,
+                        Real_ptr B) {
+
+  Index_type tx = threadIdx.x;
+  Index_type ty = threadIdx.y;
+  Index_type bx = blockIdx.x;
+  Index_type by = blockIdx.y;
+
+  MAT_MAT_BODY_1(tile_size)
+
+  for (Index_type k = 0; k < (tile_size + N - 1) / tile_size; k++) {
+
+    MAT_MAT_BODY_2(tile_size)
+  }
+
+  MAT_MAT_BODY_3(tile_size)
+}
+
+template < size_t block_size >
+void MAT_MAT::runHipVariantImpl(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  constexpr Index_type tile_size = integer::sqrt(block_size);
+  static_assert(tile_size*tile_size == block_size, "Invalid block_size");
+
+  const Index_type run_reps = getRunReps();
+  const Index_type N = m_N;
+
+  dim3 blockDim(tile_size, tile_size);
+  dim3 gridDim(RAJA_DIVIDE_CEILING_INT(N, blockDim.x),
+               RAJA_DIVIDE_CEILING_INT(N, blockDim.y));
+  constexpr size_t shmem = 0;
+
+  const Index_type Nx = gridDim.x;
+  const Index_type Ny = gridDim.y;
+
+  auto res{getHipResource()};
+
+  MAT_MAT_DATA_SETUP;
+
+  if (vid == Base_HIP) {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      RPlaunchHipKernel( (mat_mat<tile_size>),
+                         gridDim, blockDim,
+                         shmem, res.get_stream(),
+                         N, C, A, B );
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+    }
+    stopTimer();
+
+  } else if (vid == Lambda_HIP) {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      auto mat_mat_lambda = [=] __device__() {
+
+        auto outer_y = [&](Index_type by) {
+          auto outer_x = [&](Index_type bx) {
+
+            auto inner_y = [&](Index_type ty) {
+              auto inner_x = [&](Index_type tx) {
+
+                MAT_MAT_BODY_1(tile_size)
+
+                for (Index_type k = 0; k < (tile_size + N - 1) / tile_size; ++k) {
+                  MAT_MAT_BODY_2(tile_size)
+                }
+
+                MAT_MAT_BODY_3(tile_size)
+              };
+
+              {
+                Index_type tx = threadIdx.x;
+                if (tx < tile_size)
+                  inner_x(tx);
+              }
+            };
+
+            {
+              Index_type ty = threadIdx.y;
+              if (ty < tile_size)
+                inner_y(ty);
+            }
+          }; // outer_x
+
+          {
+            Index_type bx = blockIdx.x;
+            if(bx < Nx) outer_x(bx);
+          }
+        };
+
+        {
+          Index_type by = blockIdx.y;
+          if(by < Ny) outer_y(by);
+        }
+      };
+
+      RPlaunchHipKernel( (lambda_hip<tile_size*tile_size,
+                                     decltype(mat_mat_lambda)>),
+                         gridDim, blockDim,
+                         shmem, res.get_stream(),
+                         mat_mat_lambda );
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+    }
+    stopTimer();
+
+  } else if (vid == RAJA_HIP) {
+
+    constexpr bool async = true;
+
+    using launch_policy = RAJA::LaunchPolicy<RAJA::hip_launch_t<async, tile_size*tile_size>>;
+
+    using teams_x = RAJA::LoopPolicy<RAJA::hip_block_x_direct>;
+
+    using teams_y = RAJA::LoopPolicy<RAJA::hip_block_y_direct>;
+
+    using threads_x = RAJA::LoopPolicy<RAJA::hip_thread_size_x_direct<tile_size>>;
+
+    using threads_y = RAJA::LoopPolicy<RAJA::hip_thread_size_y_direct<tile_size>>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      RAJA::launch<launch_policy>( res,
+        RAJA::LaunchParams(RAJA::Teams(Nx, Ny),
+                         RAJA::Threads(tile_size, tile_size)),
+        [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+          RAJA::loop<teams_y>(ctx, RAJA::RangeSegment(0, Ny),
+            [&](Index_type by) {
+              RAJA::loop<teams_x>(ctx, RAJA::RangeSegment(0, Nx),
+                [&](Index_type bx) {
+
+                  RAJA::loop<threads_y>(ctx, RAJA::RangeSegment(0, tile_size),
+                    [&](Index_type ty) {
+                      RAJA::loop<threads_x>(ctx, RAJA::RangeSegment(0, tile_size),
+                        [&](Index_type tx) {
+
+                          MAT_MAT_BODY_1(tile_size)
+
+                          for (Index_type k = 0; k < (tile_size + N - 1) / tile_size; k++) {
+                            MAT_MAT_BODY_2(tile_size)
+                          }  // for (k)
+
+                          MAT_MAT_BODY_3(tile_size)
+                        }
+                      );  // RAJA::loop<threads_x>
+                    }
+                  );  // RAJA::loop<threads_y>
+
+                }  // lambda (bx)
+              );  // RAJA::loop<teams_x>
+            }  // lambda (by)
+          );  // RAJA::loop<teams_y>
+
+        }  // outer lambda (ctx)
+      );  // RAJA::launch
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+
+    }  // loop over kernel reps
+    stopTimer();
+
+  } else {
+    getCout() << "\n  MAT_MAT : Unknown Hip variant id = " << vid
+              << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(MAT_MAT, Hip, Base_HIP, Lambda_HIP, RAJA_HIP)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // RAJA_ENABLE_HIP

--- a/src/basic/MAT_MAT-OMP.cpp
+++ b/src/basic/MAT_MAT-OMP.cpp
@@ -1,0 +1,192 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void MAT_MAT::runOpenMPVariant(VariantID vid) {
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+
+  const Index_type run_reps = getRunReps();
+  const Index_type N = m_N;
+
+  MAT_MAT_DATA_SETUP;
+
+  const Index_type Nx = RAJA_DIVIDE_CEILING_INT(N, MAT_MAT_TL_SZ);
+  const Index_type Ny = RAJA_DIVIDE_CEILING_INT(N, MAT_MAT_TL_SZ);
+
+  switch (vid) {
+
+  case Base_OpenMP: {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+#pragma omp parallel
+      {
+#pragma omp for
+        for (Index_type by = 0; by < Ny; ++by) {
+          for (Index_type bx = 0; bx < Nx; ++bx) {
+
+            for (Index_type ty = 0; ty < MAT_MAT_TL_SZ; ++ty) {
+              for (Index_type tx = 0; tx < MAT_MAT_TL_SZ; ++tx) {
+
+                MAT_MAT_BODY_1(MAT_MAT_TL_SZ)
+
+                for (Index_type k = 0; k < (MAT_MAT_TL_SZ + N - 1) / MAT_MAT_TL_SZ; ++k) {
+                  MAT_MAT_BODY_2(MAT_MAT_TL_SZ)
+                }
+
+                MAT_MAT_BODY_3(MAT_MAT_TL_SZ)
+              }
+            }
+          }
+        }
+      }
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+    }
+    stopTimer();
+
+    break;
+  }
+
+  case Lambda_OpenMP: {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      auto outer_y = [&](Index_type by) {
+        auto outer_x = [&](Index_type bx) {
+
+          auto inner_y = [&](Index_type ty) {
+            auto inner_x = [&](Index_type tx) {
+
+              MAT_MAT_BODY_1(MAT_MAT_TL_SZ)
+
+              for (Index_type k = 0; k < (MAT_MAT_TL_SZ + N - 1) / MAT_MAT_TL_SZ; ++k) {
+                MAT_MAT_BODY_2(MAT_MAT_TL_SZ)
+              }
+
+              MAT_MAT_BODY_3(MAT_MAT_TL_SZ)
+            };
+
+            for (Index_type tx = 0; tx < MAT_MAT_TL_SZ; ++tx) {
+              if (tx < MAT_MAT_TL_SZ)
+                inner_x(tx);
+            }
+          };
+
+          for (Index_type ty = 0; ty < MAT_MAT_TL_SZ; ++ty) {
+            if (ty < MAT_MAT_TL_SZ)
+              inner_y(ty);
+          }
+        }; // outer_x
+
+        for (Index_type bx = 0; bx < Nx; ++bx) {
+          outer_x(bx);
+        }
+      };
+
+#pragma omp parallel for
+      for (Index_type by = 0; by < Ny; ++by) {
+        outer_y(by);
+      }
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+    }
+    stopTimer();
+
+    break;
+  }
+
+  case RAJA_OpenMP: {
+
+    auto res{getHostResource()};
+
+    using launch_policy = RAJA::LaunchPolicy<RAJA::omp_launch_t>;
+
+    using outer_x = RAJA::LoopPolicy<RAJA::omp_for_exec>;
+
+    using outer_y = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+    using inner_x = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+    using inner_y = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      //Grid is empty as the host does not need a compute grid to be specified
+      RAJA::launch<launch_policy>( res,
+        RAJA::LaunchParams(),
+        [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+          RAJA::loop<outer_y>(ctx, RAJA::RangeSegment(0, Ny),
+            [&](Index_type by) {
+              RAJA::loop<outer_x>(ctx, RAJA::RangeSegment(0, Nx),
+                [&](Index_type bx) {
+
+                  RAJA::loop<inner_y>(ctx, RAJA::RangeSegment(0, MAT_MAT_TL_SZ),
+                    [&](Index_type ty) {
+                      RAJA::loop<inner_x>(ctx, RAJA::RangeSegment(0, MAT_MAT_TL_SZ),
+                        [&](Index_type tx) {
+
+                          MAT_MAT_BODY_1(MAT_MAT_TL_SZ)
+
+                          for (Index_type k = 0; k < (MAT_MAT_TL_SZ + N - 1) / MAT_MAT_TL_SZ; k++) {
+                            MAT_MAT_BODY_2(MAT_MAT_TL_SZ)
+                          }  // for (k)
+
+                          MAT_MAT_BODY_3(MAT_MAT_TL_SZ)
+                        }
+                      );  // RAJA::loop<inner_x>
+                    }
+                  );  // RAJA::loop<inner_y>
+
+                }  // lambda (bx)
+              );  // RAJA::loop<outer_x>
+            }  // lambda (by)
+          );  // RAJA::loop<outer_y>
+
+        }  // outer lambda (ctx)
+      );  // RAJA::launch
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+
+    }  // loop over kernel reps
+    stopTimer();
+
+    break;
+  }
+
+  default: {
+    getCout() << "\n  MAT_MAT : Unknown variant id = " << vid
+              << std::endl;
+  }
+  }
+
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(MAT_MAT, OpenMP, Base_OpenMP, Lambda_OpenMP, RAJA_OpenMP)
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/MAT_MAT-Seq.cpp
+++ b/src/basic/MAT_MAT-Seq.cpp
@@ -1,0 +1,181 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT.hpp"
+
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void MAT_MAT::runSeqVariant(VariantID vid) {
+
+  const Index_type run_reps = getRunReps();
+  const Index_type N = m_N;
+
+  MAT_MAT_DATA_SETUP;
+  const Index_type Nx = RAJA_DIVIDE_CEILING_INT(N, MAT_MAT_TL_SZ);
+  const Index_type Ny = RAJA_DIVIDE_CEILING_INT(N, MAT_MAT_TL_SZ);
+
+  switch (vid) {
+
+  case Base_Seq: {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      for (Index_type by = 0; by < Ny; ++by) {
+        for (Index_type bx = 0; bx < Nx; ++bx) {
+
+          for (Index_type ty = 0; ty < MAT_MAT_TL_SZ; ++ty) {
+            for (Index_type tx = 0; tx < MAT_MAT_TL_SZ; ++tx) {
+
+              MAT_MAT_BODY_1(MAT_MAT_TL_SZ)
+
+              for (Index_type k = 0; k < (MAT_MAT_TL_SZ + N - 1) / MAT_MAT_TL_SZ; ++k) {
+                MAT_MAT_BODY_2(MAT_MAT_TL_SZ)
+              } // Sequential loop
+
+              MAT_MAT_BODY_3(MAT_MAT_TL_SZ)
+            }
+          }
+        }
+      }
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+
+    } // number of iterations
+    stopTimer();
+
+    break;
+  }
+
+#if defined(RUN_RAJA_SEQ)
+  case Lambda_Seq: {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      auto outer_y = [&](Index_type by) {
+        auto outer_x = [&](Index_type bx) {
+
+          auto inner_y = [&](Index_type ty) {
+            auto inner_x = [&](Index_type tx) {
+
+              MAT_MAT_BODY_1(MAT_MAT_TL_SZ)
+
+              for (Index_type k = 0; k < (MAT_MAT_TL_SZ + N - 1) / MAT_MAT_TL_SZ; ++k) {
+                MAT_MAT_BODY_2(MAT_MAT_TL_SZ)
+              }
+
+              MAT_MAT_BODY_3(MAT_MAT_TL_SZ)
+            };
+
+            for (Index_type tx = 0; tx < MAT_MAT_TL_SZ; ++tx) {
+              if (tx < MAT_MAT_TL_SZ)
+                inner_x(tx);
+            }
+          };
+
+          for (Index_type ty = 0; ty < MAT_MAT_TL_SZ; ++ty) {
+            if (ty < MAT_MAT_TL_SZ)
+              inner_y(ty);
+          }
+        }; // outer_x
+
+        for (Index_type bx = 0; bx < Nx; ++bx) {
+          outer_x(bx);
+        }
+      };
+
+      for (Index_type by = 0; by < Ny; ++by) {
+        outer_y(by);
+      }
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+    } // irep
+    stopTimer();
+
+    break;
+  }
+
+  case RAJA_Seq: {
+
+    auto res{getHostResource()};
+
+    using launch_policy = RAJA::LaunchPolicy<RAJA::seq_launch_t>;
+
+    using outer_x = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+    using outer_y = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+    using inner_x = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+    using inner_y = RAJA::LoopPolicy<RAJA::seq_exec>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      //Grid is empty as the host does not need a compute grid to be specified
+      RAJA::launch<launch_policy>( res,
+        RAJA::LaunchParams(),
+        [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+          RAJA::loop<outer_y>(ctx, RAJA::RangeSegment(0, Ny),
+            [&](Index_type by) {
+              RAJA::loop<outer_x>(ctx, RAJA::RangeSegment(0, Nx),
+                [&](Index_type bx) {
+
+                  RAJA::loop<inner_y>(ctx, RAJA::RangeSegment(0, MAT_MAT_TL_SZ),
+                    [&](Index_type ty) {
+                      RAJA::loop<inner_x>(ctx, RAJA::RangeSegment(0, MAT_MAT_TL_SZ),
+                        [&](Index_type tx) {
+
+                          MAT_MAT_BODY_1(MAT_MAT_TL_SZ)
+
+                          for (Index_type k = 0; k < (MAT_MAT_TL_SZ + N - 1) / MAT_MAT_TL_SZ; k++) {
+                            MAT_MAT_BODY_2(MAT_MAT_TL_SZ)
+                          }  // for (k)
+
+                          MAT_MAT_BODY_3(MAT_MAT_TL_SZ)
+                        }
+                      );  // RAJA::loop<inner_x>
+                    }
+                  );  // RAJA::loop<inner_y>
+
+                }  // lambda (bx)
+              );  // RAJA::loop<outer_x>
+            }  // lambda (by)
+          );  // RAJA::loop<outer_y>
+
+        }  // outer lambda (ctx)
+      );  // RAJA::launch
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+    }  // loop over kernel reps
+    stopTimer();
+
+    break;
+  }
+#endif // RUN_RAJA_SEQ
+
+  default: {
+    getCout() << "\n  MAT_MAT : Unknown variant id = " << vid
+              << std::endl;
+  }
+  }
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(MAT_MAT, Seq, Base_Seq, Lambda_Seq, RAJA_Seq)
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/MAT_MAT-Sycl.cpp
+++ b/src/basic/MAT_MAT-Sycl.cpp
@@ -1,0 +1,156 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_SYCL)
+
+#include "common/SyclDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+template < size_t work_group_size >
+void MAT_MAT::runSyclVariantImpl(VariantID vid)
+{
+  setBlockSize(work_group_size);
+
+  constexpr Index_type tile_size = integer::sqrt(work_group_size);
+  static_assert(tile_size*tile_size == work_group_size, "Invalid block_size");
+
+  const Index_type run_reps = getRunReps();
+  const Index_type N = m_N;
+
+  const Index_type Nx = RAJA_DIVIDE_CEILING_INT(N, tile_size);
+  const Index_type Ny = RAJA_DIVIDE_CEILING_INT(N, tile_size);
+
+  //Right most is the fastest index
+  const ::sycl::range<3> workGroupSize(1, tile_size, tile_size);
+  const ::sycl::range<3> gridSize(1, Ny*tile_size, Nx*tile_size);
+
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
+  MAT_MAT_DATA_SETUP;
+
+  if (vid == Base_SYCL) {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      qu->submit([&](::sycl::handler& h) {
+
+        //No local accessors are needed as nothing is shared between
+        //work-items in this variant
+
+        h.parallel_for
+          (::sycl::nd_range<3>(gridSize, workGroupSize),
+           [=] (::sycl::nd_item<3> itm) {
+
+             Index_type tx = itm.get_local_id(2);
+             Index_type ty = itm.get_local_id(1);
+             Index_type bx = itm.get_group(2);
+             Index_type by = itm.get_group(1);
+
+             MAT_MAT_BODY_1(tile_size)
+
+               for (Index_type k = 0; k < (tile_size + N - 1) / tile_size; k++) {
+
+                 MAT_MAT_BODY_2(tile_size)
+               }
+
+             MAT_MAT_BODY_3(tile_size)
+
+           });
+
+      });
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+
+
+    }
+    stopTimer();
+
+  } else if (vid == RAJA_SYCL) {
+
+    constexpr bool async = true;
+
+    using launch_policy = RAJA::LaunchPolicy<RAJA::sycl_launch_t<async>>;
+
+    using teams_x = RAJA::LoopPolicy<RAJA::sycl_group_2_direct>;
+
+    using teams_y = RAJA::LoopPolicy<RAJA::sycl_group_1_direct>;
+
+    using threads_x = RAJA::LoopPolicy<RAJA::sycl_local_2_direct>;
+
+    using threads_y = RAJA::LoopPolicy<RAJA::sycl_local_1_direct>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_1");
+      RAJA::launch<launch_policy>( res,
+        RAJA::LaunchParams(RAJA::Teams(Nx, Ny),
+                           RAJA::Threads(tile_size, tile_size)),
+        [=] RAJA_HOST_DEVICE(RAJA::LaunchContext ctx) {
+
+          RAJA::loop<teams_y>(ctx, RAJA::RangeSegment(0, Ny),
+            [&](Index_type by) {
+              RAJA::loop<teams_x>(ctx, RAJA::RangeSegment(0, Nx),
+                [&](Index_type bx) {
+
+                  RAJA::loop<threads_y>(ctx, RAJA::RangeSegment(0, tile_size),
+                    [&](Index_type ty) {
+                      RAJA::loop<threads_x>(ctx, RAJA::RangeSegment(0, tile_size),
+                        [&](Index_type tx) {
+
+                          MAT_MAT_BODY_1(tile_size)
+
+                          for (Index_type k = 0; k < (tile_size + N - 1) / tile_size; k++) {
+                            MAT_MAT_BODY_2(tile_size)
+                          }  // for (k)
+
+                          MAT_MAT_BODY_3(tile_size)
+                        }
+                      );  // RAJA::loop<threads_x>
+                    }
+                  );  // RAJA::loop<threads_y>
+
+                }  // lambda (bx)
+              );  // RAJA::loop<teams_x>
+            }  // lambda (by)
+          );  // RAJA::loop<teams_y>
+
+        }   // outer lambda (ctx)
+      );  // RAJA::launch
+      RP_CALI_SUBKERNEL_END("MAT_MAT_1");
+
+    }  // loop over kernel reps
+    stopTimer();
+
+  } else {
+    getCout() << "\n  MAT_MAT : Unknown Sycl variant id = " << vid
+              << std::endl;
+  }
+
+}
+
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(MAT_MAT, Sycl, Base_SYCL, RAJA_SYCL)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // RAJA_ENABLE_SYCL

--- a/src/basic/MAT_MAT.cpp
+++ b/src/basic/MAT_MAT.cpp
@@ -1,0 +1,87 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
+#include <algorithm>
+
+namespace rajaperf {
+namespace basic {
+
+MAT_MAT::MAT_MAT(const RunParams &params)
+    : KernelBase(rajaperf::Basic_MAT_MAT, params)
+{
+  m_N_default = 1000;
+  setDefaultProblemSize(m_N_default*m_N_default);
+  setDefaultReps(5);
+
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning); // Change to Inconsistent if internal reductions use atomics
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N_to_the_three_halves);
+
+  setMaxPerfectLoopDimensions(2);
+  setProblemDimensionality(2);
+
+  setUsesFeature(Launch);
+
+  addVariantTunings();
+}
+
+void MAT_MAT::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_N = std::sqrt(target_size) + std::sqrt(2)-1;
+  const Index_type num_tiles = RAJA_DIVIDE_CEILING_INT(m_N, MAT_MAT_TL_SZ);
+
+  setActualProblemSize(m_N*m_N);
+  setRunReps( target_reps );
+
+  setItsPerRep( num_tiles*num_tiles * MAT_MAT_TL_SZ*MAT_MAT_TL_SZ );
+  setKernelsPerRep(1);
+
+  setBytesAllocatedPerRep( 3*sizeof(Real_type) * m_N*m_N ); // A, B, C
+  setBytesReadPerRep( 2*sizeof(Real_type) * m_N*m_N ); // A, B
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * m_N*m_N  ); // C
+  setBytesModifyWrittenPerRep( 0 );
+  setBytesAtomicModifyWrittenPerRep( 0 );
+
+  setFLOPsPerRep(2 * MAT_MAT_TL_SZ * MAT_MAT_TL_SZ * MAT_MAT_TL_SZ *
+                 num_tiles * num_tiles * num_tiles);
+}
+
+MAT_MAT::~MAT_MAT() {}
+
+void MAT_MAT::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  allocAndInitDataConst(m_A, m_N*m_N, 1.0, vid);
+  allocAndInitDataConst(m_B, m_N*m_N, 1.0, vid);
+  allocAndInitDataConst(m_C, m_N*m_N, 0.0, vid);
+}
+
+void MAT_MAT::updateChecksum(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  addToChecksum(m_C, m_N*m_N, vid);
+}
+
+void MAT_MAT::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  deallocData(m_A, vid);
+  deallocData(m_B, vid);
+  deallocData(m_C, vid);
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/MAT_MAT.hpp
+++ b/src/basic/MAT_MAT.hpp
@@ -1,0 +1,136 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// Matrix matrix multiplication with tiling, but WITHOUT shared memory
+/// reference implementation:
+///
+/// This kernel is the companion of MAT_MAT_SHARED. It uses the identical
+/// tiled decomposition of the iteration space and computes the identical
+/// result, but each thread accumulates into a private scalar and reads A and
+/// B directly from global memory, rather than the team cooperatively staging
+/// tiles of A and B into shared memory. Because nothing is shared between
+/// threads, the separate tile-load phase and the team synchronizations it
+/// requires are both gone. Comparing the two kernels therefore isolates the
+/// cost/benefit of the shared memory staging alone.
+///
+///      for (Index_type by = 0; by < Ny; ++by) {
+///        for (Index_type bx = 0; bx < Nx; ++bx) {
+///
+///          for (Index_type ty = 0; ty < TL_SZ; ++ty) {
+///            for (Index_type tx = 0; tx < TL_SZ; ++tx) {
+///
+///              const Index_type Row = by * TL_SZ + ty;
+///              const Index_type Col = bx * TL_SZ + tx;
+///              double dot = 0.0;
+///
+///              for (Index_type k = 0; k < (TL_SZ + N - 1) / TL_SZ; ++k) {
+///                for (Index_type n = 0; n < TL_SZ; ++n) {
+///                  const Index_type kn = k * TL_SZ + n;
+///                  const double a = (kn < N && Row < N) ? A[Row * N + kn] : 0.0;
+///                  const double b = (kn < N && Col < N) ? B[kn * N + Col] : 0.0;
+///                  dot += a * b;
+///                }
+///              }
+///
+///              if (Row < N && Col < N)
+///                C[Col + N * Row] = dot;
+///            }
+///          }
+///        }
+///      }
+///
+///
+
+#ifndef RAJAPerf_Basic_MAT_MAT_HPP
+#define RAJAPerf_Basic_MAT_MAT_HPP
+
+#include "RAJA/RAJA.hpp"
+#include "common/KernelBase.hpp"
+
+//
+// Tile size. Named distinctly from MAT_MAT_SHARED's TL_SZ because both
+// headers are included by common/RAJAPerfSuite.cpp.
+//
+constexpr rajaperf::Index_type MAT_MAT_TL_SZ = 16;
+
+#define MAT_MAT_DATA_SETUP                                                     \
+  Real_ptr A = m_A;                                                            \
+  Real_ptr B = m_B;                                                            \
+  Real_ptr C = m_C;
+
+//
+// Unlike MAT_MAT_SHARED, no RAJA_TEAM_SHARED arrays are declared, so there is
+// no BODY_0 and no need for the CLANG/HIP host-compile workaround.
+//
+#define MAT_MAT_BODY_1(tile_size)                                              \
+  const Index_type Row = by * tile_size + ty;                                  \
+  const Index_type Col = bx * tile_size + tx;                                  \
+  Real_type dot = 0.0;
+
+#define MAT_MAT_BODY_2(tile_size)                                              \
+  for (Index_type n = 0; n < tile_size; ++n) {                                 \
+    const Index_type kn = k * tile_size + n;                                   \
+    const Real_type a_kn = (kn < N && Row < N) ? A[Row * N + kn] : 0.0;        \
+    const Real_type b_kn = (kn < N && Col < N) ? B[kn * N + Col] : 0.0;        \
+    dot += a_kn * b_kn;                                                        \
+  }
+
+#define MAT_MAT_BODY_3(tile_size)                                              \
+  if (Row < N && Col < N)                                                      \
+    C[Col + N * Row] = dot;
+
+namespace rajaperf {
+class RunParams;
+
+namespace basic {
+
+class MAT_MAT : public KernelBase {
+public:
+  MAT_MAT(const RunParams &params);
+
+  ~MAT_MAT();
+
+  void setSize(Index_type target_size, Index_type target_reps);
+  void setUp(VariantID vid, size_t tune_idx);
+  void updateChecksum(VariantID vid, size_t tune_idx);
+  void tearDown(VariantID vid, size_t tune_idx);
+
+  void defineSeqVariantTunings();
+  void defineOpenMPVariantTunings();
+  void defineCudaVariantTunings();
+  void defineHipVariantTunings();
+  void defineSyclVariantTunings();
+
+  void runSeqVariant(VariantID vid);
+  void runOpenMPVariant(VariantID vid);
+
+  template < size_t block_size >
+  void runCudaVariantImpl(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantImpl(VariantID vid);
+  template < size_t work_group_size >
+  void runSyclVariantImpl(VariantID vid);
+
+private:
+  static const size_t default_gpu_block_size = MAT_MAT_TL_SZ * MAT_MAT_TL_SZ;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size, integer::ExactSqrt>;
+
+  Real_ptr m_A;
+  Real_ptr m_B;
+  Real_ptr m_C;
+
+  Index_type m_N;
+  Index_type m_N_default;
+};
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/basic/MAT_MAT_SHARED-OMP.cpp
+++ b/src/basic/MAT_MAT_SHARED-OMP.cpp
@@ -34,7 +34,7 @@ void MAT_MAT_SHARED::runOpenMPVariant(VariantID vid) {
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_SHARED_1");
+      RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_SHARED_1");
 #pragma omp parallel
       {
 #pragma omp for
@@ -76,7 +76,7 @@ RP_CALI_SUBKERNEL_BEGIN("MAT_MAT_SHARED_1");
           }
         }
       }
-RP_CALI_SUBKERNEL_END("MAT_MAT_SHARED_1");
+      RP_CALI_SUBKERNEL_END("MAT_MAT_SHARED_1");
     }
     stopTimer();
 

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -29,6 +29,7 @@
 #include "basic/INIT3.hpp"
 #include "basic/INIT_VIEW1D.hpp"
 #include "basic/INIT_VIEW1D_OFFSET.hpp"
+#include "basic/MAT_MAT.hpp"
 #include "basic/MAT_MAT_SHARED.hpp"
 #include "basic/MULADDSUB.hpp"
 #include "basic/NESTED_INIT.hpp"
@@ -189,6 +190,7 @@ static const std::string KernelNames [] =
   std::string("Basic_INIT3"),
   std::string("Basic_INIT_VIEW1D"),
   std::string("Basic_INIT_VIEW1D_OFFSET"),
+  std::string("Basic_MAT_MAT"),
   std::string("Basic_MAT_MAT_SHARED"),
   std::string("Basic_MULADDSUB"),
   std::string("Basic_NESTED_INIT"),
@@ -988,6 +990,10 @@ KernelBase* getKernelObject(KernelID kid,
     }
     case Basic_INIT_VIEW1D_OFFSET : {
        kernel = new basic::INIT_VIEW1D_OFFSET(run_params);
+       break;
+    }
+    case Basic_MAT_MAT : {
+       kernel = new basic::MAT_MAT(run_params);
        break;
     }
     case Basic_MAT_MAT_SHARED : {

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -89,6 +89,7 @@ enum KernelID {
   Basic_INIT3,
   Basic_INIT_VIEW1D,
   Basic_INIT_VIEW1D_OFFSET,
+  Basic_MAT_MAT,
   Basic_MAT_MAT_SHARED,
   Basic_MULADDSUB,
   Basic_NESTED_INIT,


### PR DESCRIPTION
# Summary

- Adds `Basic_MAT_MAT`, a non-shared-memory variant of `Basic_MAT_MAT_SHARED`.

# Motivation

In a performance study comparing NVIDIA and AMD GPUs on the same kernels, we observed a large NVIDIA/AMD performance gap for `Polybench_GEMM`, while the gap was much narrower for `Basic_MAT_MAT_SHARED`.

This PR adds `Basic_MAT_MAT` to isolate the effect of shared memory and compare the same tiled matrix-matrix computation without shared-memory staging.