### PR TITLE
Multi Dim Grid Size Option

### DIFF
--- a/src/apps/AppsData.hpp
+++ b/src/apps/AppsData.hpp
@@ -10,6 +10,7 @@
 #ifndef RAJAPerf_AppsData_HPP
 #define RAJAPerf_AppsData_HPP
 
+#include <array>
 #include <ostream>
 
 #include "common/RPTypes.hpp"
@@ -48,9 +49,47 @@ class ADomain
 {
 public:
 
+   struct Nodal {};
+   struct Zonal {};
+
    ADomain() = delete;
 
    ADomain( Index_type real_nodes_per_dim, Index_type ndims )
+      : ADomain(Nodal{}, {real_nodes_per_dim, real_nodes_per_dim, real_nodes_per_dim}, ndims)
+   {
+   }
+
+   ADomain( Zonal,
+            Index_type real_zones_i,
+            Index_type real_zones_j)
+      : ADomain(Nodal{}, {real_zones_i+1, real_zones_j+1, 0}, 2)
+   {
+   }
+
+   ADomain( Zonal,
+            Index_type real_zones_i,
+            Index_type real_zones_j,
+            Index_type real_zones_k)
+      : ADomain(Nodal{}, {real_zones_i+1, real_zones_j+1, real_zones_k+1}, 3)
+   {
+   }
+
+   ADomain( Nodal,
+            Index_type real_nodes_i,
+            Index_type real_nodes_j)
+      : ADomain(Nodal{}, {real_nodes_i, real_nodes_j, 0}, 2)
+   {
+   }
+
+   ADomain( Nodal,
+            Index_type real_nodes_i,
+            Index_type real_nodes_j,
+            Index_type real_nodes_k)
+      : ADomain(Nodal{}, {real_nodes_i, real_nodes_j, real_nodes_k}, 3)
+   {
+   }
+
+   ADomain( Nodal, std::array<Index_type, 3> dims, Index_type ndims)
       : ndims(ndims), NPNL(2), NPNR(1)
    {
       int NPZL = NPNL - 1;
@@ -58,7 +97,7 @@ public:
 
       if ( ndims >= 1 ) {
          imin = NPNL;
-         imax = NPNL + real_nodes_per_dim-1;
+         imax = NPNL + dims[0]-1;
          nnalls = (imax+1 - imin + NPNL + NPNR);
          n_real_zones = (imax - imin);
          n_real_nodes = (imax+1 - imin);
@@ -70,7 +109,7 @@ public:
 
       if ( ndims >= 2 ) {
          jmin = NPNL;
-         jmax = NPNL + real_nodes_per_dim-1;
+         jmax = NPNL + dims[1]-1;
          jp = nnalls;
          nnalls *= (jmax+1 - jmin + NPNL + NPNR);
          n_real_zones *= (jmax - jmin);
@@ -83,7 +122,7 @@ public:
 
       if ( ndims >= 3 ) {
          kmin = NPNL;
-         kmax = NPNL + real_nodes_per_dim-1;
+         kmax = NPNL + dims[2]-1;
          kp = nnalls;
          nnalls *= (kmax+1 - kmin + NPNL + NPNR);
          n_real_zones *= (kmax - kmin);

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -26,6 +26,9 @@ namespace apps
 DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
   : KernelBase(rajaperf::Apps_DEL_DOT_VEC_2D, params)
 {
+  m_i_zones = params.getADomain2DIZones();
+  m_j_zones = params.getADomain2DJZones();
+
   setDefaultProblemSize(1000*1000);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
@@ -47,8 +50,13 @@ DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
 
 void DEL_DOT_VEC_2D::setSize(Index_type target_size, Index_type target_reps)
 {
-  Index_type rzmax = std::sqrt(target_size) + 1 + std::sqrt(2)-1;
-  m_domain.reset(new ADomain(rzmax, /* ndims = */ 2));
+  if (!run_params.useADomain2DMeshDims())
+  {
+    Index_type rzmax = std::sqrt(target_size) + 1 + std::sqrt(2)-1;
+    m_i_zones = rzmax-1;
+    m_j_zones = rzmax-1;
+  }
+  m_domain.reset(new ADomain(ADomain::Zonal{}, m_i_zones, m_j_zones));
 
   m_array_length = m_domain->nnalls;
 

--- a/src/apps/DEL_DOT_VEC_2D.cpp
+++ b/src/apps/DEL_DOT_VEC_2D.cpp
@@ -26,8 +26,8 @@ namespace apps
 DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
   : KernelBase(rajaperf::Apps_DEL_DOT_VEC_2D, params)
 {
-  m_i_zones = params.getADomain2DIZones();
-  m_j_zones = params.getADomain2DJZones();
+  m_i_zones = params.getGrid2DMeshX();
+  m_j_zones = params.getGrid2DMeshY();
 
   setDefaultProblemSize(1000*1000);  // See rzmax in ADomain struct
   setDefaultReps(100);
@@ -50,7 +50,7 @@ DEL_DOT_VEC_2D::DEL_DOT_VEC_2D(const RunParams& params)
 
 void DEL_DOT_VEC_2D::setSize(Index_type target_size, Index_type target_reps)
 {
-  if (!run_params.useADomain2DMeshDims())
+  if (!run_params.useGrid2DMeshDims())
   {
     Index_type rzmax = std::sqrt(target_size) + 1 + std::sqrt(2)-1;
     m_i_zones = rzmax-1;

--- a/src/apps/DEL_DOT_VEC_2D.hpp
+++ b/src/apps/DEL_DOT_VEC_2D.hpp
@@ -146,6 +146,8 @@ private:
   Real_type m_ptiny;
   Real_type m_half;
 
+  Index_type m_i_zones;
+  Index_type m_j_zones;
   std::unique_ptr<ADomain> m_domain;
   Index_type* m_real_zones;
   Index_type m_array_length;

--- a/src/apps/EDGE3D.cpp
+++ b/src/apps/EDGE3D.cpp
@@ -26,6 +26,10 @@ namespace apps
 EDGE3D::EDGE3D(const RunParams& params)
   : KernelBase(rajaperf::Apps_EDGE3D, params)
 {
+  m_i_zones = params.getADomain3DIZones();
+  m_j_zones = params.getADomain3DJZones();
+  m_k_zones = params.getADomain3DKZones();
+
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(10);
 
@@ -47,8 +51,14 @@ EDGE3D::EDGE3D(const RunParams& params)
 
 void EDGE3D::setSize(Index_type target_size, Index_type target_reps)
 {
-  Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
-  m_domain.reset(new ADomain(rzmax, /* ndims = */ 3));
+  if (!run_params.useADomain3DMeshDims())
+  {
+    Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
+    m_i_zones = rzmax-1;
+    m_j_zones = rzmax-1;
+    m_k_zones = rzmax-1;
+  }
+  m_domain.reset(new ADomain(ADomain::Zonal{}, m_i_zones, m_j_zones, m_k_zones));
 
   m_array_length = m_domain->nnalls;
   size_t number_of_elements = m_domain->lpz+1 - m_domain->fpz;

--- a/src/apps/EDGE3D.cpp
+++ b/src/apps/EDGE3D.cpp
@@ -26,9 +26,9 @@ namespace apps
 EDGE3D::EDGE3D(const RunParams& params)
   : KernelBase(rajaperf::Apps_EDGE3D, params)
 {
-  m_i_zones = params.getADomain3DIZones();
-  m_j_zones = params.getADomain3DJZones();
-  m_k_zones = params.getADomain3DKZones();
+  m_i_zones = params.getGrid3DMeshX();
+  m_j_zones = params.getGrid3DMeshY();
+  m_k_zones = params.getGrid3DMeshZ();
 
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(10);
@@ -51,7 +51,7 @@ EDGE3D::EDGE3D(const RunParams& params)
 
 void EDGE3D::setSize(Index_type target_size, Index_type target_reps)
 {
-  if (!run_params.useADomain3DMeshDims())
+  if (!run_params.useGrid3DMeshDims())
   {
     Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
     m_i_zones = rzmax-1;

--- a/src/apps/EDGE3D.hpp
+++ b/src/apps/EDGE3D.hpp
@@ -441,6 +441,9 @@ private:
   Real_ptr m_z;
   Real_ptr m_sum;
 
+  Index_type m_i_zones;
+  Index_type m_j_zones;
+  Index_type m_k_zones;
   std::unique_ptr<ADomain> m_domain;
   Index_type m_array_length;
 };

--- a/src/apps/MATVEC_3D_STENCIL.cpp
+++ b/src/apps/MATVEC_3D_STENCIL.cpp
@@ -26,9 +26,9 @@ namespace apps
 MATVEC_3D_STENCIL::MATVEC_3D_STENCIL(const RunParams& params)
   : KernelBase(rajaperf::Apps_MATVEC_3D_STENCIL, params)
 {
-  m_i_zones = params.getADomain3DIZones();
-  m_j_zones = params.getADomain3DJZones();
-  m_k_zones = params.getADomain3DKZones();
+  m_i_zones = params.getGrid3DMeshX();
+  m_j_zones = params.getGrid3DMeshY();
+  m_k_zones = params.getGrid3DMeshZ();
 
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
@@ -51,7 +51,7 @@ MATVEC_3D_STENCIL::MATVEC_3D_STENCIL(const RunParams& params)
 
 void MATVEC_3D_STENCIL::setSize(Index_type target_size, Index_type target_reps)
 {
-  if (!run_params.useADomain3DMeshDims())
+  if (!run_params.useGrid3DMeshDims())
   {
     Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
     m_i_zones = rzmax-1;

--- a/src/apps/MATVEC_3D_STENCIL.cpp
+++ b/src/apps/MATVEC_3D_STENCIL.cpp
@@ -26,6 +26,10 @@ namespace apps
 MATVEC_3D_STENCIL::MATVEC_3D_STENCIL(const RunParams& params)
   : KernelBase(rajaperf::Apps_MATVEC_3D_STENCIL, params)
 {
+  m_i_zones = params.getADomain3DIZones();
+  m_j_zones = params.getADomain3DJZones();
+  m_k_zones = params.getADomain3DKZones();
+
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
@@ -47,8 +51,14 @@ MATVEC_3D_STENCIL::MATVEC_3D_STENCIL(const RunParams& params)
 
 void MATVEC_3D_STENCIL::setSize(Index_type target_size, Index_type target_reps)
 {
-  Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
-  m_domain.reset(new ADomain(rzmax, /* ndims = */ 3));
+  if (!run_params.useADomain3DMeshDims())
+  {
+    Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
+    m_i_zones = rzmax-1;
+    m_j_zones = rzmax-1;
+    m_k_zones = rzmax-1;
+  }
+  m_domain.reset(new ADomain(ADomain::Zonal{}, m_i_zones, m_j_zones, m_k_zones));
 
   m_zonal_array_length = m_domain->lpz+1;
 

--- a/src/apps/MATVEC_3D_STENCIL.hpp
+++ b/src/apps/MATVEC_3D_STENCIL.hpp
@@ -191,6 +191,9 @@ private:
   Real_ptr m_x;
   Matrix m_matrix;
 
+  Index_type m_i_zones;
+  Index_type m_j_zones;
+  Index_type m_k_zones;
   std::unique_ptr<ADomain> m_domain;
   Index_type* m_real_zones;
   Index_type m_zonal_array_length;

--- a/src/apps/NODAL_ACCUMULATION_3D.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D.cpp
@@ -26,6 +26,10 @@ namespace apps
 NODAL_ACCUMULATION_3D::NODAL_ACCUMULATION_3D(const RunParams& params)
   : KernelBase(rajaperf::Apps_NODAL_ACCUMULATION_3D, params)
 {
+  m_i_zones = params.getADomain3DIZones();
+  m_j_zones = params.getADomain3DJZones();
+  m_k_zones = params.getADomain3DKZones();
+
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
@@ -48,8 +52,14 @@ NODAL_ACCUMULATION_3D::NODAL_ACCUMULATION_3D(const RunParams& params)
 
 void NODAL_ACCUMULATION_3D::setSize(Index_type target_size, Index_type target_reps)
 {
-  Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
-  m_domain.reset(new ADomain(rzmax, /* ndims = */ 3));
+  if (!run_params.useADomain3DMeshDims())
+  {
+    Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
+    m_i_zones = rzmax-1;
+    m_j_zones = rzmax-1;
+    m_k_zones = rzmax-1;
+  }
+  m_domain.reset(new ADomain(ADomain::Zonal{}, m_i_zones, m_j_zones, m_k_zones));
 
   m_nodal_array_length = m_domain->nnalls;
   m_zonal_array_length = m_domain->lpz+1;

--- a/src/apps/NODAL_ACCUMULATION_3D.cpp
+++ b/src/apps/NODAL_ACCUMULATION_3D.cpp
@@ -26,9 +26,9 @@ namespace apps
 NODAL_ACCUMULATION_3D::NODAL_ACCUMULATION_3D(const RunParams& params)
   : KernelBase(rajaperf::Apps_NODAL_ACCUMULATION_3D, params)
 {
-  m_i_zones = params.getADomain3DIZones();
-  m_j_zones = params.getADomain3DJZones();
-  m_k_zones = params.getADomain3DKZones();
+  m_i_zones = params.getGrid3DMeshX();
+  m_j_zones = params.getGrid3DMeshY();
+  m_k_zones = params.getGrid3DMeshZ();
 
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
@@ -52,7 +52,7 @@ NODAL_ACCUMULATION_3D::NODAL_ACCUMULATION_3D(const RunParams& params)
 
 void NODAL_ACCUMULATION_3D::setSize(Index_type target_size, Index_type target_reps)
 {
-  if (!run_params.useADomain3DMeshDims())
+  if (!run_params.useGrid3DMeshDims())
   {
     Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
     m_i_zones = rzmax-1;

--- a/src/apps/NODAL_ACCUMULATION_3D.hpp
+++ b/src/apps/NODAL_ACCUMULATION_3D.hpp
@@ -106,6 +106,9 @@ private:
   Real_ptr m_x;
   Real_ptr m_vol;
 
+  Index_type m_i_zones;
+  Index_type m_j_zones;
+  Index_type m_k_zones;
   std::unique_ptr<ADomain> m_domain;
   Index_type* m_real_zones;
   Index_type m_nodal_array_length;

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -26,6 +26,10 @@ namespace apps
 VOL3D::VOL3D(const RunParams& params)
   : KernelBase(rajaperf::Apps_VOL3D, params)
 {
+  m_i_zones = params.getADomain3DIZones();
+  m_j_zones = params.getADomain3DJZones();
+  m_k_zones = params.getADomain3DKZones();
+
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
@@ -47,8 +51,14 @@ VOL3D::VOL3D(const RunParams& params)
 
 void VOL3D::setSize(Index_type target_size, Index_type target_reps)
 {
-  Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
-  m_domain.reset(new ADomain(rzmax, /* ndims = */ 3));
+  if (!run_params.useADomain3DMeshDims())
+  {
+    Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
+    m_i_zones = rzmax-1;
+    m_j_zones = rzmax-1;
+    m_k_zones = rzmax-1;
+  }
+  m_domain.reset(new ADomain(ADomain::Zonal{}, m_i_zones, m_j_zones, m_k_zones));
 
   m_array_length = m_domain->nnalls;
 

--- a/src/apps/VOL3D.cpp
+++ b/src/apps/VOL3D.cpp
@@ -26,9 +26,9 @@ namespace apps
 VOL3D::VOL3D(const RunParams& params)
   : KernelBase(rajaperf::Apps_VOL3D, params)
 {
-  m_i_zones = params.getADomain3DIZones();
-  m_j_zones = params.getADomain3DJZones();
-  m_k_zones = params.getADomain3DKZones();
+  m_i_zones = params.getGrid3DMeshX();
+  m_j_zones = params.getGrid3DMeshY();
+  m_k_zones = params.getGrid3DMeshZ();
 
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
@@ -51,7 +51,7 @@ VOL3D::VOL3D(const RunParams& params)
 
 void VOL3D::setSize(Index_type target_size, Index_type target_reps)
 {
-  if (!run_params.useADomain3DMeshDims())
+  if (!run_params.useGrid3DMeshDims())
   {
     Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
     m_i_zones = rzmax-1;

--- a/src/apps/VOL3D.hpp
+++ b/src/apps/VOL3D.hpp
@@ -190,6 +190,9 @@ private:
 
   Real_type m_vnormq;
 
+  Index_type m_i_zones;
+  Index_type m_j_zones;
+  Index_type m_k_zones;
   std::unique_ptr<ADomain> m_domain;
   Index_type m_array_length;
 };

--- a/src/apps/ZONAL_ACCUMULATION_3D.cpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D.cpp
@@ -26,9 +26,9 @@ namespace apps
 ZONAL_ACCUMULATION_3D::ZONAL_ACCUMULATION_3D(const RunParams& params)
   : KernelBase(rajaperf::Apps_ZONAL_ACCUMULATION_3D, params)
 {
-  m_i_zones = params.getADomain3DIZones();
-  m_j_zones = params.getADomain3DJZones();
-  m_k_zones = params.getADomain3DKZones();
+  m_i_zones = params.getGrid3DMeshX();
+  m_j_zones = params.getGrid3DMeshY();
+  m_k_zones = params.getGrid3DMeshZ();
 
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
@@ -51,7 +51,7 @@ ZONAL_ACCUMULATION_3D::ZONAL_ACCUMULATION_3D(const RunParams& params)
 
 void ZONAL_ACCUMULATION_3D::setSize(Index_type target_size, Index_type target_reps)
 {
-  if (!run_params.useADomain3DMeshDims())
+  if (!run_params.useGrid3DMeshDims())
   {
     Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
     m_i_zones = rzmax-1;

--- a/src/apps/ZONAL_ACCUMULATION_3D.cpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D.cpp
@@ -26,6 +26,10 @@ namespace apps
 ZONAL_ACCUMULATION_3D::ZONAL_ACCUMULATION_3D(const RunParams& params)
   : KernelBase(rajaperf::Apps_ZONAL_ACCUMULATION_3D, params)
 {
+  m_i_zones = params.getADomain3DIZones();
+  m_j_zones = params.getADomain3DJZones();
+  m_k_zones = params.getADomain3DKZones();
+
   setDefaultProblemSize(100*100*100);  // See rzmax in ADomain struct
   setDefaultReps(100);
 
@@ -47,8 +51,14 @@ ZONAL_ACCUMULATION_3D::ZONAL_ACCUMULATION_3D(const RunParams& params)
 
 void ZONAL_ACCUMULATION_3D::setSize(Index_type target_size, Index_type target_reps)
 {
-  Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
-  m_domain.reset(new ADomain(rzmax, /* ndims = */ 3));
+  if (!run_params.useADomain3DMeshDims())
+  {
+    Index_type rzmax = std::cbrt(target_size) + 1 + std::cbrt(3)-1;
+    m_i_zones = rzmax-1;
+    m_j_zones = rzmax-1;
+    m_k_zones = rzmax-1;
+  }
+  m_domain.reset(new ADomain(ADomain::Zonal{}, m_i_zones, m_j_zones, m_k_zones));
 
   m_nodal_array_length = m_domain->nnalls;
   m_zonal_array_length = m_domain->lpz+1;

--- a/src/apps/ZONAL_ACCUMULATION_3D.hpp
+++ b/src/apps/ZONAL_ACCUMULATION_3D.hpp
@@ -103,6 +103,9 @@ private:
   Real_ptr m_x;
   Real_ptr m_vol;
 
+  Index_type m_i_zones;
+  Index_type m_j_zones;
+  Index_type m_k_zones;
   std::unique_ptr<ADomain> m_domain;
   Index_type* m_real_zones;
   Index_type m_nodal_array_length;

--- a/src/basic/NESTED_INIT.cpp
+++ b/src/basic/NESTED_INIT.cpp
@@ -25,9 +25,11 @@ namespace basic
 NESTED_INIT::NESTED_INIT(const RunParams& params)
   : KernelBase(rajaperf::Basic_NESTED_INIT, params)
 {
-  m_n_init = 100;
+  m_ni = params.getGrid3DMeshX();
+  m_nj = params.getGrid3DMeshY();
+  m_nk = params.getGrid3DMeshZ();
 
-  setDefaultProblemSize(m_n_init * m_n_init * m_n_init);
+  setDefaultProblemSize(100 * 100 * 100);
   setDefaultReps(1000);
 
   setSize(params.getTargetSize(getDefaultProblemSize()),
@@ -48,10 +50,13 @@ NESTED_INIT::NESTED_INIT(const RunParams& params)
 
 void NESTED_INIT::setSize(Index_type target_size, Index_type target_reps)
 {
-  auto n_final = std::cbrt( target_size ) + std::cbrt(3)-1;
-  m_ni = n_final;
-  m_nj = n_final;
-  m_nk = n_final;
+  if (!run_params.useGrid3DMeshDims())
+  {
+    auto n_final = std::cbrt( target_size ) + std::cbrt(3)-1;
+    m_ni = n_final;
+    m_nj = n_final;
+    m_nk = n_final;
+  }
   m_array_length = m_ni * m_nj * m_nk;
 
   setActualProblemSize( m_array_length );

--- a/src/basic/NESTED_INIT.hpp
+++ b/src/basic/NESTED_INIT.hpp
@@ -87,7 +87,6 @@ private:
   Index_type m_ni;
   Index_type m_nj;
   Index_type m_nk;
-  Index_type m_n_init;
 };
 
 } // end namespace basic

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -44,6 +44,10 @@ RunParams::RunParams(int argc, char** argv)
    data_alignment(RAJA::DATA_ALIGN),
    multi_reduce_num_bins(10),
    multi_reduce_bin_assignment_algorithm(BinAssignmentAlgorithm::RunsRandomSizes),
+   adomain_2d_mesh_dims({1000, 1000}),
+   use_adomain_2d_mesh_dims(false),
+   adomain_3d_mesh_dims({100, 100, 100}),
+   use_adomain_3d_mesh_dims(false),
    ltimes_num_d(6),
    ltimes_num_g(32),
    ltimes_num_m(25),
@@ -146,6 +150,18 @@ void RunParams::print(std::ostream& str) const
 
   str << "\n multi_reduce_num_bins = " << multi_reduce_num_bins;
   str << "\n multi_reduce_bin_assignment_algorithm = " << BinAssignmentAlgorithmToStr(multi_reduce_bin_assignment_algorithm);
+
+  str << "\n use_adomain_2d_mesh_dims = " << (use_adomain_2d_mesh_dims ? "true" : "false");
+  str << "\n adomain_2d_mesh_dims = ";
+  for (size_t j = 0; j < adomain_2d_mesh_dims.size(); ++j) {
+    str << "\n\t" << adomain_2d_mesh_dims[j];
+  }
+
+  str << "\n use_adomain_3d_mesh_dims = " << (use_adomain_3d_mesh_dims ? "true" : "false");
+  str << "\n adomain_3d_mesh_dims = ";
+  for (size_t j = 0; j < adomain_3d_mesh_dims.size(); ++j) {
+    str << "\n\t" << adomain_3d_mesh_dims[j];
+  }
 
   str << "\n ltimes_num_d = " << ltimes_num_d;
   str << "\n ltimes_num_g = " << ltimes_num_g;
@@ -646,6 +662,74 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
                   << std::endl;
         input_state = BadInput;
       }
+
+    } else if ( opt == std::string("--adomain_2d_mesh_dims") ) {
+
+      bool done = false;
+      constexpr int total_dims = 2;
+      int count = 0;
+      adomain_2d_mesh_dims.clear();
+      i++;
+      while ( i < argc && !done ) {
+        opt = std::string(argv[i]);
+        if ( opt.at(0) == '-' ) {
+          i--;
+          done = true;
+        } else {
+          int dimension = ::atoi( opt.c_str() );
+          if ( dimension <= 0 ) {
+            getCout() << "\nBad input:"
+                      << " must give --adomain_2d_mesh_dims POSITIVE values (int)"
+                      << std::endl;
+            input_state = BadInput;
+          } else {
+            adomain_2d_mesh_dims.push_back(dimension);
+            ++count;
+          }
+          ++i;
+        }
+      }
+      if (count != total_dims) {
+        getCout() << "\nBad input:"
+                  << " must give --adomain_2d_mesh_dims exactly 2 positive values (int)"
+                  << std::endl;
+        input_state = BadInput;
+      }
+      use_adomain_2d_mesh_dims = true;
+
+    } else if ( opt == std::string("--adomain_3d_mesh_dims") ) {
+
+      bool done = false;
+      constexpr int total_dims = 3;
+      int count = 0;
+      adomain_3d_mesh_dims.clear();
+      i++;
+      while ( i < argc && !done ) {
+        opt = std::string(argv[i]);
+        if ( opt.at(0) == '-' ) {
+          i--;
+          done = true;
+        } else {
+          int dimension = ::atoi( opt.c_str() );
+          if ( dimension <= 0 ) {
+            getCout() << "\nBad input:"
+                      << " must give --adomain_3d_mesh_dims POSITIVE values (int)"
+                      << std::endl;
+            input_state = BadInput;
+          } else {
+            adomain_3d_mesh_dims.push_back(dimension);
+            ++count;
+          }
+          ++i;
+        }
+      }
+      if (count != total_dims) {
+        getCout() << "\nBad input:"
+                  << " must give --adomain_3d_mesh_dims exactly 3 positive values (int)"
+                  << std::endl;
+        input_state = BadInput;
+      }
+      use_adomain_3d_mesh_dims = true;
 
     } else if ( opt == std::string("--ltimes_num_d") ) {
 
@@ -1712,6 +1796,20 @@ void RunParams::printHelpMessage(std::ostream& str) const
   str << "\t\t Example...\n"
       << "\t\t --sizefact 0.5 (run each kernel with size half its calculated size)\n"
       << "\t\t --sizefact 2.0 (run each kernel with size twice its calculated size)\n\n";
+
+  str << "\t --adomain_2d_mesh_dims <two space-separated ints> [default is 1000 1000]\n"
+      << "\t      (Mesh dimensions in i and j for 2D ADomain kernels)\n"
+      << "\t      Must be greater than 0.\n"
+      << "\t      If specified, these dimensions generate the mesh for supported kernels instead of --size or --memory* options.\n";
+  str << "\t\t Example...\n"
+      << "\t\t --adomain_2d_mesh_dims 2000 500 (runs supported 2D ADomain kernels with 2000 by 500 zones)\n\n";
+
+  str << "\t --adomain_3d_mesh_dims <three space-separated ints> [default is 100 100 100]\n"
+      << "\t      (Mesh dimensions in i, j, and k for 3D ADomain kernels)\n"
+      << "\t      Must be greater than 0.\n"
+      << "\t      If specified, these dimensions generate the mesh for supported kernels instead of --size or --memory* options.\n";
+  str << "\t\t Example...\n"
+      << "\t\t --adomain_3d_mesh_dims 200 100 50 (runs supported 3D ADomain kernels with 200 by 100 by 50 zones)\n\n";
 
   str << "\t --ltimes_num_d <int> [default is 6]\n"
       << "\t      (For LTIMES kernels only: num_d used in kernels)\n"

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -44,10 +44,10 @@ RunParams::RunParams(int argc, char** argv)
    data_alignment(RAJA::DATA_ALIGN),
    multi_reduce_num_bins(10),
    multi_reduce_bin_assignment_algorithm(BinAssignmentAlgorithm::RunsRandomSizes),
-   adomain_2d_mesh_dims({1000, 1000}),
-   use_adomain_2d_mesh_dims(false),
-   adomain_3d_mesh_dims({100, 100, 100}),
-   use_adomain_3d_mesh_dims(false),
+   grid_2d_mesh_dims({1000, 1000}),
+   use_grid_2d_mesh_dims(false),
+   grid_3d_mesh_dims({100, 100, 100}),
+   use_grid_3d_mesh_dims(false),
    ltimes_num_d(6),
    ltimes_num_g(32),
    ltimes_num_m(25),
@@ -151,16 +151,16 @@ void RunParams::print(std::ostream& str) const
   str << "\n multi_reduce_num_bins = " << multi_reduce_num_bins;
   str << "\n multi_reduce_bin_assignment_algorithm = " << BinAssignmentAlgorithmToStr(multi_reduce_bin_assignment_algorithm);
 
-  str << "\n use_adomain_2d_mesh_dims = " << (use_adomain_2d_mesh_dims ? "true" : "false");
-  str << "\n adomain_2d_mesh_dims = ";
-  for (size_t j = 0; j < adomain_2d_mesh_dims.size(); ++j) {
-    str << "\n\t" << adomain_2d_mesh_dims[j];
+  str << "\n use_grid_2d_mesh_dims = " << (use_grid_2d_mesh_dims ? "true" : "false");
+  str << "\n grid_2d_mesh_dims = ";
+  for (size_t j = 0; j < grid_2d_mesh_dims.size(); ++j) {
+    str << "\n\t" << grid_2d_mesh_dims[j];
   }
 
-  str << "\n use_adomain_3d_mesh_dims = " << (use_adomain_3d_mesh_dims ? "true" : "false");
-  str << "\n adomain_3d_mesh_dims = ";
-  for (size_t j = 0; j < adomain_3d_mesh_dims.size(); ++j) {
-    str << "\n\t" << adomain_3d_mesh_dims[j];
+  str << "\n use_grid_3d_mesh_dims = " << (use_grid_3d_mesh_dims ? "true" : "false");
+  str << "\n grid_3d_mesh_dims = ";
+  for (size_t j = 0; j < grid_3d_mesh_dims.size(); ++j) {
+    str << "\n\t" << grid_3d_mesh_dims[j];
   }
 
   str << "\n ltimes_num_d = " << ltimes_num_d;
@@ -663,12 +663,16 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
         input_state = BadInput;
       }
 
-    } else if ( opt == std::string("--adomain_2d_mesh_dims") ) {
+    } else if ( opt == std::string("--grid_2d_mesh_dims") ||
+                opt == std::string("--grid_3d_mesh_dims") ) {
 
       bool done = false;
-      constexpr int total_dims = 2;
+      std::string mesh_opt = opt;
+      const int total_dims = (mesh_opt == std::string("--grid_2d_mesh_dims")) ? 2 : 3;
       int count = 0;
-      adomain_2d_mesh_dims.clear();
+      std::vector<Index_type>& dims =
+          total_dims == 2 ? grid_2d_mesh_dims : grid_3d_mesh_dims;
+      dims.clear();
       i++;
       while ( i < argc && !done ) {
         opt = std::string(argv[i]);
@@ -679,11 +683,11 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
           int dimension = ::atoi( opt.c_str() );
           if ( dimension <= 0 ) {
             getCout() << "\nBad input:"
-                      << " must give --adomain_2d_mesh_dims POSITIVE values (int)"
+                      << " must give " << mesh_opt << " POSITIVE values (int)"
                       << std::endl;
             input_state = BadInput;
           } else {
-            adomain_2d_mesh_dims.push_back(dimension);
+            dims.push_back(dimension);
             ++count;
           }
           ++i;
@@ -691,45 +695,16 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
       }
       if (count != total_dims) {
         getCout() << "\nBad input:"
-                  << " must give --adomain_2d_mesh_dims exactly 2 positive values (int)"
+                  << " must give " << mesh_opt << " exactly " << total_dims
+                  << " positive values (int)"
                   << std::endl;
         input_state = BadInput;
       }
-      use_adomain_2d_mesh_dims = true;
-
-    } else if ( opt == std::string("--adomain_3d_mesh_dims") ) {
-
-      bool done = false;
-      constexpr int total_dims = 3;
-      int count = 0;
-      adomain_3d_mesh_dims.clear();
-      i++;
-      while ( i < argc && !done ) {
-        opt = std::string(argv[i]);
-        if ( opt.at(0) == '-' ) {
-          i--;
-          done = true;
-        } else {
-          int dimension = ::atoi( opt.c_str() );
-          if ( dimension <= 0 ) {
-            getCout() << "\nBad input:"
-                      << " must give --adomain_3d_mesh_dims POSITIVE values (int)"
-                      << std::endl;
-            input_state = BadInput;
-          } else {
-            adomain_3d_mesh_dims.push_back(dimension);
-            ++count;
-          }
-          ++i;
-        }
+      if (total_dims == 2) {
+        use_grid_2d_mesh_dims = true;
+      } else {
+        use_grid_3d_mesh_dims = true;
       }
-      if (count != total_dims) {
-        getCout() << "\nBad input:"
-                  << " must give --adomain_3d_mesh_dims exactly 3 positive values (int)"
-                  << std::endl;
-        input_state = BadInput;
-      }
-      use_adomain_3d_mesh_dims = true;
 
     } else if ( opt == std::string("--ltimes_num_d") ) {
 
@@ -1797,19 +1772,19 @@ void RunParams::printHelpMessage(std::ostream& str) const
       << "\t\t --sizefact 0.5 (run each kernel with size half its calculated size)\n"
       << "\t\t --sizefact 2.0 (run each kernel with size twice its calculated size)\n\n";
 
-  str << "\t --adomain_2d_mesh_dims <two space-separated ints> [default is 1000 1000]\n"
-      << "\t      (Mesh dimensions in i and j for 2D ADomain kernels)\n"
+  str << "\t --grid_2d_mesh_dims <two space-separated ints>\n"
+      << "\t      (Active grid dimensions x and y for supported 2D kernels)\n"
       << "\t      Must be greater than 0.\n"
-      << "\t      If specified, these dimensions generate the mesh for supported kernels instead of --size or --memory* options.\n";
+      << "\t      If specified, these dimensions override --size and --memory* options.\n";
   str << "\t\t Example...\n"
-      << "\t\t --adomain_2d_mesh_dims 2000 500 (runs supported 2D ADomain kernels with 2000 by 500 zones)\n\n";
+      << "\t\t --grid_2d_mesh_dims 2000 500 (runs supported 2D kernels with a 2000 by 500 active grid)\n\n";
 
-  str << "\t --adomain_3d_mesh_dims <three space-separated ints> [default is 100 100 100]\n"
-      << "\t      (Mesh dimensions in i, j, and k for 3D ADomain kernels)\n"
+  str << "\t --grid_3d_mesh_dims <three space-separated ints>\n"
+      << "\t      (Active grid dimensions x, y, and z for supported 3D kernels)\n"
       << "\t      Must be greater than 0.\n"
-      << "\t      If specified, these dimensions generate the mesh for supported kernels instead of --size or --memory* options.\n";
+      << "\t      If specified, these dimensions override --size and --memory* options.\n";
   str << "\t\t Example...\n"
-      << "\t\t --adomain_3d_mesh_dims 200 100 50 (runs supported 3D ADomain kernels with 200 by 100 by 50 zones)\n\n";
+      << "\t\t --grid_3d_mesh_dims 200 100 50 (runs supported 3D kernels with a 200 by 100 by 50 active grid)\n\n";
 
   str << "\t --ltimes_num_d <int> [default is 6]\n"
       << "\t      (For LTIMES kernels only: num_d used in kernels)\n"

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -259,14 +259,14 @@ public:
   Index_type getMultiReduceNumBins() const { return multi_reduce_num_bins; }
   BinAssignmentAlgorithm getMultiReduceBinAssignmentAlgorithm() const { return multi_reduce_bin_assignment_algorithm; }
 
-  Index_type getADomain2DIZones() const { return adomain_2d_mesh_dims[0]; }
-  Index_type getADomain2DJZones() const { return adomain_2d_mesh_dims[1]; }
-  bool useADomain2DMeshDims() const { return use_adomain_2d_mesh_dims; }
+  Index_type getGrid2DMeshX() const { return grid_2d_mesh_dims[0]; }
+  Index_type getGrid2DMeshY() const { return grid_2d_mesh_dims[1]; }
+  bool useGrid2DMeshDims() const { return use_grid_2d_mesh_dims; }
 
-  Index_type getADomain3DIZones() const { return adomain_3d_mesh_dims[0]; }
-  Index_type getADomain3DJZones() const { return adomain_3d_mesh_dims[1]; }
-  Index_type getADomain3DKZones() const { return adomain_3d_mesh_dims[2]; }
-  bool useADomain3DMeshDims() const { return use_adomain_3d_mesh_dims; }
+  Index_type getGrid3DMeshX() const { return grid_3d_mesh_dims[0]; }
+  Index_type getGrid3DMeshY() const { return grid_3d_mesh_dims[1]; }
+  Index_type getGrid3DMeshZ() const { return grid_3d_mesh_dims[2]; }
+  bool useGrid3DMeshDims() const { return use_grid_3d_mesh_dims; }
 
   Index_type getLtimesNumD() const { return ltimes_num_d; }
   Index_type getLtimesNumG() const { return ltimes_num_g; }
@@ -445,11 +445,11 @@ private:
   Index_type multi_reduce_num_bins; /*!< number of bins used in multi reduction kernels (input option) */
   BinAssignmentAlgorithm multi_reduce_bin_assignment_algorithm; /*!< algorithm used to assign bins to iterates used in multi reduction kernels (input option) */
 
-  std::vector<Index_type> adomain_2d_mesh_dims; /*!< mesh dimensions i, j used in 2d ADomain kernels (input option) */
-  bool use_adomain_2d_mesh_dims; /*!< enable user input of ADomain mesh dimensions multiple kernel (true if vector adomain_2D_dims is properly passed on command line) */
+  std::vector<Index_type> grid_2d_mesh_dims; /*!< active mesh dimensions x, y used by supported 2d kernels (input option) */
+  bool use_grid_2d_mesh_dims; /*!< enable user input of 2d active mesh dimensions */
 
-  std::vector<Index_type> adomain_3d_mesh_dims; /*!< mesh dimensions i, j, k used in 3d ADomain kernels (input option) */
-  bool use_adomain_3d_mesh_dims; /*!< enable user input of ADomain mesh dimensions multiple kernel (true if vector adomain_3D_dims is properly passed on command line) */
+  std::vector<Index_type> grid_3d_mesh_dims; /*!< active mesh dimensions x, y, z used by supported 3d kernels (input option) */
+  bool use_grid_3d_mesh_dims; /*!< enable user input of 3d active mesh dimensions */
 
   Index_type ltimes_num_d; /*!< num_d used in ltimes kernels (input option) */
   Index_type ltimes_num_g; /*!< num_g used in ltimes kernels (input option) */

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -259,6 +259,15 @@ public:
   Index_type getMultiReduceNumBins() const { return multi_reduce_num_bins; }
   BinAssignmentAlgorithm getMultiReduceBinAssignmentAlgorithm() const { return multi_reduce_bin_assignment_algorithm; }
 
+  Index_type getADomain2DIZones() const { return adomain_2d_mesh_dims[0]; }
+  Index_type getADomain2DJZones() const { return adomain_2d_mesh_dims[1]; }
+  bool useADomain2DMeshDims() const { return use_adomain_2d_mesh_dims; }
+
+  Index_type getADomain3DIZones() const { return adomain_3d_mesh_dims[0]; }
+  Index_type getADomain3DJZones() const { return adomain_3d_mesh_dims[1]; }
+  Index_type getADomain3DKZones() const { return adomain_3d_mesh_dims[2]; }
+  bool useADomain3DMeshDims() const { return use_adomain_3d_mesh_dims; }
+
   Index_type getLtimesNumD() const { return ltimes_num_d; }
   Index_type getLtimesNumG() const { return ltimes_num_g; }
   Index_type getLtimesNumM() const { return ltimes_num_m; }
@@ -435,6 +444,12 @@ private:
 
   Index_type multi_reduce_num_bins; /*!< number of bins used in multi reduction kernels (input option) */
   BinAssignmentAlgorithm multi_reduce_bin_assignment_algorithm; /*!< algorithm used to assign bins to iterates used in multi reduction kernels (input option) */
+
+  std::vector<Index_type> adomain_2d_mesh_dims; /*!< mesh dimensions i, j used in 2d ADomain kernels (input option) */
+  bool use_adomain_2d_mesh_dims; /*!< enable user input of ADomain mesh dimensions multiple kernel (true if vector adomain_2D_dims is properly passed on command line) */
+
+  std::vector<Index_type> adomain_3d_mesh_dims; /*!< mesh dimensions i, j, k used in 3d ADomain kernels (input option) */
+  bool use_adomain_3d_mesh_dims; /*!< enable user input of ADomain mesh dimensions multiple kernel (true if vector adomain_3D_dims is properly passed on command line) */
 
   Index_type ltimes_num_d; /*!< num_d used in ltimes kernels (input option) */
   Index_type ltimes_num_g; /*!< num_g used in ltimes kernels (input option) */

--- a/src/lcals/HYDRO_2D.cpp
+++ b/src/lcals/HYDRO_2D.cpp
@@ -25,13 +25,13 @@ namespace lcals
 HYDRO_2D::HYDRO_2D(const RunParams& params)
   : KernelBase(rajaperf::Lcals_HYDRO_2D, params)
 {
-  m_jn = 1000;
-  m_kn = 1000;
+  m_jn = params.getGrid2DMeshX() + 2;
+  m_kn = params.getGrid2DMeshY() + 2;
 
   m_s = 0.0041;
   m_t = 0.0037;
 
-  setDefaultProblemSize(m_kn * m_jn);
+  setDefaultProblemSize((m_kn - 2) * (m_jn - 2));
   setDefaultReps(100);
 
   setSize(params.getTargetSize(getDefaultProblemSize()),
@@ -52,9 +52,14 @@ HYDRO_2D::HYDRO_2D(const RunParams& params)
 
 void HYDRO_2D::setSize(Index_type target_size, Index_type target_reps)
 {
-  m_jn = m_kn = std::sqrt(target_size) + std::sqrt(2)-1;
+  if (!run_params.useGrid2DMeshDims())
+  {
+    const Index_type active_extent = std::sqrt(target_size) + std::sqrt(2)-1;
+    m_jn = active_extent + 2;
+    m_kn = active_extent + 2;
+  }
 
-  setActualProblemSize( m_kn*m_jn );
+  setActualProblemSize( (m_kn-2)*(m_jn-2) );
   setRunReps( target_reps );
 
   setItsPerRep( 3 * (m_kn-2)*(m_jn-2) );

--- a/src/polybench-kokkos/POLYBENCH_HEAT_3D-Kokkos.cpp
+++ b/src/polybench-kokkos/POLYBENCH_HEAT_3D-Kokkos.cpp
@@ -23,8 +23,8 @@ void POLYBENCH_HEAT_3D::runKokkosVariant(VariantID vid) {
 
   POLYBENCH_HEAT_3D_DATA_SETUP;
 
-  auto A_view = getViewFromPointer(A, N, N, N);
-  auto B_view = getViewFromPointer(B, N, N, N);
+  auto A_view = getViewFromPointer(A, NI, NJ, NK);
+  auto B_view = getViewFromPointer(B, NI, NJ, NK);
 
   switch (vid) {
     case Kokkos_Lambda: {
@@ -40,7 +40,7 @@ void POLYBENCH_HEAT_3D::runKokkosVariant(VariantID vid) {
             "POLYBENCH_HEAT_3D Kokkos_Lambda--BODY1",
             Kokkos::MDRangePolicy<Kokkos::Rank<3>,
                                   Kokkos::IndexType<Index_type>>(
-                {1, 1, 1}, {N - 1, N - 1, N - 1}),
+                {1, 1, 1}, {NI - 1, NJ - 1, NK - 1}),
             KOKKOS_LAMBDA(Index_type i, Index_type j, Index_type k) {
               B_view(i, j, k) =
                   0.125 * (A_view(i + 1, j, k) - 2.0 * A_view(i, j, k) +
@@ -58,7 +58,7 @@ void POLYBENCH_HEAT_3D::runKokkosVariant(VariantID vid) {
             "POLYBENCH_HEAT_3D Kokkos_Lambda--BODY2",
             Kokkos::MDRangePolicy<Kokkos::Rank<3>,
                                   Kokkos::IndexType<Index_type>>(
-                {1, 1, 1}, {N - 1, N - 1, N - 1}),
+                {1, 1, 1}, {NI - 1, NJ - 1, NK - 1}),
             KOKKOS_LAMBDA(Index_type i, Index_type j, Index_type k) {
               A_view(i, j, k) =
                   0.125 * (B_view(i + 1, j, k) - 2.0 * B_view(i, j, k) +
@@ -76,8 +76,8 @@ void POLYBENCH_HEAT_3D::runKokkosVariant(VariantID vid) {
       Kokkos::fence();
       stopTimer();
 
-      moveDataToHostFromKokkosView(A, A_view, N, N, N);
-      moveDataToHostFromKokkosView(B, B_view, N, N, N);
+      moveDataToHostFromKokkosView(A, A_view, NI, NJ, NK);
+      moveDataToHostFromKokkosView(B, B_view, NI, NJ, NK);
 
       break;
     }

--- a/src/polybench-kokkos/POLYBENCH_JACOBI_2D-Kokkos.cpp
+++ b/src/polybench-kokkos/POLYBENCH_JACOBI_2D-Kokkos.cpp
@@ -23,8 +23,8 @@ void POLYBENCH_JACOBI_2D::runKokkosVariant(VariantID vid) {
 
   POLYBENCH_JACOBI_2D_DATA_SETUP;
 
-  auto A_view = getViewFromPointer(A, N, N);
-  auto B_view = getViewFromPointer(B, N, N);
+  auto A_view = getViewFromPointer(A, NI, NJ);
+  auto B_view = getViewFromPointer(B, NI, NJ);
 
   switch (vid) {
     case Kokkos_Lambda: {
@@ -40,7 +40,7 @@ void POLYBENCH_JACOBI_2D::runKokkosVariant(VariantID vid) {
             "JACOBI_2D_Kokkos Kokkos_Lambda--BODY1",
             Kokkos::MDRangePolicy<Kokkos::Rank<2>,
                                   Kokkos::IndexType<Index_type>>(
-                {1, 1}, {N - 1, N - 1}),
+                {1, 1}, {NI - 1, NJ - 1}),
             KOKKOS_LAMBDA(Index_type i, Index_type j) {
               B_view(i, j) =
                   0.2 * (A_view(i, j) + A_view(i, j - 1) + A_view(i, j + 1) +
@@ -53,7 +53,7 @@ void POLYBENCH_JACOBI_2D::runKokkosVariant(VariantID vid) {
             "JACOBI_2D_Kokkos Kokkos_Lambda--BODY2",
             Kokkos::MDRangePolicy<Kokkos::Rank<2>,
                                   Kokkos::IndexType<Index_type>>(
-                {1, 1}, {N - 1, N - 1}),
+                {1, 1}, {NI - 1, NJ - 1}),
             KOKKOS_LAMBDA(Index_type i, Index_type j) {
               A_view(i, j) =
                   0.2 * (B_view(i, j) + B_view(i, j - 1) + B_view(i, j + 1) +
@@ -66,8 +66,8 @@ void POLYBENCH_JACOBI_2D::runKokkosVariant(VariantID vid) {
       Kokkos::fence();
       stopTimer();
 
-      moveDataToHostFromKokkosView(A, A_view, N, N);
-      moveDataToHostFromKokkosView(B, B_view, N, N);
+      moveDataToHostFromKokkosView(A, A_view, NI, NJ);
+      moveDataToHostFromKokkosView(B, B_view, NI, NJ);
 
       break;
     }

--- a/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Cuda.cpp
@@ -36,46 +36,46 @@ namespace polybench
   dim3 nthreads_per_block(HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA);
 
 #define HEAT_3D_NBLOCKS_CUDA \
-  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, k_block_sz)), \
-               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, j_block_sz)), \
-               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, i_block_sz)));
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(NK-2, k_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(NJ-2, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(NI-2, i_block_sz)));
 
 
 template < size_t k_block_size, size_t j_block_size, size_t i_block_size >
 __launch_bounds__(k_block_size*j_block_size*i_block_size)
-__global__ void poly_heat_3D_1(Real_ptr A, Real_ptr B, Index_type N)
+__global__ void poly_heat_3D_1(Real_ptr A, Real_ptr B, Index_type NI, Index_type NJ, Index_type NK)
 {
    Index_type i = 1 + blockIdx.z;
    Index_type j = 1 + blockIdx.y * j_block_size + threadIdx.y;
    Index_type k = 1 + blockIdx.x * k_block_size + threadIdx.x;
 
-   if (i < N-1 && j < N-1 && k < N-1) {
+   if (i < NI-1 && j < NJ-1 && k < NK-1) {
      POLYBENCH_HEAT_3D_BODY1;
    }
 }
 
 template < size_t k_block_size, size_t j_block_size, size_t i_block_size >
 __launch_bounds__(k_block_size*j_block_size*i_block_size)
-__global__ void poly_heat_3D_2(Real_ptr A, Real_ptr B, Index_type N)
+__global__ void poly_heat_3D_2(Real_ptr A, Real_ptr B, Index_type NI, Index_type NJ, Index_type NK)
 {
    Index_type i = 1 + blockIdx.z;
    Index_type j = 1 + blockIdx.y * j_block_size + threadIdx.y;
    Index_type k = 1 + blockIdx.x * k_block_size + threadIdx.x;
 
-   if (i < N-1 && j < N-1 && k < N-1) {
+   if (i < NI-1 && j < NJ-1 && k < NK-1) {
      POLYBENCH_HEAT_3D_BODY2;
    }
 }
 
 template< size_t k_block_size, size_t j_block_size, size_t i_block_size, typename Lambda >
 __launch_bounds__(k_block_size*j_block_size*i_block_size)
-__global__ void poly_heat_3D_lam(Index_type N, Lambda body)
+__global__ void poly_heat_3D_lam(Index_type NI, Index_type NJ, Index_type NK, Lambda body)
 {
    Index_type i = 1 + blockIdx.z;
    Index_type j = 1 + blockIdx.y * j_block_size + threadIdx.y;
    Index_type k = 1 + blockIdx.x * k_block_size + threadIdx.x;
 
-   if (i < N-1 && j < N-1 && k < N-1) {
+   if (i < NI-1 && j < NJ-1 && k < NK-1) {
      body(i, j, k);
    }
 }
@@ -107,7 +107,7 @@ void POLYBENCH_HEAT_3D::runCudaVariantImpl(VariantID vid)
         (poly_heat_3D_1<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        A, B, N );
+        A, B, NI, NJ, NK );
       RP_CALI_SUBKERNEL_END("POLYBENCH_HEAT_3D_1");
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
@@ -115,7 +115,7 @@ void POLYBENCH_HEAT_3D::runCudaVariantImpl(VariantID vid)
         (poly_heat_3D_2<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        A, B, N );
+        A, B, NI, NJ, NK );
       RP_CALI_SUBKERNEL_END("POLYBENCH_HEAT_3D_2");
 
     }
@@ -143,7 +143,7 @@ void POLYBENCH_HEAT_3D::runCudaVariantImpl(VariantID vid)
                           decltype(poly_heat_3D_1_lambda)>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        N, poly_heat_3D_1_lambda );
+        NI, NJ, NK, poly_heat_3D_1_lambda );
       RP_CALI_SUBKERNEL_END("POLYBENCH_HEAT_3D_1");
 
       auto poly_heat_3D_2_lambda = [=] __device__ (Index_type i,
@@ -158,7 +158,7 @@ void POLYBENCH_HEAT_3D::runCudaVariantImpl(VariantID vid)
                           decltype(poly_heat_3D_2_lambda)>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        N, poly_heat_3D_2_lambda );
+        NI, NJ, NK, poly_heat_3D_2_lambda );
       RP_CALI_SUBKERNEL_END("POLYBENCH_HEAT_3D_2");
 
     }
@@ -188,9 +188,9 @@ void POLYBENCH_HEAT_3D::runCudaVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_1");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1},
+                         RAJA::RangeSegment{1, NK-1}),
         res,
         [=] __device__ (Index_type i, Index_type j, Index_type k) {
           POLYBENCH_HEAT_3D_BODY1_RAJA;
@@ -200,9 +200,9 @@ void POLYBENCH_HEAT_3D::runCudaVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1},
+                         RAJA::RangeSegment{1, NK-1}),
         res,
         [=] __device__ (Index_type i, Index_type j, Index_type k) {
           POLYBENCH_HEAT_3D_BODY2_RAJA;

--- a/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Hip.cpp
@@ -36,46 +36,46 @@ namespace polybench
   dim3 nthreads_per_block(HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP);
 
 #define HEAT_3D_NBLOCKS_HIP \
-  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, k_block_sz)), \
-               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, j_block_sz)), \
-               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, i_block_sz)));
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(NK-2, k_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(NJ-2, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(NI-2, i_block_sz)));
 
 
 template < size_t k_block_size, size_t j_block_size, size_t i_block_size >
 __launch_bounds__(k_block_size*j_block_size*i_block_size)
-__global__ void poly_heat_3D_1(Real_ptr A, Real_ptr B, Index_type N)
+__global__ void poly_heat_3D_1(Real_ptr A, Real_ptr B, Index_type NI, Index_type NJ, Index_type NK)
 {
    Index_type i = 1 + blockIdx.z;
    Index_type j = 1 + blockIdx.y * j_block_size + threadIdx.y;
    Index_type k = 1 + blockIdx.x * k_block_size + threadIdx.x;
 
-   if (i < N-1 && j < N-1 && k < N-1) {
+   if (i < NI-1 && j < NJ-1 && k < NK-1) {
      POLYBENCH_HEAT_3D_BODY1;
    }
 }
 
 template < size_t k_block_size, size_t j_block_size, size_t i_block_size >
 __launch_bounds__(k_block_size*j_block_size*i_block_size)
-__global__ void poly_heat_3D_2(Real_ptr A, Real_ptr B, Index_type N)
+__global__ void poly_heat_3D_2(Real_ptr A, Real_ptr B, Index_type NI, Index_type NJ, Index_type NK)
 {
    Index_type i = 1 + blockIdx.z;
    Index_type j = 1 + blockIdx.y * j_block_size + threadIdx.y;
    Index_type k = 1 + blockIdx.x * k_block_size + threadIdx.x;
 
-   if (i < N-1 && j < N-1 && k < N-1) {
+   if (i < NI-1 && j < NJ-1 && k < NK-1) {
      POLYBENCH_HEAT_3D_BODY2;
    }
 }
 
 template< size_t k_block_size, size_t j_block_size, size_t i_block_size, typename Lambda >
 __launch_bounds__(k_block_size*j_block_size*i_block_size)
-__global__ void poly_heat_3D_lam(Index_type N, Lambda body)
+__global__ void poly_heat_3D_lam(Index_type NI, Index_type NJ, Index_type NK, Lambda body)
 {
    Index_type i = 1 + blockIdx.z;
    Index_type j = 1 + blockIdx.y * j_block_size + threadIdx.y;
    Index_type k = 1 + blockIdx.x * k_block_size + threadIdx.x;
 
-   if (i < N-1 && j < N-1 && k < N-1) {
+   if (i < NI-1 && j < NJ-1 && k < NK-1) {
      body(i, j, k);
    }
 }
@@ -107,7 +107,7 @@ void POLYBENCH_HEAT_3D::runHipVariantImpl(VariantID vid)
         (poly_heat_3D_1<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        A, B, N );
+        A, B, NI, NJ, NK );
       RP_CALI_SUBKERNEL_END("POLYBENCH_HEAT_3D_1");
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
@@ -115,7 +115,7 @@ void POLYBENCH_HEAT_3D::runHipVariantImpl(VariantID vid)
         (poly_heat_3D_2<HEAT_3D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        A, B, N );
+        A, B, NI, NJ, NK );
       RP_CALI_SUBKERNEL_END("POLYBENCH_HEAT_3D_2");
 
     }
@@ -143,7 +143,7 @@ void POLYBENCH_HEAT_3D::runHipVariantImpl(VariantID vid)
                           decltype(poly_heat_3D_1_lambda)>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        N, poly_heat_3D_1_lambda );
+        NI, NJ, NK, poly_heat_3D_1_lambda );
       RP_CALI_SUBKERNEL_END("POLYBENCH_HEAT_3D_1");
 
       auto poly_heat_3D_2_lambda = [=] __device__ (Index_type i,
@@ -158,7 +158,7 @@ void POLYBENCH_HEAT_3D::runHipVariantImpl(VariantID vid)
                           decltype(poly_heat_3D_2_lambda)>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        N, poly_heat_3D_2_lambda );
+        NI, NJ, NK, poly_heat_3D_2_lambda );
       RP_CALI_SUBKERNEL_END("POLYBENCH_HEAT_3D_2");
 
     }
@@ -187,9 +187,9 @@ void POLYBENCH_HEAT_3D::runHipVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_1");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1},
+                         RAJA::RangeSegment{1, NK-1}),
         res,
         [=] __device__ (Index_type i, Index_type j, Index_type k) {
           POLYBENCH_HEAT_3D_BODY1_RAJA;
@@ -199,9 +199,9 @@ void POLYBENCH_HEAT_3D::runHipVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1},
+                         RAJA::RangeSegment{1, NK-1}),
         res,
         [=] __device__ (Index_type i, Index_type j, Index_type k) {
           POLYBENCH_HEAT_3D_BODY2_RAJA;

--- a/src/polybench/POLYBENCH_HEAT_3D-OMP.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-OMP.cpp
@@ -38,9 +38,9 @@ void POLYBENCH_HEAT_3D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_1");
         #pragma omp parallel for collapse(2)
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
-            for (Index_type k = 1; k < N-1; ++k ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
+            for (Index_type k = 1; k < NK-1; ++k ) {
               POLYBENCH_HEAT_3D_BODY1;
             }
           }
@@ -49,9 +49,9 @@ void POLYBENCH_HEAT_3D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
         #pragma omp parallel for collapse(2)
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
-            for (Index_type k = 1; k < N-1; ++k ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
+            for (Index_type k = 1; k < NK-1; ++k ) {
               POLYBENCH_HEAT_3D_BODY2;
             }
           }
@@ -81,9 +81,9 @@ void POLYBENCH_HEAT_3D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_1");
         #pragma omp parallel for collapse(2)
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
-            for (Index_type k = 1; k < N-1; ++k ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
+            for (Index_type k = 1; k < NK-1; ++k ) {
               poly_heat3d_base_lam1(i, j, k);
             }
           }
@@ -92,9 +92,9 @@ void POLYBENCH_HEAT_3D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
         #pragma omp parallel for collapse(2)
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
-            for (Index_type k = 1; k < N-1; ++k ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
+            for (Index_type k = 1; k < NK-1; ++k ) {
               poly_heat3d_base_lam2(i, j, k);
             }
           }
@@ -129,9 +129,9 @@ void POLYBENCH_HEAT_3D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_1");
         RAJA::kernel_resource<EXEC_POL>(
-          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1}),
+          RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                           RAJA::RangeSegment{1, NJ-1},
+                           RAJA::RangeSegment{1, NK-1}),
           res,
           [=](Index_type i, Index_type j, Index_type k) {
             POLYBENCH_HEAT_3D_BODY1_RAJA;
@@ -141,9 +141,9 @@ void POLYBENCH_HEAT_3D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
         RAJA::kernel_resource<EXEC_POL>(
-          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1}),
+          RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                           RAJA::RangeSegment{1, NJ-1},
+                           RAJA::RangeSegment{1, NK-1}),
           res,
           [=](Index_type i, Index_type j, Index_type k) {
             POLYBENCH_HEAT_3D_BODY2_RAJA;

--- a/src/polybench/POLYBENCH_HEAT_3D-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-OMPTarget.cpp
@@ -37,9 +37,9 @@ void POLYBENCH_HEAT_3D::runOpenMPTargetVariant(VariantID vid)
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_1");
       #pragma omp target is_device_ptr(A,B) device( did )
       #pragma omp teams distribute parallel for schedule(static, 1) collapse(3)
-      for (Index_type i = 1; i < N-1; ++i ) {
-        for (Index_type j = 1; j < N-1; ++j ) {
-          for (Index_type k = 1; k < N-1; ++k ) {
+      for (Index_type i = 1; i < NI-1; ++i ) {
+        for (Index_type j = 1; j < NJ-1; ++j ) {
+          for (Index_type k = 1; k < NK-1; ++k ) {
             POLYBENCH_HEAT_3D_BODY1;
           }
         }
@@ -49,9 +49,9 @@ void POLYBENCH_HEAT_3D::runOpenMPTargetVariant(VariantID vid)
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
       #pragma omp target is_device_ptr(A,B) device( did )
       #pragma omp teams distribute parallel for schedule(static, 1) collapse(3)
-      for (Index_type i = 1; i < N-1; ++i ) {
-        for (Index_type j = 1; j < N-1; ++j ) {
-          for (Index_type k = 1; k < N-1; ++k ) {
+      for (Index_type i = 1; i < NI-1; ++i ) {
+        for (Index_type j = 1; j < NJ-1; ++j ) {
+          for (Index_type k = 1; k < NK-1; ++k ) {
             POLYBENCH_HEAT_3D_BODY2;
           }
         }
@@ -81,9 +81,9 @@ void POLYBENCH_HEAT_3D::runOpenMPTargetVariant(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_1");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1},
+                         RAJA::RangeSegment{1, NK-1}),
         res,
         [=] (Index_type i, Index_type j, Index_type k) {
           POLYBENCH_HEAT_3D_BODY1_RAJA;
@@ -93,9 +93,9 @@ void POLYBENCH_HEAT_3D::runOpenMPTargetVariant(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1},
+                         RAJA::RangeSegment{1, NK-1}),
         res,
         [=] (Index_type i, Index_type j, Index_type k) {
           POLYBENCH_HEAT_3D_BODY2_RAJA;

--- a/src/polybench/POLYBENCH_HEAT_3D-Seq.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Seq.cpp
@@ -35,9 +35,9 @@ void POLYBENCH_HEAT_3D::runSeqVariant(VariantID vid)
       for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_1");
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
-            for (Index_type k = 1; k < N-1; ++k ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
+            for (Index_type k = 1; k < NK-1; ++k ) {
               POLYBENCH_HEAT_3D_BODY1;
             }
           }
@@ -45,9 +45,9 @@ void POLYBENCH_HEAT_3D::runSeqVariant(VariantID vid)
         RP_CALI_SUBKERNEL_END("POLYBENCH_HEAT_3D_1");
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
-            for (Index_type k = 1; k < N-1; ++k ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
+            for (Index_type k = 1; k < NK-1; ++k ) {
               POLYBENCH_HEAT_3D_BODY2;
             }
           }
@@ -77,9 +77,9 @@ void POLYBENCH_HEAT_3D::runSeqVariant(VariantID vid)
       for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_1");
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
-            for (Index_type k = 1; k < N-1; ++k ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
+            for (Index_type k = 1; k < NK-1; ++k ) {
               poly_heat3d_base_lam1(i, j, k);
             }
           }
@@ -87,9 +87,9 @@ void POLYBENCH_HEAT_3D::runSeqVariant(VariantID vid)
         RP_CALI_SUBKERNEL_END("POLYBENCH_HEAT_3D_1");
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
-            for (Index_type k = 1; k < N-1; ++k ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
+            for (Index_type k = 1; k < NK-1; ++k ) {
               poly_heat3d_base_lam2(i, j, k);
             }
           }
@@ -125,9 +125,9 @@ void POLYBENCH_HEAT_3D::runSeqVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_1");
         RAJA::kernel_resource<EXEC_POL>(
-          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1}),
+          RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                           RAJA::RangeSegment{1, NJ-1},
+                           RAJA::RangeSegment{1, NK-1}),
           res,
 
           [=](Index_type i, Index_type j, Index_type k) {
@@ -139,9 +139,9 @@ void POLYBENCH_HEAT_3D::runSeqVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
         RAJA::kernel_resource<EXEC_POL>(
-          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1}),
+          RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                           RAJA::RangeSegment{1, NJ-1},
+                           RAJA::RangeSegment{1, NK-1}),
           res,
 
           [=](Index_type i, Index_type j, Index_type k) {

--- a/src/polybench/POLYBENCH_HEAT_3D-Sycl.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D-Sycl.cpp
@@ -48,9 +48,9 @@ void POLYBENCH_HEAT_3D::runSyclVariantImpl(VariantID vid)
     // Loop counter increment uses macro to quiet C++20 compiler warning
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
-      sycl::range<3> global_dim(i_wg_sz * RAJA_DIVIDE_CEILING_INT(N-2, i_wg_sz),
-                                j_wg_sz * RAJA_DIVIDE_CEILING_INT(N-2, j_wg_sz),
-                                k_wg_sz * RAJA_DIVIDE_CEILING_INT(N-2, k_wg_sz));
+      sycl::range<3> global_dim(i_wg_sz * RAJA_DIVIDE_CEILING_INT(NI-2, i_wg_sz),
+                                j_wg_sz * RAJA_DIVIDE_CEILING_INT(NJ-2, j_wg_sz),
+                                k_wg_sz * RAJA_DIVIDE_CEILING_INT(NK-2, k_wg_sz));
 
       sycl::range<3> wkgroup_dim(i_wg_sz, j_wg_sz, k_wg_sz);
 
@@ -63,7 +63,7 @@ void POLYBENCH_HEAT_3D::runSyclVariantImpl(VariantID vid)
           Index_type j = 1 + item.get_global_id(1);
           Index_type k = 1 + item.get_global_id(2);
 
-          if (i < N-1 && j < N-1 && k < N-1) {
+          if (i < NI-1 && j < NJ-1 && k < NK-1) {
             POLYBENCH_HEAT_3D_BODY1;
           }
 
@@ -80,7 +80,7 @@ void POLYBENCH_HEAT_3D::runSyclVariantImpl(VariantID vid)
           Index_type j = 1 + item.get_global_id(1);
           Index_type k = 1 + item.get_global_id(2);
 
-          if (i < N-1 && j < N-1 && k < N-1) {
+          if (i < NI-1 && j < NJ-1 && k < NK-1) {
             POLYBENCH_HEAT_3D_BODY2;
           }
 
@@ -115,9 +115,9 @@ void POLYBENCH_HEAT_3D::runSyclVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_1");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1},
+                         RAJA::RangeSegment{1, NK-1}),
         res,
         [=] (Index_type i, Index_type j, Index_type k) {
           POLYBENCH_HEAT_3D_BODY1_RAJA;
@@ -127,9 +127,9 @@ void POLYBENCH_HEAT_3D::runSyclVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_HEAT_3D_2");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1},
+                         RAJA::RangeSegment{1, NK-1}),
         res,
         [=] (Index_type i, Index_type j, Index_type k) {
           POLYBENCH_HEAT_3D_BODY2_RAJA;

--- a/src/polybench/POLYBENCH_HEAT_3D.cpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.cpp
@@ -24,6 +24,9 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_HEAT_3D, params)
 {
   Index_type N_default = 102;
+  m_ni = params.getGrid3DMeshX() + 2;
+  m_nj = params.getGrid3DMeshY() + 2;
+  m_nk = params.getGrid3DMeshZ() + 2;
   setDefaultProblemSize( (N_default-2)*(N_default-2)*(N_default-2) );
   setDefaultReps(400);
 
@@ -45,25 +48,30 @@ POLYBENCH_HEAT_3D::POLYBENCH_HEAT_3D(const RunParams& params)
 
 void POLYBENCH_HEAT_3D::setSize(Index_type target_size, Index_type target_reps)
 {
-  m_N = std::cbrt( target_size ) + 2 + std::cbrt(3)-1;
+  if (!run_params.useGrid3DMeshDims())
+  {
+    m_ni = m_nj = m_nk = std::cbrt( target_size ) + 2 + std::cbrt(3)-1;
+  }
 
-  setActualProblemSize( (m_N-2)*(m_N-2)*(m_N-2) );
+  setActualProblemSize( (m_ni-2)*(m_nj-2)*(m_nk-2) );
   setRunReps( target_reps );
 
   setItsPerRep( 2 * getActualProblemSize() );
   setKernelsPerRep( 2 );
 
-  setBytesAllocatedPerRep( 2*sizeof(Real_type) * m_N*m_N*m_N ); // A, B
-  setBytesReadPerRep( 1*sizeof(Real_type) * (m_N*m_N*m_N - 12*(m_N-2) - 8) + // A (7 point stencil)
+  setBytesAllocatedPerRep( 2*sizeof(Real_type) * m_ni*m_nj*m_nk ); // A, B
+  setBytesReadPerRep( 1*sizeof(Real_type) *
+                      (m_ni*m_nj*m_nk - 4*(m_ni-2) - 4*(m_nj-2) - 4*(m_nk-2) - 8) + // A (7 point stencil)
 
-                      1*sizeof(Real_type) * (m_N*m_N*m_N - 12*(m_N-2) - 8)); // B (7 point stencil)
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * (m_N-2)*(m_N-2)*(m_N-2) +  // B
+                      1*sizeof(Real_type) *
+                      (m_ni*m_nj*m_nk - 4*(m_ni-2) - 4*(m_nj-2) - 4*(m_nk-2) - 8) ); // B (7 point stencil)
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * (m_ni-2)*(m_nj-2)*(m_nk-2) +  // B
 
-                         1*sizeof(Real_type) * (m_N-2)*(m_N-2)*(m_N-2) ); // A
+                         1*sizeof(Real_type) * (m_ni-2)*(m_nj-2)*(m_nk-2) ); // A
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep( 15 * (m_N-2)*(m_N-2)*(m_N-2) +
-                  15 * (m_N-2)*(m_N-2)*(m_N-2) );
+  setFLOPsPerRep(15 * (m_ni-2)*(m_nj-2)*(m_nk-2) +
+                  15 * (m_ni-2)*(m_nj-2)*(m_nk-2) );
 }
 
 POLYBENCH_HEAT_3D::~POLYBENCH_HEAT_3D()
@@ -72,14 +80,14 @@ POLYBENCH_HEAT_3D::~POLYBENCH_HEAT_3D()
 
 void POLYBENCH_HEAT_3D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  allocAndInitData(m_A, m_N*m_N*m_N, vid);
-  allocAndInitData(m_B, m_N*m_N*m_N, vid);
+  allocAndInitData(m_A, m_ni*m_nj*m_nk, vid);
+  allocAndInitData(m_B, m_ni*m_nj*m_nk, vid);
 }
 
 void POLYBENCH_HEAT_3D::updateChecksum(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  addToChecksum(m_A, m_N*m_N*m_N, vid);
-  addToChecksum(m_B, m_N*m_N*m_N, vid);
+  addToChecksum(m_A, m_ni*m_nj*m_nk, vid);
+  addToChecksum(m_B, m_ni*m_nj*m_nk, vid);
 }
 
 void POLYBENCH_HEAT_3D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/src/polybench/POLYBENCH_HEAT_3D.hpp
+++ b/src/polybench/POLYBENCH_HEAT_3D.hpp
@@ -39,28 +39,30 @@
 #define POLYBENCH_HEAT_3D_DATA_SETUP \
   Real_ptr A = m_A; \
   Real_ptr B = m_B; \
-  const Index_type N = m_N;
+  const Index_type NI = m_ni; \
+  const Index_type NJ = m_nj; \
+  const Index_type NK = m_nk;
 
 
 #define POLYBENCH_HEAT_3D_BODY1 \
-  B[k + N*(j + N*i)] = \
-                   0.125*( A[k + N*(j + N*(i+1))] - 2.0*A[k + N*(j + N*i)] + \
-                           A[k + N*(j + N*(i-1))] ) + \
-                   0.125*( A[k + N*(j+1 + N*i)]   - 2.0*A[k + N*(j + N*i)] + \
-                           A[k + N*(j-1 + N*i)] ) + \
-                   0.125*( A[k+1 + N*(j + N*i)]   - 2.0*A[k + N*(j + N*i)] + \
-                           A[k-1 + N*(j + N*i)] ) + \
-                   A[k + N*(j + N*i)];
+  B[k + NK*(j + NJ*i)] = \
+                   0.125*( A[k + NK*(j + NJ*(i+1))] - 2.0*A[k + NK*(j + NJ*i)] + \
+                           A[k + NK*(j + NJ*(i-1))] ) + \
+                   0.125*( A[k + NK*(j+1 + NJ*i)]   - 2.0*A[k + NK*(j + NJ*i)] + \
+                           A[k + NK*(j-1 + NJ*i)] ) + \
+                   0.125*( A[k+1 + NK*(j + NJ*i)]   - 2.0*A[k + NK*(j + NJ*i)] + \
+                           A[k-1 + NK*(j + NJ*i)] ) + \
+                   A[k + NK*(j + NJ*i)];
 
 #define POLYBENCH_HEAT_3D_BODY2 \
-  A[k + N*(j + N*i)] = \
-                   0.125*( B[k + N*(j + N*(i+1))] - 2.0*B[k + N*(j + N*i)] + \
-                           B[k + N*(j + N*(i-1))] ) + \
-                   0.125*( B[k + N*(j+1 + N*i)]   - 2.0*B[k + N*(j + N*i)] + \
-                           B[k + N*(j-1 + N*i)] ) + \
-                   0.125*( B[k+1 + N*(j + N*i)]   - 2.0*B[k + N*(j + N*i)] + \
-                           B[k-1 + N*(j + N*i)] ) + \
-                   B[k + N*(j + N*i)];
+  A[k + NK*(j + NJ*i)] = \
+                   0.125*( B[k + NK*(j + NJ*(i+1))] - 2.0*B[k + NK*(j + NJ*i)] + \
+                           B[k + NK*(j + NJ*(i-1))] ) + \
+                   0.125*( B[k + NK*(j+1 + NJ*i)]   - 2.0*B[k + NK*(j + NJ*i)] + \
+                           B[k + NK*(j-1 + NJ*i)] ) + \
+                   0.125*( B[k+1 + NK*(j + NJ*i)]   - 2.0*B[k + NK*(j + NJ*i)] + \
+                           B[k-1 + NK*(j + NJ*i)] ) + \
+                   B[k + NK*(j + NJ*i)];
 
 
 #define POLYBENCH_HEAT_3D_BODY1_RAJA \
@@ -82,8 +84,8 @@
 using VIEW_TYPE = RAJA::View<Real_type, \
                              RAJA::Layout<3, Index_type, 2>>; \
 \
-  VIEW_TYPE Aview(A, RAJA::Layout<3>(N, N, N)); \
-  VIEW_TYPE Bview(B, RAJA::Layout<3>(N, N, N));
+  VIEW_TYPE Aview(A, RAJA::Layout<3>(NI, NJ, NK)); \
+  VIEW_TYPE Bview(B, RAJA::Layout<3>(NI, NJ, NK));
 
 
 #include "common/KernelBase.hpp"
@@ -134,7 +136,9 @@ private:
   using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
                                                          integer::MultipleOf<32>>;
 
-  Index_type m_N;
+  Index_type m_ni;
+  Index_type m_nj;
+  Index_type m_nk;
 
   Real_ptr m_A;
   Real_ptr m_B;

--- a/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Cuda.cpp
@@ -35,43 +35,43 @@ namespace polybench
   dim3 nthreads_per_block(JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA, 1);
 
 #define JACOBI_2D_NBLOCKS_CUDA \
-  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, j_block_sz)), \
-               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, i_block_sz)), \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(NJ-2, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(NI-2, i_block_sz)), \
                static_cast<size_t>(1));
 
 
 template < size_t j_block_size, size_t i_block_size >
 __launch_bounds__(j_block_size*i_block_size)
-__global__ void poly_jacobi_2D_1(Real_ptr A, Real_ptr B, Index_type N)
+__global__ void poly_jacobi_2D_1(Real_ptr A, Real_ptr B, Index_type NI, Index_type NJ)
 {
   Index_type i = 1 + blockIdx.y * i_block_size + threadIdx.y;
   Index_type j = 1 + blockIdx.x * j_block_size + threadIdx.x;
 
-  if ( i < N-1 && j < N-1 ) {
+  if ( i < NI-1 && j < NJ-1 ) {
     POLYBENCH_JACOBI_2D_BODY1;
   }
 }
 
 template < size_t j_block_size, size_t i_block_size >
 __launch_bounds__(j_block_size*i_block_size)
-__global__ void poly_jacobi_2D_2(Real_ptr A, Real_ptr B, Index_type N)
+__global__ void poly_jacobi_2D_2(Real_ptr A, Real_ptr B, Index_type NI, Index_type NJ)
 {
   Index_type i = 1 + blockIdx.y * i_block_size + threadIdx.y;
   Index_type j = 1 + blockIdx.x * j_block_size + threadIdx.x;
 
-  if ( i < N-1 && j < N-1 ) {
+  if ( i < NI-1 && j < NJ-1 ) {
     POLYBENCH_JACOBI_2D_BODY2;
   }
 }
 
 template < size_t j_block_size, size_t i_block_size, typename Lambda >
 __launch_bounds__(j_block_size*i_block_size)
-__global__ void poly_jacobi_2D_lam(Index_type N, Lambda body)
+__global__ void poly_jacobi_2D_lam(Index_type NI, Index_type NJ, Lambda body)
 {
   Index_type i = 1 + blockIdx.y * i_block_size + threadIdx.y;
   Index_type j = 1 + blockIdx.x * j_block_size + threadIdx.x;
 
-  if ( i < N-1 && j < N-1 ) {
+  if ( i < NI-1 && j < NJ-1 ) {
     body(i, j);
   }
 }
@@ -103,7 +103,7 @@ void POLYBENCH_JACOBI_2D::runCudaVariantImpl(VariantID vid)
         (poly_jacobi_2D_1<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        A, B, N );
+        A, B, NI, NJ );
       RP_CALI_SUBKERNEL_END("POLYBENCH_JACOBI_2D_1");
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
@@ -111,7 +111,7 @@ void POLYBENCH_JACOBI_2D::runCudaVariantImpl(VariantID vid)
         (poly_jacobi_2D_2<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_CUDA>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        A, B, N );
+        A, B, NI, NJ );
       RP_CALI_SUBKERNEL_END("POLYBENCH_JACOBI_2D_2");
 
     }
@@ -138,7 +138,7 @@ void POLYBENCH_JACOBI_2D::runCudaVariantImpl(VariantID vid)
                             decltype(poly_jacobi_2D_1_lambda)>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        N, poly_jacobi_2D_1_lambda );
+        NI, NJ, poly_jacobi_2D_1_lambda );
       RP_CALI_SUBKERNEL_END("POLYBENCH_JACOBI_2D_1");
 
       auto poly_jacobi_2D_2_lambda = [=] __device__ (Index_type i,
@@ -152,7 +152,7 @@ void POLYBENCH_JACOBI_2D::runCudaVariantImpl(VariantID vid)
                             decltype(poly_jacobi_2D_2_lambda)>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        N, poly_jacobi_2D_2_lambda );
+        NI, NJ, poly_jacobi_2D_2_lambda );
       RP_CALI_SUBKERNEL_END("POLYBENCH_JACOBI_2D_2");
 
     }
@@ -179,8 +179,8 @@ void POLYBENCH_JACOBI_2D::runCudaVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_1");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1}),
         res,
         [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_JACOBI_2D_BODY1_RAJA;
@@ -190,8 +190,8 @@ void POLYBENCH_JACOBI_2D::runCudaVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1}),
         res,
         [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_JACOBI_2D_BODY2_RAJA;

--- a/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Hip.cpp
@@ -35,43 +35,43 @@ namespace polybench
   dim3 nthreads_per_block(JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP, 1);
 
 #define JACOBI_2D_NBLOCKS_HIP \
-  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, j_block_sz)), \
-               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(N-2, i_block_sz)), \
+  dim3 nblocks(static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(NJ-2, j_block_sz)), \
+               static_cast<size_t>(RAJA_DIVIDE_CEILING_INT(NI-2, i_block_sz)), \
                static_cast<size_t>(1));
 
 
 template < size_t j_block_size, size_t i_block_size >
 __launch_bounds__(j_block_size*i_block_size)
-__global__ void poly_jacobi_2D_1(Real_ptr A, Real_ptr B, Index_type N)
+__global__ void poly_jacobi_2D_1(Real_ptr A, Real_ptr B, Index_type NI, Index_type NJ)
 {
   Index_type i = 1 + blockIdx.y * i_block_size + threadIdx.y;
   Index_type j = 1 + blockIdx.x * j_block_size + threadIdx.x;
 
-  if ( i < N-1 && j < N-1 ) {
+  if ( i < NI-1 && j < NJ-1 ) {
     POLYBENCH_JACOBI_2D_BODY1;
   }
 }
 
 template < size_t j_block_size, size_t i_block_size >
 __launch_bounds__(j_block_size*i_block_size)
-__global__ void poly_jacobi_2D_2(Real_ptr A, Real_ptr B, Index_type N)
+__global__ void poly_jacobi_2D_2(Real_ptr A, Real_ptr B, Index_type NI, Index_type NJ)
 {
   Index_type i = 1 + blockIdx.y * i_block_size + threadIdx.y;
   Index_type j = 1 + blockIdx.x * j_block_size + threadIdx.x;
 
-  if ( i < N-1 && j < N-1 ) {
+  if ( i < NI-1 && j < NJ-1 ) {
     POLYBENCH_JACOBI_2D_BODY2;
   }
 }
 
 template < size_t j_block_size, size_t i_block_size, typename Lambda >
 __launch_bounds__(j_block_size*i_block_size)
-__global__ void poly_jacobi_2D_lam(Index_type N, Lambda body)
+__global__ void poly_jacobi_2D_lam(Index_type NI, Index_type NJ, Lambda body)
 {
   Index_type i = 1 + blockIdx.y * i_block_size + threadIdx.y;
   Index_type j = 1 + blockIdx.x * j_block_size + threadIdx.x;
 
-  if ( i < N-1 && j < N-1 ) {
+  if ( i < NI-1 && j < NJ-1 ) {
     body(i, j);
   }
 }
@@ -103,7 +103,7 @@ void POLYBENCH_JACOBI_2D::runHipVariantImpl(VariantID vid)
         (poly_jacobi_2D_1<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        A, B, N );
+        A, B, NI, NJ );
       RP_CALI_SUBKERNEL_END("POLYBENCH_JACOBI_2D_1");
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
@@ -111,7 +111,7 @@ void POLYBENCH_JACOBI_2D::runHipVariantImpl(VariantID vid)
         (poly_jacobi_2D_2<JACOBI_2D_THREADS_PER_BLOCK_TEMPLATE_PARAMS_HIP>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        A, B, N );
+        A, B, NI, NJ );
       RP_CALI_SUBKERNEL_END("POLYBENCH_JACOBI_2D_2");
 
     }
@@ -138,7 +138,7 @@ void POLYBENCH_JACOBI_2D::runHipVariantImpl(VariantID vid)
                             decltype(poly_jacobi_2D_1_lambda)>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        N, poly_jacobi_2D_1_lambda );
+        NI, NJ, poly_jacobi_2D_1_lambda );
       RP_CALI_SUBKERNEL_END("POLYBENCH_JACOBI_2D_1");
 
       auto poly_jacobi_2D_2_lambda = [=] __device__ (Index_type i,
@@ -152,7 +152,7 @@ void POLYBENCH_JACOBI_2D::runHipVariantImpl(VariantID vid)
                             decltype(poly_jacobi_2D_2_lambda)>),
         nblocks, nthreads_per_block,
         shmem, res.get_stream(),
-        N, poly_jacobi_2D_2_lambda );
+        NI, NJ, poly_jacobi_2D_2_lambda );
       RP_CALI_SUBKERNEL_END("POLYBENCH_JACOBI_2D_2");
 
     }
@@ -179,8 +179,8 @@ void POLYBENCH_JACOBI_2D::runHipVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_1");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1}),
         res,
         [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_JACOBI_2D_BODY1_RAJA;
@@ -190,8 +190,8 @@ void POLYBENCH_JACOBI_2D::runHipVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1}),
         res,
         [=] __device__ (Index_type i, Index_type j) {
           POLYBENCH_JACOBI_2D_BODY2_RAJA;

--- a/src/polybench/POLYBENCH_JACOBI_2D-OMP.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-OMP.cpp
@@ -38,8 +38,8 @@ void POLYBENCH_JACOBI_2D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_1");
         #pragma omp parallel for
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
             POLYBENCH_JACOBI_2D_BODY1;
           }
         }
@@ -47,8 +47,8 @@ void POLYBENCH_JACOBI_2D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
         #pragma omp parallel for
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
             POLYBENCH_JACOBI_2D_BODY2;
           }
         }
@@ -75,8 +75,8 @@ void POLYBENCH_JACOBI_2D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_1");
         #pragma omp parallel for
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
             poly_jacobi2d_base_lam1(i, j);
           }
         }
@@ -84,8 +84,8 @@ void POLYBENCH_JACOBI_2D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
         #pragma omp parallel for
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
             poly_jacobi2d_base_lam2(i, j);
           }
         }
@@ -125,8 +125,8 @@ void POLYBENCH_JACOBI_2D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_1");
         RAJA::kernel_resource<EXEC_POL>(
-          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1}),
+          RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                           RAJA::RangeSegment{1, NJ-1}),
           res,
           poly_jacobi2d_lam1
         );
@@ -134,8 +134,8 @@ void POLYBENCH_JACOBI_2D::runOpenMPVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
         RAJA::kernel_resource<EXEC_POL>(
-          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1}),
+          RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                           RAJA::RangeSegment{1, NJ-1}),
           res,
           poly_jacobi2d_lam2
         );

--- a/src/polybench/POLYBENCH_JACOBI_2D-OMPTarget.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-OMPTarget.cpp
@@ -37,8 +37,8 @@ void POLYBENCH_JACOBI_2D::runOpenMPTargetVariant(VariantID vid)
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_1");
       #pragma omp target is_device_ptr(A,B) device( did )
       #pragma omp teams distribute parallel for schedule(static, 1) collapse(2)
-      for (Index_type i = 1; i < N-1; ++i ) {
-        for (Index_type j = 1; j < N-1; ++j ) {
+      for (Index_type i = 1; i < NI-1; ++i ) {
+        for (Index_type j = 1; j < NJ-1; ++j ) {
           POLYBENCH_JACOBI_2D_BODY1;
         }
       }
@@ -47,8 +47,8 @@ void POLYBENCH_JACOBI_2D::runOpenMPTargetVariant(VariantID vid)
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
       #pragma omp target is_device_ptr(A,B) device( did )
       #pragma omp teams distribute parallel for schedule(static, 1) collapse(2)
-      for (Index_type i = 1; i < N-1; ++i ) {
-        for (Index_type j = 1; j < N-1; ++j ) {
+      for (Index_type i = 1; i < NI-1; ++i ) {
+        for (Index_type j = 1; j < NJ-1; ++j ) {
           POLYBENCH_JACOBI_2D_BODY2;
         }
       }
@@ -77,8 +77,8 @@ void POLYBENCH_JACOBI_2D::runOpenMPTargetVariant(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_1");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1}),
         res,
         [=] (Index_type i, Index_type j) {
           POLYBENCH_JACOBI_2D_BODY1_RAJA;
@@ -88,8 +88,8 @@ void POLYBENCH_JACOBI_2D::runOpenMPTargetVariant(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1}),
         res,
         [=] (Index_type i, Index_type j) {
           POLYBENCH_JACOBI_2D_BODY2_RAJA;

--- a/src/polybench/POLYBENCH_JACOBI_2D-Seq.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Seq.cpp
@@ -35,16 +35,16 @@ void POLYBENCH_JACOBI_2D::runSeqVariant(VariantID vid)
       for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_1");
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
             POLYBENCH_JACOBI_2D_BODY1;
           }
         }
         RP_CALI_SUBKERNEL_END("POLYBENCH_JACOBI_2D_1");
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
             POLYBENCH_JACOBI_2D_BODY2;
           }
         }
@@ -72,16 +72,16 @@ void POLYBENCH_JACOBI_2D::runSeqVariant(VariantID vid)
       for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_1");
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
             poly_jacobi2d_base_lam1(i, j);
           }
         }
         RP_CALI_SUBKERNEL_END("POLYBENCH_JACOBI_2D_1");
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
-        for (Index_type i = 1; i < N-1; ++i ) {
-          for (Index_type j = 1; j < N-1; ++j ) {
+        for (Index_type i = 1; i < NI-1; ++i ) {
+          for (Index_type j = 1; j < NJ-1; ++j ) {
             poly_jacobi2d_base_lam2(i, j);
           }
         }
@@ -121,8 +121,8 @@ void POLYBENCH_JACOBI_2D::runSeqVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_1");
         RAJA::kernel_resource<EXEC_POL>(
-          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1}),
+          RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                           RAJA::RangeSegment{1, NJ-1}),
           res,
           poly_jacobi2d_lam1
         );
@@ -130,8 +130,8 @@ void POLYBENCH_JACOBI_2D::runSeqVariant(VariantID vid)
 
         RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
         RAJA::kernel_resource<EXEC_POL>(
-          RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                           RAJA::RangeSegment{1, N-1}),
+          RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                           RAJA::RangeSegment{1, NJ-1}),
           res,
           poly_jacobi2d_lam2
         );

--- a/src/polybench/POLYBENCH_JACOBI_2D-Sycl.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D-Sycl.cpp
@@ -48,8 +48,8 @@ void POLYBENCH_JACOBI_2D::runSyclVariantImpl(VariantID vid)
     for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
 
       sycl::range<3> global_dim(1,
-                                i_wg_sz * RAJA_DIVIDE_CEILING_INT(N-2, i_wg_sz),
-                                j_wg_sz * RAJA_DIVIDE_CEILING_INT(N-2, j_wg_sz));
+                                i_wg_sz * RAJA_DIVIDE_CEILING_INT(NI-2, i_wg_sz),
+                                j_wg_sz * RAJA_DIVIDE_CEILING_INT(NJ-2, j_wg_sz));
 
       sycl::range<3> wkgroup_dim(1, i_wg_sz, j_wg_sz);
 
@@ -61,7 +61,7 @@ void POLYBENCH_JACOBI_2D::runSyclVariantImpl(VariantID vid)
           Index_type i = item.get_global_id(1) + 1;
           Index_type j = item.get_global_id(2) + 1;
 
-          if ( i < N-1 && j < N-1 ) {
+          if ( i < NI-1 && j < NJ-1 ) {
             POLYBENCH_JACOBI_2D_BODY1;
           }
 
@@ -77,7 +77,7 @@ void POLYBENCH_JACOBI_2D::runSyclVariantImpl(VariantID vid)
           Index_type i = item.get_global_id(1) + 1;
           Index_type j = item.get_global_id(2) + 1;
 
-          if ( i < N-1 && j < N-1 ) {
+          if ( i < NI-1 && j < NJ-1 ) {
             POLYBENCH_JACOBI_2D_BODY2;
           }
 
@@ -109,8 +109,8 @@ void POLYBENCH_JACOBI_2D::runSyclVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_1");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1}),
         res,
         [=] (Index_type i, Index_type j) {
           POLYBENCH_JACOBI_2D_BODY1_RAJA;
@@ -120,8 +120,8 @@ void POLYBENCH_JACOBI_2D::runSyclVariantImpl(VariantID vid)
 
       RP_CALI_SUBKERNEL_BEGIN("POLYBENCH_JACOBI_2D_2");
       RAJA::kernel_resource<EXEC_POL>(
-        RAJA::make_tuple(RAJA::RangeSegment{1, N-1},
-                         RAJA::RangeSegment{1, N-1}),
+        RAJA::make_tuple(RAJA::RangeSegment{1, NI-1},
+                         RAJA::RangeSegment{1, NJ-1}),
         res,
         [=] (Index_type i, Index_type j) {
           POLYBENCH_JACOBI_2D_BODY2_RAJA;

--- a/src/polybench/POLYBENCH_JACOBI_2D.cpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.cpp
@@ -23,6 +23,8 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
   : KernelBase(rajaperf::Polybench_JACOBI_2D, params)
 {
   Index_type N_default = 1002;
+  m_ni = params.getGrid2DMeshX() + 2;
+  m_nj = params.getGrid2DMeshY() + 2;
 
   setDefaultProblemSize( (N_default-2)*(N_default-2) );
   setDefaultReps(2000);
@@ -45,25 +47,28 @@ POLYBENCH_JACOBI_2D::POLYBENCH_JACOBI_2D(const RunParams& params)
 
 void POLYBENCH_JACOBI_2D::setSize(Index_type target_size, Index_type target_reps)
 {
-  m_N = std::sqrt( target_size ) + 2 + std::sqrt(2)-1;
+  if (!run_params.useGrid2DMeshDims())
+  {
+    m_ni = m_nj = std::sqrt( target_size ) + 2 + std::sqrt(2)-1;
+  }
 
-  setActualProblemSize( (m_N-2)*(m_N-2) );
+  setActualProblemSize( (m_ni-2)*(m_nj-2) );
   setRunReps( target_reps );
 
-  setItsPerRep( 2 * (m_N-2)*(m_N-2) );
+  setItsPerRep( 2 * (m_ni-2)*(m_nj-2) );
   setKernelsPerRep(2);
 
-  setBytesAllocatedPerRep( 2*sizeof(Real_type) * m_N*m_N ); // A, B
-  setBytesReadPerRep( 1*sizeof(Real_type) * (m_N*m_N - 4) + // A (5 point stencil)
+  setBytesAllocatedPerRep( 2*sizeof(Real_type) * m_ni*m_nj ); // A, B
+  setBytesReadPerRep( 1*sizeof(Real_type) * (m_ni*m_nj - 4) + // A (5 point stencil)
 
-                      1*sizeof(Real_type) * (m_N*m_N - 4) ); // B (5 point stencil)
-  setBytesWrittenPerRep( 1*sizeof(Real_type) * (m_N-2)*(m_N-2) + // B
+                      1*sizeof(Real_type) * (m_ni*m_nj - 4) ); // B (5 point stencil)
+  setBytesWrittenPerRep( 1*sizeof(Real_type) * (m_ni-2)*(m_nj-2) + // B
 
-                         1*sizeof(Real_type) * (m_N-2)*(m_N-2) ); // A
+                         1*sizeof(Real_type) * (m_ni-2)*(m_nj-2) ); // A
   setBytesModifyWrittenPerRep( 0 );
   setBytesAtomicModifyWrittenPerRep( 0 );
-  setFLOPsPerRep( 5 * (m_N-2)*(m_N-2) +
-                  5 * (m_N-2)*(m_N-2) );
+  setFLOPsPerRep( 5 * (m_ni-2)*(m_nj-2) +
+                  5 * (m_ni-2)*(m_nj-2) );
 }
 
 POLYBENCH_JACOBI_2D::~POLYBENCH_JACOBI_2D()
@@ -72,14 +77,14 @@ POLYBENCH_JACOBI_2D::~POLYBENCH_JACOBI_2D()
 
 void POLYBENCH_JACOBI_2D::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  allocAndInitData(m_A, m_N*m_N, vid);
-  allocAndInitData(m_B, m_N*m_N, vid);
+  allocAndInitData(m_A, m_ni*m_nj, vid);
+  allocAndInitData(m_B, m_ni*m_nj, vid);
 }
 
 void POLYBENCH_JACOBI_2D::updateChecksum(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
 {
-  addToChecksum(m_A, m_N*m_N, vid);
-  addToChecksum(m_B, m_N*m_N, vid);
+  addToChecksum(m_A, m_ni*m_nj, vid);
+  addToChecksum(m_B, m_ni*m_nj, vid);
 }
 
 void POLYBENCH_JACOBI_2D::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))

--- a/src/polybench/POLYBENCH_JACOBI_2D.hpp
+++ b/src/polybench/POLYBENCH_JACOBI_2D.hpp
@@ -28,14 +28,15 @@
 #define POLYBENCH_JACOBI_2D_DATA_SETUP \
   Real_ptr A = m_A; \
   Real_ptr B = m_B; \
-  const Index_type N = m_N;
+  const Index_type NI = m_ni; \
+  const Index_type NJ = m_nj;
 
 
 #define POLYBENCH_JACOBI_2D_BODY1 \
-  B[j + i*N] = 0.2 * (A[j + i*N] + A[j-1 + i*N] + A[j+1 + i*N] + A[j + (i+1)*N] + A[j + (i-1)*N]);
+  B[j + i*NJ] = 0.2 * (A[j + i*NJ] + A[j-1 + i*NJ] + A[j+1 + i*NJ] + A[j + (i+1)*NJ] + A[j + (i-1)*NJ]);
 
 #define POLYBENCH_JACOBI_2D_BODY2 \
-  A[j + i*N] = 0.2 * (B[j + i*N] + B[j-1 + i*N] + B[j+1 + i*N] + B[j + (i+1)*N] + B[j + (i-1)*N]);
+  A[j + i*NJ] = 0.2 * (B[j + i*NJ] + B[j-1 + i*NJ] + B[j+1 + i*NJ] + B[j + (i+1)*NJ] + B[j + (i-1)*NJ]);
 
 
 #define POLYBENCH_JACOBI_2D_BODY1_RAJA \
@@ -49,8 +50,8 @@
 using VIEW_TYPE = RAJA::View<Real_type, \
                              RAJA::Layout<2, Index_type, 1>>; \
 \
-  VIEW_TYPE Aview(A, RAJA::Layout<2>(N, N)); \
-  VIEW_TYPE Bview(B, RAJA::Layout<2>(N, N));
+  VIEW_TYPE Aview(A, RAJA::Layout<2>(NI, NJ)); \
+  VIEW_TYPE Bview(B, RAJA::Layout<2>(NI, NJ));
 
 
 #include "common/KernelBase.hpp"
@@ -101,7 +102,8 @@ private:
   using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
                                                          integer::MultipleOf<32>>;
 
-  Index_type m_N;
+  Index_type m_ni;
+  Index_type m_nj;
 
   Real_ptr m_A;
   Real_ptr m_B;


### PR DESCRIPTION
# Summary

Add command line options to change the grid size of 2D and 3D kernels in each dimension.

This changes the definition of problem size for the LCALS_HYDRO_2D kernel to match the other multi dimensional mesh kernels. Now it only counts the interior of the mesh where calculations take place instead of the whole mesh including ghost/phony elements.

- This PR is a feature
- It does the following:
  - Adds option to set grid dimensions at the request of me