### PR TITLE
Add pointer chase kernel for testing memory latency

### DIFF
--- a/src/basic/CMakeLists.txt
+++ b/src/basic/CMakeLists.txt
@@ -122,6 +122,10 @@ blt_add_library(
           PI_REDUCE-OMP.cpp
           PI_REDUCE-OMPTarget.cpp
           PI_REDUCE-Sycl.cpp
+          POINTER_CHASE.cpp
+          POINTER_CHASE-Seq.cpp
+          POINTER_CHASE-Hip.cpp
+          POINTER_CHASE-Cuda.cpp
           REDUCE3_INT.cpp
           REDUCE3_INT-Seq.cpp
           REDUCE3_INT-Hip.cpp

--- a/src/basic/POINTER_CHASE-Cuda.cpp
+++ b/src/basic/POINTER_CHASE-Cuda.cpp
@@ -1,0 +1,110 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "POINTER_CHASE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_CUDA)
+
+#include "common/CudaDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+__launch_bounds__(1)
+__global__ void pointer_chase_cuda(Index_ptr next, Index_ptr result,
+                                   Index_type start_idx,
+                                   std::uint64_t num_steps)
+{
+  POINTER_CHASE_BODY;
+}
+
+void POINTER_CHASE::runCudaVariant(VariantID vid)
+{
+  setBlockSize(1);
+
+  const Index_type run_reps = getRunReps();
+  auto res{getCudaResource()};
+
+  POINTER_CHASE_DATA_SETUP;
+
+  if (vid == Base_CUDA) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps;
+         RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("POINTER_CHASE_1");
+      RPlaunchCudaKernel((pointer_chase_cuda),
+                         1, 1, 0, res.get_stream(),
+                         next, result, start_idx, num_steps);
+      RP_CALI_SUBKERNEL_END("POINTER_CHASE_1");
+
+    }
+    stopTimer();
+
+  } else if (vid == Lambda_CUDA) {
+
+    auto pointer_chase_lam = [=] __device__ (Index_type) {
+      POINTER_CHASE_BODY;
+    };
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps;
+         RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("POINTER_CHASE_1");
+      RPlaunchCudaKernel((lambda_cuda_forall<1,
+                                            decltype(pointer_chase_lam)>),
+                         1, 1, 0, res.get_stream(),
+                         Index_type(0), Index_type(1), pointer_chase_lam);
+      RP_CALI_SUBKERNEL_END("POINTER_CHASE_1");
+
+    }
+    stopTimer();
+
+  } else if (vid == RAJA_CUDA) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps;
+         RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("POINTER_CHASE_1");
+      RAJA::forall<RAJA::cuda_exec<1, true>>(res,
+        RAJA::RangeSegment(0, 1), [=] __device__ (Index_type) {
+          POINTER_CHASE_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("POINTER_CHASE_1");
+
+    }
+    stopTimer();
+
+  } else {
+    getCout() << "\n  POINTER_CHASE : Unknown Cuda variant id = " << vid
+              << std::endl;
+  }
+}
+
+void POINTER_CHASE::defineCudaVariantTunings()
+{
+  for (VariantID vid : {Base_CUDA, Lambda_CUDA, RAJA_CUDA}) {
+    addVariantTuning<&POINTER_CHASE::runCudaVariant>(
+        vid, getDefaultTuningName(), Index_type(1));
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // RAJA_ENABLE_CUDA

--- a/src/basic/POINTER_CHASE-Hip.cpp
+++ b/src/basic/POINTER_CHASE-Hip.cpp
@@ -1,0 +1,110 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "POINTER_CHASE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#if defined(RAJA_ENABLE_HIP)
+
+#include "common/HipDataUtils.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+__launch_bounds__(1)
+__global__ void pointer_chase_hip(Index_ptr next, Index_ptr result,
+                                  Index_type start_idx,
+                                  std::uint64_t num_steps)
+{
+  POINTER_CHASE_BODY;
+}
+
+void POINTER_CHASE::runHipVariant(VariantID vid)
+{
+  setBlockSize(1);
+
+  const Index_type run_reps = getRunReps();
+  auto res{getHipResource()};
+
+  POINTER_CHASE_DATA_SETUP;
+
+  if (vid == Base_HIP) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps;
+         RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("POINTER_CHASE_1");
+      RPlaunchHipKernel((pointer_chase_hip),
+                        1, 1, 0, res.get_stream(),
+                        next, result, start_idx, num_steps);
+      RP_CALI_SUBKERNEL_END("POINTER_CHASE_1");
+
+    }
+    stopTimer();
+
+  } else if (vid == Lambda_HIP) {
+
+    auto pointer_chase_lam = [=] __device__ (Index_type) {
+      POINTER_CHASE_BODY;
+    };
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps;
+         RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("POINTER_CHASE_1");
+      RPlaunchHipKernel((lambda_hip_forall<1,
+                                          decltype(pointer_chase_lam)>),
+                        1, 1, 0, res.get_stream(),
+                        Index_type(0), Index_type(1), pointer_chase_lam);
+      RP_CALI_SUBKERNEL_END("POINTER_CHASE_1");
+
+    }
+    stopTimer();
+
+  } else if (vid == RAJA_HIP) {
+
+    startTimer();
+    for (RepIndex_type irep = 0; irep < run_reps;
+         RP_REPCOUNTINC(irep)) {
+
+      RP_CALI_SUBKERNEL_BEGIN("POINTER_CHASE_1");
+      RAJA::forall<RAJA::hip_exec<1, true>>(res,
+        RAJA::RangeSegment(0, 1), [=] __device__ (Index_type) {
+          POINTER_CHASE_BODY;
+      });
+      RP_CALI_SUBKERNEL_END("POINTER_CHASE_1");
+
+    }
+    stopTimer();
+
+  } else {
+    getCout() << "\n  POINTER_CHASE : Unknown Hip variant id = " << vid
+              << std::endl;
+  }
+}
+
+void POINTER_CHASE::defineHipVariantTunings()
+{
+  for (VariantID vid : {Base_HIP, Lambda_HIP, RAJA_HIP}) {
+    addVariantTuning<&POINTER_CHASE::runHipVariant>(
+        vid, getDefaultTuningName(), Index_type(1));
+  }
+}
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // RAJA_ENABLE_HIP

--- a/src/basic/POINTER_CHASE-Seq.cpp
+++ b/src/basic/POINTER_CHASE-Seq.cpp
@@ -1,0 +1,100 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "POINTER_CHASE.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <iostream>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+void POINTER_CHASE::runSeqVariant(VariantID vid)
+{
+  const Index_type run_reps = getRunReps();
+
+  POINTER_CHASE_DATA_SETUP;
+
+#if defined(RUN_RAJA_SEQ)
+  auto pointer_chase_lam = [=](Index_type) {
+    POINTER_CHASE_BODY;
+  };
+#endif
+
+  switch (vid) {
+
+    case Base_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps;
+           RP_REPCOUNTINC(irep)) {
+
+        RP_CALI_SUBKERNEL_BEGIN("POINTER_CHASE_1");
+        POINTER_CHASE_BODY;
+        RP_CALI_SUBKERNEL_END("POINTER_CHASE_1");
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+#if defined(RUN_RAJA_SEQ)
+    case Lambda_Seq : {
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps;
+           RP_REPCOUNTINC(irep)) {
+
+        RP_CALI_SUBKERNEL_BEGIN("POINTER_CHASE_1");
+        pointer_chase_lam(0);
+        RP_CALI_SUBKERNEL_END("POINTER_CHASE_1");
+
+      }
+      stopTimer();
+
+      break;
+    }
+
+    case RAJA_Seq : {
+
+      auto res{getHostResource()};
+
+      startTimer();
+      for (RepIndex_type irep = 0; irep < run_reps;
+           RP_REPCOUNTINC(irep)) {
+
+        RP_CALI_SUBKERNEL_BEGIN("POINTER_CHASE_1");
+        RAJA::forall<RAJA::seq_exec>(res, RAJA::RangeSegment(0, 1),
+                                    pointer_chase_lam);
+        RP_CALI_SUBKERNEL_END("POINTER_CHASE_1");
+
+      }
+      stopTimer();
+
+      break;
+    }
+#endif
+
+    default : {
+      getCout() << "\n  POINTER_CHASE : Unknown variant id = " << vid
+                << std::endl;
+    }
+
+  }
+}
+
+RAJAPERF_DEFAULT_TUNING_DEFINE_BOILERPLATE(
+    POINTER_CHASE, Seq, Base_Seq, Lambda_Seq, RAJA_Seq)
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/POINTER_CHASE.cpp
+++ b/src/basic/POINTER_CHASE.cpp
@@ -1,0 +1,133 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+#include "POINTER_CHASE.hpp"
+
+#include "common/DataUtils.hpp"
+#include "common/RunParams.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <stdexcept>
+#include <vector>
+
+namespace rajaperf
+{
+namespace basic
+{
+
+POINTER_CHASE::POINTER_CHASE(const RunParams& params)
+  : KernelBase(rajaperf::Basic_POINTER_CHASE, params),
+    m_traversals(params.getPointerChaseTraversals())
+{
+  setDefaultProblemSize(1000000);
+  setDefaultReps(10);
+
+  setSize(params.getTargetSize(getDefaultProblemSize()),
+          params.getReps(getDefaultReps()));
+
+  setChecksumConsistency(ChecksumConsistency::Consistent);
+  setChecksumTolerance(ChecksumTolerance::zero);
+
+  setComplexity(Complexity::N);
+  setMaxPerfectLoopDimensions(1);
+  setProblemDimensionality(1);
+  setProblemSizeAlignment(ProblemSizeAlignment::OneDimensional);
+
+  setUsesFeature(Forall);
+
+  addVariantTunings();
+}
+
+void POINTER_CHASE::setSize(Index_type target_size, Index_type target_reps)
+{
+  m_N = std::max<Index_type>(target_size, 1);
+
+  const std::uint64_t n = static_cast<std::uint64_t>(m_N);
+  const std::uint64_t metadata_max =
+      static_cast<std::uint64_t>(std::numeric_limits<Index_type>::max());
+
+  if (m_traversals > std::numeric_limits<std::uint64_t>::max() / n) {
+    throw std::overflow_error("POINTER_CHASE num_steps overflow");
+  }
+
+  m_num_steps = n * m_traversals;
+
+  if (m_num_steps > metadata_max ||
+      m_num_steps > metadata_max / sizeof(Index_type) ||
+      n > metadata_max / sizeof(Index_type) - 1) {
+    throw std::overflow_error("POINTER_CHASE metadata overflow");
+  }
+
+  setActualProblemSize(m_N);
+  setRunReps(target_reps);
+
+  setItsPerRep(static_cast<Index_type>(m_num_steps));
+  setKernelsPerRep(1);
+
+  setBytesAllocatedPerRep(
+      static_cast<Index_type>((n + 1) * sizeof(Index_type)));
+  setBytesReadPerRep(
+      static_cast<Index_type>(m_num_steps * sizeof(Index_type)));
+  setBytesWrittenPerRep(sizeof(Index_type));
+  setBytesModifyWrittenPerRep(0);
+  setBytesAtomicModifyWrittenPerRep(0);
+  setFLOPsPerRep(0);
+}
+
+POINTER_CHASE::~POINTER_CHASE()
+{
+}
+
+void POINTER_CHASE::setUp(VariantID vid,
+                          size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  auto next_data = allocDataForInit(m_next, m_N, vid);
+  auto result_data = allocAndInitDataConstForInit(
+      m_result, 1, Index_type(-1), vid);
+
+  std::vector<Index_type> permutation(static_cast<size_t>(m_N));
+  std::iota(permutation.begin(), permutation.end(), Index_type(0));
+  std::mt19937 generator(12345);
+  std::shuffle(permutation.begin(), permutation.end(), generator);
+
+  for (Index_type i = 0; i < m_N; ++i) {
+    m_next[permutation[static_cast<size_t>(i)]] =
+        permutation[static_cast<size_t>((i + 1) % m_N)];
+  }
+
+  m_start_idx = permutation[0];
+  if (m_start_idx == 0 && m_N > 1) {
+    m_start_idx = permutation[1];
+  }
+}
+
+void POINTER_CHASE::updateChecksum(
+    VariantID vid, size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  auto result_data = scopedMoveData(m_result, 1, vid);
+
+  if (m_result[0] != m_start_idx) {
+    throw std::runtime_error("POINTER_CHASE result does not match start index");
+  }
+
+  addToChecksum(m_result[0]);
+}
+
+void POINTER_CHASE::tearDown(VariantID vid,
+                             size_t RAJAPERF_UNUSED_ARG(tune_idx))
+{
+  deallocData(m_next, vid);
+  deallocData(m_result, vid);
+}
+
+} // end namespace basic
+} // end namespace rajaperf

--- a/src/basic/POINTER_CHASE.hpp
+++ b/src/basic/POINTER_CHASE.hpp
@@ -1,0 +1,78 @@
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+// Copyright (c) Lawrence Livermore National Security, LLC and other
+// RAJA Project Developers. See top-level LICENSE and COPYRIGHT
+// files for dates and other details. No copyright assignment is required
+// to contribute to RAJA Performance Suite.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~//
+
+///
+/// POINTER_CHASE kernel reference implementation:
+///
+/// Index_type idx = start_idx;
+/// for (std::uint64_t step = 0; step < num_steps; ++step) {
+///   idx = next[idx];
+/// }
+/// result[0] = idx;
+///
+
+#ifndef RAJAPerf_Basic_POINTER_CHASE_HPP
+#define RAJAPerf_Basic_POINTER_CHASE_HPP
+
+#include "common/KernelBase.hpp"
+
+#include <cstdint>
+
+#define POINTER_CHASE_DATA_SETUP                                              \
+  Index_ptr next = m_next;                                                    \
+  Index_ptr result = m_result;                                                \
+  const Index_type start_idx = m_start_idx;                                   \
+  const std::uint64_t num_steps = m_num_steps;
+
+#define POINTER_CHASE_BODY                                                    \
+  Index_type idx = start_idx;                                                 \
+  for (std::uint64_t step = 0; step < num_steps; ++step) {                    \
+    idx = next[idx];                                                          \
+  }                                                                           \
+  result[0] = idx;
+
+namespace rajaperf
+{
+class RunParams;
+
+namespace basic
+{
+
+class POINTER_CHASE : public KernelBase
+{
+public:
+  POINTER_CHASE(const RunParams& params);
+  ~POINTER_CHASE();
+
+  void setSize(Index_type target_size, Index_type target_reps);
+  void setUp(VariantID vid, size_t tune_idx);
+  void updateChecksum(VariantID vid, size_t tune_idx);
+  void tearDown(VariantID vid, size_t tune_idx);
+
+  void defineSeqVariantTunings();
+  void defineCudaVariantTunings();
+  void defineHipVariantTunings();
+
+  void runSeqVariant(VariantID vid);
+  void runCudaVariant(VariantID vid);
+  void runHipVariant(VariantID vid);
+
+private:
+  Index_ptr m_next;
+  Index_ptr m_result;
+  Index_type m_N;
+  Index_type m_start_idx;
+  std::uint64_t m_traversals;
+  std::uint64_t m_num_steps;
+};
+
+} // end namespace basic
+} // end namespace rajaperf
+
+#endif // closing endif for header file include guard

--- a/src/common/RAJAPerfSuite.cpp
+++ b/src/common/RAJAPerfSuite.cpp
@@ -39,6 +39,7 @@
 #include "basic/REDUCE_STRUCT.hpp"
 #include "basic/TRAP_INT.hpp"
 #include "basic/MULTI_REDUCE.hpp"
+#include "basic/POINTER_CHASE.hpp"
 
 //
 // Lcals kernels...
@@ -200,6 +201,7 @@ static const std::string KernelNames [] =
   std::string("Basic_REDUCE_STRUCT"),
   std::string("Basic_TRAP_INT"),
   std::string("Basic_MULTI_REDUCE"),
+  std::string("Basic_POINTER_CHASE"),
 
 //
 // Lcals kernels...
@@ -1030,6 +1032,10 @@ KernelBase* getKernelObject(KernelID kid,
     }
     case Basic_MULTI_REDUCE : {
        kernel = new basic::MULTI_REDUCE(run_params);
+       break;
+    }
+    case Basic_POINTER_CHASE : {
+       kernel = new basic::POINTER_CHASE(run_params);
        break;
     }
 

--- a/src/common/RAJAPerfSuite.hpp
+++ b/src/common/RAJAPerfSuite.hpp
@@ -99,6 +99,7 @@ enum KernelID {
   Basic_REDUCE_STRUCT,
   Basic_TRAP_INT,
   Basic_MULTI_REDUCE,
+  Basic_POINTER_CHASE,
 
 //
 // Lcals kernels...

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -13,7 +13,9 @@
 
 #include <cstdlib>
 #include <cstdio>
+#include <cerrno>
 #include <iostream>
+#include <limits>
 
 #include <list>
 #include <set>
@@ -53,6 +55,7 @@ RunParams::RunParams(int argc, char** argv)
    femsweep_mesh_dims({5, 5, 5}),
    use_femsweep_mesh_dims(false),
    array_of_ptrs_array_size(ARRAY_OF_PTRS_MAX_ARRAY_SIZE),
+   pointer_chase_traversals(POINTER_CHASE_DEFAULT_TRAVERSALS),
    halo_width(1),
    halo_num_vars(3),
    enable_custom_scan(true),
@@ -161,6 +164,7 @@ void RunParams::print(std::ostream& str) const
   }
 
   str << "\n array_of_ptrs_array_size = " << array_of_ptrs_array_size;
+  str << "\n pointer_chase_traversals = " << pointer_chase_traversals;
 
   str << "\n halo_width = " << halo_width;
   str << "\n halo_num_vars = " << halo_num_vars;
@@ -826,6 +830,31 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
           input_state = BadInput;
         } else {
           array_of_ptrs_array_size = num;
+        }
+      } else {
+        getCout() << "\nBad input:"
+                  << " must give " << opt << " a value (int)"
+                  << std::endl;
+        input_state = BadInput;
+      }
+
+    } else if ( opt == std::string("--pointer_chase_traversals") ) {
+
+      i++;
+      if ( i < argc ) {
+        char* end = nullptr;
+        errno = 0;
+        const char* value = argv[i];
+        unsigned long long num = std::strtoull(value, &end, 10);
+        if ( value[0] == '-' || errno == ERANGE || end == value ||
+             *end != '\0' || num == 0 ||
+             num > std::numeric_limits<std::uint64_t>::max() ) {
+          getCout() << "\nBad input:"
+                    << " must give " << opt << " a positive 64-bit integer"
+                    << std::endl;
+          input_state = BadInput;
+        } else {
+          pointer_chase_traversals = static_cast<std::uint64_t>(num);
         }
       } else {
         getCout() << "\nBad input:"
@@ -1761,6 +1790,13 @@ void RunParams::printHelpMessage(std::ostream& str) const
       << "\t      Must be less than or equal to " << ARRAY_OF_PTRS_MAX_ARRAY_SIZE << ".\n";
   str << "\t\t Example...\n"
       << "\t\t --array_of_ptrs_array_size 4\n\n";
+
+  str << "\t --pointer_chase_traversals <int> [default is "
+      << POINTER_CHASE_DEFAULT_TRAVERSALS << "]\n"
+      << "\t      (For POINTER_CHASE only: full chain traversals per repetition)\n"
+      << "\t      Must be greater than 0.\n";
+  str << "\t\t Example...\n"
+      << "\t\t --pointer_chase_traversals 4\n\n";
 
   str << "\t --halo_width <int> [default is 1]\n"
       << "\t      (For HALO kernels only: halo width used in kernels)\n"

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -14,6 +14,7 @@
 #include <set>
 #include <vector>
 #include <array>
+#include <cstdint>
 #include <iosfwd>
 
 #include "RAJAPerfSuite.hpp"
@@ -25,6 +26,8 @@
 
 namespace rajaperf
 {
+
+inline constexpr std::uint64_t POINTER_CHASE_DEFAULT_TRAVERSALS = 1;
 
 /*!
  *******************************************************************************
@@ -284,6 +287,9 @@ public:
 
   Index_type getArrayOfPtrsArraySize() const { return array_of_ptrs_array_size; }
 
+  std::uint64_t getPointerChaseTraversals() const
+  { return pointer_chase_traversals; }
+
   Index_type getHaloWidth() const { return halo_width; }
   Index_type getHaloNumVars() const { return halo_num_vars; }
 
@@ -447,6 +453,8 @@ private:
   bool use_femsweep_mesh_dims; /*!< enable user input of femsweep mesh dimensions x, y, and z in femsweep kernel (true if vector femsweep_mesh_dims is properly passed on command line) */
 
   Index_type array_of_ptrs_array_size; /*!< number of pointers used in ARRAY_OF_PTRS kernel (input option) */
+
+  std::uint64_t pointer_chase_traversals; /*!< number of full POINTER_CHASE traversals per repetition */
 
   Index_type halo_width; /*!< halo width used in halo kernels (input option) */
   Index_type halo_num_vars; /*!< num vars used in halo kernels (input option) */


### PR DESCRIPTION
Adds a pointer chasing kernel to measure memory latency.

Inspired from [lmbench lat_mem_rd](https://lmbench.sourceforge.net/man/lat_mem_rd.8.html) and [nvbandwidth](https://github.com/NVIDIA/nvbandwidth).