### PR TITLE
Implementation of remaining Basic kernels using Kokkos

### DIFF
--- a/src/apps-kokkos/NODAL_ACCUMULATION_3D-Kokkos.cpp
+++ b/src/apps-kokkos/NODAL_ACCUMULATION_3D-Kokkos.cpp
@@ -30,18 +30,21 @@ void NODAL_ACCUMULATION_3D::runKokkosVariant(VariantID vid)
     int jp = m_domain->jp;
     int kp = m_domain->kp;
     auto real_zones_v = getViewFromPointer(real_zones, iend);
-    auto vol_v = getViewFromPointer(vol, m_nodal_array_length);
+    auto vol_v = getViewFromPointer(vol, m_zonal_array_length);
     auto x_v = getViewFromPointer(x, m_nodal_array_length);
    
+    // Offsets must match NDPTRSET in AppsData.hpp:
+    //   x0 = x        x1 = x + 1        x2 = x + jp        x3 = x + 1 + jp
+    //   x4 = x + kp   x5 = x + 1 + kp   x6 = x + jp + kp   x7 = x + 1 + jp + kp
     using view_t = decltype(x_v);
     view_t x0_v = x_v;
-    view_t x1_v(x_v.data() + 1, m_nodal_array_length - 1); 
-    view_t x2_v(x_v.data() + jp, m_nodal_array_length - jp); 
-    view_t x3_v(x_v.data() + jp, m_nodal_array_length - jp); 
-    view_t x4_v(x_v.data() + jp, m_nodal_array_length - jp); 
-    view_t x5_v(x_v.data() + kp, m_nodal_array_length - kp); 
-    view_t x6_v(x_v.data() + kp, m_nodal_array_length - kp); 
-    view_t x7_v(x_v.data() + kp, m_nodal_array_length - kp); 
+    view_t x1_v(x_v.data() + 1, m_nodal_array_length - 1);
+    view_t x2_v(x_v.data() + jp, m_nodal_array_length - jp);
+    view_t x3_v(x_v.data() + 1 + jp, m_nodal_array_length - 1 - jp);
+    view_t x4_v(x_v.data() + kp, m_nodal_array_length - kp);
+    view_t x5_v(x_v.data() + 1 + kp, m_nodal_array_length - 1 - kp);
+    view_t x6_v(x_v.data() + jp + kp, m_nodal_array_length - jp - kp);
+    view_t x7_v(x_v.data() + 1 + jp + kp, m_nodal_array_length - 1 - jp - kp);
 
     Kokkos::fence();
     startTimer();

--- a/src/basic-kokkos/ARRAY_OF_PTRS-Kokkos.cpp
+++ b/src/basic-kokkos/ARRAY_OF_PTRS-Kokkos.cpp
@@ -44,7 +44,7 @@ void ARRAY_OF_PTRS::runKokkosVariant(VariantID vid) {
           KOKKOS_LAMBDA(Index_type i) {
             y_view[i] = 0.0;
             for (Index_type a = 0; a < array_size; ++a) {
-              y_view[i] += a * x_view[a][i];
+              y_view[i] += x_view[a][i];
             }
           });
       RP_CALI_SUBKERNEL_END("ARRAY_OF_PTRS_1");

--- a/src/basic-kokkos/COPY8-Kokkos.cpp
+++ b/src/basic-kokkos/COPY8-Kokkos.cpp
@@ -1,0 +1,25 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "COPY8.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void COPY8::runKokkosVariant(VariantID vid) {
+// TODO
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(COPY8, Kokkos, Kokkos_Lambda)
+
+} // end namespace basic
+} // end namespace rajaperf
+#endif

--- a/src/basic-kokkos/EMPTY-Kokkos.cpp
+++ b/src/basic-kokkos/EMPTY-Kokkos.cpp
@@ -1,0 +1,25 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "EMPTY.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void EMPTY::runKokkosVariant(VariantID vid) {
+// TODO
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(EMPTY, Kokkos, Kokkos_Lambda)
+
+} // end namespace basic
+} // end namespace rajaperf
+#endif

--- a/src/basic-kokkos/INDEXLIST-Kokkos.cpp
+++ b/src/basic-kokkos/INDEXLIST-Kokkos.cpp
@@ -1,0 +1,25 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "INDEXLIST.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void INDEXLIST::runKokkosVariant(VariantID vid) {
+// TODO
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(INDEXLIST, Kokkos, Kokkos_Lambda)
+
+} // end namespace basic
+} // end namespace rajaperf
+#endif

--- a/src/basic-kokkos/INDEXLIST_3LOOP-Kokkos.cpp
+++ b/src/basic-kokkos/INDEXLIST_3LOOP-Kokkos.cpp
@@ -1,0 +1,25 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "INDEXLIST_3LOOP.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void INDEXLIST_3LOOP::runKokkosVariant(VariantID vid) {
+// TODO
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(INDEXLIST_3LOOP, Kokkos, Kokkos_Lambda)
+
+} // end namespace basic
+} // end namespace rajaperf
+#endif

--- a/src/basic-kokkos/MAT_MAT-Kokkos.cpp
+++ b/src/basic-kokkos/MAT_MAT-Kokkos.cpp
@@ -1,0 +1,25 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void MAT_MAT::runKokkosVariant(VariantID vid) {
+// TODO
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(MAT_MAT, Kokkos, Kokkos_Lambda)
+
+} // end namespace basic
+} // end namespace rajaperf
+#endif

--- a/src/basic-kokkos/MAT_MAT_SHARED-Kokkos.cpp
+++ b/src/basic-kokkos/MAT_MAT_SHARED-Kokkos.cpp
@@ -1,0 +1,25 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MAT_MAT_SHARED.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void MAT_MAT_SHARED::runKokkosVariant(VariantID vid) {
+// TODO
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(MAT_MAT_SHARED, Kokkos, Kokkos_Lambda)
+
+} // end namespace basic
+} // end namespace rajaperf
+#endif

--- a/src/basic-kokkos/MULTI_REDUCE-Kokkos.cpp
+++ b/src/basic-kokkos/MULTI_REDUCE-Kokkos.cpp
@@ -1,0 +1,25 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "MULTI_REDUCE.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void MULTI_REDUCE::runKokkosVariant(VariantID vid) {
+// TODO
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(MULTI_REDUCE, Kokkos, Kokkos_Lambda)
+
+} // end namespace basic
+} // end namespace rajaperf
+#endif

--- a/src/basic-kokkos/PI_ATOMIC-Kokkos.cpp
+++ b/src/basic-kokkos/PI_ATOMIC-Kokkos.cpp
@@ -52,7 +52,7 @@ void PI_ATOMIC::runKokkosVariant(VariantID vid) {
       // Moving the data on the device (held in the KokkosView) BACK to the
       // pointer, pi.
       moveDataToHostFromKokkosView(pi, pi_view, 1);
-      *pi *= 4.0;
+      m_pi_final = *pi * 4.0;
       RP_CALI_SUBKERNEL_END("PI_ATOMIC_1");
     }
 
@@ -66,6 +66,8 @@ void PI_ATOMIC::runKokkosVariant(VariantID vid) {
     std::cout << "\n  PI_ATOMIC : Unknown variant id = " << vid << std::endl;
   }
   }
+
+  PI_ATOMIC_DATA_TEARDOWN;
 }
 
 RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(PI_ATOMIC, Kokkos, Kokkos_Lambda)

--- a/src/basic-kokkos/PI_REDUCE-Kokkos.cpp
+++ b/src/basic-kokkos/PI_REDUCE-Kokkos.cpp
@@ -1,0 +1,25 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "PI_REDUCE.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void PI_REDUCE::runKokkosVariant(VariantID vid) {
+// TODO
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(PI_REDUCE, Kokkos, Kokkos_Lambda)
+
+} // end namespace basic
+} // end namespace rajaperf
+#endif

--- a/src/basic-kokkos/REDUCE3_INT-Kokkos.cpp
+++ b/src/basic-kokkos/REDUCE3_INT-Kokkos.cpp
@@ -57,9 +57,9 @@ void REDUCE3_INT::runKokkosVariant(VariantID vid) {
           },
           Kokkos::Max<Int_type>(max_value), Kokkos::Min<Int_type>(min_value),
           sum);
-      m_vsum += static_cast<Int_type>(sum);
-      m_vmin = std::min(m_vmin, static_cast<Int_type>(min_value));
-      m_vmax = std::max(m_vmax, static_cast<Int_type>(max_value));
+      m_vsum = static_cast<Int_type>(sum);
+      m_vmin = static_cast<Int_type>(min_value);
+      m_vmax = static_cast<Int_type>(max_value);
       RP_CALI_SUBKERNEL_END("REDUCE3_INT_1");
     }
     Kokkos::fence();

--- a/src/basic-kokkos/REDUCE_STRUCT-Kokkos.cpp
+++ b/src/basic-kokkos/REDUCE_STRUCT-Kokkos.cpp
@@ -1,0 +1,25 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) 2017-23, Lawrence Livermore National Security, LLC
+// and RAJA Performance Suite project contributors.
+// See the RAJAPerf/COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "REDUCE_STRUCT.hpp"
+#if defined(RUN_KOKKOS)
+#include "common/KokkosViewUtils.hpp"
+#include <iostream>
+
+namespace rajaperf {
+namespace basic {
+
+void REDUCE_STRUCT::runKokkosVariant(VariantID vid) {
+// TODO
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(REDUCE_STRUCT, Kokkos, Kokkos_Lambda)
+
+} // end namespace basic
+} // end namespace rajaperf
+#endif

--- a/src/lcals-kokkos/DIFF_PREDICT-Kokkos.cpp
+++ b/src/lcals-kokkos/DIFF_PREDICT-Kokkos.cpp
@@ -23,16 +23,18 @@ void DIFF_PREDICT::runKokkosVariant(VariantID vid) {
 
   DIFF_PREDICT_DATA_SETUP;
 
-  // Wrapping pointers in Kokkos Views
-  // Nota bene: get the actual array size to catch errors
+  // DIFF_PREDICT_DATA_SETUP shifts both pointers back by offset * 4, so
+  // px + offset * 4 is m_px (10 * iend elements) and cx + offset * 4 is
+  // m_cx (iend elements). Wrap the allocations, not the shifted pointers:
+  // getViewFromPointer copies the whole extent it is given, in both
+  // directions. The body only touches px columns 4..13 and cx column 4,
+  // so the column index is rebased by 4 below.
 
-  auto px_flat_view = getViewFromPointer(px, iend * 14);
-  auto cx_flat_view = getViewFromPointer(cx, iend * 14);
+  auto px_flat_view = getViewFromPointer(px + offset * 4, iend * 10);
+  auto cx_view = getViewFromPointer(cx + offset * 4, iend);
 
   // 2D View w/ runtime and compile time dimension
-  Kokkos::View<Real_type *[14], Kokkos::LayoutLeft> px_view(px_flat_view.data(),
-                                                            iend);
-  Kokkos::View<Real_type *[14], Kokkos::LayoutLeft> cx_view(cx_flat_view.data(),
+  Kokkos::View<Real_type *[10], Kokkos::LayoutLeft> px_view(px_flat_view.data(),
                                                             iend);
   switch (vid) {
 
@@ -52,25 +54,25 @@ void DIFF_PREDICT::runKokkosVariant(VariantID vid) {
             // DIFF_PREDICT_BODY with Kokkos Views
             Real_type ar, br, cr;
 
-            ar = cx_view(i, 4);
-            br = ar - px_view(i, 4);
-            px_view(i, 4) = ar;
-            cr = br - px_view(i, 5);
-            px_view(i, 5) = br;
-            ar = cr - px_view(i, 6);
-            px_view(i, 6) = cr;
-            br = ar - px_view(i, 7);
-            px_view(i, 7) = ar;
-            cr = br - px_view(i, 8);
-            px_view(i, 8) = br;
-            ar = cr - px_view(i, 9);
-            px_view(i, 9) = cr;
-            br = ar - px_view(i, 10);
-            px_view(i, 10) = ar;
-            cr = br - px_view(i, 11);
-            px_view(i, 11) = br;
-            px_view(i, 13) = cr - px_view(i, 12);
-            px_view(i, 12) = cr;
+            ar = cx_view(i);
+            br = ar - px_view(i, 0);
+            px_view(i, 0) = ar;
+            cr = br - px_view(i, 1);
+            px_view(i, 1) = br;
+            ar = cr - px_view(i, 2);
+            px_view(i, 2) = cr;
+            br = ar - px_view(i, 3);
+            px_view(i, 3) = ar;
+            cr = br - px_view(i, 4);
+            px_view(i, 4) = br;
+            ar = cr - px_view(i, 5);
+            px_view(i, 5) = cr;
+            br = ar - px_view(i, 6);
+            px_view(i, 6) = ar;
+            cr = br - px_view(i, 7);
+            px_view(i, 7) = br;
+            px_view(i, 9) = cr - px_view(i, 8);
+            px_view(i, 8) = cr;
           });
       RP_CALI_SUBKERNEL_END("DIFF_PREDICT_1");
     }
@@ -84,8 +86,8 @@ void DIFF_PREDICT::runKokkosVariant(VariantID vid) {
   }
   }
 
-  moveDataToHostFromKokkosView(px, px_flat_view, iend * 14);
-  moveDataToHostFromKokkosView(cx, cx_flat_view, iend * 14);
+  moveDataToHostFromKokkosView(px + offset * 4, px_flat_view, iend * 10);
+  moveDataToHostFromKokkosView(cx + offset * 4, cx_view, iend);
 }
 
 RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(DIFF_PREDICT, Kokkos, Kokkos_Lambda)

--- a/src/lcals-kokkos/HYDRO_1D-Kokkos.cpp
+++ b/src/lcals-kokkos/HYDRO_1D-Kokkos.cpp
@@ -23,9 +23,12 @@ void HYDRO_1D::runKokkosVariant(VariantID vid) {
   HYDRO_1D_DATA_SETUP;
 
   // Wrap pointers in Kokkos Views
-  auto x_view = getViewFromPointer(x, iend + 12);
-  auto y_view = getViewFromPointer(y, iend + 12);
-  auto z_view = getViewFromPointer(z, iend + 12);
+  // x and y hold iend elements; z is m_z - 10, and m_z holds iend + 1.
+  // Views must wrap the allocations, not the shifted pointer, because
+  // getViewFromPointer copies the whole extent it is given.
+  auto x_view = getViewFromPointer(x, iend);
+  auto y_view = getViewFromPointer(y, iend);
+  auto z_view = getViewFromPointer(z + 10, iend + 1);
 
   switch (vid) {
 
@@ -42,8 +45,7 @@ void HYDRO_1D::runKokkosVariant(VariantID vid) {
           "HYDRO_1D_Kokkos Kokkos_Lambda",
           Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(ibegin, iend),
           KOKKOS_LAMBDA(Index_type i) {
-            x_view[i] =
-                q + y_view[i] * (r * z_view[i + 10] + t * z_view[i + 11]);
+            x_view[i] = q + y_view[i] * (r * z_view[i] + t * z_view[i + 1]);
           });
       RP_CALI_SUBKERNEL_END("HYDRO_1D_1");
     }
@@ -59,9 +61,9 @@ void HYDRO_1D::runKokkosVariant(VariantID vid) {
   }
   }
 
-  moveDataToHostFromKokkosView(x, x_view, iend + 12);
-  moveDataToHostFromKokkosView(y, y_view, iend + 12);
-  moveDataToHostFromKokkosView(z, z_view, iend + 12);
+  moveDataToHostFromKokkosView(x, x_view, iend);
+  moveDataToHostFromKokkosView(y, y_view, iend);
+  moveDataToHostFromKokkosView(z + 10, z_view, iend + 1);
 }
 
 RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(HYDRO_1D, Kokkos, Kokkos_Lambda)

--- a/src/polybench-kokkos/POLYBENCH_HEAT_3D-Kokkos.cpp
+++ b/src/polybench-kokkos/POLYBENCH_HEAT_3D-Kokkos.cpp
@@ -83,10 +83,10 @@ void POLYBENCH_HEAT_3D::runKokkosVariant(VariantID vid) {
       std::cout << "\n  POLYBENCH_HEAT_3D : Unknown variant id = " << vid
                 << std::endl;
     }
-
-    moveDataToHostFromKokkosView(A, A_view, N, N, N);
-    moveDataToHostFromKokkosView(B, B_view, N, N, N);
   }
+
+  moveDataToHostFromKokkosView(A, A_view, N, N, N);
+  moveDataToHostFromKokkosView(B, B_view, N, N, N);
 }
 
 RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(POLYBENCH_HEAT_3D, Kokkos, Kokkos_Lambda)


### PR DESCRIPTION
# Summary
This PR depends on PR's #708 and #709.

This PR contains implementations of the following kernels using Kokkos:
- `EMPTY`
- `COPY8`
- `PI_REDUCE`
- `REDUCE_STRUCT`
- `MULTI_REDUCE`
- `INDEXLIST_3LOOP`
- `INDEXLIST`
- `MAT_MAT`
- `MAT_MAT_SHARED`
