### PR TITLE
Switch warmup default to be 'same as perfrun'

### DIFF
--- a/docs/sphinx/user_guide/run.rst
+++ b/docs/sphinx/user_guide/run.rst
@@ -60,9 +60,10 @@ were specified to configure the build.
 The Suite can be run in many different ways chosen by the command-line 
 options passed to the executable. For example, you can run or exclude subsets 
 of kernels, variants, or groups. You can also pass options to set problem 
-sizes, number of times each kernel is run (sampled), and many other run 
-parameters. The goal is to build the code once and use scripts or other means 
-to run the Suite in different ways for the analyses you want to perform.
+sizes, number of times each kernel is run (sampled), how to run warmup kernels
+for more precise execution timings, etc. The goal is to build the code once and
+use scripts or other means to run the Suite in different ways for the analyses
+you want to perform.
 
 Many options appear in a *long form* with a double hyphen prefix (i.e., '--').
 Commonly used options are also available in a one or two character *short form*

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -1120,7 +1120,7 @@ void Executor::runWarmupKernels()
   } else if ( warmup_mode == RunParams::WarmupMode::Minimal ) {
 
     //
-    // No warmup kernel input given, choose a warmup kernel for each feature
+    // Minimal warmup mode. Choose a warmup kernel for each feature.
     //
     // First, assemble a set of feature IDs
     //

--- a/src/common/Executor.cpp
+++ b/src/common/Executor.cpp
@@ -1117,7 +1117,7 @@ void Executor::runWarmupKernels()
       warmup_kernel_ids.insert( kernel->getKernelID() );
     } // iterate over kernels to run
 
-  } else if ( warmup_mode == RunParams::WarmupMode::Default ) {
+  } else if ( warmup_mode == RunParams::WarmupMode::Minimal ) {
 
     //
     // No warmup kernel input given, choose a warmup kernel for each feature

--- a/src/common/RunParams.cpp
+++ b/src/common/RunParams.cpp
@@ -67,7 +67,7 @@ RunParams::RunParams(int argc, char** argv)
    checkrun_reps(1),
    reference_variant(),
    reference_vid(NumVariants),
-   warmup_mode(WarmupMode::Default),
+   warmup_mode(WarmupMode::PerfRunSame),
    warmup_kernel_input(),
    invalid_warmup_kernel_input(),
    kernel_input(),
@@ -1025,24 +1025,6 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
         input_state = BadInput;
       }
 
-    } else if ( opt == std::string("--warmup-kernels") ||
-                opt == std::string("-wk") ) {
-
-      bool done = false;
-      i++;
-      while ( i < argc && !done ) {
-        opt = std::string(argv[i]);
-        if ( opt.at(0) == '-' ) {
-          i--;
-          done = true;
-        } else {
-          warmup_kernel_input.push_back(opt);
-          ++i;
-        }
-      }
-
-      warmup_mode = WarmupMode::Explicit;
-
     } else if ( opt == std::string("--kernels") ||
                 opt == std::string("-k") ) {
 
@@ -1342,9 +1324,31 @@ void RunParams::parseCommandLineOptions(int argc, char** argv)
 
       warmup_mode = WarmupMode::Disable;
 
+    } else if ( std::string(argv[i]) == std::string("--warmup-minimal") ) {
+
+      warmup_mode = WarmupMode::Minimal;
+
     } else if ( std::string(argv[i]) == std::string("--warmup-perfrun-same") ) {
 
       warmup_mode = WarmupMode::PerfRunSame;
+
+    } else if ( opt == std::string("--warmup-kernels") ||
+                opt == std::string("-wk") ) {
+
+      bool done = false;
+      i++;
+      while ( i < argc && !done ) {
+        opt = std::string(argv[i]);
+        if ( opt.at(0) == '-' ) {
+          i--;
+          done = true;
+        } else {
+          warmup_kernel_input.push_back(opt);
+          ++i;
+        }
+      }
+
+      warmup_mode = WarmupMode::Explicit;
 
     } else if ( std::string(argv[i]) == std::string("--checkrun") ) {
 
@@ -1557,15 +1561,18 @@ void RunParams::printHelpMessage(std::ostream& str) const
       << "\t\t --outfile mydata (output data will be in files named 'mydata*')\n"
       << "\t\t -of dat (output data will be in files named 'dat*')\n\n";
 
-  str << "\t Options for selecting which kernels to run....\n"
+  str << "\t Options for selecting kernels to run....\n"
       << "\t ========================================\n\n";
 
-  str << "\t For warmup kernels, the default case (no option given) will run a minimal set of warmup kernels based on\n"
-      << "\t RAJA features exercised in kernels selected to run. Other options are:\n\n";
+  str << "\t For warmup kernels, the default case (no option given) is to run the same set of kernels for warmup\n"
+      << "\t that are selected to run. Warmup options are:\n\n";
 
   str << "\t --warmup-disable (do not run any warmup kernels)\n\n";
 
-  str << "\t --warmup-perfrun-same (run same set of kernels for warmup as selected to run)\n\n";
+  str << "\t --warmup-minimal (run a minimal set of warmup kernels based on\n"
+      << "\t      RAJA features exercised in kernels selected to run)\n\n";
+
+  str << "\t --warmup-perfrun-same (run kernels for warmup that are selected to run, default case)\n\n";
 
   str << "\t --warmup-kernels, -wk <space-separated strings> [if no kernel names specified, none will be run for warmup]\n"
       << "\t      (names of individual kernels and/or groups of kernels to warmup)\n"

--- a/src/common/RunParams.hpp
+++ b/src/common/RunParams.hpp
@@ -171,7 +171,7 @@ public:
    */
   enum WarmupMode {
     Disable,       /*!< no warmup kernels will be run */
-    Default,       /*!< run minimal set of warmup kernels based kernels to run */
+    Minimal,       /*!< run minimal set of warmup kernels based features used in kernels to run */
     PerfRunSame,   /*!< run warmup pass of each kernel to run */
     Explicit,      /*!< run warmup pass of each kernel explicitly named for warmup in input */
   };
@@ -184,8 +184,8 @@ public:
     switch (wm) {
       case WarmupMode::Disable:
         return "Disable";
-      case WarmupMode::Default:
-        return "Default";
+      case WarmupMode::Minimal:
+        return "Minimal";
       case WarmupMode::PerfRunSame:
         return "PerfRunSame";
       case WarmupMode::Explicit:


### PR DESCRIPTION
# Summary

- This PR changes default kernel warmup behavior.
- The new default is to run all kernels, variants, etc. that are selected to run.
