### PR TITLE
[Discussion] RAJA::fornest Kernels

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,8 @@ blt_add_executable(
   basic/DAXPY_ATOMIC.cpp
   basic/DAXPY_ATOMIC-Seq.cpp
   basic/DAXPY_ATOMIC-OMPTarget.cpp
+  basic/DYANAMIC_TILE.cpp
+  basic/DYANAMIC_TILE-Seq.cpp
   basic/EMPTY.cpp
   basic/EMPTY-Seq.cpp
   basic/EMPTY-OMPTarget.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,8 @@ blt_add_executable(
   basic/EMPTY.cpp
   basic/EMPTY-Seq.cpp
   basic/EMPTY-OMPTarget.cpp
+  basic/QUADRATURE_LOOP.cpp
+  basic/QUADRATURE_LOOP-Seq.cpp
   basic/IF_QUAD.cpp
   basic/IF_QUAD-Seq.cpp
   basic/IF_QUAD-OMPTarget.cpp

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -43,6 +43,12 @@ blt_add_library(
           EMPTY-OMP.cpp
           EMPTY-OMPTarget.cpp
           EMPTY-Sycl.cpp
+          QUADRATURE_LOOP.cpp
+          QUADRATURE_LOOP-Seq.cpp
+          QUADRATURE_LOOP-OMP.cpp
+          QUADRATURE_LOOP-Cuda.cpp
+          QUADRATURE_LOOP-Hip.cpp
+          QUADRATURE_LOOP-Sycl.cpp
           IF_QUAD.cpp
           IF_QUAD-Seq.cpp
           IF_QUAD-Hip.cpp

--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -36,6 +36,12 @@ blt_add_library(
           DAXPY_ATOMIC-Cuda.cpp
           DAXPY_ATOMIC-OMP.cpp
           DAXPY_ATOMIC-OMPTarget.cpp
+          DYANAMIC_TILE.cpp
+          DYANAMIC_TILE-Seq.cpp
+          DYANAMIC_TILE-Hip.cpp
+          DYANAMIC_TILE-Cuda.cpp
+          DYANAMIC_TILE-OMP.cpp
+          DYANAMIC_TILE-Sycl.cpp
           EMPTY.cpp
           EMPTY-Seq.cpp
           EMPTY-Hip.cpp

--- a/src/basic/DYANAMIC_TILE-Cuda.cpp
+++ b/src/basic/DYANAMIC_TILE-Cuda.cpp
@@ -1,0 +1,219 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DYANAMIC_TILE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void dyanamic_tile(Real_ptr input, Real_ptr output,
+                              Index_type offset,
+                              Index_type ni, Index_type nj, Index_type nk)
+{
+  Index_type flat = blockIdx.x * block_size + threadIdx.x;
+  if (flat < ni * nj * nk) {
+    Index_type i = flat % ni;
+    Index_type j = (flat / ni) % nj;
+    Index_type k = flat / (ni * nj);
+    DYANAMIC_TILE_BODY(offset, ni, nj);
+  }
+}
+
+
+
+template < size_t block_size >
+void DYANAMIC_TILE::runCudaVariantImpl(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getCudaResource()};
+
+  DYANAMIC_TILE_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    const size_t grid_size0 = RAJA_DIVIDE_CEILING_INT(len0, block_size);
+    const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(len1, block_size);
+    const size_t grid_size2 = RAJA_DIVIDE_CEILING_INT(len2, block_size);
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+      RPlaunchCudaKernel( (dyanamic_tile<block_size>),
+                          grid_size0, block_size,
+                          0, res.get_stream(),
+                          input, output, offset0, ni0, nj0, nk0 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+      RPlaunchCudaKernel( (dyanamic_tile<block_size>),
+                          grid_size1, block_size,
+                          0, res.get_stream(),
+                          input, output, offset1, ni1, nj1, nk1 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+      RPlaunchCudaKernel( (dyanamic_tile<block_size>),
+                          grid_size2, block_size,
+                          0, res.get_stream(),
+                          input, output, offset2, ni2, nj2, nk2 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+    }
+    stopTimer();
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    const Index_type ibegin = 0;
+    const size_t grid_size0 = RAJA_DIVIDE_CEILING_INT(len0, block_size);
+    const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(len1, block_size);
+    const size_t grid_size2 = RAJA_DIVIDE_CEILING_INT(len2, block_size);
+
+    auto flat_body0 = [=] __device__ (Index_type flat) {
+      Index_type i = flat % ni0;
+      Index_type j = (flat / ni0) % nj0;
+      Index_type k = flat / (ni0 * nj0);
+      DYANAMIC_TILE_BODY(offset0, ni0, nj0);
+    };
+    auto flat_body1 = [=] __device__ (Index_type flat) {
+      Index_type i = flat % ni1;
+      Index_type j = (flat / ni1) % nj1;
+      Index_type k = flat / (ni1 * nj1);
+      DYANAMIC_TILE_BODY(offset1, ni1, nj1);
+    };
+    auto flat_body2 = [=] __device__ (Index_type flat) {
+      Index_type i = flat % ni2;
+      Index_type j = (flat / ni2) % nj2;
+      Index_type k = flat / (ni2 * nj2);
+      DYANAMIC_TILE_BODY(offset2, ni2, nj2);
+    };
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size,
+                                              decltype(flat_body0)>),
+                          grid_size0, block_size,
+                          0, res.get_stream(),
+                          ibegin, len0, flat_body0 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size,
+                                              decltype(flat_body1)>),
+                          grid_size1, block_size,
+                          0, res.get_stream(),
+                          ibegin, len1, flat_body1 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size,
+                                              decltype(flat_body2)>),
+                          grid_size2, block_size,
+                          0, res.get_stream(),
+                          ibegin, len2, flat_body2 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<RAJA::cuda_exec<block_size, true /*async*/>,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto>;
+
+    auto body0 = [=] __device__ (Index_type k, Index_type j, Index_type i) {
+      DYANAMIC_TILE_BODY(offset0, ni0, nj0);
+    };
+    auto body1 = [=] __device__ (Index_type k, Index_type j, Index_type i) {
+      DYANAMIC_TILE_BODY(offset1, ni1, nj1);
+    };
+    auto body2 = [=] __device__ (Index_type k, Index_type j, Index_type i) {
+      DYANAMIC_TILE_BODY(offset2, ni2, nj2);
+    };
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk0), RAJA::range(nj0), RAJA::range(ni0),
+                    body0);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk1), RAJA::range(nj1), RAJA::range(ni1),
+                    body1);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk2), RAJA::range(nj2), RAJA::range(ni2),
+                    body2);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  DYANAMIC_TILE : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+void DYANAMIC_TILE::defineCudaVariantTunings()
+{
+  for (VariantID vid : {Base_CUDA, Lambda_CUDA, RAJA_CUDA}) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (vid == RAJA_CUDA) {
+          addVariantTuning<&DYANAMIC_TILE::runCudaVariantImpl<block_size>>(
+              vid, "fornest-auto-tile_block_"+std::to_string(block_size));
+        } else {
+          addVariantTuning<&DYANAMIC_TILE::runCudaVariantImpl<block_size>>(
+              vid, "block_"+std::to_string(block_size));
+        }
+
+      }
+
+    });
+
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/basic/DYANAMIC_TILE-Hip.cpp
+++ b/src/basic/DYANAMIC_TILE-Hip.cpp
@@ -1,0 +1,219 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DYANAMIC_TILE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+#include "common/HipDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void dyanamic_tile(Real_ptr input, Real_ptr output,
+                              Index_type offset,
+                              Index_type ni, Index_type nj, Index_type nk)
+{
+  Index_type flat = blockIdx.x * block_size + threadIdx.x;
+  if (flat < ni * nj * nk) {
+    Index_type i = flat % ni;
+    Index_type j = (flat / ni) % nj;
+    Index_type k = flat / (ni * nj);
+    DYANAMIC_TILE_BODY(offset, ni, nj);
+  }
+}
+
+
+
+template < size_t block_size >
+void DYANAMIC_TILE::runHipVariantImpl(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getHipResource()};
+
+  DYANAMIC_TILE_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    const size_t grid_size0 = RAJA_DIVIDE_CEILING_INT(len0, block_size);
+    const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(len1, block_size);
+    const size_t grid_size2 = RAJA_DIVIDE_CEILING_INT(len2, block_size);
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+      RPlaunchHipKernel( (dyanamic_tile<block_size>),
+                         grid_size0, block_size,
+                         0, res.get_stream(),
+                         input, output, offset0, ni0, nj0, nk0 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+      RPlaunchHipKernel( (dyanamic_tile<block_size>),
+                         grid_size1, block_size,
+                         0, res.get_stream(),
+                         input, output, offset1, ni1, nj1, nk1 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+      RPlaunchHipKernel( (dyanamic_tile<block_size>),
+                         grid_size2, block_size,
+                         0, res.get_stream(),
+                         input, output, offset2, ni2, nj2, nk2 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+    }
+    stopTimer();
+
+  } else if ( vid == Lambda_HIP ) {
+
+    const Index_type ibegin = 0;
+    const size_t grid_size0 = RAJA_DIVIDE_CEILING_INT(len0, block_size);
+    const size_t grid_size1 = RAJA_DIVIDE_CEILING_INT(len1, block_size);
+    const size_t grid_size2 = RAJA_DIVIDE_CEILING_INT(len2, block_size);
+
+    auto flat_body0 = [=] __device__ (Index_type flat) {
+      Index_type i = flat % ni0;
+      Index_type j = (flat / ni0) % nj0;
+      Index_type k = flat / (ni0 * nj0);
+      DYANAMIC_TILE_BODY(offset0, ni0, nj0);
+    };
+    auto flat_body1 = [=] __device__ (Index_type flat) {
+      Index_type i = flat % ni1;
+      Index_type j = (flat / ni1) % nj1;
+      Index_type k = flat / (ni1 * nj1);
+      DYANAMIC_TILE_BODY(offset1, ni1, nj1);
+    };
+    auto flat_body2 = [=] __device__ (Index_type flat) {
+      Index_type i = flat % ni2;
+      Index_type j = (flat / ni2) % nj2;
+      Index_type k = flat / (ni2 * nj2);
+      DYANAMIC_TILE_BODY(offset2, ni2, nj2);
+    };
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(flat_body0)>),
+                         grid_size0, block_size,
+                         0, res.get_stream(),
+                         ibegin, len0, flat_body0 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(flat_body1)>),
+                         grid_size1, block_size,
+                         0, res.get_stream(),
+                         ibegin, len1, flat_body1 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(flat_body2)>),
+                         grid_size2, block_size,
+                         0, res.get_stream(),
+                         ibegin, len2, flat_body2 );
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_HIP ) {
+
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<RAJA::hip_exec<block_size, true /*async*/>,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto>;
+
+    auto body0 = [=] __device__ (Index_type k, Index_type j, Index_type i) {
+      DYANAMIC_TILE_BODY(offset0, ni0, nj0);
+    };
+    auto body1 = [=] __device__ (Index_type k, Index_type j, Index_type i) {
+      DYANAMIC_TILE_BODY(offset1, ni1, nj1);
+    };
+    auto body2 = [=] __device__ (Index_type k, Index_type j, Index_type i) {
+      DYANAMIC_TILE_BODY(offset2, ni2, nj2);
+    };
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk0), RAJA::range(nj0), RAJA::range(ni0),
+                    body0);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk1), RAJA::range(nj1), RAJA::range(ni1),
+                    body1);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk2), RAJA::range(nj2), RAJA::range(ni2),
+                    body2);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  DYANAMIC_TILE : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+void DYANAMIC_TILE::defineHipVariantTunings()
+{
+  for (VariantID vid : {Base_HIP, Lambda_HIP, RAJA_HIP}) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        if (vid == RAJA_HIP) {
+          addVariantTuning<&DYANAMIC_TILE::runHipVariantImpl<block_size>>(
+              vid, "fornest-auto-tile_block_"+std::to_string(block_size));
+        } else {
+          addVariantTuning<&DYANAMIC_TILE::runHipVariantImpl<block_size>>(
+              vid, "block_"+std::to_string(block_size));
+        }
+
+      }
+
+    });
+
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_HIP

--- a/src/basic/DYANAMIC_TILE-OMP.cpp
+++ b/src/basic/DYANAMIC_TILE-OMP.cpp
@@ -1,0 +1,191 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DYANAMIC_TILE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+void DYANAMIC_TILE::runOpenMPVariant(VariantID vid)
+{
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+  const Index_type run_reps = getRunReps();
+
+  DYANAMIC_TILE_DATA_SETUP;
+
+  auto body0 = [=](Index_type k, Index_type j, Index_type i) {
+                 DYANAMIC_TILE_BODY(offset0, ni0, nj0);
+               };
+  auto body1 = [=](Index_type k, Index_type j, Index_type i) {
+                 DYANAMIC_TILE_BODY(offset1, ni1, nj1);
+               };
+  auto body2 = [=](Index_type k, Index_type j, Index_type i) {
+                 DYANAMIC_TILE_BODY(offset2, ni2, nj2);
+               };
+
+  switch ( vid ) {
+
+    case Base_OpenMP : {
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+        #pragma omp parallel for
+        for (Index_type k = 0; k < nk0; ++k ) {
+          for (Index_type j = 0; j < nj0; ++j ) {
+            for (Index_type i = 0; i < ni0; ++i ) {
+              DYANAMIC_TILE_BODY(offset0, ni0, nj0);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+        #pragma omp parallel for
+        for (Index_type k = 0; k < nk1; ++k ) {
+          for (Index_type j = 0; j < nj1; ++j ) {
+            for (Index_type i = 0; i < ni1; ++i ) {
+              DYANAMIC_TILE_BODY(offset1, ni1, nj1);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+        #pragma omp parallel for
+        for (Index_type k = 0; k < nk2; ++k ) {
+          for (Index_type j = 0; j < nj2; ++j ) {
+            for (Index_type i = 0; i < ni2; ++i ) {
+              DYANAMIC_TILE_BODY(offset2, ni2, nj2);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case Lambda_OpenMP : {
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+        #pragma omp parallel for
+        for (Index_type k = 0; k < nk0; ++k ) {
+          for (Index_type j = 0; j < nj0; ++j ) {
+            for (Index_type i = 0; i < ni0; ++i ) {
+              body0(k, j, i);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+        #pragma omp parallel for
+        for (Index_type k = 0; k < nk1; ++k ) {
+          for (Index_type j = 0; j < nj1; ++j ) {
+            for (Index_type i = 0; i < ni1; ++i ) {
+              body1(k, j, i);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+        #pragma omp parallel for
+        for (Index_type k = 0; k < nk2; ++k ) {
+          for (Index_type j = 0; j < nj2; ++j ) {
+            for (Index_type i = 0; i < ni2; ++i ) {
+              body2(k, j, i);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_OpenMP : {
+
+      using EXEC_POL =
+        RAJA::fornest_tiling_policy<
+          RAJA::fornest_basic_omp_outer_3d<RAJA::seq_exec>,
+          RAJA::fornest_tile_auto,
+          RAJA::fornest_tile_auto,
+          RAJA::fornest_tile_auto>;
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+        RAJA::fornest(EXEC_POL {},
+                      RAJA::range(nk0), RAJA::range(nj0), RAJA::range(ni0),
+                      body0);
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+        RAJA::fornest(EXEC_POL {},
+                      RAJA::range(nk1), RAJA::range(nj1), RAJA::range(ni1),
+                      body1);
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+        RAJA::fornest(EXEC_POL {},
+                      RAJA::range(nk2), RAJA::range(nj2), RAJA::range(ni2),
+                      body2);
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    default : {
+      getCout() << "\n  DYANAMIC_TILE : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+void DYANAMIC_TILE::defineOpenMPVariantTunings()
+{
+  for (VariantID vid : {Base_OpenMP, Lambda_OpenMP, RAJA_OpenMP}) {
+    if (vid == RAJA_OpenMP) {
+      addVariantTuning<&DYANAMIC_TILE::runOpenMPVariant>(
+          vid, "fornest-auto-tile");
+    } else {
+      addVariantTuning<&DYANAMIC_TILE::runOpenMPVariant>(
+          vid, getDefaultTuningName());
+    }
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/DYANAMIC_TILE-Seq.cpp
+++ b/src/basic/DYANAMIC_TILE-Seq.cpp
@@ -1,0 +1,184 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DYANAMIC_TILE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+void DYANAMIC_TILE::runSeqVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  DYANAMIC_TILE_DATA_SETUP;
+
+#if defined(RUN_RAJA_SEQ)
+  auto body0 = [=](Index_type k, Index_type j, Index_type i) {
+                 DYANAMIC_TILE_BODY(offset0, ni0, nj0);
+               };
+  auto body1 = [=](Index_type k, Index_type j, Index_type i) {
+                 DYANAMIC_TILE_BODY(offset1, ni1, nj1);
+               };
+  auto body2 = [=](Index_type k, Index_type j, Index_type i) {
+                 DYANAMIC_TILE_BODY(offset2, ni2, nj2);
+               };
+#endif
+
+  switch ( vid ) {
+
+    case Base_Seq : {
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+        for (Index_type k = 0; k < nk0; ++k ) {
+          for (Index_type j = 0; j < nj0; ++j ) {
+            for (Index_type i = 0; i < ni0; ++i ) {
+              DYANAMIC_TILE_BODY(offset0, ni0, nj0);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+        for (Index_type k = 0; k < nk1; ++k ) {
+          for (Index_type j = 0; j < nj1; ++j ) {
+            for (Index_type i = 0; i < ni1; ++i ) {
+              DYANAMIC_TILE_BODY(offset1, ni1, nj1);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+        for (Index_type k = 0; k < nk2; ++k ) {
+          for (Index_type j = 0; j < nj2; ++j ) {
+            for (Index_type i = 0; i < ni2; ++i ) {
+              DYANAMIC_TILE_BODY(offset2, ni2, nj2);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+#if defined(RUN_RAJA_SEQ)
+    case Lambda_Seq : {
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+        for (Index_type k = 0; k < nk0; ++k ) {
+          for (Index_type j = 0; j < nj0; ++j ) {
+            for (Index_type i = 0; i < ni0; ++i ) {
+              body0(k, j, i);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+        for (Index_type k = 0; k < nk1; ++k ) {
+          for (Index_type j = 0; j < nj1; ++j ) {
+            for (Index_type i = 0; i < ni1; ++i ) {
+              body1(k, j, i);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+        for (Index_type k = 0; k < nk2; ++k ) {
+          for (Index_type j = 0; j < nj2; ++j ) {
+            for (Index_type i = 0; i < ni2; ++i ) {
+              body2(k, j, i);
+            }
+          }
+        }
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_Seq : {
+
+      using EXEC_POL =
+        RAJA::fornest_tiling_policy<RAJA::fornest_basic_seq_3d<RAJA::seq_exec>,
+                                    RAJA::fornest_tile_auto,
+                                    RAJA::fornest_tile_auto,
+                                    RAJA::fornest_tile_auto>;
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+        RAJA::fornest(EXEC_POL {},
+                      RAJA::range(nk0), RAJA::range(nj0), RAJA::range(ni0),
+                      body0);
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+        RAJA::fornest(EXEC_POL {},
+                      RAJA::range(nk1), RAJA::range(nj1), RAJA::range(ni1),
+                      body1);
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+        RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+        RAJA::fornest(EXEC_POL {},
+                      RAJA::range(nk2), RAJA::range(nj2), RAJA::range(ni2),
+                      body2);
+        RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+      }
+      stopTimer();
+
+      break;
+    }
+#endif // RUN_RAJA_SEQ
+
+    default : {
+      getCout() << "\n  DYANAMIC_TILE : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+}
+
+void DYANAMIC_TILE::defineSeqVariantTunings()
+{
+  for (VariantID vid : {Base_Seq, Lambda_Seq, RAJA_Seq}) {
+    if (vid == RAJA_Seq) {
+      addVariantTuning<&DYANAMIC_TILE::runSeqVariant>(
+          vid, "fornest-auto-tile");
+    } else {
+      addVariantTuning<&DYANAMIC_TILE::runSeqVariant>(
+          vid, getDefaultTuningName());
+    }
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/DYANAMIC_TILE-Sycl.cpp
+++ b/src/basic/DYANAMIC_TILE-Sycl.cpp
@@ -1,0 +1,153 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DYANAMIC_TILE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_SYCL)
+
+#include "common/SyclDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+template < size_t work_group_size >
+void DYANAMIC_TILE::runSyclVariantImpl(VariantID vid)
+{
+  setBlockSize(work_group_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
+  DYANAMIC_TILE_DATA_SETUP;
+
+  if ( vid == Base_SYCL ) {
+
+    auto submit = [&](Index_type offset,
+                      Index_type ni, Index_type nj, Index_type nk) {
+      const Index_type len = ni * nj * nk;
+      const size_t global_size =
+        work_group_size * RAJA_DIVIDE_CEILING_INT(len, work_group_size);
+
+      qu.submit([&] (sycl::handler& h) {
+        h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
+                       [=] (sycl::nd_item<1> item) {
+          Index_type flat = item.get_global_id(0);
+          if (flat < len) {
+            Index_type i = flat % ni;
+            Index_type j = (flat / ni) % nj;
+            Index_type k = flat / (ni * nj);
+            DYANAMIC_TILE_BODY(offset, ni, nj);
+          }
+        });
+      });
+    };
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+      submit(offset0, ni0, nj0, nk0);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+      submit(offset1, ni1, nj1, nk1);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+      submit(offset2, ni2, nj2, nk2);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_SYCL ) {
+
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<RAJA::sycl_exec<work_group_size>,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto>;
+
+    auto body0 = [=] (Index_type k, Index_type j, Index_type i) {
+      DYANAMIC_TILE_BODY(offset0, ni0, nj0);
+    };
+    auto body1 = [=] (Index_type k, Index_type j, Index_type i) {
+      DYANAMIC_TILE_BODY(offset1, ni1, nj1);
+    };
+    auto body2 = [=] (Index_type k, Index_type j, Index_type i) {
+      DYANAMIC_TILE_BODY(offset2, ni2, nj2);
+    };
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_1");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk0), RAJA::range(nj0), RAJA::range(ni0),
+                    body0);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_1");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_2");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk1), RAJA::range(nj1), RAJA::range(ni1),
+                    body1);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_2");
+
+      RP_CALI_SUBKERNEL_BEGIN("DYANAMIC_TILE_3");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk2), RAJA::range(nj2), RAJA::range(ni2),
+                    body2);
+      RP_CALI_SUBKERNEL_END("DYANAMIC_TILE_3");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  DYANAMIC_TILE : Unknown Sycl variant id = " << vid << std::endl;
+  }
+}
+
+void DYANAMIC_TILE::defineSyclVariantTunings()
+{
+  for (VariantID vid : {Base_SYCL, RAJA_SYCL}) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto work_group_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(work_group_size)) {
+
+        if (vid == RAJA_SYCL) {
+          addVariantTuning<&DYANAMIC_TILE::runSyclVariantImpl<work_group_size>>(
+              vid, "fornest-auto-tile_block_"+std::to_string(work_group_size));
+        } else {
+          addVariantTuning<&DYANAMIC_TILE::runSyclVariantImpl<work_group_size>>(
+              vid, "block_"+std::to_string(work_group_size));
+        }
+
+      }
+
+    });
+
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_SYCL

--- a/src/basic/DYANAMIC_TILE.cpp
+++ b/src/basic/DYANAMIC_TILE.cpp
@@ -1,0 +1,114 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "DYANAMIC_TILE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
+#include <cmath>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+DYANAMIC_TILE::DYANAMIC_TILE(const RunParams& params)
+  : KernelBase(rajaperf::Basic_DYANAMIC_TILE, params)
+{
+  setDefaultProblemSize(1000000);
+  setDefaultReps(500);
+
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setMaxPerfectLoopDimensions(3);
+  setProblemDimensionality(3);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void DYANAMIC_TILE::setSize(Index_type target_size, Index_type target_reps)
+{
+  const Index_type target_per_kernel = (target_size + 2) / 3;
+  Index_type base =
+    static_cast<Index_type>(std::cbrt(static_cast<double>(target_per_kernel)));
+  if (base < 1) {
+    base = 1;
+  }
+
+  auto ceil_div = [](Index_type len, Index_type div) {
+                    return (len + div - 1) / div;
+                  };
+
+  m_ni0 = 8 * base;
+  m_nj0 = 2 * base;
+  m_nk0 = ceil_div(target_per_kernel, m_ni0 * m_nj0);
+
+  m_ni1 = 2 * base;
+  m_nj1 = 8 * base;
+  m_nk1 = ceil_div(target_per_kernel, m_ni1 * m_nj1);
+
+  m_ni2 = 4 * base;
+  m_nj2 = 4 * base;
+  m_nk2 = ceil_div(target_per_kernel, m_ni2 * m_nj2);
+
+  m_len0 = m_ni0 * m_nj0 * m_nk0;
+  m_len1 = m_ni1 * m_nj1 * m_nk1;
+  m_len2 = m_ni2 * m_nj2 * m_nk2;
+
+  m_offset0 = 0;
+  m_offset1 = m_len0;
+  m_offset2 = m_len0 + m_len1;
+
+  setActualProblemSize(m_len0 + m_len1 + m_len2);
+  setRunReps(target_reps);
+
+  setItsPerRep(getActualProblemSize());
+  setKernelsPerRep(3);
+
+  setBytesAllocatedPerRep(2 * sizeof(Real_type) * getActualProblemSize());
+  setBytesReadPerRep(1 * sizeof(Real_type) * getActualProblemSize());
+  setBytesWrittenPerRep(1 * sizeof(Real_type) * getActualProblemSize());
+  setBytesModifyWrittenPerRep(0);
+  setBytesAtomicModifyWrittenPerRep(0);
+  setFLOPsPerRep(4 * getActualProblemSize());
+}
+
+DYANAMIC_TILE::~DYANAMIC_TILE()
+{
+}
+
+void DYANAMIC_TILE::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  allocAndInitData(m_input, getActualProblemSize(), vid);
+  allocAndInitDataConst(m_output, getActualProblemSize(), 0.0, vid);
+}
+
+void DYANAMIC_TILE::updateChecksum(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  addToChecksum(m_output, getActualProblemSize(), vid);
+}
+
+void DYANAMIC_TILE::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  deallocData(m_input, vid);
+  deallocData(m_output, vid);
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/DYANAMIC_TILE.hpp
+++ b/src/basic/DYANAMIC_TILE.hpp
@@ -1,0 +1,131 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// DYANAMIC_TILE kernel reference implementation:
+///
+/// for each of three runtime-sized 3D boxes:
+///   for (Index_type k = 0; k < nk; ++k ) {
+///     for (Index_type j = 0; j < nj; ++j ) {
+///       for (Index_type i = 0; i < ni; ++i ) {
+///         Index_type idx = offset + i + ni * (j + nj * k);
+///         output[idx] = input[idx] +
+///                       0.00000001 * (i + 2 * j + 3 * k);
+///       }
+///     }
+///   }
+///
+/// The three boxes use different runtime dimensions so RAJA::fornest auto
+/// tiling can choose different tile shapes. On GPU those tile shapes determine
+/// the thread-block/work-group dimensions.
+///
+
+#ifndef RAJAPerf_Basic_DYANAMIC_TILE_HPP
+#define RAJAPerf_Basic_DYANAMIC_TILE_HPP
+
+
+#define DYANAMIC_TILE_DATA_SETUP \
+  Real_ptr input = m_input; \
+  Real_ptr output = m_output; \
+  Index_type offset0 = m_offset0; \
+  Index_type offset1 = m_offset1; \
+  Index_type offset2 = m_offset2; \
+  Index_type ni0 = m_ni0; \
+  Index_type nj0 = m_nj0; \
+  Index_type nk0 = m_nk0; \
+  Index_type ni1 = m_ni1; \
+  Index_type nj1 = m_nj1; \
+  Index_type nk1 = m_nk1; \
+  Index_type ni2 = m_ni2; \
+  Index_type nj2 = m_nj2; \
+  Index_type nk2 = m_nk2; \
+  Index_type len0 = m_len0; \
+  Index_type len1 = m_len1; \
+  Index_type len2 = m_len2;
+
+#define DYANAMIC_TILE_BODY(INDEX_OFFSET, NI, NJ) \
+  { \
+    Index_type idx = (INDEX_OFFSET) + i + (NI) * (j + (NJ) * k); \
+    output[idx] = input[idx] + \
+                  static_cast<Real_type>(0.00000001) * \
+                      (i + static_cast<Index_type>(2) * j + \
+                       static_cast<Index_type>(3) * k); \
+  }
+
+
+#include "common/KernelBase.hpp"
+
+namespace rajaperf
+{
+class RunParams;
+
+namespace basic
+{
+
+class DYANAMIC_TILE : public KernelBase
+{
+public:
+
+  DYANAMIC_TILE(const RunParams& params);
+
+  ~DYANAMIC_TILE();
+
+  void setSize(Index_type target_size, Index_type target_reps);
+  void setUp(VariantID vid, size_t tune_idx);
+  void updateChecksum(VariantID vid, size_t tune_idx);
+  void tearDown(VariantID vid, size_t tune_idx);
+
+  void defineSeqVariantTunings();
+  void defineOpenMPVariantTunings();
+  void defineCudaVariantTunings();
+  void defineHipVariantTunings();
+  void defineSyclVariantTunings();
+
+  void runSeqVariant(VariantID vid);
+  void runOpenMPVariant(VariantID vid);
+
+  template < size_t block_size >
+  void runCudaVariantImpl(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantImpl(VariantID vid);
+  template < size_t work_group_size >
+  void runSyclVariantImpl(VariantID vid);
+
+private:
+  static const size_t default_gpu_block_size = 256;
+  using gpu_block_sizes_type =
+    integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                           integer::MultipleOf<32>>;
+
+  Real_ptr m_input;
+  Real_ptr m_output;
+
+  Index_type m_offset0;
+  Index_type m_offset1;
+  Index_type m_offset2;
+
+  Index_type m_ni0;
+  Index_type m_nj0;
+  Index_type m_nk0;
+  Index_type m_ni1;
+  Index_type m_nj1;
+  Index_type m_nk1;
+  Index_type m_ni2;
+  Index_type m_nj2;
+  Index_type m_nk2;
+
+  Index_type m_len0;
+  Index_type m_len1;
+  Index_type m_len2;
+};
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/basic/NESTED_INIT-Cuda.cpp
+++ b/src/basic/NESTED_INIT-Cuda.cpp
@@ -172,7 +172,161 @@ void NESTED_INIT::runCudaVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(NESTED_INIT, Cuda, Base_CUDA, Lambda_CUDA, RAJA_CUDA)
+template < size_t block_size >
+void NESTED_INIT::runCudaVariantFornest(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getCudaResource()};
+
+  NESTED_INIT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    using EXEC_POL =
+      RAJA::fornest_collapsed_policy<RAJA::cuda_exec<block_size, true /*async*/>>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    [=] __device__ (Index_type k, Index_type j, Index_type i) {
+        NESTED_INIT_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t block_size, size_t tile_k, size_t tile_j, size_t tile_i >
+void NESTED_INIT::runCudaVariantFornestRuntimeTiled(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getCudaResource()};
+
+  NESTED_INIT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<RAJA::cuda_exec<block_size, true /*async*/>,
+                                  RAJA::fornest_tile_runtime,
+                                  RAJA::fornest_tile_runtime,
+                                  RAJA::fornest_tile_runtime>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(res,
+                    EXEC_POL {RAJA::TileSize(tile_k),
+                              RAJA::TileSize(tile_j),
+                              RAJA::TileSize(tile_i)},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    [=] __device__ (Index_type k, Index_type j, Index_type i) {
+        NESTED_INIT_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t block_size >
+void NESTED_INIT::runCudaVariantFornestAutoTiled(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getCudaResource()};
+
+  NESTED_INIT_DATA_SETUP;
+
+  if ( vid == RAJA_CUDA ) {
+
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<RAJA::cuda_exec<block_size, true /*async*/>,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    [=] __device__ (Index_type k, Index_type j, Index_type i) {
+        NESTED_INIT_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+void NESTED_INIT::defineCudaVariantTunings()
+{
+  for (VariantID vid : {Base_CUDA, Lambda_CUDA, RAJA_CUDA}) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuning<&NESTED_INIT::runCudaVariantImpl<block_size>>(
+            vid, "block_"+std::to_string(block_size));
+
+        if (vid == RAJA_CUDA) {
+          addVariantTuning<&NESTED_INIT::runCudaVariantFornest<block_size>>(
+              vid, "fornest-collapse_block_"+std::to_string(block_size));
+          addVariantTuning<&NESTED_INIT::runCudaVariantFornestAutoTiled<block_size>>(
+              vid, "fornest-auto-tile_block_"+std::to_string(block_size));
+
+          if constexpr (decltype(block_size)::value == 1 * 8 * 32) {
+            addVariantTuning<&NESTED_INIT::runCudaVariantFornestRuntimeTiled<block_size, 1, 8, 32>>(
+                vid, "fornest-runtime-tile_1x8x32_block_"+std::to_string(block_size));
+          }
+          if constexpr (decltype(block_size)::value == 2 * 4 * 32) {
+            addVariantTuning<&NESTED_INIT::runCudaVariantFornestRuntimeTiled<block_size, 2, 4, 32>>(
+                vid, "fornest-runtime-tile_2x4x32_block_"+std::to_string(block_size));
+          }
+          if constexpr (decltype(block_size)::value == 4 * 4 * 16) {
+            addVariantTuning<&NESTED_INIT::runCudaVariantFornestRuntimeTiled<block_size, 4, 4, 16>>(
+                vid, "fornest-runtime-tile_4x4x16_block_"+std::to_string(block_size));
+          }
+        }
+
+      }
+
+    });
+
+  }
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/NESTED_INIT-Hip.cpp
+++ b/src/basic/NESTED_INIT-Hip.cpp
@@ -172,7 +172,161 @@ void NESTED_INIT::runHipVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(NESTED_INIT, Hip, Base_HIP, Lambda_HIP, RAJA_HIP)
+template < size_t block_size >
+void NESTED_INIT::runHipVariantFornest(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getHipResource()};
+
+  NESTED_INIT_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    using EXEC_POL =
+      RAJA::fornest_collapsed_policy<RAJA::hip_exec<block_size, true /*async*/>>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    [=] __device__ (Index_type k, Index_type j, Index_type i) {
+        NESTED_INIT_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t block_size, size_t tile_k, size_t tile_j, size_t tile_i >
+void NESTED_INIT::runHipVariantFornestRuntimeTiled(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getHipResource()};
+
+  NESTED_INIT_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<RAJA::hip_exec<block_size, true /*async*/>,
+                                  RAJA::fornest_tile_runtime,
+                                  RAJA::fornest_tile_runtime,
+                                  RAJA::fornest_tile_runtime>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(res,
+                    EXEC_POL {RAJA::TileSize(tile_k),
+                              RAJA::TileSize(tile_j),
+                              RAJA::TileSize(tile_i)},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    [=] __device__ (Index_type k, Index_type j, Index_type i) {
+        NESTED_INIT_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t block_size >
+void NESTED_INIT::runHipVariantFornestAutoTiled(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getHipResource()};
+
+  NESTED_INIT_DATA_SETUP;
+
+  if ( vid == RAJA_HIP ) {
+
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<RAJA::hip_exec<block_size, true /*async*/>,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    [=] __device__ (Index_type k, Index_type j, Index_type i) {
+        NESTED_INIT_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+void NESTED_INIT::defineHipVariantTunings()
+{
+  for (VariantID vid : {Base_HIP, Lambda_HIP, RAJA_HIP}) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto block_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(block_size)) {
+
+        addVariantTuning<&NESTED_INIT::runHipVariantImpl<block_size>>(
+            vid, "block_"+std::to_string(block_size));
+
+        if (vid == RAJA_HIP) {
+          addVariantTuning<&NESTED_INIT::runHipVariantFornest<block_size>>(
+              vid, "fornest-collapse_block_"+std::to_string(block_size));
+          addVariantTuning<&NESTED_INIT::runHipVariantFornestAutoTiled<block_size>>(
+              vid, "fornest-auto-tile_block_"+std::to_string(block_size));
+
+          if constexpr (decltype(block_size)::value == 1 * 8 * 32) {
+            addVariantTuning<&NESTED_INIT::runHipVariantFornestRuntimeTiled<block_size, 1, 8, 32>>(
+                vid, "fornest-runtime-tile_1x8x32_block_"+std::to_string(block_size));
+          }
+          if constexpr (decltype(block_size)::value == 2 * 4 * 32) {
+            addVariantTuning<&NESTED_INIT::runHipVariantFornestRuntimeTiled<block_size, 2, 4, 32>>(
+                vid, "fornest-runtime-tile_2x4x32_block_"+std::to_string(block_size));
+          }
+          if constexpr (decltype(block_size)::value == 4 * 4 * 16) {
+            addVariantTuning<&NESTED_INIT::runHipVariantFornestRuntimeTiled<block_size, 4, 4, 16>>(
+                vid, "fornest-runtime-tile_4x4x16_block_"+std::to_string(block_size));
+          }
+        }
+
+      }
+
+    });
+
+  }
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/NESTED_INIT-OMP.cpp
+++ b/src/basic/NESTED_INIT-OMP.cpp
@@ -145,7 +145,155 @@ RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
 #endif
 }
 
-RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(NESTED_INIT, OpenMP, Base_OpenMP, Lambda_OpenMP, RAJA_OpenMP)
+void NESTED_INIT::runOpenMPVariantFornest(VariantID vid)
+{
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+
+  const Index_type run_reps = getRunReps();
+
+  NESTED_INIT_DATA_SETUP;
+
+  auto nestedinit_lam = [=](Index_type k, Index_type j, Index_type i) {
+                          NESTED_INIT_BODY;
+                        };
+
+  if ( vid == RAJA_OpenMP ) {
+
+    using EXEC_POL = RAJA::fornest_basic_omp_outer_3d<RAJA::seq_exec>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(EXEC_POL {},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    nestedinit_lam);
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown variant id = " << vid << std::endl;
+  }
+
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+template < size_t tile_k, size_t tile_j, size_t tile_i >
+void NESTED_INIT::runOpenMPVariantFornestRuntimeTiled(VariantID vid)
+{
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+
+  const Index_type run_reps = getRunReps();
+
+  NESTED_INIT_DATA_SETUP;
+
+  auto nestedinit_lam = [=](Index_type k, Index_type j, Index_type i) {
+                          NESTED_INIT_BODY;
+                        };
+
+  if ( vid == RAJA_OpenMP ) {
+
+    using BASE_POL = RAJA::fornest_basic_omp_outer_3d<RAJA::seq_exec>;
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<BASE_POL,
+                                  RAJA::fornest_tile_runtime,
+                                  RAJA::fornest_tile_runtime,
+                                  RAJA::fornest_tile_runtime>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(EXEC_POL {RAJA::TileSize(tile_k),
+                              RAJA::TileSize(tile_j),
+                              RAJA::TileSize(tile_i)},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    nestedinit_lam);
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown variant id = " << vid << std::endl;
+  }
+
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+void NESTED_INIT::runOpenMPVariantFornestAutoTiled(VariantID vid)
+{
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+
+  const Index_type run_reps = getRunReps();
+
+  NESTED_INIT_DATA_SETUP;
+
+  auto nestedinit_lam = [=](Index_type k, Index_type j, Index_type i) {
+                          NESTED_INIT_BODY;
+                        };
+
+  if ( vid == RAJA_OpenMP ) {
+
+    using BASE_POL = RAJA::fornest_basic_omp_outer_3d<RAJA::seq_exec>;
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<BASE_POL,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(EXEC_POL {},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    nestedinit_lam);
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown variant id = " << vid << std::endl;
+  }
+
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+void NESTED_INIT::defineOpenMPVariantTunings()
+{
+  for (VariantID vid : {Base_OpenMP, Lambda_OpenMP, RAJA_OpenMP}) {
+
+    addVariantTuning<&NESTED_INIT::runOpenMPVariant>(
+        vid, getDefaultTuningName());
+
+    if (vid == RAJA_OpenMP) {
+      addVariantTuning<&NESTED_INIT::runOpenMPVariantFornest>(
+          vid, "fornest");
+      addVariantTuning<&NESTED_INIT::runOpenMPVariantFornestRuntimeTiled<1, 8, 32>>(
+          vid, "fornest-runtime-tile_1x8x32");
+      addVariantTuning<&NESTED_INIT::runOpenMPVariantFornestRuntimeTiled<2, 4, 32>>(
+          vid, "fornest-runtime-tile_2x4x32");
+      addVariantTuning<&NESTED_INIT::runOpenMPVariantFornestRuntimeTiled<4, 4, 16>>(
+          vid, "fornest-runtime-tile_4x4x16");
+      addVariantTuning<&NESTED_INIT::runOpenMPVariantFornestAutoTiled>(
+          vid, "fornest-auto-tile");
+    }
+
+  }
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/NESTED_INIT-Seq.cpp
+++ b/src/basic/NESTED_INIT-Seq.cpp
@@ -121,7 +121,149 @@ void NESTED_INIT::runSeqVariant(VariantID vid)
 
 }
 
-RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(NESTED_INIT, Seq, Base_Seq, Lambda_Seq, RAJA_Seq)
+void NESTED_INIT::runSeqVariantFornest(VariantID vid)
+{
+#if defined(RUN_RAJA_SEQ)
+  const Index_type run_reps = getRunReps();
+
+  NESTED_INIT_DATA_SETUP;
+
+  auto nestedinit_lam = [=](Index_type k, Index_type j, Index_type i) {
+                          NESTED_INIT_BODY;
+                        };
+
+  if ( vid == RAJA_Seq ) {
+
+    using EXEC_POL = RAJA::fornest_basic_seq_3d<RAJA::seq_exec>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(EXEC_POL {},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    nestedinit_lam);
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown variant id = " << vid << std::endl;
+  }
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+template < size_t tile_k, size_t tile_j, size_t tile_i >
+void NESTED_INIT::runSeqVariantFornestRuntimeTiled(VariantID vid)
+{
+#if defined(RUN_RAJA_SEQ)
+  const Index_type run_reps = getRunReps();
+
+  NESTED_INIT_DATA_SETUP;
+
+  auto nestedinit_lam = [=](Index_type k, Index_type j, Index_type i) {
+                          NESTED_INIT_BODY;
+                        };
+
+  if ( vid == RAJA_Seq ) {
+
+    using BASE_POL = RAJA::fornest_basic_seq_3d<RAJA::seq_exec>;
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<BASE_POL,
+                                  RAJA::fornest_tile_runtime,
+                                  RAJA::fornest_tile_runtime,
+                                  RAJA::fornest_tile_runtime>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(EXEC_POL {RAJA::TileSize(tile_k),
+                              RAJA::TileSize(tile_j),
+                              RAJA::TileSize(tile_i)},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    nestedinit_lam);
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown variant id = " << vid << std::endl;
+  }
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+void NESTED_INIT::runSeqVariantFornestAutoTiled(VariantID vid)
+{
+#if defined(RUN_RAJA_SEQ)
+  const Index_type run_reps = getRunReps();
+
+  NESTED_INIT_DATA_SETUP;
+
+  auto nestedinit_lam = [=](Index_type k, Index_type j, Index_type i) {
+                          NESTED_INIT_BODY;
+                        };
+
+  if ( vid == RAJA_Seq ) {
+
+    using BASE_POL = RAJA::fornest_basic_seq_3d<RAJA::seq_exec>;
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<BASE_POL,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(EXEC_POL {},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    nestedinit_lam);
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown variant id = " << vid << std::endl;
+  }
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+void NESTED_INIT::defineSeqVariantTunings()
+{
+  for (VariantID vid : {Base_Seq, Lambda_Seq, RAJA_Seq}) {
+
+    addVariantTuning<&NESTED_INIT::runSeqVariant>(
+        vid, getDefaultTuningName());
+
+    if (vid == RAJA_Seq) {
+      addVariantTuning<&NESTED_INIT::runSeqVariantFornest>(
+          vid, "fornest");
+      addVariantTuning<&NESTED_INIT::runSeqVariantFornestRuntimeTiled<1, 8, 32>>(
+          vid, "fornest-runtime-tile_1x8x32");
+      addVariantTuning<&NESTED_INIT::runSeqVariantFornestRuntimeTiled<2, 4, 32>>(
+          vid, "fornest-runtime-tile_2x4x32");
+      addVariantTuning<&NESTED_INIT::runSeqVariantFornestRuntimeTiled<4, 4, 16>>(
+          vid, "fornest-runtime-tile_4x4x16");
+      addVariantTuning<&NESTED_INIT::runSeqVariantFornestAutoTiled>(
+          vid, "fornest-auto-tile");
+    }
+
+  }
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/NESTED_INIT-Sycl.cpp
+++ b/src/basic/NESTED_INIT-Sycl.cpp
@@ -110,7 +110,161 @@ void NESTED_INIT::runSyclVariantImpl(VariantID vid)
   }
 }
 
-RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(NESTED_INIT, Sycl, Base_SYCL, RAJA_SYCL)
+template < size_t work_group_size >
+void NESTED_INIT::runSyclVariantFornest(VariantID vid)
+{
+  setBlockSize(work_group_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getSyclResource()};
+
+  NESTED_INIT_DATA_SETUP;
+
+  if ( vid == RAJA_SYCL ) {
+
+    using EXEC_POL =
+      RAJA::fornest_collapsed_policy<RAJA::sycl_exec<work_group_size>>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    [=] (Index_type k, Index_type j, Index_type i) {
+        NESTED_INIT_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown Sycl variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t work_group_size, size_t tile_k, size_t tile_j, size_t tile_i >
+void NESTED_INIT::runSyclVariantFornestRuntimeTiled(VariantID vid)
+{
+  setBlockSize(work_group_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getSyclResource()};
+
+  NESTED_INIT_DATA_SETUP;
+
+  if ( vid == RAJA_SYCL ) {
+
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<RAJA::sycl_exec<work_group_size>,
+                                  RAJA::fornest_tile_runtime,
+                                  RAJA::fornest_tile_runtime,
+                                  RAJA::fornest_tile_runtime>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(res,
+                    EXEC_POL {RAJA::TileSize(tile_k),
+                              RAJA::TileSize(tile_j),
+                              RAJA::TileSize(tile_i)},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    [=] (Index_type k, Index_type j, Index_type i) {
+        NESTED_INIT_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown Sycl variant id = " << vid << std::endl;
+  }
+}
+
+template < size_t work_group_size >
+void NESTED_INIT::runSyclVariantFornestAutoTiled(VariantID vid)
+{
+  setBlockSize(work_group_size);
+
+  const Index_type run_reps = getRunReps();
+
+  auto res{getSyclResource()};
+
+  NESTED_INIT_DATA_SETUP;
+
+  if ( vid == RAJA_SYCL ) {
+
+    using EXEC_POL =
+      RAJA::fornest_tiling_policy<RAJA::sycl_exec<work_group_size>,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto,
+                                  RAJA::fornest_tile_auto>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("NESTED_INIT_1");
+      RAJA::fornest(res, EXEC_POL {},
+                    RAJA::range(nk), RAJA::range(nj), RAJA::range(ni),
+                    [=] (Index_type k, Index_type j, Index_type i) {
+        NESTED_INIT_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("NESTED_INIT_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  NESTED_INIT : Unknown Sycl variant id = " << vid << std::endl;
+  }
+}
+
+void NESTED_INIT::defineSyclVariantTunings()
+{
+  for (VariantID vid : {Base_SYCL, RAJA_SYCL}) {
+
+    seq_for(gpu_block_sizes_type{}, [&](auto work_group_size) {
+
+      if (run_params.numValidGPUBlockSize() == 0u ||
+          run_params.validGPUBlockSize(work_group_size)) {
+
+        addVariantTuning<&NESTED_INIT::runSyclVariantImpl<work_group_size>>(
+            vid, "block_"+std::to_string(work_group_size));
+
+        if (vid == RAJA_SYCL) {
+          addVariantTuning<&NESTED_INIT::runSyclVariantFornest<work_group_size>>(
+              vid, "fornest-collapse_block_"+std::to_string(work_group_size));
+          addVariantTuning<&NESTED_INIT::runSyclVariantFornestAutoTiled<work_group_size>>(
+              vid, "fornest-auto-tile_block_"+std::to_string(work_group_size));
+
+          if constexpr (decltype(work_group_size)::value == 1 * 8 * 32) {
+            addVariantTuning<&NESTED_INIT::runSyclVariantFornestRuntimeTiled<work_group_size, 1, 8, 32>>(
+                vid, "fornest-runtime-tile_1x8x32_block_"+std::to_string(work_group_size));
+          }
+          if constexpr (decltype(work_group_size)::value == 2 * 4 * 32) {
+            addVariantTuning<&NESTED_INIT::runSyclVariantFornestRuntimeTiled<work_group_size, 2, 4, 32>>(
+                vid, "fornest-runtime-tile_2x4x32_block_"+std::to_string(work_group_size));
+          }
+          if constexpr (decltype(work_group_size)::value == 4 * 4 * 16) {
+            addVariantTuning<&NESTED_INIT::runSyclVariantFornestRuntimeTiled<work_group_size, 4, 4, 16>>(
+                vid, "fornest-runtime-tile_4x4x16_block_"+std::to_string(work_group_size));
+          }
+        }
+
+      }
+
+    });
+
+  }
+}
 
 } // end namespace basic
 } // end namespace rajaperf

--- a/src/basic/NESTED_INIT.hpp
+++ b/src/basic/NESTED_INIT.hpp
@@ -68,12 +68,39 @@ public:
   void runOpenMPTargetVariant(VariantID vid);
   void runKokkosVariant(VariantID vid);
 
+  void runSeqVariantFornest(VariantID vid);
+  template < size_t tile_k, size_t tile_j, size_t tile_i >
+  void runSeqVariantFornestRuntimeTiled(VariantID vid);
+  void runSeqVariantFornestAutoTiled(VariantID vid);
+  void runOpenMPVariantFornest(VariantID vid);
+  template < size_t tile_k, size_t tile_j, size_t tile_i >
+  void runOpenMPVariantFornestRuntimeTiled(VariantID vid);
+  void runOpenMPVariantFornestAutoTiled(VariantID vid);
+
   template < size_t block_size >
   void runCudaVariantImpl(VariantID vid);
   template < size_t block_size >
+  void runCudaVariantFornest(VariantID vid);
+  template < size_t block_size, size_t tile_k, size_t tile_j, size_t tile_i >
+  void runCudaVariantFornestRuntimeTiled(VariantID vid);
+  template < size_t block_size >
+  void runCudaVariantFornestAutoTiled(VariantID vid);
+  template < size_t block_size >
   void runHipVariantImpl(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantFornest(VariantID vid);
+  template < size_t block_size, size_t tile_k, size_t tile_j, size_t tile_i >
+  void runHipVariantFornestRuntimeTiled(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantFornestAutoTiled(VariantID vid);
   template < size_t work_group_size >
   void runSyclVariantImpl(VariantID vid);
+  template < size_t work_group_size >
+  void runSyclVariantFornest(VariantID vid);
+  template < size_t work_group_size, size_t tile_k, size_t tile_j, size_t tile_i >
+  void runSyclVariantFornestRuntimeTiled(VariantID vid);
+  template < size_t work_group_size >
+  void runSyclVariantFornestAutoTiled(VariantID vid);
 
 private:
   static const size_t default_gpu_block_size = 256;

--- a/src/basic/QUADRATURE_LOOP-Cuda.cpp
+++ b/src/basic/QUADRATURE_LOOP-Cuda.cpp
@@ -1,0 +1,130 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "QUADRATURE_LOOP.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void quadrature_loop(Real_ptr values, Real_ptr weights,
+                                Real_ptr output,
+                                Index_type num_zones)
+{
+  Index_type idx = blockIdx.x * block_size + threadIdx.x;
+  if (idx < 27 * num_zones) {
+    Index_type zone = idx / 27;
+    Index_type q = idx - 27 * zone;
+    QUADRATURE_LOOP_BODY;
+  }
+}
+
+
+
+template < size_t block_size >
+void QUADRATURE_LOOP::runCudaVariantImpl(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getCudaResource()};
+
+  QUADRATURE_LOOP_DATA_SETUP;
+
+  if ( vid == Base_CUDA ) {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("QUADRATURE_LOOP_1");
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchCudaKernel( (quadrature_loop<block_size>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          values, weights, output,
+                          num_zones );
+      RP_CALI_SUBKERNEL_END("QUADRATURE_LOOP_1");
+
+    }
+    stopTimer();
+
+  } else if ( vid == Lambda_CUDA ) {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("QUADRATURE_LOOP_1");
+      auto quadratureloop_lam = [=] __device__ (Index_type idx) {
+        Index_type zone = idx / 27;
+        Index_type q = idx - 27 * zone;
+        QUADRATURE_LOOP_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchCudaKernel( (lambda_cuda_forall<block_size,
+                                              decltype(quadratureloop_lam)>),
+                          grid_size, block_size,
+                          shmem, res.get_stream(),
+                          ibegin, iend, quadratureloop_lam );
+      RP_CALI_SUBKERNEL_END("QUADRATURE_LOOP_1");
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_CUDA ) {
+
+    using FORNEST_POL =
+      RAJA::fornest_collapsed_policy<RAJA::cuda_exec<block_size, true /*async*/>>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("QUADRATURE_LOOP_1");
+      RAJA::fornest(res, FORNEST_POL {},
+                    RAJA::range(num_zones), RAJA::range(27),
+                    [=] __device__ (Index_type zone, Index_type q) {
+        QUADRATURE_LOOP_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("QUADRATURE_LOOP_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  QUADRATURE_LOOP : Unknown Cuda variant id = " << vid << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(QUADRATURE_LOOP, Cuda, Base_CUDA, Lambda_CUDA, RAJA_CUDA)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_CUDA

--- a/src/basic/QUADRATURE_LOOP-Hip.cpp
+++ b/src/basic/QUADRATURE_LOOP-Hip.cpp
@@ -1,0 +1,130 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "QUADRATURE_LOOP.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+#include "common/HipDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+template < size_t block_size >
+__launch_bounds__(block_size)
+__global__ void quadrature_loop(Real_ptr values, Real_ptr weights,
+                                Real_ptr output,
+                                Index_type num_zones)
+{
+  Index_type idx = blockIdx.x * block_size + threadIdx.x;
+  if (idx < 27 * num_zones) {
+    Index_type zone = idx / 27;
+    Index_type q = idx - 27 * zone;
+    QUADRATURE_LOOP_BODY;
+  }
+}
+
+
+
+template < size_t block_size >
+void QUADRATURE_LOOP::runHipVariantImpl(VariantID vid)
+{
+  setBlockSize(block_size);
+
+  const Index_type run_reps = getRunReps();
+  const Index_type ibegin = 0;
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getHipResource()};
+
+  QUADRATURE_LOOP_DATA_SETUP;
+
+  if ( vid == Base_HIP ) {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("QUADRATURE_LOOP_1");
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchHipKernel( (quadrature_loop<block_size>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         values, weights, output,
+                         num_zones );
+      RP_CALI_SUBKERNEL_END("QUADRATURE_LOOP_1");
+
+    }
+    stopTimer();
+
+  } else if ( vid == Lambda_HIP ) {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("QUADRATURE_LOOP_1");
+      auto quadratureloop_lam = [=] __device__ (Index_type idx) {
+        Index_type zone = idx / 27;
+        Index_type q = idx - 27 * zone;
+        QUADRATURE_LOOP_BODY;
+      };
+
+      const size_t grid_size = RAJA_DIVIDE_CEILING_INT(iend, block_size);
+      constexpr size_t shmem = 0;
+
+      RPlaunchHipKernel( (lambda_hip_forall<block_size,
+                                            decltype(quadratureloop_lam)>),
+                         grid_size, block_size,
+                         shmem, res.get_stream(),
+                         ibegin, iend, quadratureloop_lam );
+      RP_CALI_SUBKERNEL_END("QUADRATURE_LOOP_1");
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_HIP ) {
+
+    using FORNEST_POL =
+      RAJA::fornest_collapsed_policy<RAJA::hip_exec<block_size, true /*async*/>>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("QUADRATURE_LOOP_1");
+      RAJA::fornest(res, FORNEST_POL {},
+                    RAJA::range(num_zones), RAJA::range(27),
+                    [=] __device__ (Index_type zone, Index_type q) {
+        QUADRATURE_LOOP_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("QUADRATURE_LOOP_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  QUADRATURE_LOOP : Unknown Hip variant id = " << vid << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(QUADRATURE_LOOP, Hip, Base_HIP, Lambda_HIP, RAJA_HIP)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_HIP

--- a/src/basic/QUADRATURE_LOOP-OMP.cpp
+++ b/src/basic/QUADRATURE_LOOP-OMP.cpp
@@ -1,0 +1,104 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other 
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "QUADRATURE_LOOP.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+
+void QUADRATURE_LOOP::runOpenMPVariant(VariantID vid)
+{
+#if defined(RAJA_ENABLE_OPENMP) && defined(RUN_OPENMP)
+  const Index_type run_reps = getRunReps();
+
+  QUADRATURE_LOOP_DATA_SETUP;
+
+  auto quadratureloop_lam = [=](Index_type zone, Index_type q) {
+                            QUADRATURE_LOOP_BODY;
+                          };
+
+  switch ( vid ) {
+
+    case Base_OpenMP : {
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        #pragma omp parallel for
+        for (Index_type zone = 0; zone < num_zones; ++zone ) {
+          for (Index_type q = 0; q < 27; ++q ) {
+            QUADRATURE_LOOP_BODY;
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case Lambda_OpenMP : {
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        #pragma omp parallel for
+        for (Index_type zone = 0; zone < num_zones; ++zone ) {
+          for (Index_type q = 0; q < 27; ++q ) {
+            quadratureloop_lam(zone, q);
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_OpenMP : {
+
+      using EXEC_POL = RAJA::fornest_basic_omp_outer_2d<RAJA::seq_exec>;
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        RAJA::fornest(EXEC_POL {},
+                      RAJA::range(num_zones), RAJA::range(27),
+                      quadratureloop_lam);
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    default : {
+      getCout() << "\n  QUADRATURE_LOOP : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+#else
+  RAJA_UNUSED_VAR(vid);
+#endif
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(QUADRATURE_LOOP, OpenMP, Base_OpenMP, Lambda_OpenMP, RAJA_OpenMP)
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/QUADRATURE_LOOP-Seq.cpp
+++ b/src/basic/QUADRATURE_LOOP-Seq.cpp
@@ -1,0 +1,102 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other 
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "QUADRATURE_LOOP.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+
+void QUADRATURE_LOOP::runSeqVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  QUADRATURE_LOOP_DATA_SETUP;
+
+#if defined(RUN_RAJA_SEQ)
+  auto quadratureloop_lam = [=](Index_type zone, Index_type q) {
+                            QUADRATURE_LOOP_BODY;
+                          };
+#endif
+
+  switch ( vid ) {
+
+    case Base_Seq : {
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        for (Index_type zone = 0; zone < num_zones; ++zone ) {
+          for (Index_type q = 0; q < 27; ++q ) {
+            QUADRATURE_LOOP_BODY;
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+#if defined(RUN_RAJA_SEQ)
+    case Lambda_Seq : {
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        for (Index_type zone = 0; zone < num_zones; ++zone ) {
+          for (Index_type q = 0; q < 27; ++q ) {
+            quadratureloop_lam(zone, q);
+          }
+        }
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_Seq : {
+
+      using EXEC_POL = RAJA::fornest_basic_seq_2d<RAJA::seq_exec>;
+
+      startTimer();
+      // Loop counter increment uses macro to quiet C++20 compiler warning
+      for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+        RAJA::fornest(EXEC_POL {},
+                      RAJA::range(num_zones), RAJA::range(27),
+                      quadratureloop_lam);
+
+      }
+      stopTimer();
+
+      break;
+    }
+#endif // RUN_RAJA_SEQ
+
+    default : {
+      getCout() << "\n  QUADRATURE_LOOP : Unknown variant id = " << vid << std::endl;
+    }
+
+  }
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(QUADRATURE_LOOP, Seq, Base_Seq, Lambda_Seq, RAJA_Seq)
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/QUADRATURE_LOOP-Sycl.cpp
+++ b/src/basic/QUADRATURE_LOOP-Sycl.cpp
@@ -1,0 +1,96 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "QUADRATURE_LOOP.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_SYCL)
+
+#include "common/SyclDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+template < size_t work_group_size >
+void QUADRATURE_LOOP::runSyclVariantImpl(VariantID vid)
+{
+  setBlockSize(work_group_size);
+
+  const Index_type run_reps = getRunReps();
+  const Index_type iend = getActualProblemSize();
+
+  auto res{getSyclResource()};
+  auto qu = res.get_queue();
+
+  QUADRATURE_LOOP_DATA_SETUP;
+
+  if ( vid == Base_SYCL ) {
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("QUADRATURE_LOOP_1");
+      const size_t global_size =
+        work_group_size * RAJA_DIVIDE_CEILING_INT(iend, work_group_size);
+
+      qu.submit([&] (sycl::handler& h) {
+        h.parallel_for(sycl::nd_range<1>(global_size, work_group_size),
+                                        [=] (sycl::nd_item<1> item ) {
+
+          Index_type idx = item.get_global_id(0);
+          if (idx < iend) {
+            Index_type zone = idx / 27;
+            Index_type q = idx - 27 * zone;
+            QUADRATURE_LOOP_BODY;
+          }
+
+        });
+      });
+      RP_CALI_SUBKERNEL_END("QUADRATURE_LOOP_1");
+
+    }
+    stopTimer();
+
+  } else if ( vid == RAJA_SYCL ) {
+
+    using FORNEST_POL =
+      RAJA::fornest_collapsed_policy<RAJA::sycl_exec<work_group_size>>;
+
+    startTimer();
+    // Loop counter increment uses macro to quiet C++20 compiler warning
+    for (RepIndex_type irep = 0; irep < run_reps; RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("QUADRATURE_LOOP_1");
+      RAJA::fornest(res, FORNEST_POL {},
+                    RAJA::range(num_zones), RAJA::range(27),
+                    [=] (Index_type zone, Index_type q) {
+        QUADRATURE_LOOP_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("QUADRATURE_LOOP_1");
+
+    }
+    stopTimer();
+
+  } else {
+     getCout() << "\n  QUADRATURE_LOOP : Unknown Sycl variant id = " << vid << std::endl;
+  }
+}
+
+RAJAPERF_GPU_BLOCK_SIZE_TUNING_DEFINE_BOILERPLATE(QUADRATURE_LOOP, Sycl, Base_SYCL, RAJA_SYCL)
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif  // RAJA_ENABLE_SYCL

--- a/src/basic/QUADRATURE_LOOP.cpp
+++ b/src/basic/QUADRATURE_LOOP.cpp
@@ -1,0 +1,87 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other 
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "QUADRATURE_LOOP.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include "common/DataUtils.hpp"
+
+namespace rajaperf
+{
+namespace basic
+{
+
+QUADRATURE_LOOP::QUADRATURE_LOOP(const RunParams& params)
+  : KernelBase(rajaperf::Basic_QUADRATURE_LOOP, params)
+{
+  setDefaultProblemSize(1000000);
+  setDefaultReps(500);
+
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::ConsistentPerVariantTuning);
+  setChecksumTolerance(ChecksumTolerance::normal);
+
+  setComplexity(Complexity::N);
+
+  setMaxPerfectLoopDimensions(2);
+  setProblemDimensionality(2);
+
+  setUsesFeature(Kernel);
+
+  addVariantTunings();
+}
+
+void QUADRATURE_LOOP::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_num_zones = (target_size + 26) / 27;
+
+  setActualProblemSize(27 * m_num_zones);
+  setRunReps(target_reps);
+
+  setItsPerRep(27 * m_num_zones);
+  setKernelsPerRep(1);
+
+  setBytesAllocatedPerRep((27 * m_num_zones + 27 + 27 * m_num_zones) *
+                          sizeof(Real_type));
+  setBytesReadPerRep((27 * m_num_zones + 27 * m_num_zones) *
+                     sizeof(Real_type));
+  setBytesWrittenPerRep(27 * m_num_zones * sizeof(Real_type));
+  setBytesModifyWrittenPerRep(0);
+  setBytesAtomicModifyWrittenPerRep(0);
+  setFLOPsPerRep(27 * m_num_zones);
+}
+
+QUADRATURE_LOOP::~QUADRATURE_LOOP()
+{
+}
+
+void QUADRATURE_LOOP::setUp(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  allocAndInitData(m_values, 27 * m_num_zones, vid);
+  allocAndInitData(m_weights, 27, vid);
+  allocAndInitDataConst(m_output, 27 * m_num_zones, 0.0, vid);
+}
+
+void QUADRATURE_LOOP::updateChecksum(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  addToChecksum(m_output, 27 * m_num_zones, vid);
+}
+
+void QUADRATURE_LOOP::tearDown(VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  deallocData(m_values, vid);
+  deallocData(m_weights, vid);
+  deallocData(m_output, vid);
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/QUADRATURE_LOOP.hpp
+++ b/src/basic/QUADRATURE_LOOP.hpp
@@ -1,0 +1,87 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other 
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// QUADRATURE_LOOP kernel reference implementation:
+///
+/// for (Index_type zone = 0; zone < num_zones; ++zone ) {
+///   for (Index_type q = 0; q < 27; ++q ) {
+///     output[27 * zone + q] = weights[q] * values[27 * zone + q];
+///   }
+/// }
+///
+
+#ifndef RAJAPerf_Basic_QUADRATURE_LOOP_HPP
+#define RAJAPerf_Basic_QUADRATURE_LOOP_HPP
+
+
+#define QUADRATURE_LOOP_DATA_SETUP \
+  Real_ptr values = m_values; \
+  Real_ptr weights = m_weights; \
+  Real_ptr output = m_output; \
+  Index_type num_zones = m_num_zones;
+
+#define QUADRATURE_LOOP_BODY  \
+  output[27 * zone + q] = weights[q] * values[27 * zone + q];
+
+
+#include "common/KernelBase.hpp"
+
+namespace rajaperf
+{
+class RunParams;
+
+namespace basic
+{
+
+class QUADRATURE_LOOP : public KernelBase
+{
+public:
+
+  QUADRATURE_LOOP(const RunParams& params);
+
+  ~QUADRATURE_LOOP();
+
+  void setSize(Index_type target_size, Index_type target_reps);
+  void setUp(VariantID vid, size_t tune_idx);
+  void updateChecksum(VariantID vid, size_t tune_idx);
+  void tearDown(VariantID vid, size_t tune_idx);
+
+  void defineSeqVariantTunings();
+  void defineOpenMPVariantTunings();
+  void defineCudaVariantTunings();
+  void defineHipVariantTunings();
+  void defineSyclVariantTunings();
+
+  void runSeqVariant(VariantID vid);
+  void runOpenMPVariant(VariantID vid);
+
+  template < size_t block_size >
+  void runCudaVariantImpl(VariantID vid);
+  template < size_t block_size >
+  void runHipVariantImpl(VariantID vid);
+  template < size_t work_group_size >
+  void runSyclVariantImpl(VariantID vid);
+
+private:
+  static const size_t default_gpu_block_size = 256;
+  using gpu_block_sizes_type = integer::make_gpu_block_size_list_type<default_gpu_block_size,
+                                                         integer::MultipleOf<32>>;
+
+  Index_type m_num_zones;
+
+  Real_ptr m_values;
+  Real_ptr m_weights;
+  Real_ptr m_output;
+};
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -22,6 +22,7 @@
 #include "basic/COPY8.hpp"
 #include "basic/DAXPY.hpp"
 #include "basic/DAXPY_ATOMIC.hpp"
+#include "basic/DYANAMIC_TILE.hpp"
 #include "basic/EMPTY.hpp"
 #include "basic/QUADRATURE_LOOP.hpp"
 #include "basic/IF_QUAD.hpp"
@@ -183,6 +184,7 @@ static const std::string KernelNames [] =
   std::string("Basic_COPY8"),
   std::string("Basic_DAXPY"),
   std::string("Basic_DAXPY_ATOMIC"),
+  std::string("Basic_DYANAMIC_TILE"),
   std::string("Basic_EMPTY"),
   std::string("Basic_QUADRATURE_LOOP"),
   std::string("Basic_IF_QUAD"),
@@ -962,6 +964,10 @@ KernelBase* getKernelObject(KernelID kid,
     }
     case Basic_DAXPY_ATOMIC : {
        kernel = new basic::DAXPY_ATOMIC(run_params);
+       break;
+    }
+    case Basic_DYANAMIC_TILE : {
+       kernel = new basic::DYANAMIC_TILE(run_params);
        break;
     }
     case Basic_EMPTY : {

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -23,6 +23,7 @@
 #include "basic/DAXPY.hpp"
 #include "basic/DAXPY_ATOMIC.hpp"
 #include "basic/EMPTY.hpp"
+#include "basic/QUADRATURE_LOOP.hpp"
 #include "basic/IF_QUAD.hpp"
 #include "basic/INDEXLIST.hpp"
 #include "basic/INDEXLIST_3LOOP.hpp"
@@ -183,6 +184,7 @@ static const std::string KernelNames [] =
   std::string("Basic_DAXPY"),
   std::string("Basic_DAXPY_ATOMIC"),
   std::string("Basic_EMPTY"),
+  std::string("Basic_QUADRATURE_LOOP"),
   std::string("Basic_IF_QUAD"),
   std::string("Basic_INDEXLIST"),
   std::string("Basic_INDEXLIST_3LOOP"),
@@ -964,6 +966,10 @@ KernelBase* getKernelObject(KernelID kid,
     }
     case Basic_EMPTY : {
        kernel = new basic::EMPTY(run_params);
+       break;
+    }
+    case Basic_QUADRATURE_LOOP : {
+       kernel = new basic::QUADRATURE_LOOP(run_params);
        break;
     }
     case Basic_IF_QUAD : {

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -82,6 +82,7 @@ enum KernelID {
   Basic_COPY8,
   Basic_DAXPY,
   Basic_DAXPY_ATOMIC,
+  Basic_DYANAMIC_TILE,
   Basic_EMPTY,
   Basic_QUADRATURE_LOOP,
   Basic_IF_QUAD,

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -83,6 +83,7 @@ enum KernelID {
   Basic_DAXPY,
   Basic_DAXPY_ATOMIC,
   Basic_EMPTY,
+  Basic_QUADRATURE_LOOP,
   Basic_IF_QUAD,
   Basic_INDEXLIST,
   Basic_INDEXLIST_3LOOP,


### PR DESCRIPTION
# Summary

Added RAJA fornest coverage to the perf suite:
  - Added QUADRATURE_LOOP: CPU uses regular nested loops/RAJA fornest; GPU RAJA uses collapsed fornest over zones × 27.
  - Added DYANAMIC_TILE: three 3D loop nests using RAJA fornest with fornest_tile_auto; on GPU, auto tiling selects the thread-block/work-group shape.
  - Added fornest tunings to NESTED_INIT, including collapsed, runtime-tiled, and auto-tiled variants.
