### PR TITLE
Task/smith84/gha sync with raja

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   docker_build_and_test:
     strategy:
       matrix:
-        target: [gcc12, gcc12_debug, gcc13, gcc13_desul, clang14_debug, clang14_desul, intel2024_2, intel2024_2_debug, intel2024_2_sycl, rocm6_4_3_desul]
+        target: [gcc12, gcc12_debug, gcc13, gcc13_desul, clang19_debug, clang19_desul, intel2024_2, intel2024_2_debug, intel2024_2_sycl, rocm6_4_3_desul]
     runs-on: ubuntu-latest
     steps:
     - run: |
@@ -26,23 +26,31 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+
+## Back off version of cmake with known issue
+      - name: Install CMake 3.29
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3  # v4.4.0
+        with:
+          cmakeVersion: "~3.29.0"
+
       - uses: threeal/cmake-action@v1.3.0
         with:
           build-dir: build
           options:
-            CMAKE_CXX_STANDARD=17
+            BLT_CXX_STD=c++20
             ENABLE_OPENMP=Off
             CMAKE_BUILD_TYPE=Release
           run-build: true
           build-args: '--parallel 16'
       - uses: threeal/ctest-action@v1.1.0
+
   windows_build_and_test:
-    runs-on: windows-latest
     strategy:
       # If any of check fails, allow other jobs to continue running.
       fail-fast: false
       matrix:
-        shared: 
+        shared:
+        - args:
 ## ====================================
 ## Shared library build generated undefined symbol errors that are not
 ## understood -RDH
@@ -50,18 +58,32 @@ jobs:
 ##          BUILD_SHARED_LIBS=On 
 ##          CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=On
         - args: BUILD_SHARED_LIBS=Off
-          
+
+# Notes on Windows CI
+# The windows-2025 runner has converted to Visual Studio (VS) 2026.
+# cmake added VS 2026 support in cmake v4.2, we had issues with cmake 4.4 related to JSON parsing.
+# Testing is currently done on the windows-2022 runner with VS 2022 until the issue can
+# be resolved.
+    runs-on: windows-2022
     steps:
       - name: Checkout RAJA Perf
         uses: actions/checkout@v2
         with:
           submodules: recursive
+
+## Back off version of cmake with known issue
+      - name: Install CMake 3.29
+        uses: lukka/get-cmake@e6906078ebd1ccb8ce51ab4626ac46a1b5a517e3  # v4.4.0
+        with:
+          cmakeVersion: "~3.29.0"
+
 ## ====================================
 ## Config and build action
       - name: Windows CMake and Build
         uses: threeal/cmake-action@v1.3.0
         with:
           build-dir: build
+          generator: 'Visual Studio 17 2022'     # force VS generator so MSVC is used instead of NMake
           options:
             ENABLE_WARNINGS_AS_ERRORS=Off
             BLT_CXX_STD=c++20

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ FROM ghcr.io/llnl/radiuss:ubuntu-24.04-clang-19 AS clang19_debug
 ENV GTEST_COLOR=1
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug  -DENABLE_OPENMP=On -DBLT_CXX_STD=c++20 .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DENABLE_OPENMP=On -DPERFSUITE_RUN_SHORT_TEST=On -DBLT_CXX_STD=c++20 .. && \
     make -j 16 &&\
     ctest -T test --output-on-failure && \
     make clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,60 +49,20 @@ RUN cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=Release -DRAJA_ENABLE_WARN
     ctest -T test --output-on-failure && \
     make clean
 
-# SGS Testing if this fixes the pipeline
-# Is there a better way to do this, likely want a new radiuss image so we don't rebuild this as part of the CI.
-FROM ghcr.io/llnl/radiuss:ubuntu-24.04-clang-14 AS clang14_debug
+FROM ghcr.io/llnl/radiuss:ubuntu-24.04-clang-19 AS clang19_debug
 ENV GTEST_COLOR=1
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install GCC 10 for improved compatibility with Clang 14 and create isolated install directory to prevent CLANG picking up GCC 13 from /usr
-# Note CLANG 14 --gcc-toolchain option searches the directory for latest and Ubuntu install mixes headers/libs together in /usr
-# This is rather ugly
-RUN sudo apt-get update && \
-    sudo apt-get install -y gcc-10 g++-10 && \
-    sudo apt-get clean && \
-    sudo rm -rf /var/lib/apt/lists/* && \
-    sudo mkdir -p /opt/gcc-10/lib/gcc/x86_64-linux-gnu /opt/gcc-10/include/c++ /opt/gcc-10/include/x86_64-linux-gnu/c++ && \
-    sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/10 /opt/gcc-10/lib/gcc/x86_64-linux-gnu/10 && \
-    sudo ln -s /usr/include/c++/10 /opt/gcc-10/include/c++/10 && \
-    sudo ln -s /usr/include/x86_64-linux-gnu/c++/10 /opt/gcc-10/include/x86_64-linux-gnu/c++/10
-
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_C_COMPILER=clang-14 \
-          -DCMAKE_CXX_COMPILER=clang++-14 \
-          -DCMAKE_C_FLAGS="--gcc-toolchain=/opt/gcc-10" \
-          -DCMAKE_CXX_FLAGS="--gcc-toolchain=/opt/gcc-10" \
-          -DCMAKE_BUILD_TYPE=Debug  -DENABLE_OPENMP=On -DPERFSUITE_RUN_SHORT_TEST=On -DBLT_CXX_STD=c++20 .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug  -DENABLE_OPENMP=On -DBLT_CXX_STD=c++20 .. && \
     make -j 16 &&\
     ctest -T test --output-on-failure && \
     make clean
 
-# SGS Testing if this fixes the pipeline
-# Is there a better way to do this, likely want a new radiuss image so we don't rebuild this as part of the CI.
-FROM ghcr.io/llnl/radiuss:ubuntu-24.04-clang-14 AS clang14_desul
+FROM ghcr.io/llnl/radiuss:ubuntu-24.04-clang-19 AS clang19_desul
 ENV GTEST_COLOR=1
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install GCC 10 for improved compatibility with Clang 14 and create isolated install directory to prevent CLANG picking up GCC 13 from /usr
-# Note CLANG 14 --gcc-toolchain option searches the directory for latest and Ubuntu install mixes headers/libs together in /usr
-# This is rather ugly
-RUN sudo apt-get update && \
-    sudo apt-get install -y gcc-10 g++-10 && \
-    sudo apt-get clean && \
-    sudo rm -rf /var/lib/apt/lists/* && \
-    sudo mkdir -p /opt/gcc-10/lib/gcc/x86_64-linux-gnu /opt/gcc-10/include/c++ /opt/gcc-10/include/x86_64-linux-gnu/c++ && \
-    sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/10 /opt/gcc-10/lib/gcc/x86_64-linux-gnu/10 && \
-    sudo ln -s /usr/include/c++/10 /opt/gcc-10/include/c++/10 && \
-    sudo ln -s /usr/include/x86_64-linux-gnu/c++/10 /opt/gcc-10/include/x86_64-linux-gnu/c++/10
-
 COPY . /home/raja/workspace
 WORKDIR /home/raja/workspace/build
-RUN cmake -DCMAKE_C_COMPILER=clang-14 \
-          -DCMAKE_CXX_COMPILER=clang++-14 \
-          -DCMAKE_C_FLAGS="--gcc-toolchain=/opt/gcc-10" \
-          -DCMAKE_CXX_FLAGS="--gcc-toolchain=/opt/gcc-10" \
-          -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=On -DRAJA_ENABLE_DESUL_ATOMICS=On -DBLT_CXX_STD=c++20 .. && \
+RUN cmake -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DENABLE_OPENMP=On -DRAJA_ENABLE_DESUL_ATOMICS=On -DBLT_CXX_STD=c++20 .. && \
     make -j 16 &&\
     ctest -T test --output-on-failure && \
     make clean


### PR DESCRIPTION
Update GHA to match RAJA

The GitHub branch protection rules should be updated to reflect change of clang14 tests to clang19.   https://github.com/llnl/RAJAPerf/settings/branches
